### PR TITLE
Migrate logging to tracing instrumentation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +360,7 @@ version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -962,6 +971,8 @@ dependencies = [
  "chrono",
  "env_logger 0.7.1",
  "log",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1632,6 +1643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,7 +1854,7 @@ checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 dependencies = [
  "libc",
  "rand 0.4.6",
- "smallvec",
+ "smallvec 0.6.13",
  "winapi",
 ]
 
@@ -1849,7 +1869,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.13",
  "winapi",
 ]
 
@@ -2192,6 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2435,6 +2456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2499,12 @@ checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "smol"
@@ -2750,6 +2786,48 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.4.1",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ version = "2.0.0"
 dependencies = [
  "flv-metadata-cluster",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "kf-protocol",
  "log",
  "serde",
@@ -691,7 +691,7 @@ dependencies = [
  "flv-sc-k8",
  "flv-spu",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "k8-client",
  "k8-config",
@@ -727,7 +727,7 @@ dependencies = [
  "flv-api-spu",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -749,7 +749,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "k8-metadata-client",
  "log",
@@ -765,7 +765,7 @@ version = "0.1.0"
 dependencies = [
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -784,7 +784,7 @@ dependencies = [
  "async-tls",
  "async-trait",
  "bytes 0.5.6",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "futures-timer 2.0.2",
  "log",
@@ -805,7 +805,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -830,7 +830,7 @@ dependencies = [
  "flv-future-aio",
  "flv-metadata-cluster",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.0",
  "futures",
  "internal-api",
  "k8-metadata-client",
@@ -859,7 +859,7 @@ dependencies = [
  "flv-sc-core",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.0",
  "futures",
  "k8-client",
  "rand 0.7.3",
@@ -885,7 +885,7 @@ dependencies = [
  "flv-storage",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.0",
  "futures",
  "internal-api",
  "kf-protocol",
@@ -912,7 +912,7 @@ dependencies = [
  "bytes 0.5.6",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -976,23 +976,23 @@ dependencies = [
 [[package]]
 name = "flv-util"
 version = "0.2.1"
-dependencies = [
- "chrono",
- "env_logger 0.7.1",
- "log",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "flv-util"
-version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d86d88e0fd6a90e453fb257f9f65819b6b1179fc888fadff6bb1aba1eb84707"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
  "log",
+]
+
+[[package]]
+name = "flv-util"
+version = "0.3.0"
+dependencies = [
+ "chrono",
+ "env_logger 0.7.1",
+ "log",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8dc4adddeb3a44e29f02acd70ae0737009ac7fb8f6ecc8d18a89d876956ea8"
 dependencies = [
  "content_inspector",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "kf-protocol-api",
  "kf-protocol-core",
  "kf-protocol-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -866,6 +867,7 @@ dependencies = [
  "structopt",
  "toml",
  "tracing",
+ "tracing-futures",
  "utils",
 ]
 
@@ -898,6 +900,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-futures",
  "utils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,8 @@ dependencies = [
 [[package]]
 name = "flv-util"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da61ce3a9a3a4b0f7b4ef48bcc2a02e3eaca4d8532cc93845d713502aca347b"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "kf-protocol",
  "log",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -673,6 +674,7 @@ dependencies = [
  "kf-protocol",
  "log",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -696,7 +698,6 @@ dependencies = [
  "k8-metadata-client",
  "k8-obj-core",
  "k8-obj-metadata",
- "log",
  "prettytable-rs",
  "rand 0.7.3",
  "rpassword",
@@ -707,6 +708,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "toml",
+ "tracing",
  "url",
  "utils",
 ]
@@ -729,11 +731,11 @@ dependencies = [
  "futures",
  "kf-protocol",
  "kf-socket",
- "log",
  "serde",
  "serde_json",
  "tokio",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -753,6 +755,7 @@ dependencies = [
  "log",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -765,8 +768,8 @@ dependencies = [
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
- "log",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -808,6 +811,7 @@ dependencies = [
  "kf-protocol",
  "log",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -840,6 +844,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-futures",
  "utils",
 ]
 
@@ -856,11 +861,11 @@ dependencies = [
  "flv-util 0.2.1",
  "futures",
  "k8-client",
- "log",
  "rand 0.7.3",
  "serde",
  "structopt",
  "toml",
+ "tracing",
  "utils",
 ]
 
@@ -878,7 +883,7 @@ dependencies = [
  "flv-storage",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util 0.2.1",
  "futures",
  "internal-api",
  "kf-protocol",
@@ -892,6 +897,7 @@ dependencies = [
  "structopt",
  "tokio",
  "toml",
+ "tracing",
  "utils",
 ]
 
@@ -908,10 +914,10 @@ dependencies = [
  "kf-protocol",
  "kf-socket",
  "libc",
- "log",
  "pin-utils",
  "serde",
  "structopt",
+ "tracing",
  "utils",
 ]
 
@@ -950,7 +956,7 @@ dependencies = [
 name = "flv-types"
 version = "0.2.2"
 dependencies = [
- "log",
+ "tracing",
 ]
 
 [[package]]
@@ -1268,6 +1274,7 @@ dependencies = [
  "flv-types",
  "kf-protocol",
  "log",
+ "tracing",
 ]
 
 [[package]]
@@ -1567,6 +1574,7 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2962,9 +2970,9 @@ name = "utils"
 version = "0.3.0"
 dependencies = [
  "flv-types",
- "log",
  "rand 0.7.3",
  "regex",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-channel"
-version = "1.1.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee81ba99bee79f3c8ae114ae4baa7eaa326f63447cf2ec65e4393618b63f8770"
+checksum = "43de69555a39d52918e2bc33a408d3c0a86c829b212d898f4ca25d21a6387478"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -113,7 +113,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.1.2"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1582139bb74d97ef232c30bc236646017db06f13ee7cc01fa24c9e55640f86d4"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54dedab740bc412d514cfbc4a1d9d5d16fed02c4b14a7be129003c07fdc33b9b"
+checksum = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 dependencies = [
  "nix",
  "winapi",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.33+curl-7.71.1"
+version = "0.4.34+curl-7.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9818ea018327f79c811612f29b9834d2abddbe7db81460a2d5c7e12946b337"
+checksum = "ad4eff0be6985b7e709f64b5a541f700e9ad1407190a29f4884319eb663ed1d6"
 dependencies = [
  "cc",
  "libc",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.11.7"
+version = "3.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7a3766904c6f4734f2bbf8a037b6f84753d19fe65f54b0f4d97d8f62187bb"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
+checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
 
 [[package]]
 name = "deunicode"
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.2.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829694371bd7bbc6aee17c4ff624aad8bf9f4dc06c6f9f6071eaa08c89530d10"
+checksum = "7f14646a9e0430150a87951622ba9675472b68e384b7701b8423b30560805c7a"
 
 [[package]]
 name = "fake-simd"
@@ -640,9 +640,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
+checksum = "4bd3bdaaf0a72155260a1c098989b60db1cbb22d6a628e64f16237aa4da93cc7"
 
 [[package]]
 name = "flv-api-sc"
@@ -650,7 +650,7 @@ version = "2.0.0"
 dependencies = [
  "flv-metadata-cluster",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kf-protocol",
  "log",
  "serde",
@@ -680,7 +680,7 @@ dependencies = [
  "flv-sc-k8",
  "flv-spu",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "k8-client",
  "k8-config",
@@ -716,7 +716,7 @@ dependencies = [
  "flv-api-spu",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -738,7 +738,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "k8-metadata-client",
  "log",
@@ -752,7 +752,7 @@ version = "0.1.0"
 dependencies = [
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -771,7 +771,7 @@ dependencies = [
  "async-tls",
  "async-trait",
  "bytes 0.5.6",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "futures-timer 2.0.2",
  "log",
@@ -792,7 +792,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -830,6 +830,7 @@ dependencies = [
  "serde",
  "tokio",
  "toml",
+ "tracing",
  "utils",
 ]
 
@@ -868,7 +869,7 @@ dependencies = [
  "flv-storage",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "internal-api",
  "kf-protocol",
@@ -893,7 +894,7 @@ dependencies = [
  "bytes 0.5.6",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -951,6 +952,15 @@ checksum = "63dfd9a699e5b73d0163b7abd4019c0e37c7293c68b822dfb12cae2ca753703d"
 dependencies = [
  "chrono",
  "env_logger 0.6.2",
+ "log",
+]
+
+[[package]]
+name = "flv-util"
+version = "0.2.1"
+dependencies = [
+ "chrono",
+ "env_logger 0.7.1",
  "log",
 ]
 
@@ -1049,7 +1059,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1290,9 +1300,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8712512671fd243aa2ab95ca816506c6bd0c36221694bb6b58d9ce93df795"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1487,7 +1497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8dc4adddeb3a44e29f02acd70ae0737009ac7fb8f6ecc8d18a89d876956ea8"
 dependencies = [
  "content_inspector",
- "flv-util 0.2.1",
+ "flv-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kf-protocol-api",
  "kf-protocol-core",
  "kf-protocol-derive",
@@ -1524,6 +1534,8 @@ dependencies = [
  "log",
  "pin-utils",
  "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1910,7 +1922,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1941,7 +1953,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1984,27 +1996,25 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
- "syn-mid",
  "version_check",
 ]
 
@@ -2347,22 +2357,22 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2513,9 +2523,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2524,15 +2534,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
+checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2559,24 +2569,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.36",
 ]
 
 [[package]]
@@ -2590,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9598067511caa7edb41886c4a29efe6d0564926837bde7dffa4a130ea6cc975"
+checksum = "1381c83828bedd5ce4e59473110afa5381ffe523406d9ade4b77c9f7be70ff9a"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2685,7 +2684,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2710,6 +2709,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -2898,9 +2938,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79baa72a2f1274a76ff3e0fde524ab9dad4e6761182f334e7285c9e954890584"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2908,24 +2948,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd8ace32c1037c1abe65e58a42c48b2dfcab895144e63762cff2cbdd6c9d184"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de69cfc3f6641a90c43efb615529b64750015cf88a9c21ec9927c7dd71df170f"
+checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2935,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c239a0e7818632afc1999ea4d81f4dcbde41a1298484b220558fc233a1051248"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -2945,28 +2985,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e7bfd8f80de01ef004806b4fd449cb0a20959a546265adbe25c3b31128240d"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e05c256872262748a8efd455b292b37ea8aad5e0b4a59ff520cda359125236"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "web-sys"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3362f54c47d0da11569b6115a1c1fbe5e7162ca720c382066e96aa2263d06c2"
+checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -20,9 +20,9 @@ cluster_components = ["flv-spu", "flv-sc-k8"]
 rustc_version = "0.2.3"
 
 [dependencies]
+tracing = "0.1.19"
 url = "2.1.1"
 semver = "0.10.0"
-log = "0.4.8"
 bytes = "0.5.3"
 structopt = { version = "0.3.15", default-features = false }
 toml = "0.5.5"

--- a/src/cli/src/cluster/install/helm.rs
+++ b/src/cli/src/cluster/install/helm.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use log::debug;
+use tracing::debug;
 use serde::Deserialize;
 
 use super::*;

--- a/src/cli/src/cluster/install/local.rs
+++ b/src/cli/src/cluster/install/local.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::process::Stdio;
 use std::io::Error as IoError;
 
-use log::debug;
+use tracing::debug;
 
 use k8_client::SharedK8Client;
 use flv_future_aio::timer::sleep;

--- a/src/cli/src/cluster/uninstall.rs
+++ b/src/cli/src/cluster/uninstall.rs
@@ -3,7 +3,7 @@ use crate::Terminal;
 use crate::CliError;
 
 use structopt::StructOpt;
-use log::debug;
+use tracing::debug;
 
 #[derive(Debug, StructOpt)]
 pub struct UninstallCommand {
@@ -86,7 +86,7 @@ fn remove_objects(object_type: &str, namespace: &str) {
 fn remove_local_cluster() {
     use std::fs::remove_dir_all;
 
-    use log::warn;
+    use tracing::warn;
 
     println!("removing local cluster ");
     Command::new("pkill")

--- a/src/cli/src/cluster/util.rs
+++ b/src/cli/src/cluster/util.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::process::Command;
 
-use log::debug;
+use tracing::debug;
 
 pub use cmd_util::*;
 

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -7,7 +7,7 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
+use tracing::debug;
 
 use flv_client::params::*;
 use flv_client::Consumer;

--- a/src/cli/src/consume/logs_output.rs
+++ b/src/cli/src/consume/logs_output.rs
@@ -4,7 +4,7 @@
 //! Connects to server and fetches logs
 //!
 
-use log::debug;
+use tracing::debug;
 use serde_json;
 use serde_json::Value;
 

--- a/src/cli/src/consume/mod.rs
+++ b/src/cli/src/consume/mod.rs
@@ -14,7 +14,7 @@ pub use process::process_consume_log;
 
 mod process {
 
-    use log::debug;
+    use tracing::debug;
 
     use crate::CliError;
     use crate::Terminal;

--- a/src/cli/src/group/create.rs
+++ b/src/cli/src/group/create.rs
@@ -4,7 +4,7 @@
 //! CLI tree to generate Create Managed SPU Groups
 //!
 
-use log::debug;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_client::ClusterConfig;

--- a/src/cli/src/group/list.rs
+++ b/src/cli/src/group/list.rs
@@ -59,7 +59,7 @@ mod output {
     use prettytable::Cell;
     use prettytable::cell;
     use prettytable::format::Alignment;
-    use log::debug;
+    use tracing::debug;
 
     use flv_client::metadata::objects::Metadata;
     use flv_metadata_cluster::spg::SpuGroupSpec;

--- a/src/cli/src/produce/mod.rs
+++ b/src/cli/src/produce/mod.rs
@@ -101,7 +101,7 @@ pub async fn process_produce_record<O>(
 where
     O: Terminal,
 {
-    use log::debug;
+    use tracing::debug;
     use flv_client::kf::api::ReplicaKey;
 
     let (target_server, (cfg, file_records)) = opt.validate()?;
@@ -123,7 +123,7 @@ where
 
 mod produce {
 
-    use log::debug;
+    use tracing::debug;
     use futures::stream::StreamExt;
 
     use flv_future_aio::fs::File;

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
+use tracing::debug;
 
 use k8_client::K8Client;
 

--- a/src/cli/src/tls/mod.rs
+++ b/src/cli/src/tls/mod.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_client::config::TlsConfig as TlsProfileConfig;

--- a/src/cli/src/topic/create.rs
+++ b/src/cli/src/topic/create.rs
@@ -8,7 +8,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
-use log::debug;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_client::ClusterConfig;

--- a/src/cli/src/topic/delete.rs
+++ b/src/cli/src/topic/delete.rs
@@ -4,7 +4,7 @@
 //! CLI tree to generate Delete Topics
 //!
 
-use log::debug;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_client::config::ClusterConfig;

--- a/src/cli/src/topic/describe.rs
+++ b/src/cli/src/topic/describe.rs
@@ -4,7 +4,7 @@
 //! CLI to describe Topics and their corresponding Partitions
 //!
 
-use log::debug;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_client::ClusterConfig;

--- a/src/cli/src/topic/list.rs
+++ b/src/cli/src/topic/list.rs
@@ -6,7 +6,7 @@
 
 use structopt::StructOpt;
 
-use log::debug;
+use tracing::debug;
 
 use flv_client::ClusterConfig;
 use flv_client::metadata::topic::TopicSpec;

--- a/src/client-rs/Cargo.toml
+++ b/src/client-rs/Cargo.toml
@@ -10,7 +10,7 @@ description = "Fluvio rust client"
 
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1.19"
 dirs = "1.0.2"
 toml = "0.5.5"
 dashmap = "3.11.4"

--- a/src/client-rs/src/client/client.rs
+++ b/src/client-rs/src/client/client.rs
@@ -1,7 +1,7 @@
 use std::default::Default;
 use std::fmt;
 
-use log::trace;
+use tracing::trace;
 use async_trait::async_trait;
 
 use kf_protocol::api::RequestMessage;

--- a/src/client-rs/src/client/cluster.rs
+++ b/src/client-rs/src/client/cluster.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use tracing::debug;
 
 use kf_socket::AllMultiplexerSocket;
 use kf_protocol::api::ReplicaKey;

--- a/src/client-rs/src/config/cluster.rs
+++ b/src/client-rs/src/config/cluster.rs
@@ -7,7 +7,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::convert::TryFrom;
 
-use log::debug;
+use tracing::debug;
 
 use flv_future_aio::net::tls::AllDomainConnector;
 

--- a/src/client-rs/src/config/config.rs
+++ b/src/client-rs/src/config/config.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::fs::create_dir_all;
 
-use log::debug;
+use tracing::debug;
 use dirs::home_dir;
 use serde::Deserialize;
 use serde::Serialize;

--- a/src/client-rs/src/config/tls.rs
+++ b/src/client-rs/src/config/tls.rs
@@ -3,7 +3,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::path::Path;
 
-use log::info;
+use tracing::info;
 use base64::decode;
 use serde::Deserialize;
 use serde::Serialize;

--- a/src/client-rs/src/consumer.rs
+++ b/src/client-rs/src/consumer.rs
@@ -1,8 +1,8 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use crate::kf::api::ReplicaKey;
 use crate::kf::api::RecordSet;

--- a/src/client-rs/src/producer.rs
+++ b/src/client-rs/src/producer.rs
@@ -1,8 +1,8 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use kf_protocol::api::ReplicaKey;
 

--- a/src/client-rs/src/replica/leader.rs
+++ b/src/client-rs/src/replica/leader.rs
@@ -1,8 +1,8 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 

--- a/src/client-rs/src/sc/mod.rs
+++ b/src/client-rs/src/sc/mod.rs
@@ -1,5 +1,5 @@
 mod controller {
-    use log::debug;
+    use tracing::debug;
     use futures::select;
     use futures::channel::mpsc::Sender;
 

--- a/src/client-rs/src/spu/spu_leader.rs
+++ b/src/client-rs/src/spu/spu_leader.rs
@@ -1,8 +1,8 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 
 use kf_protocol::api::RecordSet;

--- a/src/client-rs/src/spu/spu_pool.rs
+++ b/src/client-rs/src/spu/spu_pool.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use tracing::debug;
 
 use kf_protocol::api::ReplicaKey;
 

--- a/src/client-rs/src/sync/controller.rs
+++ b/src/client-rs/src/sync/controller.rs
@@ -4,8 +4,8 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::fmt::Display;
 
-use log::debug;
-use log::error;
+use tracing::debug;
+use tracing::error;
 
 use kf_protocol::Encoder;
 use kf_protocol::Decoder;

--- a/src/client-rs/src/sync/mod.rs
+++ b/src/client-rs/src/sync/mod.rs
@@ -9,7 +9,7 @@ mod context {
     use std::sync::Arc;
     use std::fmt::Display;
 
-    use log::debug;
+    use tracing::debug;
 
     use event_listener::Event;
     use event_listener::EventListener;

--- a/src/client-rs/src/sync/store.rs
+++ b/src/client-rs/src/sync/store.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use tracing::debug;
 
 use kf_socket::AllMultiplexerSocket;
 use kf_socket::KfSocketError;

--- a/src/event-stream-k8/Cargo.toml
+++ b/src/event-stream-k8/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.19"
 serde = { version ="1.0.103", features = ['derive'] }
 futures = { version = "0.3.1" }
 async-trait = "0.1.21"

--- a/src/event-stream-k8/Cargo.toml
+++ b/src/event-stream-k8/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.4.8"
 tracing = "0.1.19"
+tracing-futures = "0.2.4"
 serde = { version ="1.0.103", features = ['derive'] }
 futures = { version = "0.3.1" }
 async-trait = "0.1.21"

--- a/src/event-stream-k8/src/dispatcher/k8_dispatcher.rs
+++ b/src/event-stream-k8/src/dispatcher/k8_dispatcher.rs
@@ -6,9 +6,9 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 
 use futures::stream::StreamExt;
-use log::debug;
-use log::error;
-use log::info;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -258,7 +258,7 @@ mod convert {
 
     use std::fmt::Display;
 
-    use log::{debug, error, trace};
+    use tracing::{debug, error, trace};
     use crate::k8::metadata::K8List;
     use crate::k8::metadata::K8Obj;
     use crate::k8::metadata::K8Watch;

--- a/src/event-stream-k8/src/dispatcher/k8_dispatcher.rs
+++ b/src/event-stream-k8/src/dispatcher/k8_dispatcher.rs
@@ -9,6 +9,7 @@ use futures::stream::StreamExt;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
+use tracing::instrument;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -74,10 +75,17 @@ where
         spawn(dispatcher.outer_loop());
     }
 
+    #[instrument(
+        skip(self),
+        fields(
+            spec = S::LABEL,
+            namespace = self.namespace.named(),
+        )
+    )]
     async fn outer_loop(mut self) {
-        info!("starting {} k8 dispatcher loop", S::LABEL);
+        info!("starting k8 dispatcher loop");
         loop {
-            debug!("starting inner loop: {}", S::LABEL);
+            debug!("starting inner loop");
             self.inner_loop().await;
         }
     }
@@ -85,6 +93,7 @@ where
     ///
     /// Kubernetes Dispatcher Event Loop
     ///
+    #[instrument(skip(self))]
     async fn inner_loop(&mut self) {
         use tokio::select;
 
@@ -108,9 +117,8 @@ where
         loop {
             let reconcile_time_mark = Instant::now();
             debug!(
-                "{}: waiting events for ws/k8, reconcile seconds left: {}",
-                S::LABEL,
-                reconcile_time_left.as_secs()
+                time_left = reconcile_time_left.as_secs(),
+                "waiting events for ws/k8"
             );
             let ws_receiver = self.ctx.receiver();
 
@@ -132,11 +140,11 @@ where
                                 ).await {
                                     self.ctx.event().notify(usize::MAX);
                                 } else {
-                                    debug!("no changes to sync_all: {}",S::LABEL)
+                                    debug!("no changes to sync_all")
                                 }
 
                             }
-                            Err(err) => error!("{}: watch error {}", S::LABEL,err),
+                            Err(err) => error!("watch error {}", err),
                         }
 
                     } else {
@@ -150,11 +158,11 @@ where
                 msg = ws_receiver.recv() => {
                     match msg {
                         Ok(action) => {
-                            debug!("{} store: received ws action: {}",S::LABEL,action);
+                            debug!("store: received ws action: {}", action);
                            self.process_ws_action(action).await;
                         },
                         Err(err) => {
-                            error!("WS channel: <{}> error: {}",S::LABEL,err);
+                            error!("WS channel error: {}", err);
                             panic!(-1);
                         }
                     }
@@ -170,6 +178,7 @@ where
     ///
     /// Retrieve all items from Kubernetes (K8) store for forward them to processing engine
     ///
+    #[instrument(skip(self))]
     async fn retrieve_all_k8_items(&mut self) -> Result<String, IoError> {
         let k8_objects = self
             .client
@@ -184,10 +193,9 @@ where
 
         let version = k8_objects.metadata.resource_version.clone();
         debug!(
-            "Retrieving <{}> items: {}, version: {}",
-            S::LABEL,
-            k8_objects.items.len(),
-            version
+            version = &*version,
+            item_count = k8_objects.items.len(),
+            "Retrieving items",
         );
         // wait to receive all items before sending to channel
         k8_events_to_metadata_actions(k8_objects, self.ctx.store())
@@ -198,11 +206,12 @@ where
                     format!("error converting k8: {}", err),
                 )
             })?;
-        debug!("notifying: {} receivers", S::LABEL);
+        debug!("notifying receivers");
         self.ctx.event().notify(usize::MAX);
         Ok(version)
     }
 
+    #[instrument(skip(self, action))]
     async fn process_ws_action(&mut self, action: WSAction<S>) {
         use super::k8_actions::K8Action;
         use crate::k8::metadata::ObjectMeta;
@@ -235,9 +244,8 @@ where
                     K8Action::Delete(obj.inner().ctx().item().clone())
                 } else {
                     error!(
-                        "Store: {} trying to delete, non existent key: {}",
-                        S::LABEL,
-                        key
+                        key = &*format!("{}", key),
+                        "Store: trying to delete non existent key",
                     );
                     return;
                 }
@@ -259,6 +267,7 @@ mod convert {
     use std::fmt::Display;
 
     use tracing::{debug, error, trace};
+    use tracing::instrument;
     use crate::k8::metadata::K8List;
     use crate::k8::metadata::K8Obj;
     use crate::k8::metadata::K8Watch;
@@ -277,6 +286,7 @@ mod convert {
     /// It only generates KVInputAction if incoming k8 object is different from memstore
     ///
     /// This will be replaced with store::sync_all
+    #[instrument(skip(k8_tokens, local_store))]
     pub async fn k8_events_to_metadata_actions<S>(
         k8_tokens: K8List<S::K8Spec>,
         local_store: &LocalStore<S, K8MetaItem>,
@@ -313,6 +323,7 @@ mod convert {
     ///
     /// Translates watch events into metadata action and apply into local store
     ///
+    #[instrument(skip(stream, local_store))]
     pub async fn k8_watch_events_to_metadata_actions<S, E>(
         stream: TokenStreamResult<S::K8Spec, E>,
         local_store: &LocalStore<S, K8MetaItem>,

--- a/src/event-stream-k8/src/dispatcher/k8_ws_service.rs
+++ b/src/event-stream-k8/src/dispatcher/k8_ws_service.rs
@@ -5,8 +5,8 @@ use std::fmt::Display;
 use std::convert::Into;
 use std::marker::PhantomData;
 
-use log::trace;
-use log::debug;
+use tracing::trace;
+use tracing::debug;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 

--- a/src/event-stream-k8/src/store/mod.rs
+++ b/src/event-stream-k8/src/store/mod.rs
@@ -9,7 +9,7 @@ mod context {
     use std::io::ErrorKind;
     use std::fmt::Display;
 
-    use log::error;
+    use tracing::error;
     use event_listener::{Event, EventListener};
     use async_channel::{Sender, Receiver, bounded, SendError};
 
@@ -90,8 +90,8 @@ mod context {
             use std::time::Instant;
 
             use tokio::select;
-            use log::debug;
-            use log::warn;
+            use tracing::debug;
+            use tracing::warn;
             use flv_future_aio::timer::sleep;
 
             const MAX_WAIT_TIME: u64 = 5;
@@ -151,8 +151,8 @@ mod context {
             use std::time::Instant;
 
             use tokio::select;
-            use log::debug;
-            use log::warn;
+            use tracing::debug;
+            use tracing::warn;
             use flv_future_aio::timer::sleep;
 
             const MAX_WAIT_TIME: u64 = 5;

--- a/src/event-stream-model/Cargo.toml
+++ b/src/event-stream-model/Cargo.toml
@@ -12,7 +12,7 @@ use_serde = ["serde"]
 k8 = ["use_serde","k8-obj-metadata","k8-obj-core","k8-obj-app"]
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1.19"
 serde = { version ="1.0.0", features = ['derive'], optional = true }
 k8-obj-metadata = { version = "1.0.0", optional = true }
 k8-obj-core = { version = "1.1.0", optional = true}

--- a/src/event-stream-model/src/store/store.rs
+++ b/src/event-stream-model/src/store/store.rs
@@ -5,8 +5,8 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use log::debug;
-use log::error;
+use tracing::debug;
+use tracing::error;
 use flv_future_aio::sync::RwLock;
 use flv_future_aio::sync::RwLockReadGuard;
 use flv_future_aio::sync::RwLockWriteGuard;

--- a/src/internal-api/Cargo.toml
+++ b/src/internal-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-kf-protocol = { version = "2.0.0" } 
+tracing = "0.1.19"
+kf-protocol = { version = "2.0.0" }
 flv-metadata-cluster = { path = "../metadata-cluster"}
 flv-types = { path ="../types" }

--- a/src/internal-api/rust-toolchain
+++ b/src/internal-api/rust-toolchain
@@ -1,1 +1,1 @@
-../rust-toolchain
+../../rust-toolchain

--- a/src/kf-service/Cargo.toml
+++ b/src/kf-service/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["fluvio.io"]
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.18"
+tracing-futures = "0.2.4"
 futures = { version = "0.3.4", features = ["async-await"] }
 async-trait = "0.1.21"
 pin-utils = "0.1.0-alpha.4"

--- a/src/kf-service/rust-toolchain
+++ b/src/kf-service/rust-toolchain
@@ -1,1 +1,1 @@
-../rust-toolchain
+../../rust-toolchain

--- a/src/kf-service/src/kf_server.rs
+++ b/src/kf-service/src/kf_server.rs
@@ -122,7 +122,7 @@ where
 impl<R, A, C, S, T> InnerKfApiServer<R, A, C, S, T>
 where
     R: KfRequestMessage<ApiKey = A> + Send + Debug + 'static,
-    C: Clone + Sync + Send + Debug +'static,
+    C: Clone + Sync + Send + Debug + 'static,
     A: Send + KfDecoder + Debug + 'static,
     S: KfService<T::Stream, Request = R, Context = C> + Send + Sync + Debug + 'static,
     T: SocketBuilder + Send + Debug + 'static,
@@ -140,7 +140,7 @@ where
     async fn run_shutdown(self, shutdown_signal: Arc<Event>) {
         match TcpListener::bind(&self.addr).await {
             Ok(listener) => {
-                info!("starting event loop for: {}", &self.addr);
+                info!("starting event loop");
                 self.event_loop(listener, shutdown_signal).await;
             }
             Err(err) => {
@@ -186,10 +186,11 @@ where
                     let builder = self.builder.clone();
 
                     let ft = async move {
-                        let address = stream.peer_addr()
+                        let address = stream
+                            .peer_addr()
                             .map(|addr| addr.to_string())
                             .unwrap_or_else(|_| "".to_owned());
-                        debug!(address = &*address, "new connection");
+                        debug!(peer = &*address, "new peer connection");
 
                         let socket_res = builder.to_socket(stream);
                         match socket_res.await {

--- a/src/kf-service/src/lib.rs
+++ b/src/kf-service/src/lib.rs
@@ -14,11 +14,11 @@ macro_rules! call_service {
     ($req:expr,$handler:expr,$sink:expr,$msg:expr) => {{
         {
             let version = $req.header.api_version();
-            log::trace!("invoking handler: {}", $msg);
+            tracing::trace!("invoking handler: {}", $msg);
             let response = $handler.await?;
-            log::trace!("send back response: {:#?}", &response);
+            tracing::trace!("send back response: {:#?}", &response);
             $sink.send_response(&response, version).await?;
-            log::trace!("finish send");
+            tracing::trace!("finish send");
         }
     }};
 
@@ -34,20 +34,20 @@ macro_rules! api_loop {
         use futures::stream::StreamExt;
         loop {
 
-            log::debug!("waiting for next api request");
+            tracing::debug!("waiting for next api request");
             if let Some(msg) = $api_stream.next().await {
                 if let Ok(req_message) = msg {
-                    log::trace!("received request: {:#?}",req_message);
+                    tracing::trace!("received request: {:#?}",req_message);
                     match req_message {
                         $($matcher => $result),*
                     }
                 } else {
-                    log::debug!("no content, end of connection {:#?}", msg);
+                    tracing::debug!("no content, end of connection {:#?}", msg);
                     break;
                 }
 
             } else {
-                log::debug!("client connect terminated");
+                tracing::debug!("client connect terminated");
                 break;
             }
         }
@@ -58,20 +58,20 @@ macro_rules! api_loop {
         use futures::stream::StreamExt;
         loop {
 
-            log::debug!("waiting for next api request: {}",$debug_msg);
+            tracing::debug!("waiting for next api request: {}",$debug_msg);
             if let Some(msg) = $api_stream.next().await {
                 if let Ok(req_message) = msg {
-                    log::trace!("received request: {:#?}",req_message);
+                    tracing::trace!("received request: {:#?}",req_message);
                     match req_message {
                         $($matcher => $result),*
                     }
                 } else {
-                    log::debug!("no content, end of connection {}", $debug_msg);
+                    tracing::debug!("no content, end of connection {}", $debug_msg);
                     break;
                 }
 
             } else {
-                log::debug!("client connect terminated: {}",$debug_msg);
+                tracing::debug!("client connect terminated: {}",$debug_msg);
                 break;
             }
         }
@@ -86,20 +86,20 @@ macro_rules! wait_for_request {
 
         if let Some(msg) = $api_stream.next().await {
             if let Ok(req_message) = msg {
-                log::trace!("received request: {:#?}", req_message);
+                tracing::trace!("received request: {:#?}", req_message);
                 match req_message {
                     $matcher => $result,
                     _ => {
-                        log::error!("unexpected request: {:#?}", req_message);
+                        tracing::error!("unexpected request: {:#?}", req_message);
                         return Ok(());
                     }
                 }
             } else {
-                log::trace!("no content, end of connection");
+                tracing::trace!("no content, end of connection");
                 return Ok(());
             }
         } else {
-            log::trace!("client connect terminated");
+            tracing::trace!("client connect terminated");
             return Ok(());
         }
     }};

--- a/src/kf-service/src/test_request.rs
+++ b/src/kf-service/src/test_request.rs
@@ -97,6 +97,7 @@ impl KfRequestMessage for TestApiRequest {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct TestContext {}
 
 impl TestContext {
@@ -107,6 +108,7 @@ impl TestContext {
 
 pub(crate) type SharedTestContext = Arc<TestContext>;
 
+#[derive(Debug)]
 pub(crate) struct TestService {}
 
 impl TestService {

--- a/src/kf-socket/Cargo.toml
+++ b/src/kf-socket/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["encoding"]
 
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1.19"
 bytes = "0.5.4"
 futures = { version = "0.3.4" }
 pin-utils = "0.1.0-alpha.4"
@@ -26,5 +26,6 @@ flv-future-aio = { version = "2.2.1", features = ["tls"] }
 
 
 [dev-dependencies]
+log = "0.4.8"
 flv-util = { version = "0.1.0", features = ["fixture"]}
 flv-future-aio = { version = "2.2.1", features = ["fixture"] }

--- a/src/kf-socket/src/multiplexing.rs
+++ b/src/kf-socket/src/multiplexing.rs
@@ -6,9 +6,9 @@ use std::io::Cursor;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use log::debug;
-use log::error;
-use log::trace;
+use tracing::debug;
+use tracing::error;
+use tracing::trace;
 use bytes::BytesMut;
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::StreamExt;
@@ -388,7 +388,7 @@ mod tests {
 
     use std::time::Duration;
 
-    use log::debug;
+    use tracing::debug;
     use futures::stream::StreamExt;
     use futures::future::join;
     use futures::future::join3;

--- a/src/kf-socket/src/pooling.rs
+++ b/src/kf-socket/src/pooling.rs
@@ -6,7 +6,7 @@ use std::sync::RwLock;
 
 use chashmap::CHashMap;
 use chashmap::WriteGuard;
-use log::trace;
+use tracing::trace;
 
 use crate::KfSocket;
 use crate::KfSocketError;
@@ -109,8 +109,8 @@ pub(crate) mod test {
 
     use futures::future::join;
     use futures::stream::StreamExt;
-    use log::debug;
-    use log::error;
+    use tracing::debug;
+    use tracing::error;
 
     use flv_future_aio::net::TcpListener;
     use flv_future_aio::timer::sleep;

--- a/src/kf-socket/src/sink.rs
+++ b/src/kf-socket/src/sink.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 use std::os::unix::io::RawFd;
 use std::os::unix::io::AsRawFd;
 
-use log::trace;
-use log::debug;
+use tracing::trace;
+use tracing::debug;
 use bytes::Bytes;
 
 use futures::sink::SinkExt;
@@ -218,8 +218,8 @@ mod tests {
     use std::fs::remove_file;
     use std::env::temp_dir;
 
-    use log::debug;
-    use log::info;
+    use tracing::debug;
+    use tracing::info;
     use futures::stream::StreamExt;
     use futures::future::join;
     use futures::io::AsyncWriteExt;

--- a/src/kf-socket/src/sink_pool.rs
+++ b/src/kf-socket/src/sink_pool.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use chashmap::CHashMap;
 use chashmap::WriteGuard;
-use log::trace;
+use tracing::trace;
 
 use crate::KfSink;
 
@@ -48,8 +48,8 @@ mod tests {
 
     use std::time::Duration;
 
-    use log::debug;
-    use log::info;
+    use tracing::debug;
+    use tracing::info;
     use futures::stream::StreamExt;
     use futures::future::join;
 

--- a/src/kf-socket/src/socket.rs
+++ b/src/kf-socket/src/socket.rs
@@ -3,7 +3,7 @@ use std::os::unix::io::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
 
-use log::debug;
+use tracing::debug;
 use futures::stream::StreamExt;
 use tokio_util::codec::Framed;
 use tokio_util::compat::FuturesAsyncReadCompatExt;

--- a/src/kf-socket/src/stream.rs
+++ b/src/kf-socket/src/stream.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::trace;
-use log::error;
+use tracing::trace;
+use tracing::error;
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::Stream;
 use futures::stream::StreamExt;

--- a/src/kf-socket/tests/file_fetch.rs
+++ b/src/kf-socket/tests/file_fetch.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 use std::env::temp_dir;
 use std::time::Duration;
 
-use log::debug;
+use tracing::debug;
 use futures::io::AsyncWriteExt;
 use futures::future::join;
 use futures::stream::StreamExt;

--- a/src/metadata-cluster/Cargo.toml
+++ b/src/metadata-cluster/Cargo.toml
@@ -13,6 +13,7 @@ k8 = ["use_serde","k8-obj-metadata","k8-obj-core","k8-obj-app","flv-eventstream-
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.19"
 serde = { version ="1.0.0", features = ['derive'], optional = true }
 async-trait = "0.1.21"
 k8-obj-metadata = { version = "1.0.0", optional = true }

--- a/src/metadata-cluster/src/partition/store.rs
+++ b/src/metadata-cluster/src/partition/store.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use async_trait::async_trait;
 
 use flv_types::SpuId;

--- a/src/metadata-cluster/src/spu/mod.rs
+++ b/src/metadata-cluster/src/spu/mod.rs
@@ -56,7 +56,7 @@ mod custom_metadata {
     use std::io::Error;
     use std::io::ErrorKind;
 
-    use log::trace;
+    use tracing::trace;
 
     use kf_protocol::Encoder;
     use kf_protocol::Decoder;

--- a/src/metadata-cluster/src/topic/spec.rs
+++ b/src/metadata-cluster/src/topic/spec.rs
@@ -8,7 +8,7 @@
 use std::io::{Error, ErrorKind};
 use std::collections::BTreeMap;
 
-use log::trace;
+use tracing::trace;
 use flv_types::{ReplicaMap, SpuId};
 use flv_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAssignment};
 

--- a/src/metadata-cluster/src/topic/store.rs
+++ b/src/metadata-cluster/src/topic/store.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use tracing::debug;
 use async_trait::async_trait;
 
 use crate::store::*;

--- a/src/sc-api/Cargo.toml
+++ b/src/sc-api/Cargo.toml
@@ -12,6 +12,7 @@ use_serde = ["flv-metadata-cluster/use_serde","serde"]
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.19"
 serde = { version ="1.0.0", features = ['derive'], optional = true }
 kf-protocol = { version = "2.0.0" } 
 flv-metadata-cluster = { version = "0.1.0", default-features = false, path = "../metadata-cluster"}

--- a/src/sc-api/src/objects/create.rs
+++ b/src/sc-api/src/objects/create.rs
@@ -31,7 +31,7 @@ mod create {
     use std::io::Error;
     use std::io::ErrorKind;
 
-    use log::trace;
+    use tracing::trace;
 
     use kf_protocol::Version;
     use kf_protocol::bytes::{Buf, BufMut};

--- a/src/sc-api/src/objects/delete.rs
+++ b/src/sc-api/src/objects/delete.rs
@@ -6,7 +6,7 @@
 use std::io::Error;
 use std::io::ErrorKind;
 
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::Encoder;
 use kf_protocol::Decoder;

--- a/src/sc-api/src/objects/list.rs
+++ b/src/sc-api/src/objects/list.rs
@@ -136,7 +136,7 @@ mod encoding {
     use std::io::Error;
     use std::io::ErrorKind;
 
-    use log::trace;
+    use tracing::trace;
 
     use kf_protocol::Encoder;
     use kf_protocol::Decoder;

--- a/src/sc-api/src/objects/watch.rs
+++ b/src/sc-api/src/objects/watch.rs
@@ -100,7 +100,7 @@ mod encoding {
     use std::io::Error;
     use std::io::ErrorKind;
 
-    use log::trace;
+    use tracing::trace;
 
     use kf_protocol::Encoder;
     use kf_protocol::Decoder;

--- a/src/sc-api/src/request.rs
+++ b/src/sc-api/src/request.rs
@@ -7,7 +7,7 @@
 use std::convert::TryInto;
 use std::io::Error as IoError;
 
-use log::debug;
+use tracing::debug;
 
 use kf_protocol::bytes::Buf;
 

--- a/src/sc-core/Cargo.toml
+++ b/src/sc-core/Cargo.toml
@@ -18,7 +18,7 @@ async-lock = "1.1.2"
 async-channel = "1.1.0"
 event-listener = "2.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-util = { version = "0.2.0"}
+flv-util = { path = "../../../flv-util", version = "0.2.0" }
 flv-future-aio = { version = "2.3.0", features =["tls","unstable"] }
 k8-metadata-client = { version = "1.0.1"}
 k8-obj-metadata = { version = "1.0.0" }
@@ -29,9 +29,10 @@ kf-socket = {path = "../kf-socket"}
 kf-service = { path = "../kf-service"}
 internal-api = { path = "../internal-api"}
 flv-metadata-cluster = { features = ["k8"],path = "../metadata-cluster"}
-sc-api = { path = "../sc-api",  package = "flv-api-sc"}
+sc-api = { version = "2.0.0", path = "../sc-api",  package = "flv-api-sc"}
 flv-eventstream-dispatcher = { path = "../event-stream-k8" }
+tracing = "0.1.17"
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}
-flv-util = { version = "0.2.0", features=["fixture"]}
+flv-util = { path = "../../../flv-util", version = "0.2.0", features=["fixture"]}

--- a/src/sc-core/Cargo.toml
+++ b/src/sc-core/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["fluvio.io"]
 [dependencies]
 rand = "0.7.2"
 log = "0.4.8"
+tracing = "0.1.19"
+tracing-futures = "0.2.4"
 toml = "0.5.5"
 serde = { version ="1.0.103", features = ['derive'] }
 futures = { version = "0.3.1" }
@@ -31,7 +33,6 @@ internal-api = { path = "../internal-api"}
 flv-metadata-cluster = { features = ["k8"],path = "../metadata-cluster"}
 sc-api = { version = "2.0.0", path = "../sc-api",  package = "flv-api-sc"}
 flv-eventstream-dispatcher = { path = "../event-stream-k8" }
-tracing = "0.1.17"
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}

--- a/src/sc-core/Cargo.toml
+++ b/src/sc-core/Cargo.toml
@@ -20,7 +20,7 @@ async-lock = "1.1.2"
 async-channel = "1.1.0"
 event-listener = "2.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-util = { path = "../../../flv-util", version = "0.2.0" }
+flv-util = { path = "../../../flv-util", version = "0.3.0" }
 flv-future-aio = { version = "2.3.0", features =["tls","unstable"] }
 k8-metadata-client = { version = "1.0.1"}
 k8-obj-metadata = { version = "1.0.0" }
@@ -36,4 +36,4 @@ flv-eventstream-dispatcher = { path = "../event-stream-k8" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}
-flv-util = { path = "../../../flv-util", version = "0.2.0", features=["fixture"]}
+flv-util = { path = "../../../flv-util", version = "0.3.0", features=["fixture"]}

--- a/src/sc-core/Cargo.toml
+++ b/src/sc-core/Cargo.toml
@@ -20,7 +20,7 @@ async-lock = "1.1.2"
 async-channel = "1.1.0"
 event-listener = "2.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-util = { path = "../../../flv-util", version = "0.3.0" }
+flv-util = { version = "0.3.0" }
 flv-future-aio = { version = "2.3.0", features =["tls","unstable"] }
 k8-metadata-client = { version = "1.0.1"}
 k8-obj-metadata = { version = "1.0.0" }
@@ -36,4 +36,4 @@ flv-eventstream-dispatcher = { path = "../event-stream-k8" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}
-flv-util = { path = "../../../flv-util", version = "0.3.0", features=["fixture"]}
+flv-util = { version = "0.3.0", features=["fixture"]}

--- a/src/sc-core/rust-toolchain
+++ b/src/sc-core/rust-toolchain
@@ -1,1 +1,1 @@
-../rust-toolchain
+../../rust-toolchain

--- a/src/sc-core/src/controllers/partitions/controller.rs
+++ b/src/sc-core/src/controllers/partitions/controller.rs
@@ -2,7 +2,7 @@
 //! # Auth Controller
 //!
 
-use log::debug;
+use tracing::debug;
 
 use flv_future_aio::task::spawn;
 

--- a/src/sc-core/src/controllers/partitions/reducer.rs
+++ b/src/sc-core/src/controllers/partitions/reducer.rs
@@ -5,8 +5,8 @@
 //!
 use std::sync::Arc;
 
-use log::debug;
-use log::warn;
+use tracing::debug;
+use tracing::warn;
 
 use flv_metadata_cluster::partition::*;
 

--- a/src/sc-core/src/controllers/partitions/replica_msgs_for_spus.rs
+++ b/src/sc-core/src/controllers/partitions/replica_msgs_for_spus.rs
@@ -11,8 +11,8 @@ use internal_api::messages::{ReplicaMsg, ReplicaMsgs};
 use internal_api::UpdateReplicaRequest;
 
 use error::ServerError;
-use log::{debug, error, trace};
-use log::warn;
+use tracing::{debug, error, trace};
+use tracing::warn;
 use utils::actions::Actions;
 
 use crate::core::common::spu_notify_by_id::SpuNotifyById;

--- a/src/sc-core/src/controllers/spus/controller.rs
+++ b/src/sc-core/src/controllers/spus/controller.rs
@@ -5,9 +5,10 @@ use std::collections::HashMap;
 use std::time::Instant;
 use std::time::Duration;
 
-use log::debug;
-use log::error;
-use log::warn;
+use tracing::debug;
+use tracing::error;
+use tracing::warn;
+use tracing::instrument;
 
 use async_channel::Receiver;
 
@@ -57,6 +58,7 @@ impl SpuController {
         });
     }
 
+    #[instrument(skip(self))]
     async fn dispatch_loop(mut self) {
         use tokio::select;
         use flv_future_aio::timer::sleep;
@@ -177,6 +179,7 @@ impl SpuController {
     }
 
     /// check if any spu has done health check
+    #[instrument(skip(self))]
     async fn health_check(&mut self) {
         debug!("performing health check");
         let mut actions: Vec<SpuAction> = vec![];
@@ -266,7 +269,7 @@ impl SpuController {
 #[cfg(test)]
 mod tests {
 
-    use log::debug;
+    use tracing::debug;
     use futures::channel::mpsc::channel;
     use futures::channel::mpsc::Receiver;
 

--- a/src/sc-core/src/controllers/spus/reducer.rs
+++ b/src/sc-core/src/controllers/spus/reducer.rs
@@ -5,7 +5,7 @@
 //!
 use std::sync::Arc;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 use flv_types::log_on_err;
 use flv_metadata_cluster::store::actions::*;
 

--- a/src/sc-core/src/controllers/topics/controller.rs
+++ b/src/sc-core/src/controllers/topics/controller.rs
@@ -3,7 +3,7 @@
 //!
 //! Reconcile Topics
 
-use log::debug;
+use tracing::debug;
 
 use flv_future_aio::task::spawn;
 
@@ -97,7 +97,7 @@ impl TopicController {
 #[cfg(test)]
 mod tests {
 
-    use log::debug;
+    use tracing::debug;
     use futures::channel::mpsc::channel;
     use futures::channel::mpsc::Receiver;
 

--- a/src/sc-core/src/controllers/topics/policy.rs
+++ b/src/sc-core/src/controllers/topics/policy.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::collections::BTreeMap;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 use rand::thread_rng;
 use rand::Rng;
 

--- a/src/sc-core/src/controllers/topics/reducer.rs
+++ b/src/sc-core/src/controllers/topics/reducer.rs
@@ -12,7 +12,7 @@
 //!
 use std::sync::Arc;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use crate::stores::topic::*;
 use crate::stores::partition::*;

--- a/src/sc-core/src/core/common/dispatcher.rs
+++ b/src/sc-core/src/core/common/dispatcher.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
-use log::trace;
+use tracing::trace;
 
-use log::info;
+use tracing::info;
 use futures::channel::mpsc::Receiver;
 use futures::stream::StreamExt;
 use futures::select;

--- a/src/sc-core/src/core/dispatcher.rs
+++ b/src/sc-core/src/core/dispatcher.rs
@@ -12,8 +12,8 @@ use futures::channel::mpsc::Receiver;
 use futures::future::TryFutureExt;
 use futures::select;
 use futures::stream::StreamExt;
-use log::{error, info};
-use log::trace;
+use tracing::{error, info};
+use tracing::trace;
 
 use crate::core::WSUpdateService;
 use crate::conn_manager::SpuConnections;

--- a/src/sc-core/src/services/private_api/mod.rs
+++ b/src/sc-core/src/services/private_api/mod.rs
@@ -1,6 +1,7 @@
 mod private_server;
 
 use tracing::info;
+use tracing::instrument;
 
 use private_server::ScInternalService;
 use kf_service::KfApiServer;
@@ -8,10 +9,15 @@ use kf_service::KfApiServer;
 use crate::core::SharedContext;
 
 // start server
+#[instrument(
+    name = "sc_private_server"
+    skip(ctx),
+    fields(address = &*ctx.config().private_endpoint)
+)]
 pub fn start_internal_server(ctx: SharedContext) {
-    let addr = ctx.config().private_endpoint.clone();
-    info!("starting internal services at {}", addr);
+    info!("starting internal services");
 
+    let addr = ctx.config().private_endpoint.clone();
     let server = KfApiServer::new(addr, ctx, ScInternalService::new());
     server.run();
 }

--- a/src/sc-core/src/services/private_api/mod.rs
+++ b/src/sc-core/src/services/private_api/mod.rs
@@ -1,6 +1,6 @@
 mod private_server;
 
-use log::info;
+use tracing::info;
 
 use private_server::ScInternalService;
 use kf_service::KfApiServer;
@@ -10,7 +10,7 @@ use crate::core::SharedContext;
 // start server
 pub fn start_internal_server(ctx: SharedContext) {
     let addr = ctx.config().private_endpoint.clone();
-    info!("starting internal services at: {}", addr);
+    info!("starting internal services at {}", addr);
 
     let server = KfApiServer::new(addr, ctx, ScInternalService::new());
     server.run();

--- a/src/sc-core/src/services/private_api/private_server.rs
+++ b/src/sc-core/src/services/private_api/private_server.rs
@@ -4,8 +4,8 @@ use std::io::ErrorKind;
 use std::time::Duration;
 use std::time::Instant;
 
-use log::error;
-use log::debug;
+use tracing::error;
+use tracing::debug;
 use async_trait::async_trait;
 use async_channel::Sender;
 use futures::Stream;
@@ -162,7 +162,7 @@ async fn dispatch_loop(
 
 
                 if let Some(spu_request) = spu_request_msg {
-                    log::trace!("received spu: {} request: {:#?}",spu_id,spu_request);
+                    tracing::trace!("received spu: {} request: {:#?}",spu_id,spu_request);
 
                     if let Ok(req_message) = spu_request {
                         match req_message {

--- a/src/sc-core/src/services/private_api/private_server.rs
+++ b/src/sc-core/src/services/private_api/private_server.rs
@@ -26,6 +26,8 @@ use crate::controllers::spus::SpuAction;
 use crate::stores::actions::WSAction;
 
 const HEALTH_DURATION: u64 = 30;
+
+#[derive(Debug)]
 pub struct ScInternalService {}
 
 impl ScInternalService {

--- a/src/sc-core/src/services/public_api/api_version.rs
+++ b/src/sc-core/src/services/public_api/api_version.rs
@@ -1,5 +1,5 @@
 use std::io::Error;
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::api::RequestMessage;
 use kf_protocol::api::ResponseMessage;

--- a/src/sc-core/src/services/public_api/delete.rs
+++ b/src/sc-core/src/services/public_api/delete.rs
@@ -4,7 +4,7 @@
 //! Delete topic request handler. Lookup topic in local metadata, grab its K8 context
 //! and send K8 a delete message.
 //!
-use log::trace;
+use tracing::trace;
 use std::io::Error;
 
 use kf_protocol::api::{RequestMessage, ResponseMessage};

--- a/src/sc-core/src/services/public_api/list.rs
+++ b/src/sc-core/src/services/public_api/list.rs
@@ -1,5 +1,5 @@
 use std::io::Error;
-use log::debug;
+use tracing::debug;
 
 use kf_protocol::api::{RequestMessage, ResponseMessage};
 use sc_api::objects::*;

--- a/src/sc-core/src/services/public_api/metadata/fetch.rs
+++ b/src/sc-core/src/services/public_api/metadata/fetch.rs
@@ -1,4 +1,4 @@
-use log::trace;
+use tracing::trace;
 use std::io::Error;
 
 use flv_types::Name;

--- a/src/sc-core/src/services/public_api/mod.rs
+++ b/src/sc-core/src/services/public_api/mod.rs
@@ -13,7 +13,7 @@ pub use context::*;
 
 mod context {
 
-    use log::info;
+    use tracing::info;
 
     use kf_service::KfApiServer;
 
@@ -23,7 +23,7 @@ mod context {
     /// create public server
     pub fn start_public_server(ctx: SharedContext) {
         let addr = ctx.config().public_endpoint.clone();
-        info!("start public api service at: {}", addr);
+        info!("start public api service at {}", addr);
 
         let server = KfApiServer::new(addr, ctx, PublicService::new());
         server.run();

--- a/src/sc-core/src/services/public_api/mod.rs
+++ b/src/sc-core/src/services/public_api/mod.rs
@@ -14,6 +14,7 @@ pub use context::*;
 mod context {
 
     use tracing::info;
+    use tracing::instrument;
 
     use kf_service::KfApiServer;
 
@@ -21,9 +22,14 @@ mod context {
     use super::public_server::PublicService;
 
     /// create public server
+    #[instrument(
+        name = "sc_public_server"
+        skip(ctx),
+        fields(address = &*ctx.config().public_endpoint)
+    )]
     pub fn start_public_server(ctx: SharedContext) {
         let addr = ctx.config().public_endpoint.clone();
-        info!("start public api service at {}", addr);
+        info!("start public api service");
 
         let server = KfApiServer::new(addr, ctx, PublicService::new());
         server.run();

--- a/src/sc-core/src/services/public_api/partition/mod.rs
+++ b/src/sc-core/src/services/public_api/partition/mod.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 
-use log::{trace, debug};
+use tracing::{trace, debug};
 
 use sc_api::objects::*;
 use sc_api::partition::*;

--- a/src/sc-core/src/services/public_api/public_server.rs
+++ b/src/sc-core/src/services/public_api/public_server.rs
@@ -24,6 +24,7 @@ use flv_future_aio::zero_copy::ZeroCopyWrite;
 
 use crate::core::*;
 
+#[derive(Debug)]
 pub struct PublicService {}
 
 impl PublicService {

--- a/src/sc-core/src/services/public_api/spg/create.rs
+++ b/src/sc-core/src/services/public_api/spg/create.rs
@@ -6,7 +6,7 @@
 
 use std::io::Error;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use sc_api::FlvStatus;
 use sc_api::spg::*;

--- a/src/sc-core/src/services/public_api/spg/delete.rs
+++ b/src/sc-core/src/services/public_api/spg/delete.rs
@@ -1,5 +1,5 @@
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use std::io::Error;
 

--- a/src/sc-core/src/services/public_api/spg/fetch.rs
+++ b/src/sc-core/src/services/public_api/spg/fetch.rs
@@ -1,7 +1,7 @@
 use std::io::Error;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use sc_api::objects::*;
 use sc_api::spg::SpuGroupSpec;

--- a/src/sc-core/src/services/public_api/spu/fetch.rs
+++ b/src/sc-core/src/services/public_api/spu/fetch.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 
-use log::{trace, debug};
+use tracing::{trace, debug};
 
 use sc_api::objects::*;
 use sc_api::spu::SpuSpec;

--- a/src/sc-core/src/services/public_api/spu/register_custom_spus_req.rs
+++ b/src/sc-core/src/services/public_api/spu/register_custom_spus_req.rs
@@ -3,7 +3,7 @@
 //!
 //! Converts Custom Spu API request into KV request and sends to KV store for processing.
 //!
-use log::{debug, trace};
+use tracing::{debug, trace};
 use std::io::Error as IoError;
 
 use kf_protocol::api::FlvErrorCode;

--- a/src/sc-core/src/services/public_api/spu/unregister_custom_spus_req.rs
+++ b/src/sc-core/src/services/public_api/spu/unregister_custom_spus_req.rs
@@ -4,7 +4,7 @@
 //! Lookup custom-spu in local metadata, grab its K8 context
 //! and send K8 a delete message.
 //!
-use log::{debug, trace};
+use tracing::{debug, trace};
 use std::io::Error;
 
 use kf_protocol::api::FlvErrorCode;

--- a/src/sc-core/src/services/public_api/spu/watch.rs
+++ b/src/sc-core/src/services/public_api/spu/watch.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 
-use log::{trace, debug};
+use tracing::{trace, debug};
 
 use sc_api::objects::*;
 use sc_api::spu::SpuSpec;

--- a/src/sc-core/src/services/public_api/topic/create.rs
+++ b/src/sc-core/src/services/public_api/topic/create.rs
@@ -11,7 +11,7 @@
 
 use std::io::Error as IoError;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use kf_protocol::api::FlvErrorCode;
 

--- a/src/sc-core/src/services/public_api/topic/delete.rs
+++ b/src/sc-core/src/services/public_api/topic/delete.rs
@@ -4,7 +4,7 @@
 //! Delete topic request handler. Lookup topic in local metadata, grab its K8 context
 //! and send K8 a delete message.
 //!
-use log::{debug, trace};
+use tracing::{debug, trace};
 use std::io::Error;
 
 use kf_protocol::api::FlvErrorCode;

--- a/src/sc-core/src/services/public_api/topic/fetch.rs
+++ b/src/sc-core/src/services/public_api/topic/fetch.rs
@@ -1,4 +1,4 @@
-use log::{trace, debug};
+use tracing::{trace, debug};
 use std::io::Error;
 
 use flv_metadata_cluster::store::KeyFilter;

--- a/src/sc-core/src/services/public_api/watch.rs
+++ b/src/sc-core/src/services/public_api/watch.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::fmt::Debug;
 
-use log::debug;
-use log::error;
+use tracing::debug;
+use tracing::error;
 use event_listener::Event;
 use futures::io::AsyncRead;
 use futures::io::AsyncWrite;

--- a/src/sc-core/src/tests/fixture/generator.rs
+++ b/src/sc-core/src/tests/fixture/generator.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::channel::mpsc::Receiver;
 use futures::channel::mpsc::channel;
 use futures::channel::mpsc::Sender;

--- a/src/sc-core/src/tests/fixture/mock_cm.rs
+++ b/src/sc-core/src/tests/fixture/mock_cm.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
 

--- a/src/sc-core/src/tests/fixture/mock_kv.rs
+++ b/src/sc-core/src/tests/fixture/mock_kv.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::SinkExt;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;

--- a/src/sc-core/src/tests/fixture/mock_spu.rs
+++ b/src/sc-core/src/tests/fixture/mock_spu.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::io::Error as IoError;
 
-use log::info;
-use log::debug;
-use log::warn;
-use log::trace;
+use tracing::info;
+use tracing::debug;
+use tracing::warn;
+use tracing::trace;
 use futures::select;
 use futures::stream::StreamExt;
 use futures::future::FutureExt;
@@ -150,7 +150,7 @@ where
                 api_msg = api_stream.next().fuse() => {
                     if let Some(msg) = api_msg {
                         if let Ok(req_message) = msg {
-                            log::trace!("received request: {:#?}",req_message);
+                            tracing::trace!("received request: {:#?}",req_message);
                             match req_message {
                                 InternalSpuRequest::UpdateSpuRequest(request) => {
                                     handle_spu_update_request(request, self.ctx.clone()).await.expect("spu handl should work");
@@ -161,12 +161,12 @@ where
                             }
                             
                         } else {
-                            log::trace!("no content, end of connection {:#?}", msg);
+                            tracing::trace!("no content, end of connection {:#?}", msg);
                             break;
                         }
 
                     } else {
-                        log::trace!("client connect terminated");
+                        tracing::trace!("client connect terminated");
                         break;
                     }
                 }

--- a/src/sc-core/src/tests/fixture/test_runner.rs
+++ b/src/sc-core/src/tests/fixture/test_runner.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::SinkExt;
 use futures::future::join;
 use futures::channel::mpsc::Sender;

--- a/src/sc-core/src/tests/suite/conn_test.rs
+++ b/src/sc-core/src/tests/suite/conn_test.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::debug;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
 use futures::SinkExt;

--- a/src/sc-core/src/tests/suite/partition_test.rs
+++ b/src/sc-core/src/tests/suite/partition_test.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::debug;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
 

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -22,7 +22,7 @@ k8-client = { version = "1.1.1"}
 flv-tls-proxy = "0.1.0"
 flv-types = { path ="../types", version = "0.2.0"}
 flv-future-aio = { version = "2.2.1", features = ["tls"] }
-flv-util = { path = "../../../flv-util", version = "0.2.0" }
+flv-util = { path = "../../../flv-util", version = "0.3.0" }
 utils = { path = "../utils"}
 flv-sc-core = { path = "../sc-core"}
 flv-metadata-cluster = { features = ["k8"],path = "../metadata-cluster"}

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+tracing = "0.1.19"
 rand = "0.7.2"
-log = "0.4.8"
 toml = "0.5.5"
 structopt = "0.3.12"
 serde = { version ="1.0.103", features = ['derive'] }

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -11,6 +11,7 @@ doc = false
 
 [dependencies]
 tracing = "0.1.19"
+tracing-futures = "0.2.4"
 rand = "0.7.2"
 toml = "0.5.5"
 structopt = "0.3.12"

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -22,7 +22,7 @@ k8-client = { version = "1.1.1"}
 flv-tls-proxy = "0.1.0"
 flv-types = { path ="../types", version = "0.2.0"}
 flv-future-aio = { version = "2.2.1", features = ["tls"] }
-flv-util = { path = "../../../flv-util", version = "0.3.0" }
+flv-util = { version = "0.3.0" }
 utils = { path = "../utils"}
 flv-sc-core = { path = "../sc-core"}
 flv-metadata-cluster = { features = ["k8"],path = "../metadata-cluster"}

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -21,7 +21,7 @@ k8-client = { version = "1.1.1"}
 flv-tls-proxy = "0.1.0"
 flv-types = { path ="../types", version = "0.2.0"}
 flv-future-aio = { version = "2.2.1", features = ["tls"] }
-flv-util = { version = "0.2.0"}
+flv-util = { path = "../../../flv-util", version = "0.2.0" }
 utils = { path = "../utils"}
 flv-sc-core = { path = "../sc-core"}
 flv-metadata-cluster = { features = ["k8"],path = "../metadata-cluster"}

--- a/src/sc-k8/src/cli.rs
+++ b/src/sc-k8/src/cli.rs
@@ -11,8 +11,8 @@ use std::process;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use log::info;
-use log::debug;
+use tracing::info;
+use tracing::debug;
 use structopt::StructOpt;
 
 use flv_types::print_cli_err;

--- a/src/sc-k8/src/init.rs
+++ b/src/sc-k8/src/init.rs
@@ -47,7 +47,7 @@ mod proxy {
 
     use std::process;
 
-    use log::info;
+    use tracing::info;
 
     use flv_types::print_cli_err;
     use flv_future_aio::net::tls::TlsAcceptor;

--- a/src/sc-k8/src/k8_operations/config_map_ops.rs
+++ b/src/sc-k8/src/k8_operations/config_map_ops.rs
@@ -5,7 +5,7 @@
 //!
 use std::collections::BTreeMap;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use flv_metadata_cluster::k8::metadata::*;
 use flv_metadata_cluster::k8::core::config_map::ConfigMapSpec;

--- a/src/sc-k8/src/main.rs
+++ b/src/sc-k8/src/main.rs
@@ -1,8 +1,7 @@
 use structopt::StructOpt;
 
 fn main() {
-    // flv_util::init_logger();
-    flv_util::init_tracer();
+    flv_util::init_tracer(None);
 
     let opt = flv_sc_k8::ScOpt::from_args();
     flv_sc_k8::main_loop(opt);

--- a/src/sc-k8/src/main.rs
+++ b/src/sc-k8/src/main.rs
@@ -1,7 +1,8 @@
 use structopt::StructOpt;
 
 fn main() {
-    flv_util::init_logger();
+    // flv_util::init_logger();
+    flv_util::init_tracer();
 
     let opt = flv_sc_k8::ScOpt::from_args();
     flv_sc_k8::main_loop(opt);

--- a/src/sc-k8/src/operator/spg_operator.rs
+++ b/src/sc-k8/src/operator/spg_operator.rs
@@ -6,6 +6,7 @@ use tracing::error;
 use tracing::info;
 use tracing::trace;
 use tracing::warn;
+use tracing::instrument;
 use futures::stream::StreamExt;
 
 use flv_future_aio::task::spawn;
@@ -75,6 +76,10 @@ impl SpgOperator {
         debug!("spg operator finished");
     }
 
+    #[instrument(
+        skip(self, events),
+        fields(namespace = &*self.namespace)
+    )]
     async fn dispatch_events(&self, events: Vec<Result<K8Watch<K8SpuGroupSpec>, ClientError>>) {
         for event_r in events {
             match event_r {
@@ -108,6 +113,10 @@ impl SpgOperator {
         }
     }
 
+    #[instrument(
+        skip(self, spu_group),
+        fields(spg_name = &*spu_group.metadata.name),
+    )]
     async fn apply_spg_changes(&self, spu_group: SpuGroupObj) -> Result<(), ClientError> {
         let spg_name = spu_group.metadata.name.as_ref();
 
@@ -115,10 +124,7 @@ impl SpgOperator {
 
         // ensure we don't have conflict with existing spu group
         if let Some(conflict_id) = spu_group.is_conflict_with(&self.spu_store).await {
-            warn!(
-                "spg group: {} is conflict with existing id: {}",
-                spg_name, conflict_id
-            );
+            warn!(conflict_id, "spg is in conflict with existing id");
             let status = SpuGroupStatus::invalid(format!("conflict with: {}", conflict_id));
 
             let k8_status_change = spu_group.as_status_update(status);
@@ -143,22 +149,16 @@ impl SpgOperator {
                         .apply_stateful_set(&spu_group, spg_spec, &spg_name, svc_name)
                         .await
                     {
-                        error!(
-                            "cluster '{}': error applying stateful sets: {}",
-                            spg_name, err
-                        );
+                        error!("error applying stateful sets: {}", err);
                     }
                 }
                 Err(err) => {
-                    error!(
-                        "cluster '{}': error applying spg services: {}",
-                        spg_name, err
-                    );
+                    error!("error applying spg services: {}", err);
                 }
             }
 
             if let Err(err) = self.apply_spus(&spu_group, spg_spec, &spg_name).await {
-                error!("cluster '{}': error applying spus: {}", spg_name, err);
+                error!("error applying spus: {}", err);
             }
         }
 
@@ -166,6 +166,10 @@ impl SpgOperator {
     }
 
     /// Generate and apply a stateful set for this cluster
+    #[instrument(
+        skip(self, spu_group, spg_spec, spg_svc_name),
+        fields(spg_svc_name = &*spg_svc_name),
+    )]
     async fn apply_stateful_set(
         &self,
         spu_group: &SpuGroupObj,
@@ -182,8 +186,8 @@ impl SpgOperator {
             self.tls.as_ref(),
         );
         debug!(
-            "cluster '{}': apply statefulset '{}' changes",
-            spg_name, input_stateful.metadata.name,
+            "apply statefulset '{}' changes",
+            input_stateful.metadata.name
         );
 
         trace!("statefulset: {:#?}", input_stateful);
@@ -194,6 +198,7 @@ impl SpgOperator {
     }
 
     /// create SPU crd objects from cluster spec
+    #[instrument(skip(self, spg_obj, spg_spec, spg_name))]
     async fn apply_spus(
         &self,
         spg_obj: &SpuGroupObj,
@@ -229,6 +234,14 @@ impl SpgOperator {
     }
 
     /// create SPU crd objects from cluster spec
+    #[instrument(
+        skip(self, k8_group, group_spec, _replica_index, id),
+        fields(
+            namespace = k8_group.metadata.namespace(),
+            replica_index = _replica_index,
+            spu_id = id,
+        )
+    )]
     async fn apply_spu(
         &self,
         k8_group: &SpuGroupObj,
@@ -294,6 +307,7 @@ impl SpgOperator {
 
     /// Apply external svc for each SPU
     /// This is owned by group svc
+    #[instrument(skip(self, spg_obj, spg_spec))]
     async fn apply_spu_load_balancers(
         &self,
         spg_obj: &SpuGroupObj,
@@ -342,8 +356,7 @@ impl SpgOperator {
             ..Default::default()
         };
 
-        debug!("spu '{}': enable external services", spu_name);
-
+        debug!("enable external services");
         self.client.apply(input_service).await
     }
 

--- a/src/sc-k8/src/operator/spg_operator.rs
+++ b/src/sc-k8/src/operator/spg_operator.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use log::debug;
-use log::error;
-use log::info;
-use log::trace;
-use log::warn;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::trace;
+use tracing::warn;
 use futures::stream::StreamExt;
 
 use flv_future_aio::task::spawn;

--- a/src/sc-k8/src/operator/svc_operator.rs
+++ b/src/sc-k8/src/operator/svc_operator.rs
@@ -1,7 +1,7 @@
-use log::debug;
-use log::error;
-use log::info;
-use log::trace;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::trace;
 use futures::stream::StreamExt;
 
 use flv_future_aio::task::spawn;

--- a/src/sc-k8/src/operator/svc_operator.rs
+++ b/src/sc-k8/src/operator/svc_operator.rs
@@ -2,6 +2,7 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
+use tracing::instrument;
 use futures::stream::StreamExt;
 
 use flv_future_aio::task::spawn;
@@ -62,6 +63,10 @@ impl SvcOperator {
         debug!("svc operator finished");
     }
 
+    #[instrument(
+        skip(self, events),
+        fields(namespace = &*self.namespace),
+    )]
     async fn dispatch_events(&self, events: Vec<Result<K8Watch<ServiceSpec>, ClientError>>) {
         for event_r in events {
             match event_r {
@@ -95,6 +100,10 @@ impl SvcOperator {
         }
     }
 
+    #[instrument(
+        skip(self, svc_obj),
+        fields(svc_name = &*svc_obj.metadata.name),
+    )]
     async fn apply_svc_changes(&self, svc_obj: K8Obj<ServiceSpec>) -> Result<(), ScK8Error> {
         debug!("received svc: {}", svc_obj.metadata.name);
         trace!("svc spec: {:#?}", svc_obj);

--- a/src/spu-api/Cargo.toml
+++ b/src/spu-api/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.19"
 bytes = "0.5.4"
 serde = { version ="1.0.103", features = ['derive'] }
 kf-protocol = { version = "2.0.1" } 

--- a/src/spu-api/src/client/api.rs
+++ b/src/spu-api/src/client/api.rs
@@ -1,7 +1,7 @@
 // ApiRequest and Response that has all request and response
 // use for generic dump and client
 
-use log::trace;
+use tracing::trace;
 use std::convert::TryInto;
 use std::io::Error as IoError;
 

--- a/src/spu-api/src/server/api.rs
+++ b/src/spu-api/src/server/api.rs
@@ -1,7 +1,7 @@
 // ApiRequest and Response that has all request and response
 // use for generic dump and client
 
-use log::trace;
+use tracing::trace;
 use std::convert::TryInto;
 use std::io::Error as IoError;
 

--- a/src/spu-server/Cargo.toml
+++ b/src/spu-server/Cargo.toml
@@ -12,6 +12,7 @@ doc = false
 
 [dependencies]
 log = "0.4.8"
+tracing = "0.1.19"
 bytes = "0.5.3"
 structopt = "0.3.5"
 toml = "0.5.5"
@@ -25,7 +26,7 @@ pin-utils = "0.1.0-alpha.4"
 regex = "1.3.1"
 tokio = { version = "0.2.21", features = ["macros"] }
 flv-future-aio = { version = "2.2.1" }
-flv-util = { version = "0.2.0" }
+flv-util = { version = "0.2.0", path = "../../../flv-util" }
 kf-protocol = { version = "2.0.0" } 
 flv-tls-proxy = "0.1.0"
 kf-socket = {path = "../kf-socket"}

--- a/src/spu-server/Cargo.toml
+++ b/src/spu-server/Cargo.toml
@@ -13,6 +13,7 @@ doc = false
 [dependencies]
 log = "0.4.8"
 tracing = "0.1.19"
+tracing-futures = "0.2.4"
 bytes = "0.5.3"
 structopt = "0.3.5"
 toml = "0.5.5"

--- a/src/spu-server/Cargo.toml
+++ b/src/spu-server/Cargo.toml
@@ -27,7 +27,7 @@ pin-utils = "0.1.0-alpha.4"
 regex = "1.3.1"
 tokio = { version = "0.2.21", features = ["macros"] }
 flv-future-aio = { version = "2.2.1" }
-flv-util = { version = "0.2.0", path = "../../../flv-util" }
+flv-util = { version = "0.3.0", path = "../../../flv-util" }
 kf-protocol = { version = "2.0.0" } 
 flv-tls-proxy = "0.1.0"
 kf-socket = {path = "../kf-socket"}

--- a/src/spu-server/Cargo.toml
+++ b/src/spu-server/Cargo.toml
@@ -27,7 +27,7 @@ pin-utils = "0.1.0-alpha.4"
 regex = "1.3.1"
 tokio = { version = "0.2.21", features = ["macros"] }
 flv-future-aio = { version = "2.2.1" }
-flv-util = { version = "0.3.0", path = "../../../flv-util" }
+flv-util = { version = "0.3.0" }
 kf-protocol = { version = "2.0.0" } 
 flv-tls-proxy = "0.1.0"
 kf-socket = {path = "../kf-socket"}

--- a/src/spu-server/rust-toolchain
+++ b/src/spu-server/rust-toolchain
@@ -1,1 +1,1 @@
-../rust-toolchain
+../../rust-toolchain

--- a/src/spu-server/src/config/cli.rs
+++ b/src/spu-server/src/config/cli.rs
@@ -8,8 +8,8 @@ use std::io::Error as IoError;
 use std::process;
 use std::io::ErrorKind;
 
-use log::debug;
-use log::info;
+use tracing::debug;
+use tracing::info;
 use structopt::StructOpt;
 
 use flv_types::print_cli_err;

--- a/src/spu-server/src/controllers/follower_replica/follower_controller.rs
+++ b/src/spu-server/src/controllers/follower_replica/follower_controller.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use log::trace;
-use log::error;
-use log::debug;
+use tracing::trace;
+use tracing::error;
+use tracing::debug;
 
 use futures::channel::mpsc::Receiver;
 use futures::select;

--- a/src/spu-server/src/controllers/follower_replica/peer_api.rs
+++ b/src/spu-server/src/controllers/follower_replica/peer_api.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::bytes::Buf;
 use kf_protocol::Decoder;

--- a/src/spu-server/src/controllers/follower_replica/state.rs
+++ b/src/spu-server/src/controllers/follower_replica/state.rs
@@ -4,9 +4,9 @@ use std::fmt::Debug;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-use log::debug;
-use log::trace;
-use log::error;
+use tracing::debug;
+use tracing::trace;
+use tracing::error;
 use futures::channel::mpsc::Sender;
 use futures::channel::mpsc::Receiver;
 use futures::channel::mpsc::channel;

--- a/src/spu-server/src/controllers/follower_replica/sync.rs
+++ b/src/spu-server/src/controllers/follower_replica/sync.rs
@@ -5,7 +5,7 @@ use std::io::Error as IoError;
 use std::marker::PhantomData;
 
 use bytes::BytesMut;
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::Encoder;
 use kf_protocol::Decoder;

--- a/src/spu-server/src/controllers/leader_replica/connection.rs
+++ b/src/spu-server/src/controllers/leader_replica/connection.rs
@@ -1,7 +1,7 @@
-use log::trace;
-use log::error;
-use log::debug;
-use log::warn;
+use tracing::trace;
+use tracing::error;
+use tracing::debug;
+use tracing::warn;
 use kf_socket::KfSocketError;
 use kf_socket::KfStream;
 use kf_socket::KfSocket;

--- a/src/spu-server/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu-server/src/controllers/leader_replica/leader_controller.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::debug;
-use log::warn;
-use log::error;
+use tracing::debug;
+use tracing::warn;
+use tracing::error;
 use futures::channel::mpsc::Receiver;
 use futures::future::FutureExt;
 use futures::future::join3;

--- a/src/spu-server/src/controllers/leader_replica/leaders_state.rs
+++ b/src/spu-server/src/controllers/leader_replica/leaders_state.rs
@@ -6,10 +6,10 @@ use chashmap::WriteGuard;
 use futures::channel::mpsc::Sender;
 use futures::channel::mpsc::SendError;
 use futures::SinkExt;
-use log::debug;
-use log::warn;
-use log::trace;
-use log::error;
+use tracing::debug;
+use tracing::warn;
+use tracing::trace;
+use tracing::error;
 
 use flv_metadata_cluster::partition::ReplicaKey;
 use kf_protocol::api::RecordSet;

--- a/src/spu-server/src/controllers/leader_replica/peer_api.rs
+++ b/src/spu-server/src/controllers/leader_replica/peer_api.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::bytes::Buf;
 use kf_protocol::Decoder;

--- a/src/spu-server/src/controllers/leader_replica/replica_state.rs
+++ b/src/spu-server/src/controllers/leader_replica/replica_state.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use log::debug;
-use log::trace;
-use log::error;
-use log::warn;
+use tracing::debug;
+use tracing::trace;
+use tracing::error;
+use tracing::warn;
 
 use kf_socket::SinkPool;
 use kf_protocol::api::RecordSet;

--- a/src/spu-server/src/controllers/sc/dispatcher.rs
+++ b/src/spu-server/src/controllers/sc/dispatcher.rs
@@ -2,11 +2,11 @@ use std::time::Duration;
 use std::io::Error as IoError;
 use std::sync::Arc;
 
-use log::info;
-use log::trace;
-use log::error;
-use log::debug;
-use log::warn;
+use tracing::info;
+use tracing::trace;
+use tracing::error;
+use tracing::debug;
+use tracing::warn;
 use flv_util::print_cli_err;
 
 use futures::channel::mpsc::Receiver;

--- a/src/spu-server/src/core/store.rs
+++ b/src/spu-server/src/core/store.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use std::fmt::Display;
 use std::fmt::Debug;
 
-use log::trace;
-use log::debug;
-use log::error;
+use tracing::trace;
+use tracing::debug;
+use tracing::error;
 
 use flv_metadata_cluster::message::*;
 use kf_protocol::{Decoder, Encoder};

--- a/src/spu-server/src/core/store.rs
+++ b/src/spu-server/src/core/store.rs
@@ -9,6 +9,7 @@ use std::fmt::Debug;
 use tracing::trace;
 use tracing::debug;
 use tracing::error;
+use tracing::instrument;
 
 use flv_metadata_cluster::message::*;
 use kf_protocol::{Decoder, Encoder};
@@ -109,18 +110,25 @@ where
 {
     /// Sync with source of truth.
     /// Returns diff as Change
+    #[instrument(skip(self, source_specs), fields(spec = S::LABEL, command_count = source_specs.len()))]
     pub fn sync_all(&self, source_specs: Vec<S>) -> Actions<SpecChange<S>> {
         let (mut add_cnt, mut mod_cnt, mut del_cnt, mut skip_cnt) = (0, 0, 0, 0);
         let mut local_keys = self.all_keys();
         let mut actions = Actions::default();
 
-        debug!("apply all <{}> {} commands", S::LABEL, source_specs.len());
+        debug!("sync all");
+        // debug!(
+        //     spec_label = S::LABEL,
+        //     command_count = source_specs.len(),
+        //     "apply all commands"
+        // );
+
         for new_spu in source_specs {
             let id = new_spu.key_owned();
 
             if let Some(old_spu) = self.insert(new_spu.clone()) {
                 if old_spu == new_spu {
-                    trace!("no changes: {}", new_spu.key());
+                    trace!(spu_key = &*format!("{}", new_spu.key()), "no changes");
                 } else {
                     actions.push(SpecChange::Mod(new_spu, old_spu));
                     mod_cnt += 1;
@@ -144,21 +152,27 @@ where
         }
 
         trace!(
-            "Apply All <{}> Spec changes: [add:{}, mod:{}, del:{}, skip:{}]",
-            S::LABEL,
-            add_cnt,
-            mod_cnt,
-            del_cnt,
-            skip_cnt
+            spec_label = S::LABEL,
+            add_count = add_cnt,
+            mod_count = mod_cnt,
+            del_count = del_cnt,
+            skip_count = skip_cnt,
+            "Apply all spec changes",
         );
 
         actions
     }
 
     /// apply changes coming from sc which generates spec change actions
+    #[instrument(skip(self, changes), fields(spec = S::LABEL, change_count = changes.len()))]
     pub fn apply_changes(&self, changes: Vec<Message<S>>) -> Actions<SpecChange<S>> {
         let (mut add_cnt, mut mod_cnt, mut del_cnt, mut skip_cnt) = (0, 0, 0, 0);
-        debug!("apply update <{}> {} requests", S::LABEL, changes.len());
+        debug!("apply changes");
+        // debug!(
+        //     spec_label = S::LABEL,
+        //     change_count = changes.len(),
+        //     "apply changes"
+        // );
         let mut actions = Actions::default();
 
         for change in changes {
@@ -191,12 +205,12 @@ where
         }
 
         debug!(
-            "Apply <{}> Spec changes: [add:{}, mod:{}, del:{}, skip:{}]",
-            S::LABEL,
-            add_cnt,
-            mod_cnt,
-            del_cnt,
-            skip_cnt
+            spec_label = S::LABEL,
+            add_count = add_cnt,
+            mod_count = mod_cnt,
+            del_count = del_cnt,
+            skip_count = skip_cnt,
+            "Apply spec changes",
         );
 
         actions

--- a/src/spu-server/src/core/stream/fetch_stream.rs
+++ b/src/spu-server/src/core/stream/fetch_stream.rs
@@ -11,9 +11,9 @@ use chashmap::ReadGuard;
 use futures::future::TryFutureExt;
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
-use log::debug;
-use log::error;
-use log::trace;
+use tracing::debug;
+use tracing::error;
+use tracing::trace;
 
 use flv_types::SpuId;
 use flv_future_core::spawn;
@@ -183,7 +183,7 @@ mod test {
 
     use futures::future::FutureExt;
     use futures::stream::StreamExt;
-    use log::debug;
+    use tracing::debug;
 
     use flv_types::SpuId;
     use flv_future_aio::net::AsyncTcpListener;

--- a/src/spu-server/src/core/stream/leader_stream.rs
+++ b/src/spu-server/src/core/stream/leader_stream.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::collections::HashMap;
 
-use log::error;
-use log::debug;
+use tracing::error;
+use tracing::debug;
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
 use futures::future::TryFutureExt;

--- a/src/spu-server/src/main.rs
+++ b/src/spu-server/src/main.rs
@@ -1,7 +1,8 @@
 use structopt::StructOpt;
 
 fn main() {
-    flv_util::init_logger();
+    // flv_util::init_logger();
+    flv_util::init_tracer();
 
     let opt = flv_spu::SpuOpt::from_args();
     flv_spu::main_loop(opt);

--- a/src/spu-server/src/main.rs
+++ b/src/spu-server/src/main.rs
@@ -1,8 +1,7 @@
 use structopt::StructOpt;
 
 fn main() {
-    // flv_util::init_logger();
-    flv_util::init_tracer();
+    flv_util::init_tracer(None);
 
     let opt = flv_spu::SpuOpt::from_args();
     flv_spu::main_loop(opt);

--- a/src/spu-server/src/services/internal/api.rs
+++ b/src/spu-server/src/services/internal/api.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::bytes::Buf;
 use kf_protocol::Decoder;

--- a/src/spu-server/src/services/internal/fetch_stream.rs
+++ b/src/spu-server/src/services/internal/fetch_stream.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use tracing::debug;
 
 use kf_protocol::api::RequestMessage;
 use kf_socket::KfSocket;

--- a/src/spu-server/src/services/internal/mod.rs
+++ b/src/spu-server/src/services/internal/mod.rs
@@ -3,7 +3,7 @@ mod fetch_stream;
 mod service_impl;
 mod fetch_stream_request;
 
-use log::info;
+use tracing::info;
 
 use kf_service::KfApiServer;
 use service_impl::InternalService;

--- a/src/spu-server/src/services/internal/service_impl.rs
+++ b/src/spu-server/src/services/internal/service_impl.rs
@@ -14,6 +14,7 @@ use super::KfSPUPeerApiEnum;
 use super::fetch_stream::handle_fetch_stream_request;
 use crate::core::DefaultSharedGlobalContext;
 
+#[derive(Debug)]
 pub struct InternalService {}
 
 impl InternalService {

--- a/src/spu-server/src/services/public/api_versions.rs
+++ b/src/spu-server/src/services/public/api_versions.rs
@@ -1,5 +1,5 @@
 use std::io::Error;
-use log::debug;
+use tracing::debug;
 
 use kf_protocol::api::RequestMessage;
 use kf_protocol::api::ResponseMessage;

--- a/src/spu-server/src/services/public/cf_handler.rs
+++ b/src/spu-server/src/services/public/cf_handler.rs
@@ -1,7 +1,7 @@
-use log::debug;
-use log::trace;
-use log::warn;
-use log::error;
+use tracing::debug;
+use tracing::trace;
+use tracing::warn;
+use tracing::error;
 
 use futures::stream::StreamExt;
 use futures::io::AsyncRead;

--- a/src/spu-server/src/services/public/fetch_handler.rs
+++ b/src/spu-server/src/services/public/fetch_handler.rs
@@ -1,5 +1,5 @@
-use log::trace;
-use log::debug;
+use tracing::trace;
+use tracing::debug;
 use futures::io::AsyncRead;
 use futures::io::AsyncWrite;
 

--- a/src/spu-server/src/services/public/mod.rs
+++ b/src/spu-server/src/services/public/mod.rs
@@ -4,7 +4,7 @@ mod produce_handler;
 mod fetch_handler;
 mod offset_request;
 
-use log::info;
+use tracing::info;
 
 use kf_service::KfApiServer;
 use service_impl::PublicService;

--- a/src/spu-server/src/services/public/offset_request.rs
+++ b/src/spu-server/src/services/public/offset_request.rs
@@ -1,6 +1,6 @@
 use std::io::Error as IoError;
 
-use log::trace;
+use tracing::trace;
 
 use kf_protocol::api::RequestMessage;
 use kf_protocol::api::ResponseMessage;

--- a/src/spu-server/src/services/public/produce_handler.rs
+++ b/src/spu-server/src/services/public/produce_handler.rs
@@ -1,8 +1,8 @@
 use std::io::Error;
 
-use log::warn;
-use log::trace;
-use log::error;
+use tracing::warn;
+use tracing::trace;
+use tracing::error;
 
 use kf_protocol::api::ErrorCode;
 use kf_protocol::message::produce::DefaultKfProduceRequest;

--- a/src/spu-server/src/services/public/service_impl.rs
+++ b/src/spu-server/src/services/public/service_impl.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 use std::collections::HashSet;
 
-use log::debug;
-use log::trace;
-use log::warn;
+use tracing::debug;
+use tracing::trace;
+use tracing::warn;
 use async_trait::async_trait;
 use futures::io::AsyncRead;
 use futures::io::AsyncWrite;
@@ -152,11 +152,11 @@ where
 
                             }
                         } else {
-                            log::debug!("conn: {} msg can't be decoded, ending connection",sink.id());
+                            tracing::debug!("conn: {} msg can't be decoded, ending connection",sink.id());
                             break;
                         }
                     } else {
-                        log::debug!("conn: {}, no content, end of connection", sink.id());
+                        tracing::debug!("conn: {}, no content, end of connection", sink.id());
                         break;
                     }
 

--- a/src/spu-server/src/services/public/service_impl.rs
+++ b/src/spu-server/src/services/public/service_impl.rs
@@ -27,6 +27,7 @@ use super::fetch_handler::handle_fetch_request;
 use super::offset_request::handle_offset_request;
 use super::OffsetReplicaList;
 
+#[derive(Debug)]
 pub struct PublicService {}
 
 impl PublicService {

--- a/src/spu-server/src/start.rs
+++ b/src/spu-server/src/start.rs
@@ -72,7 +72,7 @@ mod proxy {
 
     use std::process;
 
-    use log::info;
+    use tracing::info;
 
     use flv_util::print_cli_err;
     use flv_future_aio::net::tls::TlsAcceptor;

--- a/src/spu-server/src/tests/fixture/mock_sc.rs
+++ b/src/spu-server/src/tests/fixture/mock_sc.rs
@@ -4,8 +4,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 
-use log::info;
-use log::debug;
+use tracing::info;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
 

--- a/src/spu-server/src/tests/fixture/spu_client.rs
+++ b/src/spu-server/src/tests/fixture/spu_client.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 use std::net::SocketAddr;
 
-use log::debug;
+use tracing::debug;
 use futures::channel::mpsc::Sender;
 
 use kf_socket::KfSocketError;

--- a/src/spu-server/src/tests/fixture/test_runner.rs
+++ b/src/spu-server/src/tests/fixture/test_runner.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use log::debug;
+use tracing::debug;
 use futures::SinkExt;
 use futures::future::join3;
 use futures::future::join_all;

--- a/src/spu-server/src/tests/suites/test_fetch.rs
+++ b/src/spu-server/src/tests/suites/test_fetch.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 

--- a/src/spu-server/src/tests/suites/test_replication.rs
+++ b/src/spu-server/src/tests/suites/test_replication.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use std::sync::Arc;
 
-use log::debug;
+use tracing::debug;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -12,7 +12,7 @@ required-features = ["cli"]
 
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1.19"
 libc = "0.2.58"
 bytes = "0.5.3"
 futures = { version = "0.3.4" }

--- a/src/storage/rust-toolchain
+++ b/src/storage/rust-toolchain
@@ -1,1 +1,1 @@
-../rust-toolchain
+../../rust-toolchain

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -8,8 +8,8 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 
-use log::trace;
-use log::debug;
+use tracing::trace;
+use tracing::debug;
 use futures::Future;
 use futures::FutureExt;
 use futures::Stream;

--- a/src/storage/src/checkpoint.rs
+++ b/src/storage/src/checkpoint.rs
@@ -9,8 +9,8 @@ use bytes::BufMut;
 use futures::io::AsyncReadExt;
 use futures::io::AsyncWriteExt;
 use futures::io::AsyncSeekExt;
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use flv_future_aio::fs::File;
 use flv_future_aio::fs::metadata;

--- a/src/storage/src/fixture.rs
+++ b/src/storage/src/fixture.rs
@@ -1,4 +1,4 @@
-use log::info;
+use tracing::info;
 use std::fs::File;
 use std::io;
 use std::io::Read;

--- a/src/storage/src/index.rs
+++ b/src/storage/src/index.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 use std::slice;
 
 use libc::c_void;
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 use pin_utils::unsafe_unpinned;
 
 use flv_future_aio::fs::MemoryMappedFile;

--- a/src/storage/src/mut_index.rs
+++ b/src/storage/src/mut_index.rs
@@ -7,9 +7,9 @@ use std::ops::DerefMut;
 use std::slice;
 
 use libc::c_void;
-use log::debug;
-use log::trace;
-use log::error;
+use tracing::debug;
+use tracing::trace;
+use tracing::error;
 
 use flv_future_aio::fs::File;
 use flv_future_aio::fs::MemoryMappedMutFile;

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -2,8 +2,8 @@ use std::io::Error as IoError;
 use std::path::PathBuf;
 use std::path::Path;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 use futures::io::AsyncWriteExt;
 
 use flv_future_aio::fs::File;

--- a/src/storage/src/range_map.rs
+++ b/src/storage/src/range_map.rs
@@ -5,9 +5,9 @@ use std::ops::Bound::Excluded;
 use std::ops::Bound::Included;
 use std::ffi::OsStr;
 
-use log::debug;
-use log::trace;
-use log::error;
+use tracing::debug;
+use tracing::trace;
+use tracing::error;
 
 use kf_protocol::api::Offset;
 

--- a/src/storage/src/records.rs
+++ b/src/storage/src/records.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::path::Path;
 
-use log::debug;
+use tracing::debug;
 
 use flv_future_aio::fs::File;
 use flv_future_aio::fs::util as file_util;

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -1,9 +1,9 @@
 use std::io::Error as IoError;
 use std::mem;
 
-use log::debug;
-use log::trace;
-use log::error;
+use tracing::debug;
+use tracing::trace;
+use tracing::error;
 
 use flv_future_aio::fs::create_dir_all;
 use kf_protocol::api::ErrorCode;
@@ -328,7 +328,7 @@ fn replica_dir_name<S: AsRef<str>>(topic_name: S, partition_index: Size) -> Stri
 #[cfg(test)]
 mod tests {
 
-    use log::debug;
+    use tracing::debug;
     use std::env::temp_dir;
     use std::fs;
     use std::fs::metadata;

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -3,8 +3,8 @@ use std::io::Error as IoError;
 use std::ops::Deref;
 
 use futures::stream::StreamExt;
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use kf_protocol::api::DefaultBatch;
 use kf_protocol::api::Offset;
@@ -360,7 +360,7 @@ fn compute_batch_record_size(batch: &DefaultBatch) -> usize {
 #[cfg(test)]
 mod tests {
 
-    use log::debug;
+    use tracing::debug;
     use std::env::temp_dir;
     use std::fs::metadata;
     use std::io::Cursor;

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::path::Path;
 
 use futures::stream::StreamExt;
-use log::warn;
-use log::trace;
+use tracing::warn;
+use tracing::trace;
 
 use kf_protocol::api::Offset;
 use flv_future_aio::fs::util as file_util;

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -3,7 +3,7 @@
 use std::env::temp_dir;
 use std::time::Duration;
 
-use log::debug;
+use tracing::debug;
 use futures::stream::StreamExt;
 use futures::future::join;
 

--- a/src/types/Cargo.toml
+++ b/src/types/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1.19"

--- a/src/types/src/macros.rs
+++ b/src/types/src/macros.rs
@@ -2,13 +2,13 @@
 macro_rules! log_on_err {
     ($x:expr) => {
         if let Err(err) = $x {
-            log::error!("{}", err);
+            tracing::error!("{}", err);
         }
     };
 
     ($x:expr,$msg:expr) => {
         if let Err(err) = $x {
-            log::error!($msg, err);
+            tracing::error!($msg, err);
         }
     };
 }
@@ -16,7 +16,7 @@ macro_rules! log_on_err {
 #[macro_export]
 macro_rules! log_actions {
     ($x1:expr, $x2:expr, $x3:expr, $x4:expr, $x5:expr, $x6:expr) => {
-        log::debug!(
+        tracing::debug!(
             "{:<20}: [add:{}, mod:{}, del:{}, skip:{}]",
             format!("{}({})", $x1, $x2),
             $x3,

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 fixture = []
 
 [dependencies]
+tracing = "0.1.19"
 regex = "1.3.1"
-log = "0.4.8"
 rand = "0.7.2"
 flv-types = { path ="../types", version = "0.2.0"}

--- a/src/utils/src/bin.rs
+++ b/src/utils/src/bin.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::process::Command;
 
-use log::debug;
+use tracing::debug;
 
 pub fn get_fluvio() -> Result<Command, IoError> {
     get_binary("fluvio")


### PR DESCRIPTION
As per #151, this PR adds support for tracing as a replacement for logging. Where possible, the dependency on the `log` crate has been removed when the `tracing` crate is added. The current exception is in crates where `flv-kf-protocol` `Decode` and `Encode` are used, as they add `log` callsites as part of their code expansion.

To get the most use out of `tracing`, use the [`#[tracing]` attribute](https://docs.rs/tracing-attributes/0.1.10/tracing_attributes/attr.instrument.html) on functions to capture relevant context.

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/4210949/90044855-3dea5e00-dc9c-11ea-99a5-99dbd45e47d5.png">

In this picture log output from SC is on top and SPU is on bottom. The bolded text is part of the context captured by `#[instrument]` attributes on functions. Text inside of the bolded `{ }` represent context that is captured by the spans created by the functions. The context forms a tree-shape around the function call stack, and is very useful for tracking things such as a client connection address, SPU ID, etc. All "log" calls (e.g. "info", "debug") that are made within a span are automatically annotated with the context of that span.

Below is an example instrumentation snippet:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/4210949/90045432-06c87c80-dc9d-11ea-966f-198aa704531f.png">
