### PR TITLE
expose k8_ws_service in event-stream-k8

### DIFF
--- a/src/event-stream-k8/src/dispatcher/k8_ws_service.rs
+++ b/src/event-stream-k8/src/dispatcher/k8_ws_service.rs
@@ -46,7 +46,7 @@ where
     }
 
     /// add/update
-    async fn apply(
+    pub async fn apply(
         &self,
         value: MetadataStoreObject<S, K8MetaItem>,
     ) -> Result<(), C::MetadataClientError>
@@ -83,7 +83,7 @@ where {
     }
 
     /// only update the status
-    async fn update_status(
+    pub async fn update_status(
         &self,
         metadata: K8MetaItem,
         status: S::Status,
@@ -111,7 +111,7 @@ where {
     }
 
     /// update spec only
-    async fn update_spec(
+    pub async fn update_spec(
         &self,
         metadata: K8MetaItem,
         spec: S,
@@ -135,7 +135,7 @@ where {
         self.client.apply(k8_input).await.map(|_| ())
     }
 
-    async fn delete(&self, meta: K8MetaItem) -> Result<(), C::MetadataClientError> {
+    pub async fn delete(&self, meta: K8MetaItem) -> Result<(), C::MetadataClientError> {
         self.client
             .delete_item::<S::K8Spec, _>(&meta)
             .await

--- a/src/event-stream-k8/src/dispatcher/mod.rs
+++ b/src/event-stream-k8/src/dispatcher/mod.rs
@@ -2,7 +2,7 @@ mod k8_dispatcher;
 mod k8_ws_service;
 
 pub use k8_dispatcher::*;
-use k8_ws_service::*;
+pub use k8_ws_service::*;
 
 mod k8_actions {
 


### PR DESCRIPTION
Allow create/update spec and status directly without going thru dispatcher.