### PR TITLE
Refactor TlsConfig

### DIFF
--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -287,11 +287,11 @@ pub fn install_sys(opt: InstallCommand) {
 async fn set_profile(opt: &InstallCommand) -> Result<(), IoError> {
     use crate::profile::set_k8_context;
     use crate::profile::SetK8;
-    use crate::tls::TlsConfig;
+    use crate::tls::TlsOpt;
 
     let tls_config = &opt.tls;
     let tls = if tls_config.tls {
-        TlsConfig {
+        TlsOpt {
             tls: true,
             domain: tls_config.domain.clone(),
             enable_client_cert: true,
@@ -301,7 +301,7 @@ async fn set_profile(opt: &InstallCommand) -> Result<(), IoError> {
             ..Default::default()
         }
     } else {
-        TlsConfig::default()
+        TlsOpt::default()
     };
 
     let config = SetK8 {

--- a/src/cli/src/cluster/install/local.rs
+++ b/src/cli/src/cluster/install/local.rs
@@ -94,11 +94,11 @@ fn launch_sc(option: &InstallCommand, log_dir: &str) {
 fn set_profile(opt: &InstallCommand) -> Result<(), IoError> {
     use crate::profile::SetLocal;
     use crate::profile::set_local_context;
-    use crate::tls::TlsConfig;
+    use crate::tls::TlsOpt;
 
     let tls_config = &opt.tls;
     let tls = if tls_config.tls {
-        TlsConfig {
+        TlsOpt {
             tls: true,
             domain: tls_config.domain.clone(),
             enable_client_cert: true,
@@ -108,7 +108,7 @@ fn set_profile(opt: &InstallCommand) -> Result<(), IoError> {
             ..Default::default()
         }
     } else {
-        TlsConfig::default()
+        TlsOpt::default()
     };
 
     let local = SetLocal {

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -11,6 +11,7 @@ use crate::Terminal;
 use crate::CliError;
 
 use super::util::*;
+use std::path::PathBuf;
 
 #[derive(Debug, StructOpt)]
 pub struct K8Install {
@@ -39,34 +40,34 @@ pub struct K8Install {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct TlsConfig {
+pub struct TlsOpt {
     /// tls
     #[structopt(long)]
     tls: bool,
 
     /// TLS: path to server certificate
-    #[structopt(long, required_if("tls", "true"))]
-    pub server_cert: Option<String>,
+    #[structopt(long, required_if("tls", "true"), parse(from_os_str))]
+    pub server_cert: Option<PathBuf>,
 
     /// TLS: path to server private key
-    #[structopt(long, required_if("tls", "true"))]
-    pub server_key: Option<String>,
+    #[structopt(long, required_if("tls", "true"), parse(from_os_str))]
+    pub server_key: Option<PathBuf>,
 
     /// TLS: domain
     #[structopt(long, required_if("tls", "true"))]
     pub domain: Option<String>,
 
     /// TLS: client cert
-    #[structopt(long, required_if("tls", "true"))]
-    pub client_cert: Option<String>,
+    #[structopt(long, required_if("tls", "true"), parse(from_os_str))]
+    pub client_cert: Option<PathBuf>,
 
     /// TLS: client key
-    #[structopt(long, required_if("tls", "true"))]
-    pub client_key: Option<String>,
+    #[structopt(long, required_if("tls", "true"), parse(from_os_str))]
+    pub client_key: Option<PathBuf>,
 
     /// TLS: ca cert
-    #[structopt(long, required_if("tls", "true"))]
-    pub ca_cert: Option<String>,
+    #[structopt(long, required_if("tls", "true"), parse(from_os_str))]
+    pub ca_cert: Option<PathBuf>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -99,7 +100,7 @@ pub struct InstallCommand {
     local: bool,
 
     #[structopt(flatten)]
-    tls: TlsConfig,
+    tls: TlsOpt,
 }
 
 pub async fn process_install<O>(

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -49,7 +49,7 @@ mod target {
     use structopt::StructOpt;
 
     use flv_client::ClusterConfig;
-    use crate::tls::TlsConfig;
+    use crate::tls::TlsOpt;
     use crate::CliError;
     use crate::profile::InlineProfile;
 
@@ -61,7 +61,7 @@ mod target {
         pub cluster: Option<String>,
 
         #[structopt(flatten)]
-        tls: TlsConfig,
+        tls: TlsOpt,
 
         #[structopt(flatten)]
         profile: InlineProfile,
@@ -70,7 +70,7 @@ mod target {
     impl ClusterTarget {
         /// try to create sc config
         pub fn load(self) -> Result<ClusterConfig, CliError> {
-            let tls = self.tls.try_into_file_config()?;
+            let tls = self.tls.try_into_inline()?;
             // check case when inline profile is used
             if let Some(profile) = self.profile.profile {
                 if self.cluster.is_some() {

--- a/src/cli/src/profile/cli.rs
+++ b/src/cli/src/profile/cli.rs
@@ -4,7 +4,7 @@
 //! CLI command for Profile operation
 //!
 
-use crate::tls::TlsConfig;
+use crate::tls::TlsOpt;
 use structopt::StructOpt;
 
 use flv_client::config::ConfigFile;
@@ -62,7 +62,7 @@ pub struct SetLocal {
     pub local: String,
 
     #[structopt(flatten)]
-    pub tls: TlsConfig,
+    pub tls: TlsOpt,
 }
 
 #[derive(Debug, StructOpt, Default)]
@@ -76,7 +76,7 @@ pub struct SetK8 {
     pub name: Option<String>,
 
     #[structopt(flatten)]
-    pub tls: TlsConfig,
+    pub tls: TlsOpt,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cli/src/tls/mod.rs
+++ b/src/cli/src/tls/mod.rs
@@ -1,15 +1,16 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::convert::TryInto;
 
 use tracing::debug;
 use structopt::StructOpt;
 
-use flv_client::config::TlsConfig as TlsProfileConfig;
-use flv_client::config::TlsClientConfig;
+use flv_client::config::{TlsConfig, TlsConfigPaths};
 
 /// Optional Tls Configuration to Client
 #[derive(Debug, StructOpt, Default)]
-pub struct TlsConfig {
+pub struct TlsOpt {
     /// Enable TLS
     #[structopt(long)]
     pub tls: bool,
@@ -18,104 +19,58 @@ pub struct TlsConfig {
     #[structopt(long, required_if("tls", "true"))]
     pub domain: Option<String>,
 
-    /// Path to TLS client certificate
-    #[structopt(long)]
-    pub client_cert: Option<String>,
-    #[structopt(long)]
-    /// Path to TLS client private key
-    pub client_key: Option<String>,
     /// TLS: use client cert
     #[structopt(long)]
     pub enable_client_cert: bool,
+    /// Path to TLS client certificate
+    #[structopt(long, parse(from_os_str))]
+    pub client_cert: Option<PathBuf>,
+    /// Path to TLS client private key
+    #[structopt(long, parse(from_os_str))]
+    pub client_key: Option<PathBuf>,
     /// Path to TLS ca cert, required when client cert is enabled
-    #[structopt(long)]
-    pub ca_cert: Option<String>,
+    #[structopt(long, parse(from_os_str))]
+    pub ca_cert: Option<PathBuf>,
 }
 
-impl TlsConfig {
-    pub fn try_into_file_config(self) -> Result<Option<TlsProfileConfig>, IoError> {
-        if self.tls {
-            debug!("using tls");
-            if self.enable_client_cert {
-                debug!("using client cert");
-                if self.client_cert.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "client cert is missing".to_owned(),
-                    ))
-                } else if self.client_key.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "client private key is missing".to_owned(),
-                    ))
-                } else if self.ca_cert.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "CA cert is missing".to_owned(),
-                    ))
-                } else if self.domain.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "domain is missing".to_owned(),
-                    ))
-                } else {
-                    Ok(Some(TlsProfileConfig::File(TlsClientConfig {
-                        client_cert: self.client_cert.unwrap(),
-                        client_key: self.client_key.unwrap(),
-                        ca_cert: self.ca_cert.unwrap(),
-                        domain: self.domain.unwrap(),
-                    })))
-                }
-            } else {
+impl TryInto<Option<TlsConfigPaths>> for TlsOpt {
+    type Error = IoError;
+
+    fn try_into(self) -> Result<Option<TlsConfigPaths>, Self::Error> {
+        match (self.client_cert, self.client_key, self.ca_cert, self.domain) {
+            _ if !self.tls => {
+                debug!("no optional tls");
+                Ok(None)
+            },
+            _ if !self.enable_client_cert => {
                 debug!("using no cert verification");
-                Ok(Some(TlsProfileConfig::NoVerification))
-            }
-        } else {
-            debug!("no optional tls");
-            Ok(None)
+                Ok(Some(TlsConfigPaths::NoVerification))
+            },
+            (Some(client_cert), Some(client_key), Some(ca_cert), Some(domain)) => {
+                debug!("using tls and client cert");
+                Ok(Some(TlsConfigPaths::WithPaths {
+                    client_cert,
+                    client_key,
+                    ca_cert,
+                    domain,
+                }))
+            },
+            (None, _, _, _) => Err(IoError::new(ErrorKind::InvalidInput, "client cert is missing".to_owned())),
+            (_, None, _, _) => Err(IoError::new(ErrorKind::InvalidInput, "client private key is missing".to_owned())),
+            (_, _, None, _) => Err(IoError::new(ErrorKind::InvalidInput, "CA cert is missing".to_owned())),
+            (_, _, _, None) => Err(IoError::new(ErrorKind::InvalidInput, "domain is missing".to_owned())),
         }
     }
+}
 
-    pub fn try_into_inline(self) -> Result<Option<TlsProfileConfig>, IoError> {
-        if self.tls {
-            debug!("using tls");
-            if self.enable_client_cert {
-                debug!("using client cert");
-                if self.client_cert.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "client cert is missing".to_owned(),
-                    ))
-                } else if self.client_key.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "client private key is missing".to_owned(),
-                    ))
-                } else if self.ca_cert.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "CA cert is missing".to_owned(),
-                    ))
-                } else if self.domain.is_none() {
-                    Err(IoError::new(
-                        ErrorKind::InvalidInput,
-                        "domain is missing".to_owned(),
-                    ))
-                } else {
-                    let mut config = TlsClientConfig::default();
-                    config.set_ca_cert_from(self.ca_cert.unwrap())?;
-                    config.set_client_cert_from(self.client_cert.unwrap())?;
-                    config.set_client_key_from(self.client_key.unwrap())?;
-                    config.domain = self.domain.unwrap();
-                    Ok(Some(TlsProfileConfig::Inline(config)))
-                }
-            } else {
-                debug!("using no cert verification");
-                Ok(Some(TlsProfileConfig::NoVerification))
-            }
-        } else {
-            debug!("no tls detected");
-            Ok(None)
-        }
+impl TlsOpt {
+
+    pub fn try_into_inline(self) -> Result<Option<TlsConfig>, IoError> {
+        let maybe_tls_paths: Option<TlsConfigPaths> = self.try_into()?;
+        let maybe_tls_config = match maybe_tls_paths {
+            None => None,
+            Some(tls_paths) => Some(tls_paths.try_into()?)
+        };
+        Ok(maybe_tls_config)
     }
 }

--- a/src/cli/src/tls/mod.rs
+++ b/src/cli/src/tls/mod.rs
@@ -41,11 +41,11 @@ impl TryInto<Option<TlsConfigPaths>> for TlsOpt {
             _ if !self.tls => {
                 debug!("no optional tls");
                 Ok(None)
-            },
+            }
             _ if !self.enable_client_cert => {
                 debug!("using no cert verification");
                 Ok(Some(TlsConfigPaths::NoVerification))
-            },
+            }
             (Some(client_cert), Some(client_key), Some(ca_cert), Some(domain)) => {
                 debug!("using tls and client cert");
                 Ok(Some(TlsConfigPaths::WithPaths {
@@ -54,22 +54,33 @@ impl TryInto<Option<TlsConfigPaths>> for TlsOpt {
                     ca_cert,
                     domain,
                 }))
-            },
-            (None, _, _, _) => Err(IoError::new(ErrorKind::InvalidInput, "client cert is missing".to_owned())),
-            (_, None, _, _) => Err(IoError::new(ErrorKind::InvalidInput, "client private key is missing".to_owned())),
-            (_, _, None, _) => Err(IoError::new(ErrorKind::InvalidInput, "CA cert is missing".to_owned())),
-            (_, _, _, None) => Err(IoError::new(ErrorKind::InvalidInput, "domain is missing".to_owned())),
+            }
+            (None, _, _, _) => Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "client cert is missing".to_owned(),
+            )),
+            (_, None, _, _) => Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "client private key is missing".to_owned(),
+            )),
+            (_, _, None, _) => Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "CA cert is missing".to_owned(),
+            )),
+            (_, _, _, None) => Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "domain is missing".to_owned(),
+            )),
         }
     }
 }
 
 impl TlsOpt {
-
     pub fn try_into_inline(self) -> Result<Option<TlsConfig>, IoError> {
         let maybe_tls_paths: Option<TlsConfigPaths> = self.try_into()?;
         let maybe_tls_config = match maybe_tls_paths {
             None => None,
-            Some(tls_paths) => Some(tls_paths.try_into()?)
+            Some(tls_paths) => Some(tls_paths.try_into()?),
         };
         Ok(maybe_tls_config)
     }

--- a/src/client-rs/src/config/config.rs
+++ b/src/client-rs/src/config/config.rs
@@ -324,12 +324,9 @@ impl From<Cluster> for ClientConfig {
 
 #[cfg(test)]
 pub mod test {
-
+    use super::*;
     use std::path::PathBuf;
     use std::env::temp_dir;
-
-    use super::*;
-    use super::super::TlsClientConfig;
 
     #[test]
     fn test_default_path_arg() {
@@ -383,7 +380,7 @@ pub mod test {
     #[test]
     fn test_tls_save() {
         let mut config = Config::new_with_local_cluster("localhost:9003".to_owned());
-        let inline_tls_config = TlsClientConfig {
+        let inline_tls_config = TlsConfig::WithCerts {
             client_key: "ABCDEFF".to_owned(),
             client_cert: "JJJJ".to_owned(),
             ca_cert: "XXXXX".to_owned(),
@@ -391,7 +388,7 @@ pub mod test {
         };
 
         println!("temp: {:#?}", temp_dir());
-        config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::Inline(inline_tls_config));
+        config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(inline_tls_config);
         config
             .save_to(temp_dir().join("inline.toml"))
             .expect("save should succeed");
@@ -399,18 +396,6 @@ pub mod test {
         config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::NoVerification);
         config
             .save_to(temp_dir().join("noverf.toml"))
-            .expect("save should succeed");
-
-        let file_tls_config = TlsClientConfig {
-            client_key: "/tmp/client.key".to_owned(),
-            client_cert: "/tmp/client.cert".to_owned(),
-            ca_cert: "/tmp/ca.cert".to_owned(),
-            domain: "my_domain".to_owned(),
-        };
-
-        config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::File(file_tls_config));
-        config
-            .save_to(temp_dir().join("file.toml"))
             .expect("save should succeed");
     }
 

--- a/src/client-rs/src/config/tls.rs
+++ b/src/client-rs/src/config/tls.rs
@@ -45,14 +45,17 @@ impl TryFrom<TlsConfigPaths> for TlsConfig {
         use std::fs::read;
         match value {
             TlsConfigPaths::NoVerification => Ok(Self::NoVerification),
-            TlsConfigPaths::WithPaths { client_key, client_cert, ca_cert, domain } => {
-                Ok(Self::WithCerts {
-                    client_key: encode(&read(client_key)?),
-                    client_cert: encode(&read(client_cert)?),
-                    ca_cert: encode(&read(ca_cert)?),
-                    domain,
-                })
-            }
+            TlsConfigPaths::WithPaths {
+                client_key,
+                client_cert,
+                ca_cert,
+                domain,
+            } => Ok(Self::WithCerts {
+                client_key: encode(&read(client_key)?),
+                client_cert: encode(&read(client_cert)?),
+                ca_cert: encode(&read(ca_cert)?),
+                domain,
+            }),
         }
     }
 }
@@ -76,7 +79,7 @@ pub enum TlsConfigPaths {
 
         /// Domain name
         domain: String,
-    }
+    },
 }
 
 impl TryFrom<TlsConfig> for AllDomainConnector {
@@ -92,8 +95,14 @@ impl TryFrom<TlsConfig> for AllDomainConnector {
                         .build()
                         .into(),
                 ))
-            },
-            TlsConfig::WithCerts { client_key, client_cert, ca_cert, domain, .. } => {
+            }
+            TlsConfig::WithCerts {
+                client_key,
+                client_cert,
+                ca_cert,
+                domain,
+                ..
+            } => {
                 info!("using inline cert");
                 let ca_cert = decode(ca_cert).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))

