### PR TITLE
Check if compatible sys chart is installed

### DIFF
--- a/src/cli/src/cluster/install/helm.rs
+++ b/src/cli/src/cluster/install/helm.rs
@@ -26,6 +26,12 @@ struct Chart {
     version: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SysChart {
+    pub name: String,
+    pub app_version: String,
+}
+
 pub fn check_chart_version_exists(name: &str, version: &str) -> bool {
     let versions = core_chart_versions(name);
     versions
@@ -53,4 +59,20 @@ fn core_chart_versions(name: &str) -> Vec<Chart> {
     debug!("command output {:?}", output);
 
     serde_json::from_slice(&output.stdout).expect("invalid json from helm search")
+}
+
+pub fn installed_sys_charts(name: &str) -> Vec<SysChart> {
+    let mut cmd = Command::new("helm");
+    cmd.arg("list")
+        .arg("--filter")
+        .arg(name)
+        .arg("--output")
+        .arg("json")
+        .print();
+
+    debug!("command {:?}", cmd);
+
+    let output = cmd.output().expect("unable to fetch helm list");
+    debug!("command output {:?}", output);
+    serde_json::from_slice(&output.stdout).expect("invalid json from helm list")
 }

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -34,6 +34,7 @@ fn pre_install_check() -> Result<(), CliError> {
     if sys_charts.len() == 1 {
         let installed_chart = sys_charts.first().unwrap();
         let installed_chart_version = installed_chart.app_version.clone();
+        // checking version of chart found
         if Version::parse(&installed_chart_version) < Version::parse(SYS_CHART_VERSION) {
             return Err(CliError::Other(format!(
                 "Fluvio system chart {} is not compatible with fluvio platform, please install version >= {}",

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -28,13 +28,10 @@ fn pre_install_check() -> Result<(), CliError> {
     }
 
     const SYS_CHART_VERSION: &'static str = "0.1.0";
+    const SYS_CHART_NAME: &'static str = "fluvio-sys";
 
-    let sys_charts = helm::installed_sys_charts("fluvio-sys");
-    if sys_charts.len() < 1 {
-        return Err(CliError::Other(format!(
-            "Fluvio system chart is not installed, please install fluvio-sys first",
-        )));
-    } else {
+    let sys_charts = helm::installed_sys_charts(SYS_CHART_NAME);
+    if sys_charts.len() == 1 {
         let installed_chart = sys_charts.first().unwrap();
         let installed_chart_version = installed_chart.app_version.clone();
         if Version::parse(&installed_chart_version) < Version::parse(SYS_CHART_VERSION) {
@@ -43,6 +40,10 @@ fn pre_install_check() -> Result<(), CliError> {
                 installed_chart_version, SYS_CHART_VERSION
             )));
         }
+    } else {
+        return Err(CliError::Other(format!(
+            "Fluvio system chart is not installed, please install fluvio-sys first",
+        )));
     }
 
     Ok(())

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -40,9 +40,13 @@ fn pre_install_check() -> Result<(), CliError> {
                 installed_chart_version, SYS_CHART_VERSION
             )));
         }
-    } else {
+    } else if sys_charts.len() == 0 {
         return Err(CliError::Other(format!(
             "Fluvio system chart is not installed, please install fluvio-sys first",
+        )));
+    } else {
+        return Err(CliError::Other(format!(
+            "Multiple fluvio system charts found",
         )));
     }
 

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -20,12 +20,31 @@ fn pre_install_check() -> Result<(), CliError> {
 
     const DEFAULT_HELM_VERSION: &'static str = "3.2.0";
 
-    if Version::parse(&version_text_trimmed) <= Version::parse(DEFAULT_HELM_VERSION) {
+    if Version::parse(&version_text_trimmed) < Version::parse(DEFAULT_HELM_VERSION) {
         return Err(CliError::Other(format!(
             "Helm version {} is not compatible with fluvio platform, please install version >= {}",
             version_text_trimmed, DEFAULT_HELM_VERSION
         )));
     }
+
+    const SYS_CHART_VERSION: &'static str = "0.1.0";
+
+    let sys_charts = helm::installed_sys_charts("fluvio-sys");
+    if sys_charts.len() < 1 {
+        return Err(CliError::Other(format!(
+            "Fluvio system chart is not installed, please install fluvio-sys first",
+        )));
+    } else {
+        let installed_chart = sys_charts.first().unwrap();
+        let installed_chart_version = installed_chart.app_version.clone();
+        if Version::parse(&installed_chart_version) < Version::parse(SYS_CHART_VERSION) {
+            return Err(CliError::Other(format!(
+                "Fluvio system chart {} is not compatible with fluvio platform, please install version >= {}",
+                installed_chart_version, SYS_CHART_VERSION
+            )));
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #128 
- Added logic to check if compatible sys chart is installed(0.1.0)
- Also checking if the sys chart is not installed at all.