### PR TITLE
Add Local Persistent Volume option for fluvio-sys Helm chart

### DIFF
--- a/k8-util/helm/fluvio-sys/templates/local-pv.yaml
+++ b/k8-util/helm/fluvio-sys/templates/local-pv.yaml
@@ -5,11 +5,11 @@ metadata:
   name: fluvio-spu-pv
 spec:
   capacity:
-    storage: 1Gi
+    storage: {{ .Values.localPVStorageSize }}
   volumeMode: Filesystem
   accessModes:
   - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: {{ .Values.localPVReclaimPolicy }}
   storageClassName: fluvio-spu
   local:
     path: {{ .Values.localPVPath }}

--- a/k8-util/helm/fluvio-sys/templates/local-pv.yaml
+++ b/k8-util/helm/fluvio-sys/templates/local-pv.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.cloud "local" }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fluvio-spu-pv
+spec:
+  capacity:
+    storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: fluvio-spu
+  local:
+    path: {{ .Values.localPVPath }}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: localPVCapability
+          operator: In
+          values:
+          - FluvioSPU
+{{- end }}

--- a/k8-util/helm/fluvio-sys/templates/storage.yaml
+++ b/k8-util/helm/fluvio-sys/templates/storage.yaml
@@ -14,4 +14,7 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
   fsType: ext4 
+{{- else if eq .Values.cloud "local" }}
+provisioner:  kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
 {{- end }}

--- a/k8-util/helm/fluvio-sys/values.yaml
+++ b/k8-util/helm/fluvio-sys/values.yaml
@@ -1,6 +1,7 @@
 # Default values for fluvio-sys
 
 cloud:  minikube
+localPVPath: ""
 nameOverride: ""
 fullnameOverride: ""
 imagePolicy:  IfNotPresent

--- a/k8-util/helm/fluvio-sys/values.yaml
+++ b/k8-util/helm/fluvio-sys/values.yaml
@@ -2,6 +2,8 @@
 
 cloud:  minikube
 localPVPath: ""
+localPVStorageSize: 1Gi
+localPVReclaimPolicy: Delete
 nameOverride: ""
 fullnameOverride: ""
 imagePolicy:  IfNotPresent


### PR DESCRIPTION
Attempt to resolve #28 

This works on minikube, but I think on cloud platforms we need to have `nodeAffinity` match some label we give to nodes that have sufficient storage and are capable of running SPU.

Is there any way to define run shell commands to be run on the nodes, so that we may create a separate dir for SPU data and set its permissions? My current changes use `/tmp` because I don't know of a way to create a new dir and set permissions on it.

Do we need to write a provisioner for this? Or use something like https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/docs/provisioner.md