### PR TITLE
rename custom-spu commands to register and unregister; run cargo fmt

### DIFF
--- a/src/cli/src/spu/custom/mod.rs
+++ b/src/cli/src/spu/custom/mod.rs
@@ -1,15 +1,15 @@
-mod create;
+mod register;
 mod list;
-mod delete;
+mod unregister;
 
 
 use structopt::StructOpt;
 
-use create::CreateCustomSpuOpt;
-use create::process_create_custom_spu;
+use register::RegisterCustomSpuOpt;
+use register::process_register_custom_spu;
 
-use delete::DeleteCustomSpuOpt;
-use delete::process_delete_custom_spu;
+use unregister::UnregisterCustomSpuOpt;
+use unregister::process_unregister_custom_spu;
 
 use list::ListCustomSpusOpt;
 use list::process_list_custom_spus;
@@ -25,7 +25,7 @@ pub enum CustomSpuOpt {
 
 {all-args}
 ", about = "Create custom SPU")]
-    Create(CreateCustomSpuOpt),
+    Create(RegisterCustomSpuOpt),
 
     #[structopt(name = "delete", template = "{about}
 
@@ -33,7 +33,7 @@ pub enum CustomSpuOpt {
 
 {all-args}
 ", about = "Delete custom SPU")]
-    Delete(DeleteCustomSpuOpt),
+    Delete(UnregisterCustomSpuOpt),
 
     #[structopt(name = "list", template = "{about}
 
@@ -46,8 +46,8 @@ pub enum CustomSpuOpt {
 
 pub(crate) async fn process_custom_spu<O: Terminal>(out: std::sync::Arc<O>,custom_spu_opt: CustomSpuOpt) -> Result<String, CliError> {
     (match custom_spu_opt {
-        CustomSpuOpt::Create(custom_spu_opt) => process_create_custom_spu(custom_spu_opt).await,
-        CustomSpuOpt::Delete(custom_spu_opt) => process_delete_custom_spu(custom_spu_opt).await,
+        CustomSpuOpt::Create(custom_spu_opt) => process_register_custom_spu(custom_spu_opt).await,
+        CustomSpuOpt::Delete(custom_spu_opt) => process_unregister_custom_spu(custom_spu_opt).await,
         CustomSpuOpt::List(custom_spu_opt) => process_list_custom_spus(out,custom_spu_opt).await,
     }).map(|_| format!(""))
 }

--- a/src/cli/src/spu/custom/mod.rs
+++ b/src/cli/src/spu/custom/mod.rs
@@ -19,7 +19,7 @@ use crate::Terminal;
 
 #[derive(Debug, StructOpt)]
 pub enum CustomSpuOpt {
-    #[structopt(name = "create", template = "{about}
+    #[structopt(name = "register", template = "{about}
 
 {usage}
 
@@ -27,7 +27,7 @@ pub enum CustomSpuOpt {
 ", about = "Create custom SPU")]
     Create(RegisterCustomSpuOpt),
 
-    #[structopt(name = "delete", template = "{about}
+    #[structopt(name = "unregister", template = "{about}
 
 {usage}
 

--- a/src/cli/src/spu/custom/register.rs
+++ b/src/cli/src/spu/custom/register.rs
@@ -16,7 +16,7 @@ use crate::error::CliError;
 use crate::profile::InlineProfile;
 
 #[derive(Debug)]
-pub struct CreateCustomSpuConfig {
+pub struct RegisterCustomSpuConfig {
     pub id: i32,
     pub name: String,
     pub public_server: ServerAddress,
@@ -25,7 +25,7 @@ pub struct CreateCustomSpuConfig {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct CreateCustomSpuOpt {
+pub struct RegisterCustomSpuOpt {
     /// SPU id
     #[structopt(short = "i", long = "id")]
     id: i32,
@@ -57,9 +57,9 @@ pub struct CreateCustomSpuOpt {
     profile: InlineProfile,
 }
 
-impl CreateCustomSpuOpt {
+impl RegisterCustomSpuOpt {
     /// Validate cli options. Generate target-server and create custom spu config.
-    fn validate(self) -> Result<(ScConfig, CreateCustomSpuConfig), CliError> {
+    fn validate(self) -> Result<(ScConfig, RegisterCustomSpuConfig), CliError> {
         // profile specific configurations (target server)
         let target_server = ScConfig::new_with_profile(
             self.sc,
@@ -68,7 +68,7 @@ impl CreateCustomSpuOpt {
         )?;
 
         // create custom spu config
-        let cfg = CreateCustomSpuConfig {
+        let cfg = RegisterCustomSpuConfig {
             id: self.id,
             name: self.name.unwrap_or(format!("custom-spu-{}", self.id)),
             public_server: TryFrom::try_from(self.public_server)?,
@@ -84,12 +84,12 @@ impl CreateCustomSpuOpt {
 // -----------------------------------
 //  CLI Processing
 // -----------------------------------
-pub async fn process_create_custom_spu(opt: CreateCustomSpuOpt) -> Result<(), CliError> {
+pub async fn process_register_custom_spu(opt: RegisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, cfg) = opt.validate()?;
 
     let mut sc = target_server.connect().await?;
 
-    sc.create_custom_spu(
+    sc.register_custom_spu(
         cfg.id,
         cfg.name,
         cfg.public_server,

--- a/src/cli/src/spu/custom/register.rs
+++ b/src/cli/src/spu/custom/register.rs
@@ -58,7 +58,7 @@ pub struct RegisterCustomSpuOpt {
 }
 
 impl RegisterCustomSpuOpt {
-    /// Validate cli options. Generate target-server and create custom spu config.
+    /// Validate cli options. Generate target-server and register custom spu config.
     fn validate(self) -> Result<(ScConfig, RegisterCustomSpuConfig), CliError> {
         // profile specific configurations (target server)
         let target_server = ScConfig::new_with_profile(
@@ -67,7 +67,7 @@ impl RegisterCustomSpuOpt {
             self.profile.profile,
         )?;
 
-        // create custom spu config
+        // register custom spu config
         let cfg = RegisterCustomSpuConfig {
             id: self.id,
             name: self.name.unwrap_or(format!("custom-spu-{}", self.id)),

--- a/src/cli/src/spu/custom/unregister.rs
+++ b/src/cli/src/spu/custom/unregister.rs
@@ -20,7 +20,7 @@ use crate::profile::InlineProfile;
 // -----------------------------------
 
 #[derive(Debug, StructOpt)]
-pub struct DeleteCustomSpuOpt {
+pub struct UnregisterCustomSpuOpt {
     /// SPU id
     #[structopt(short = "i", long = "id", required_unless = "name")]
     id: Option<i32>,
@@ -45,7 +45,7 @@ pub struct DeleteCustomSpuOpt {
     profile: InlineProfile,
 }
 
-impl DeleteCustomSpuOpt {
+impl UnregisterCustomSpuOpt {
     /// Validate cli options. Generate target-server and delete custom spu config.
     fn validate(self) -> Result<(ScConfig, FlvCustomSpu), CliError> {
         let target_server = ScConfig::new_with_profile(
@@ -76,10 +76,10 @@ impl DeleteCustomSpuOpt {
 // -----------------------------------
 
 /// Process delete custom-spu cli request
-pub async fn process_delete_custom_spu(opt: DeleteCustomSpuOpt) -> Result<(), CliError> {
+pub async fn process_unregister_custom_spu(opt: UnregisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, cfg) = opt.validate()?;
 
     let mut sc = target_server.connect().await?;
 
-    sc.delete_custom_spu(cfg).await.map_err(|err| err.into())
+    sc.unregister_custom_spu(cfg).await.map_err(|err| err.into())
 }

--- a/src/cli/src/spu/custom/unregister.rs
+++ b/src/cli/src/spu/custom/unregister.rs
@@ -46,7 +46,7 @@ pub struct UnregisterCustomSpuOpt {
 }
 
 impl UnregisterCustomSpuOpt {
-    /// Validate cli options. Generate target-server and delete custom spu config.
+    /// Validate cli options. Generate target-server and unregister custom spu config.
     fn validate(self) -> Result<(ScConfig, FlvCustomSpu), CliError> {
         let target_server = ScConfig::new_with_profile(
             self.sc,
@@ -75,7 +75,7 @@ impl UnregisterCustomSpuOpt {
 //  CLI Processing
 // -----------------------------------
 
-/// Process delete custom-spu cli request
+/// Process unregister custom-spu cli request
 pub async fn process_unregister_custom_spu(opt: UnregisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, cfg) = opt.validate()?;
 

--- a/src/client-rs/src/sc.rs
+++ b/src/client-rs/src/sc.rs
@@ -13,9 +13,9 @@ use sc_api::topic::{FlvDeleteTopicsRequest};
 use sc_api::topic::{FlvCreateTopicRequest, FlvCreateTopicsRequest};
 use sc_api::topic::FlvTopicSpecMetadata;
 use sc_api::topic::FlvFetchTopicsRequest;
-use sc_api::spu::FlvCreateCustomSpusRequest;
-use sc_api::spu::{FlvCreateCustomSpuRequest, FlvEndPointMetadata};
-use sc_api::spu::FlvDeleteCustomSpusRequest;
+use sc_api::spu::FlvRegisterCustomSpusRequest;
+use sc_api::spu::{FlvRegisterCustomSpuRequest, FlvEndPointMetadata};
+use sc_api::spu::FlvUnregisterCustomSpusRequest;
 use sc_api::spu::FlvFetchSpusRequest;
 use sc_api::spu::FlvRequestSpuType;
 use sc_api::spu::FlvCreateSpuGroupRequest;
@@ -63,7 +63,7 @@ impl ScClient  {
 
     
 
-    pub async fn create_custom_spu(
+    pub async fn register_custom_spu(
         &mut self,
         id: i32,
         name: String,
@@ -71,7 +71,7 @@ impl ScClient  {
         private_server: ServerAddress,
         rack: Option<String>,
     ) -> Result<(), ClientError> {
-        let spu = FlvCreateCustomSpuRequest {
+        let spu = FlvRegisterCustomSpuRequest {
             id,
             name: name.to_owned(),
             public_server: FlvEndPointMetadata {
@@ -85,7 +85,7 @@ impl ScClient  {
             rack,
         };
         // generate request with 1 custom spu
-        let request = FlvCreateCustomSpusRequest {
+        let request = FlvRegisterCustomSpusRequest {
             custom_spus: vec![spu],
         };
 
@@ -94,8 +94,8 @@ impl ScClient  {
         responses.validate(&name).map_err(|err| err.into())
     }
 
-    pub async fn delete_custom_spu(&mut self, spu: FlvCustomSpu) -> Result<(), ClientError> {
-        let request = FlvDeleteCustomSpusRequest {
+    pub async fn unregister_custom_spu(&mut self, spu: FlvCustomSpu) -> Result<(), ClientError> {
+        let request = FlvUnregisterCustomSpusRequest {
             custom_spus: vec![spu],
         };
 

--- a/src/sc-api/src/api_key.rs
+++ b/src/sc-api/src/api_key.rs
@@ -23,8 +23,8 @@ pub enum ScApiKey {
     FlvTopicComposition = 2004,
 
     // Custom SPUs
-    FlvCreateCustomSpus = 2005,
-    FlvDeleteCustomSpus = 2006,
+    FlvRegisterCustomSpus = 2005,
+    FlvUnregisterCustomSpus = 2006,
     FlvFetchSpus = 2007,
 
     // SPU Groups

--- a/src/sc-api/src/flv_register_custom_spus.rs
+++ b/src/sc-api/src/flv_register_custom_spus.rs
@@ -14,26 +14,26 @@ use crate::ApiError;
 use super::spu::FlvEndPointMetadata;
 
 // -----------------------------------
-// FlvCreateCustomSpusRequest
+// FlvRegisterCustomSpusRequest
 // -----------------------------------
 
 #[derive(Encode, Decode, Default, Debug)]
-pub struct FlvCreateCustomSpusRequest {
+pub struct FlvRegisterCustomSpusRequest {
     /// A list of one or more custom spus to be created.
-    pub custom_spus: Vec<FlvCreateCustomSpuRequest>,
+    pub custom_spus: Vec<FlvRegisterCustomSpuRequest>,
 }
 
 
-impl Request for FlvCreateCustomSpusRequest {
-    const API_KEY: u16 = ScApiKey::FlvCreateCustomSpus as u16;
+impl Request for FlvRegisterCustomSpusRequest {
+    const API_KEY: u16 = ScApiKey::FlvRegisterCustomSpus as u16;
     const DEFAULT_API_VERSION: i16 = 1;
-    type Response = FlvCreateCustomSpusResponse;
+    type Response = FlvRegisterCustomSpusResponse;
 }
 
 
 
 #[derive(Encode, Decode, Default, Debug)]
-pub struct FlvCreateCustomSpuRequest {
+pub struct FlvRegisterCustomSpuRequest {
     /// The id of the custom spu (globally unique id)
     pub id: i32,
 
@@ -51,16 +51,16 @@ pub struct FlvCreateCustomSpuRequest {
 }
 
 // -----------------------------------
-// FlvCreateCustomSpusResponse
+// FlvRegisterCustomSpusResponse
 // -----------------------------------
 
 #[derive(Encode, Decode, Default, Debug)]
-pub struct FlvCreateCustomSpusResponse {
+pub struct FlvRegisterCustomSpusResponse {
     /// The custom spu creation result messages.
     pub results: Vec<FlvResponseMessage>,
 }
 
-impl FlvCreateCustomSpusResponse {
+impl FlvRegisterCustomSpusResponse {
 
     /// validate and extract a single response
     pub fn validate(self, name: &str) -> Result<(),ApiError> {

--- a/src/sc-api/src/flv_unregister_custom_spus.rs
+++ b/src/sc-api/src/flv_unregister_custom_spus.rs
@@ -13,26 +13,26 @@ use crate::ScApiKey;
 use crate::common::flv_spus::FlvCustomSpu;
 
 #[derive(Encode, Decode, Default, Debug)]
-pub struct FlvDeleteCustomSpusRequest {
+pub struct FlvUnregisterCustomSpusRequest {
     /// Each spu name or id to be deleted.
     pub custom_spus: Vec<FlvCustomSpu>,
 }
 
-impl Request for FlvDeleteCustomSpusRequest {
-    const API_KEY: u16 = ScApiKey::FlvDeleteCustomSpus as u16;
+impl Request for FlvUnregisterCustomSpusRequest {
+    const API_KEY: u16 = ScApiKey::FlvUnregisterCustomSpus as u16;
     const DEFAULT_API_VERSION: i16 = 1;
-    type Response = FlvDeleteCustomSpusResponse;
+    type Response = FlvUnregisterCustomSpusResponse;
 }
 
 
 #[derive(Encode, Decode, Default, Debug)]
-pub struct FlvDeleteCustomSpusResponse {
+pub struct FlvUnregisterCustomSpusResponse {
     /// A response message for each delete request
     pub results: Vec<FlvResponseMessage>,
 }
 
 
-impl FlvDeleteCustomSpusResponse {
+impl FlvUnregisterCustomSpusResponse {
 
     /// validate and extract a single response
     pub fn validate(self) -> Result<(),ApiError> {

--- a/src/sc-api/src/lib.rs
+++ b/src/sc-api/src/lib.rs
@@ -1,8 +1,8 @@
 mod api_key;
 mod flv_create_topics;
 mod flv_delete_topics;
-mod flv_create_custom_spus;
-mod flv_delete_custom_spus;
+mod flv_register_custom_spus;
+mod flv_unregister_custom_spus;
 mod flv_fetch_spus;
 mod flv_create_spu_groups;
 mod flv_delete_spu_groups;
@@ -31,8 +31,8 @@ pub mod errors {
 }
 
 pub mod spu {
-    pub use crate::flv_create_custom_spus::*;
-    pub use crate::flv_delete_custom_spus::*;
+    pub use crate::flv_register_custom_spus::*;
+    pub use crate::flv_unregister_custom_spus::*;
     pub use crate::flv_fetch_spus::*;
 
     pub use crate::flv_create_spu_groups::*;

--- a/src/sc-api/src/public_api.rs
+++ b/src/sc-api/src/public_api.rs
@@ -21,8 +21,8 @@ use kf_protocol::derive::Encode;
 use kf_protocol::message::metadata::KfMetadataRequest;
 
 use crate::versions::ApiVersionsRequest;
-use crate::spu::FlvCreateCustomSpusRequest;
-use crate::spu::FlvDeleteCustomSpusRequest;
+use crate::spu::FlvRegisterCustomSpusRequest;
+use crate::spu::FlvUnregisterCustomSpusRequest;
 use crate::spu::FlvFetchSpusRequest;
 use crate::spu::FlvCreateSpuGroupsRequest;
 use crate::spu::FlvFetchSpuGroupsRequest;
@@ -49,8 +49,8 @@ pub enum PublicRequest {
     FlvTopicCompositionRequest(RequestMessage<FlvTopicCompositionRequest>),
 
     // Fluvio - Spus
-    FlvCreateCustomSpusRequest(RequestMessage<FlvCreateCustomSpusRequest>),
-    FlvDeleteCustomSpusRequest(RequestMessage<FlvDeleteCustomSpusRequest>),
+    FlvRegisterCustomSpusRequest(RequestMessage<FlvRegisterCustomSpusRequest>),
+    FlvUnregisterCustomSpusRequest(RequestMessage<FlvUnregisterCustomSpusRequest>),
     FlvFetchSpusRequest(RequestMessage<FlvFetchSpusRequest>),
 
     FlvCreateSpuGroupsRequest(RequestMessage<FlvCreateSpuGroupsRequest>),
@@ -96,11 +96,11 @@ impl KfRequestMessage for PublicRequest {
             }
 
             // Fluvio - Custom Spus / Spu Groups
-            ScApiKey::FlvCreateCustomSpus => {
-                api_decode!(PublicRequest, FlvCreateCustomSpusRequest, src, header)
+            ScApiKey::FlvRegisterCustomSpus => {
+                api_decode!(PublicRequest, FlvRegisterCustomSpusRequest, src, header)
             }
-            ScApiKey::FlvDeleteCustomSpus => {
-                api_decode!(PublicRequest, FlvDeleteCustomSpusRequest, src, header)
+            ScApiKey::FlvUnregisterCustomSpus => {
+                api_decode!(PublicRequest, FlvUnregisterCustomSpusRequest, src, header)
             }
             ScApiKey::FlvFetchSpus => api_decode!(PublicRequest, FlvFetchSpusRequest, src, header),
 

--- a/src/sc-core/src/services/public_api/flv/mod.rs
+++ b/src/sc-core/src/services/public_api/flv/mod.rs
@@ -1,7 +1,7 @@
 pub mod api_versions_req;
 
-pub mod create_custom_spus_req;
-pub mod delete_custom_spus_req;
+pub mod register_custom_spus_req;
+pub mod unregister_custom_spus_req;
 pub mod fetch_spu_req;
 
 pub mod create_spu_groups_req;

--- a/src/sc-core/src/services/public_api/flv/unregister_custom_spus_req.rs
+++ b/src/sc-core/src/services/public_api/flv/unregister_custom_spus_req.rs
@@ -10,7 +10,7 @@ use std::io::Error;
 use kf_protocol::api::{RequestMessage, ResponseMessage};
 use kf_protocol::api::FlvErrorCode;
 use sc_api::{FlvResponseMessage};
-use sc_api::spu::{FlvDeleteCustomSpusRequest, FlvDeleteCustomSpusResponse};
+use sc_api::spu::{FlvUnregisterCustomSpusRequest, FlvUnregisterCustomSpusResponse};
 use sc_api::spu::FlvCustomSpu;
 use k8_metadata::spu::SpuSpec as K8SpuSpec;
 use k8_metadata_client::MetadataClient;
@@ -19,14 +19,14 @@ use crate::core::spus::SpuKV;
 use super::PublicContext;
 
 /// Handler for delete custom spu request
-pub async fn handle_delete_custom_spus_request<C>(
-    request: RequestMessage<FlvDeleteCustomSpusRequest>,
+pub async fn handle_unregister_custom_spus_request<C>(
+    request: RequestMessage<FlvUnregisterCustomSpusRequest>,
     ctx: &PublicContext<C>,
-) -> Result<ResponseMessage<FlvDeleteCustomSpusResponse>, Error>
+) -> Result<ResponseMessage<FlvUnregisterCustomSpusResponse>, Error>
 where
     C: MetadataClient,
 {
-    let mut response = FlvDeleteCustomSpusResponse::default();
+    let mut response = FlvUnregisterCustomSpusResponse::default();
     let mut results: Vec<FlvResponseMessage> = vec![];
 
     // look-up custom spus based on their names or ids
@@ -37,7 +37,7 @@ where
 
                 // spu-name must exist
                 if let Some(spu) = &ctx.metadata().spus().spu(spu_name) {
-                    delete_custom_spu(ctx, spu).await?
+                    unregister_custom_spu(ctx, spu).await?
                 } else {
                     // spu does not exist
                     FlvResponseMessage::new(
@@ -52,7 +52,7 @@ where
 
                 // spu-id must exist
                 if let Some(spu) = &ctx.metadata().spus().get_by_id(spu_id) {
-                    delete_custom_spu(ctx, spu).await?
+                    unregister_custom_spu(ctx, spu).await?
                 } else {
                     // spu does not exist
                     FlvResponseMessage::new(
@@ -76,7 +76,7 @@ where
 }
 
 /// Generate for delete custom spu operation and return result.
-pub async fn delete_custom_spu<C>(
+pub async fn unregister_custom_spu<C>(
     ctx: &PublicContext<C>,
     spu: &SpuKV,
 ) -> Result<FlvResponseMessage, Error>

--- a/src/sc-core/src/services/public_api/mod.rs
+++ b/src/sc-core/src/services/public_api/mod.rs
@@ -16,8 +16,8 @@ mod api {
      pub use super::flv::fetch_topics_req::*;
      pub use super::flv::topic_composition_req::*;
 
-     pub use super::flv::create_custom_spus_req::*;
-     pub use super::flv::delete_custom_spus_req::*;
+     pub use super::flv::register_custom_spus_req::*;
+     pub use super::flv::unregister_custom_spus_req::*;
      pub use super::flv::fetch_spu_req::*;
 
      pub use super::flv::create_spu_groups_req::*;

--- a/src/sc-core/src/services/public_api/public_server.rs
+++ b/src/sc-core/src/services/public_api/public_server.rs
@@ -30,8 +30,8 @@ use super::api::handle_create_topics_request;
 use super::api::handle_delete_topics_request;
 use super::api::handle_fetch_topics_request;
 use super::api::handle_topic_composition_request;
-use super::api::handle_create_custom_spus_request;
-use super::api::handle_delete_custom_spus_request;
+use super::api::handle_register_custom_spus_request;
+use super::api::handle_unregister_custom_spus_request;
 use super::api::handle_fetch_spu_request;
 use super::api::handle_create_spu_groups_request;
 use super::api::handle_delete_spu_groups_request;
@@ -110,15 +110,15 @@ where
             ),
 
             // Fluvio - Spus
-            PublicRequest::FlvCreateCustomSpusRequest(request) => call_service!(
+            PublicRequest::FlvRegisterCustomSpusRequest(request) => call_service!(
                 request,
-                handle_create_custom_spus_request(request, &ctx),
+                handle_register_custom_spus_request(request, &ctx),
                 sink,
                 "create custom spus handler"
             ),
-            PublicRequest::FlvDeleteCustomSpusRequest(request) => call_service!(
+            PublicRequest::FlvUnregisterCustomSpusRequest(request) => call_service!(
                 request,
-                handle_delete_custom_spus_request(request, &ctx),
+                handle_unregister_custom_spus_request(request, &ctx),
                 sink,
                 "delete custom spus handler"
             ),


### PR DESCRIPTION
@sehz I ran `cargo fmt`, which produced several changes in addition to the renaming `custom-spu` (issue #5). If you would prefer that I do not run `cargo fmt`, happy to force push a reversion.

`cargo test` runs successfully.

