### PR TITLE
Fixed retrieval of OS information for macos

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -69,14 +69,3 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     fs::copy("../../VERSION", "src/VERSION").expect("version copy");
 }
-
-/*#[cfg(test)]
-mod test {
-    use super::get_os;
-
-    #[test]
-    fn test_get_os() {
-        let result = get_os();
-        assert_eq!(result.is_empty(), false);
-    }
-}*/


### PR DESCRIPTION
```
$ flvd version
Fluvio version : 0.6.0
Git Commit     : f2f09621aa759bde1ab0371c3cdffa293c211d7f
OS Details     : Darwin 19.5.0 x86_64
Rustc Version  : 1.46.0-nightly (daecab3 2020-07-10)
```
