### PR TITLE
Node Client APIs for Replica to retrieve ServerAddress and ServerHost

### DIFF
--- a/src/client-node/src/replica.rs
+++ b/src/client-node/src/replica.rs
@@ -72,9 +72,8 @@ impl JsReplicaLeader {
     }
 
     /// JS method to return Servers Host:Port address
-    #[allow(non_snake_case)]
     #[node_bindgen]
-    fn serverAddress(&self) -> String {
+    fn server_address(&self) -> String {
         if let Some(server_addr) = self.server_addr() {
             format!("{}:{}", server_addr.host, server_addr.port)    
         } else {
@@ -83,9 +82,8 @@ impl JsReplicaLeader {
     }
     
     /// JS method to return Server Host or IP
-    #[allow(non_snake_case)]
     #[node_bindgen]
-    fn serverHost(&self) -> String {
+    fn server_host(&self) -> String {
         if let Some(server_addr) = self.server_addr() {
             server_addr.host
         } else {

--- a/src/client-node/src/sc.rs
+++ b/src/client-node/src/sc.rs
@@ -69,9 +69,8 @@ impl JsScClient {
     }
 
     /// JS method to return Servers Host:Port address
-    #[allow(non_snake_case)]
     #[node_bindgen]
-    fn serverAddress(&self) -> String {
+    fn server_address(&self) -> String {
         self.rust_addr()
     }
 

--- a/src/client-node/src/sc.rs
+++ b/src/client-node/src/sc.rs
@@ -68,9 +68,10 @@ impl JsScClient {
         })
     }
 
-    /// JS method to return host address
+    /// JS method to return Servers Host:Port address
+    #[allow(non_snake_case)]
     #[node_bindgen]
-    fn addr(&self) -> String {
+    fn serverAddress(&self) -> String {
         self.rust_addr()
     }
 


### PR DESCRIPTION
Added 2 APIs to retrieve Replica server information:
 - serverHost
 - serverAddress

Changed SC API (for consistency) from
 - addr
to 
 - serverAddress