### PR TITLE
Add more detailed information in `fluvio version` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .docker-cargo
 target-docker
 .vscode/tasks.json
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "log",
  "prettytable-rs",
  "rand 0.7.3",
+ "rustc_version",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -14,6 +14,8 @@ doc = false
 kf = []
 cluster_components = ["flv-spu", "flv-sc-k8"]
 
+[build-dependencies]
+rustc_version = "0.2.3"
 
 [dependencies]
 log = "0.4.8"

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,6 +1,28 @@
 use std::fs;
+use std::process::Command;
+use rustc_version::version;
 
 fn main() {
+
+    // Fetch current git hash to print version output
+    let git_version_output = Command::new("git").args(&["rev-parse", "HEAD"])
+        .output().expect("should run 'git rev-parse HEAD' to get git hash");
+    let git_hash = String::from_utf8(git_version_output.stdout)
+        .expect("should read 'git' stdout to find hash");
+    // Assign the git hash to the compile-time GIT_HASH env variable (to use with env!())
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+    // Fetch OS information
+    let uname_output = Command::new("uname").args(&["-a"]).output().ok();
+    let uname_text = uname_output
+        .map(|output| String::from_utf8(output.stdout).expect("should read uname output to string"))
+        .unwrap_or_else(|| "<this platform does not support uname -a>".to_string());
+    println!("cargo:rustc-env=UNAME_ALL={}", uname_text);
+
+    // Fetch Rustc information
+    let rust_version = version().expect("should get rustc version");
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rust_version);
+
     println!("cargo:rerun-if-changed=src/VERSION");
     println!("cargo:rerun-if-changed=../../VERSION");
     println!("cargo:rerun-if-changed=build.rs");

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -3,10 +3,11 @@ use std::process::Command;
 use rustc_version::version_meta;
 
 fn main() {
-
     // Fetch current git hash to print version output
-    let git_version_output = Command::new("git").args(&["rev-parse", "HEAD"])
-        .output().expect("should run 'git rev-parse HEAD' to get git hash");
+    let git_version_output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)
         .expect("should read 'git' stdout to find hash");
     // Assign the git hash to the compile-time GIT_HASH env variable (to use with env!())
@@ -14,28 +15,32 @@ fn main() {
 
     // Fetch OS information if on unix
     if cfg!(unix) {
-        let uname_output = Command::new("uname").args(&["-sro"])
-            .output().expect("should get OS info from uname");
-        let uname_text = String::from_utf8(uname_output.stdout)
-            .expect("should read uname output to string");
+        let uname_output = Command::new("uname")
+            .args(&["-sro"])
+            .output()
+            .expect("should get OS info from uname");
+        let uname_text =
+            String::from_utf8(uname_output.stdout).expect("should read uname output to string");
         println!("cargo:rustc-env=UNAME={}", uname_text);
     }
 
     // Fetch Rustc information
     let rust_version = version_meta().expect("should get rustc version");
     let semver = &rust_version.semver;
-    let rustc_commit = rust_version.commit_hash.as_ref()
-        .and_then(|hash| rust_version.commit_date.as_ref()
-            .map(|date| (&hash[..7], date)));
+    let rustc_commit = rust_version.commit_hash.as_ref().and_then(|hash| {
+        rust_version
+            .commit_date
+            .as_ref()
+            .map(|date| (&hash[..7], date))
+    });
 
     match rustc_commit {
         Some((commit_hash, commit_date)) => {
-            println!("cargo:rustc-env=RUSTC_VERSION={} ({} {})",
-                     semver,
-                     commit_hash,
-                     commit_date,
+            println!(
+                "cargo:rustc-env=RUSTC_VERSION={} ({} {})",
+                semver, commit_hash, commit_date,
             );
-        },
+        }
         None => {
             println!("cargo:rustc-env=RUSTC_VERSION={}", semver);
         }

--- a/src/cli/src/root_cli.rs
+++ b/src/cli/src/root_cli.rs
@@ -209,6 +209,9 @@ impl Terminal for PrintTerminal {
 struct VersionCmd {}
 
 fn process_version_cmd() -> Result<String, CliError> {
-    println!("version is: {}", crate::VERSION);
+    println!("Fluvio version : {}", crate::VERSION);
+    println!("Git Commit     : {}", env!("GIT_HASH"));
+    println!("OS Details     : {}", env!("UNAME_ALL"));
+    println!("Rustc Version  : {}", env!("RUSTC_VERSION"));
     Ok("".to_owned())
 }

--- a/src/cli/src/root_cli.rs
+++ b/src/cli/src/root_cli.rs
@@ -211,7 +211,9 @@ struct VersionCmd {}
 fn process_version_cmd() -> Result<String, CliError> {
     println!("Fluvio version : {}", crate::VERSION);
     println!("Git Commit     : {}", env!("GIT_HASH"));
-    println!("OS Details     : {}", env!("UNAME_ALL"));
+    if let Some(os_info) = option_env!("UNAME") {
+        println!("OS Details     : {}", os_info);
+    }
     println!("Rustc Version  : {}", env!("RUSTC_VERSION"));
     Ok("".to_owned())
 }


### PR DESCRIPTION
This implements #86, adding additional information to the `fluvio version` command. The added info that gets printed includes:

* Current git hash when `cargo build` is invoked
* OS version info (as reported by `uname -a`)
* Rustc version info

The new output for the version command looks like this:

```
$ fluvio version
Fluvio version : 0.6.0
Git Commit     : d3bd95af2e2cd02997f948181681719e530ab98e
OS Details     : Linux thinkpad 5.7.8-100.fc31.x86_64 #1 SMP Thu Jul 9 15:16:52 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
Rustc Version  : 1.45.0-nightly
```

---

### Notes

* I've branched this PR starting from the commit 69ec1e6 because commit fb92e83 introduces a build error for the `cli` crate.
* By using `uname -a` for OS info I may have made it platform-dependent (unless Windows users are using cygwin). I made sure to not let that break the build by adding a default value when `uname` can't be reached, in which case the OS version would simply print `<this platform does not support uname -a>`. Ideas for a more cross-platform solution are welcome :)