### PR TITLE
Added changes for pre-flight check before cluster install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "prettytable-rs",
  "rand 0.7.3",
  "rustc_version",
+ "semver 0.10.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2173,7 +2174,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2254,6 +2255,15 @@ name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
  "semver-parser",
 ]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -44,3 +44,4 @@ utils = { path= "../utils"}
 flv-types = { path ="../types", version = "0.2.0" }
 flv-spu = { path = "../spu-server", optional = true }
 flv-sc-k8 = { path = "../sc-k8", optional = true }
+semver = "0.10.0"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -18,6 +18,7 @@ cluster_components = ["flv-spu", "flv-sc-k8"]
 rustc_version = "0.2.3"
 
 [dependencies]
+semver = "0.10.0"
 log = "0.4.8"
 bytes = "0.5.3"
 structopt = { version = "0.3.15", default-features = false }
@@ -44,4 +45,4 @@ utils = { path= "../utils"}
 flv-types = { path ="../types", version = "0.2.0" }
 flv-spu = { path = "../spu-server", optional = true }
 flv-sc-k8 = { path = "../sc-k8", optional = true }
-semver = "0.10.0"
+

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -15,14 +15,16 @@ fn pre_install_check() -> Result<(), CliError> {
                 err.to_string()
             ))
         })?;
-
     let version_text = String::from_utf8(helm_version.stdout).unwrap();
     let version_text_trimmed = &version_text[1..].trim();
-    if Version::parse(&version_text_trimmed) <= Version::parse("3.2.0") {
-        println!(
-            "Installed Helm version {} is not compatible with fluvio platform, please install version >= 3.2.0",
-            version_text_trimmed
-        );
+
+    const DEFAULT_HELM_VERSION: &'static str = "3.2.0";
+
+    if Version::parse(&version_text_trimmed) <= Version::parse(DEFAULT_HELM_VERSION) {
+        return Err(CliError::Other(format!(
+            "Helm version {} is not compatible with fluvio platform, please install version >= {}",
+            version_text_trimmed, DEFAULT_HELM_VERSION
+        )));
     }
     Ok(())
 }


### PR DESCRIPTION
Fixes #119 
-  check if helm is installed and is right version.
- If helm is not installed, I am displaying an error.
- If version is <3.2.0, It is showing a warning to install a compatible version.
- For version comparsion/checking , I have used `semver` library.