--- a/src/client-rs/src/config/tls.rs
+++ b/src/client-rs/src/config/tls.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::PathBuf;
 
 use tracing::info;
 use base64::decode;
@@ -16,14 +16,20 @@ use flv_future_aio::net::tls::ConnectorBuilder;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "cert_type", content = "cert")]
 pub enum TlsConfig {
-    /// only if server allow anonymous authentication
+    /// Do not use TLS. Server must allow anonymous authentication
     NoVerification,
 
-    /// Client certs from file path
-    File(TlsClientConfig),
-
-    // Client certs from inline data
-    Inline(TlsClientConfig),
+    /// TLS client config with inline keys and certs
+    WithCerts {
+        /// Client private key
+        client_key: String,
+        /// Client certificate
+        client_cert: String,
+        /// Certificate Authority cert
+        ca_cert: String,
+        /// Domain name
+        domain: String,
+    },
 }
 
 impl Default for TlsConfig {
@@ -32,48 +38,44 @@ impl Default for TlsConfig {
     }
 }
 
-/// client config generated from either path to string
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct TlsClientConfig {
-    /// private key or path
-    pub client_key: String,
+impl TryFrom<TlsConfigPaths> for TlsConfig {
+    type Error = IoError;
 
-    /// client key or path
-    pub client_cert: String,
-
-    /// ca cert or path
-    pub ca_cert: String,
-
-    pub domain: String,
+    fn try_from(value: TlsConfigPaths) -> Result<Self, Self::Error> {
+        use std::fs::read;
+        match value {
+            TlsConfigPaths::NoVerification => Ok(Self::NoVerification),
+            TlsConfigPaths::WithPaths { client_key, client_cert, ca_cert, domain } => {
+                Ok(Self::WithCerts {
+                    client_key: encode(&read(client_key)?),
+                    client_cert: encode(&read(client_cert)?),
+                    ca_cert: encode(&read(ca_cert)?),
+                    domain,
+                })
+            }
+        }
+    }
 }
 
-impl TlsClientConfig {
-    /// set ca cert data from external certificate
-    pub fn set_ca_cert_from<P: AsRef<Path>>(&mut self, path: P) -> Result<(), IoError> {
-        self.set_ca_cert(&read_from_file(path)?);
-        Ok(())
-    }
+/// TLS client config with paths to keys and certs
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum TlsConfigPaths {
+    /// Do not use TLS. Server must allow anonymous authentication
+    NoVerification,
 
-    pub fn set_ca_cert(&mut self, cert: &Vec<u8>) {
-        self.ca_cert = encode(cert);
-    }
+    /// Paths to TLS client configs
+    WithPaths {
+        /// Path to client private key
+        client_key: PathBuf,
 
-    pub fn set_client_cert_from<P: AsRef<Path>>(&mut self, path: P) -> Result<(), IoError> {
-        self.set_client_cert(&read_from_file(path)?);
-        Ok(())
-    }
+        /// Path to client certificate
+        client_cert: PathBuf,
 
-    pub fn set_client_cert(&mut self, cert: &Vec<u8>) {
-        self.client_cert = encode(cert);
-    }
+        /// Path to Certificate Authority certificate
+        ca_cert: PathBuf,
 
-    pub fn set_client_key_from<P: AsRef<Path>>(&mut self, path: P) -> Result<(), IoError> {
-        self.set_client_key(&read_from_file(path)?);
-        Ok(())
-    }
-
-    pub fn set_client_key(&mut self, key: &Vec<u8>) {
-        self.client_key = encode(key);
+        /// Domain name
+        domain: String,
     }
 }
 
@@ -90,26 +92,16 @@ impl TryFrom<TlsConfig> for AllDomainConnector {
                         .build()
                         .into(),
                 ))
-            }
-            TlsConfig::File(file_config) => {
-                info!("using client cert");
-                Ok(AllDomainConnector::TlsDomain(TlsDomainConnector::new(
-                    ConnectorBuilder::new()
-                        .load_client_certs(file_config.client_cert, file_config.client_key)?
-                        .load_ca_cert(file_config.ca_cert)?
-                        .build(),
-                    file_config.domain,
-                )))
-            }
-            TlsConfig::Inline(inline_config) => {
+            },
+            TlsConfig::WithCerts { client_key, client_cert, ca_cert, domain, .. } => {
                 info!("using inline cert");
-                let ca_cert = decode(inline_config.ca_cert).map_err(|err| {
+                let ca_cert = decode(ca_cert).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
-                let client_key = decode(inline_config.client_key).map_err(|err| {
+                let client_key = decode(client_key).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
-                let client_cert = decode(inline_config.client_cert).map_err(|err| {
+                let client_cert = decode(client_cert).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
 
@@ -118,21 +110,9 @@ impl TryFrom<TlsConfig> for AllDomainConnector {
                         .load_client_certs_from_bytes(&client_cert, &client_key)?
                         .load_ca_cert_from_bytes(&ca_cert)?
                         .build(),
-                    inline_config.domain,
+                    domain,
                 )))
             }
         }
     }
-}
-
-/// set ca cert data from external certificate
-fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, IoError> {
-    use std::fs::File;
-    use std::io::Read;
-
-    let mut file = File::open(path)?;
-    let mut buffer = vec![];
-    file.read_to_end(&mut buffer)?;
-
-    Ok(buffer)
 }


### PR DESCRIPTION
As I was reading through the codebase getting ready for the profiles work, I noticed that there was a lot of inconsistency regarding `TlsConfig`s, including many repeated definitions and representations. I took some time to try to organize it a little bit better. Here are some of the major points:

* Renamed all instances of `TlsConfig` in the `cli` crate to `TlsOpt` in order to avoid naming confusion
* Separated `TlsConfig` enum from `client-rs` (with variants `NoVerification`, `File`, and `Inline`) into two separate enums:
  * `TlsConfig` enum with variants `NoVerification` and `WithCerts` is the "most canonical" representation of a TlsConfig, where the `WithCerts` variant carries the inline certs.
  * `TlsConfigPaths` enum with variants `NoVerification` and `WithPaths` is one step removed from `TlsConfig`. You can convert a `TlsConfigPaths` into `TlsConfig` using the `try_into` implementation (which may fail with `IoError` if the files cannot all be read)
* In the `cli` modules where a `TlsOpt` appears, certificate path field types were changed from `String` to `PathBuf`. StructOpt will automatically parse `PathBuf` and perform path validation at parse-time. (Also, when generating shell completions, it will recommend files)
* `TlsOpt` implements `TryInto<Option<TlsConfigPaths>>`

The goal of a lot of the conversions is to make a one-way flow for dealing with the configs. So `TlsOpt` -> `TlsConfigPaths` -> `TlsConfig`, where each step along the way performs more validation.