### PR TITLE
Refactor ClusterConfig and ClusterClient

### DIFF
--- a/src/cli/src/consume/mod.rs
+++ b/src/cli/src/consume/mod.rs
@@ -21,6 +21,7 @@ mod process {
 
     use super::ConsumeLogOpt;
     use super::fetch_log_loop;
+    use fluvio::ClusterClient;
 
     /// Process Consume log cli request
     pub async fn process_consume_log<O>(
@@ -37,7 +38,7 @@ mod process {
         debug!("spu  leader consume config: {:#?}", cfg);
 
         let replica: ReplicaKey = (cfg.topic.clone(), cfg.partition).into();
-        let mut target = target_server.connect().await?;
+        let mut target = ClusterClient::connect(target_server).await?;
         let consumer = target.consumer(replica).await?;
         fetch_log_loop(out, consumer, cfg).await?;
 

--- a/src/cli/src/custom/list.rs
+++ b/src/cli/src/custom/list.rs
@@ -5,7 +5,7 @@
 //!
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::spu::CustomSpuSpec;
 use fluvio::metadata::spu::SpuSpec;
 use fluvio::metadata::objects::Metadata;
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output_type) = opt.validate()?;
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     let custom_spus = admin.list::<CustomSpuSpec, _>(vec![]).await?;

--- a/src/cli/src/custom/register.rs
+++ b/src/cli/src/custom/register.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 use structopt::StructOpt;
 
 use flv_util::socket_helpers::ServerAddress;
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::spu::CustomSpuSpec;
 
 use crate::error::CliError;
@@ -68,7 +68,7 @@ impl RegisterCustomSpuOpt {
 pub async fn process_register_custom_spu(opt: RegisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, (name, spec)) = opt.validate()?;
 
-    let mut sc = target_server.connect().await?;
+    let mut sc = ClusterClient::connect(target_server).await?;
 
     let mut admin = sc.admin().await;
 

--- a/src/cli/src/custom/unregister.rs
+++ b/src/cli/src/custom/unregister.rs
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 
 use fluvio::metadata::spu::CustomSpuSpec;
 use fluvio::metadata::spu::CustomSpuKey;
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 
 use crate::target::ClusterTarget;
 use crate::error::CliError;
@@ -68,7 +68,7 @@ impl UnregisterCustomSpuOpt {
 pub async fn process_unregister_custom_spu(opt: UnregisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, delete_key) = opt.validate()?;
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     admin.delete::<CustomSpuSpec, _>(delete_key).await?;

--- a/src/cli/src/group/create.rs
+++ b/src/cli/src/group/create.rs
@@ -7,7 +7,7 @@
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::spg::*;
 
 use crate::error::CliError;
@@ -82,7 +82,7 @@ pub async fn process_create_managed_spu_group(
 
     debug!("creating spg: {}, spec: {:#?}", name, spec);
 
-    let mut target = target_server.connect().await?;
+    let mut target = ClusterClient::connect(target_server).await?;
 
     let mut admin = target.admin().await;
 

--- a/src/cli/src/group/delete.rs
+++ b/src/cli/src/group/delete.rs
@@ -5,7 +5,7 @@
 //!
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::spg::SpuGroupSpec;
 use crate::error::CliError;
 use crate::target::ClusterTarget;
@@ -43,7 +43,7 @@ pub async fn process_delete_managed_spu_group(
 ) -> Result<(), CliError> {
     let (target_server, name) = opt.validate()?;
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<SpuGroupSpec, _>(&name).await?;
     Ok(())

--- a/src/cli/src/group/list.rs
+++ b/src/cli/src/group/list.rs
@@ -5,7 +5,7 @@
 
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use flv_metadata_cluster::spg::SpuGroupSpec;
 
 use crate::output::OutputType;
@@ -39,7 +39,7 @@ pub async fn process_list_managed_spu_groups<O: Terminal>(
 ) -> Result<(), CliError> {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     let lists = admin.list::<SpuGroupSpec, _>(vec![]).await?;

--- a/src/cli/src/partition/list.rs
+++ b/src/cli/src/partition/list.rs
@@ -7,6 +7,7 @@
 use structopt::StructOpt;
 
 use fluvio::ClusterConfig;
+use fluvio::ClusterClient;
 use flv_metadata_cluster::partition::*;
 
 use crate::error::CliError;
@@ -40,7 +41,7 @@ impl ListPartitionOpt {
     {
         let (target_server, output) = self.validate()?;
 
-        let mut client = target_server.connect().await?;
+        let mut client = ClusterClient::connect(target_server).await?;
         let mut admin = client.admin().await;
 
         let spus = admin.list::<PartitionSpec, _>(vec![]).await?;

--- a/src/cli/src/produce/mod.rs
+++ b/src/cli/src/produce/mod.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 
 use crate::target::ClusterTarget;
 use crate::CliError;
@@ -106,7 +106,7 @@ where
 
     let (target_server, (cfg, file_records)) = opt.validate()?;
 
-    let mut target = target_server.connect().await?;
+    let mut target = ClusterClient::connect(target_server).await?;
 
     let replica: ReplicaKey = (cfg.topic.clone(), cfg.partition).into();
     let producer = target.producer(replica).await?;

--- a/src/cli/src/profile/context.rs
+++ b/src/cli/src/profile/context.rs
@@ -14,20 +14,20 @@ pub fn set_local_context(local_config: LocalOpt) -> Result<String, IoError> {
     let config = config_file.mut_config();
 
     // check if local cluster exists otherwise, create new one
-    match config.mut_cluster(LOCAL_PROFILE) {
+    match config.cluster_mut(LOCAL_PROFILE) {
         Some(cluster) => {
             cluster.addr = local_addr.clone();
             cluster.tls = local_config.tls.try_into_inline()?;
         }
         None => {
-            let mut local_cluster = Cluster::new(local_addr.clone());
+            let mut local_cluster = ClusterConfig::new(local_addr.clone());
             local_cluster.tls = local_config.tls.try_into_inline()?;
             config.add_cluster(local_cluster, LOCAL_PROFILE.to_owned());
         }
     };
 
     // check if we local profile exits otherwise, create new one, then set it's cluster
-    match config.mut_profile(LOCAL_PROFILE) {
+    match config.profile_mut(LOCAL_PROFILE) {
         Some(profile) => {
             profile.set_cluster(LOCAL_PROFILE.to_owned());
         }

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -37,20 +37,20 @@ pub async fn set_k8_context(opt: K8Opt, external_addr: String) -> Result<Profile
         compute_profile_name()?
     };
 
-    match config.mut_cluster(&profile_name) {
+    match config.cluster_mut(&profile_name) {
         Some(cluster) => {
-            cluster.set_addr(external_addr);
+            cluster.addr = external_addr;
             cluster.tls = opt.tls.try_into_inline()?;
         }
         None => {
-            let mut local_cluster = Cluster::new(external_addr);
+            let mut local_cluster = ClusterConfig::new(external_addr);
             local_cluster.tls = opt.tls.try_into_inline()?;
             config.add_cluster(local_cluster, profile_name.clone());
         }
     };
 
     // check if we local profile exits otherwise, create new one, then set name as cluster
-    let new_profile = match config.mut_profile(&profile_name) {
+    let new_profile = match config.profile_mut(&profile_name) {
         Some(profile) => {
             profile.set_cluster(profile_name.clone());
             profile.clone()

--- a/src/cli/src/profile/sync/cloud/login_agent.rs
+++ b/src/cli/src/profile/sync/cloud/login_agent.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
 use http_types::{Response, Request, StatusCode, Error as HttpError, Url};
 
-use fluvio::config::Cluster;
+use fluvio::ClusterConfig;
 use flv_types::defaults::CLI_CONFIG_PATH;
-use super::http::execute;
 use url::ParseError;
+use super::http::execute;
 
 const DEFAULT_AGENT_REMOTE: &str = "https://cloud.fluvio.io";
 
@@ -87,7 +87,7 @@ impl LoginAgent {
     ///
     /// Will fail if there is no saved session, or if the token
     /// in the saved session is expired.
-    pub async fn download_profile(&mut self) -> Result<Cluster, CloudError> {
+    pub async fn download_profile(&mut self) -> Result<ClusterConfig, CloudError> {
         // Check whether we have credentials in session or on disk
         let creds = match self.session.as_ref() {
             // First, try to get the token from the agent session
@@ -115,7 +115,7 @@ impl LoginAgent {
             path = "/api/v1/downloadProfile"
         )
     )]
-    async fn try_download_profile(&self, creds: &Credentials) -> Result<Cluster, CloudError> {
+    async fn try_download_profile(&self, creds: &Credentials) -> Result<ClusterConfig, CloudError> {
         let mut response = download_profile(&self.remote, creds).await?;
         trace!("Response: {:#?}", &response);
         debug!(status = response.status() as u16);
@@ -123,7 +123,7 @@ impl LoginAgent {
         match response.status() {
             StatusCode::Ok => {
                 debug!("Successfully authenticated with token");
-                let cluster: Cluster = response.body_json().await?;
+                let cluster: ClusterConfig = response.body_json().await?;
                 Ok(cluster)
             }
             _ => {

--- a/src/cli/src/profile/sync/cloud/mod.rs
+++ b/src/cli/src/profile/sync/cloud/mod.rs
@@ -12,7 +12,7 @@ use crate::Terminal;
 use crate::CliError;
 use crate::t_print;
 use crate::profile::sync::cloud::login_agent::LoginAgent;
-use fluvio::config::{Cluster, ConfigFile, Profile};
+use fluvio::config::{ClusterConfig, ConfigFile, Profile};
 
 #[derive(Debug, StructOpt)]
 pub struct CloudOpt {
@@ -79,7 +79,7 @@ where
 
 fn save_cluster<O: Terminal>(
     _out: std::sync::Arc<O>,
-    cluster: Cluster,
+    cluster: ClusterConfig,
 ) -> Result<String, CliError> {
     let mut config_file = ConfigFile::load_default_or_new()?;
     let config = config_file.mut_config();

--- a/src/cli/src/spu/list.rs
+++ b/src/cli/src/spu/list.rs
@@ -6,7 +6,7 @@
 
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use flv_metadata_cluster::spu::SpuSpec;
 
 use crate::error::CliError;
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     let spus = admin.list::<SpuSpec, _>(vec![]).await?;

--- a/src/cli/src/topic/create.rs
+++ b/src/cli/src/topic/create.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::error::CliError;
@@ -118,7 +118,7 @@ pub async fn process_create_topic(opt: CreateTopicOpt) -> Result<String, CliErro
 
     debug!("creating topic: {} spec: {:#?}", name, topic_spec);
 
-    let mut target = target_server.connect().await?;
+    let mut target = ClusterClient::connect(target_server).await?;
     let mut admin = target.admin().await;
 
     admin.create(name.clone(), dry_run, topic_spec).await?;

--- a/src/cli/src/topic/delete.rs
+++ b/src/cli/src/topic/delete.rs
@@ -11,6 +11,7 @@ use fluvio::config::ClusterConfig;
 use fluvio::metadata::topic::TopicSpec;
 use crate::error::CliError;
 use crate::target::ClusterTarget;
+use fluvio::ClusterClient;
 
 #[derive(Debug, StructOpt)]
 pub struct DeleteTopicOpt {
@@ -41,7 +42,7 @@ pub async fn process_delete_topic(opt: DeleteTopicOpt) -> Result<String, CliErro
 
     debug!("deleting topic: {}", name);
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<TopicSpec, _>(&name).await?;
     Ok(format!("topic \"{}\" deleted", name))

--- a/src/cli/src/topic/describe.rs
+++ b/src/cli/src/topic/describe.rs
@@ -7,7 +7,7 @@
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
+use fluvio::{ClusterConfig, ClusterClient};
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::target::ClusterTarget;
@@ -63,7 +63,7 @@ where
 
     debug!("describe topic: {}, {}", topic, output_type);
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![topic]).await?;

--- a/src/cli/src/topic/list.rs
+++ b/src/cli/src/topic/list.rs
@@ -8,6 +8,7 @@ use structopt::StructOpt;
 
 use tracing::debug;
 
+use fluvio::ClusterClient;
 use fluvio::ClusterConfig;
 use fluvio::metadata::topic::TopicSpec;
 
@@ -66,7 +67,7 @@ where
 
     debug!("list topics {:#?} ", output_type);
 
-    let mut client = target_server.connect().await?;
+    let mut client = ClusterClient::connect(target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![]).await?;

--- a/src/client-rs/src/client/client.rs
+++ b/src/client-rs/src/client/client.rs
@@ -138,9 +138,9 @@ impl From<String> for ClientConfig {
 }
 
 impl ClientConfig {
-    pub fn new(addr: String, connector: AllDomainConnector) -> Self {
+    pub fn new<S: Into<String>>(addr: S, connector: AllDomainConnector) -> Self {
         Self {
-            addr,
+            addr: addr.into(),
             client_id: "fluvio".to_owned(),
             connector,
         }

--- a/src/client-rs/src/config/cluster.rs
+++ b/src/client-rs/src/config/cluster.rs
@@ -9,14 +9,12 @@ use super::tls::TlsConfig;
 
 /// Public configuration for the cluster.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ClusterConfig {
     // TODO use a validated address type.
     // We don't want to have a "" address.
     pub addr: String,
     pub tls: Option<TlsConfig>,
-    // Prevent exhaustive destructuring
-    #[serde(skip)]
-    _0: (),
 }
 
 impl ClusterConfig {
@@ -25,7 +23,6 @@ impl ClusterConfig {
         Self {
             addr: addr.into(),
             tls: None,
-            _0: (),
         }
     }
 

--- a/src/client-rs/src/config/cluster.rs
+++ b/src/client-rs/src/config/cluster.rs
@@ -3,63 +3,35 @@
 //!
 //! Stores configuration parameter retrieved from the default or custom profile file.
 //!
-use std::io::Error as IoError;
-use std::io::ErrorKind;
-use std::convert::TryFrom;
+use serde::{Serialize, Deserialize};
 
-use tracing::debug;
-
-use flv_future_aio::net::tls::AllDomainConnector;
-
-use crate::client::*;
-use crate::ClientError;
-
-use super::config::ConfigFile;
 use super::tls::TlsConfig;
 
-/// public configuration for the cluster
+/// Public configuration for the cluster.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClusterConfig {
-    addr: String,
-    tls: Option<TlsConfig>,
+    // TODO use a validated address type.
+    // We don't want to have a "" address.
+    pub addr: String,
+    pub tls: Option<TlsConfig>,
+    // Prevent exhaustive destructuring
+    #[serde(skip)]
+    _0: (),
 }
 
 impl ClusterConfig {
-    /// create cluster configuration if addr and tls are known
-    pub fn new<S: Into<String>>(addr: S, tls: Option<TlsConfig>) -> Self {
+    /// Create a new cluster configuration with no TLS.
+    pub fn new<S: Into<String>>(addr: S) -> Self {
         Self {
             addr: addr.into(),
-            tls,
+            tls: None,
+            _0: (),
         }
     }
 
-    /// look up cluster configuration from profile
-    pub fn lookup_profile(profile: Option<String>) -> Result<Self, ClientError> {
-        // load with default path
-        let config_file = ConfigFile::load(None)?;
-        if let Some(cluster) = config_file
-            .config()
-            .current_cluster_or_with_profile(profile.as_ref().map(|p| p.as_ref()))
-        {
-            debug!("looking up using profile: cluster addr {}", cluster.addr);
-            Ok(Self {
-                addr: cluster.addr().to_owned(),
-                tls: cluster.tls.clone(),
-            })
-        } else {
-            Err(IoError::new(ErrorKind::Other, "no matched cluster found").into())
-        }
-    }
-
-    pub async fn connect(self) -> Result<ClusterClient, ClientError> {
-        let connector = match self.tls {
-            None => AllDomainConnector::default_tcp(),
-            Some(tls) => TryFrom::try_from(tls)?,
-        };
-        let config = ClientConfig::new(self.addr, connector);
-        let inner_client = config.connect().await?;
-        debug!("connected to cluster at: {}", inner_client.config().addr());
-        let cluster = ClusterClient::new(inner_client);
-        //cluster.start_metadata_watch().await?;
-        Ok(cluster)
+    /// Add TLS configuration for this cluster.
+    pub fn with_tls(mut self, tls: TlsConfig) -> Self {
+        self.tls = Some(tls);
+        self
     }
 }

--- a/src/client-rs/src/config/config.rs
+++ b/src/client-rs/src/config/config.rs
@@ -19,11 +19,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use flv_types::defaults::{CLI_CONFIG_PATH};
-use flv_future_aio::net::tls::AllDomainConnector;
-
-use crate::client::*;
-use crate::ClientError;
-use super::TlsConfig;
+use crate::{ClientError, ClusterConfig};
 
 pub struct ConfigFile {
     path: PathBuf,
@@ -96,10 +92,12 @@ impl ConfigFile {
         })
     }
 
+    /// Return a reference to the internal Config
     pub fn config(&self) -> &Config {
         &self.config
     }
 
+    /// Return a mutable reference to the internal Config
     pub fn mut_config(&mut self) -> &mut Config {
         &mut self.config
     }
@@ -119,7 +117,7 @@ pub struct Config {
     version: String,
     current_profile: Option<String>,
     profile: HashMap<String, Profile>,
-    cluster: HashMap<String, Cluster>,
+    cluster: HashMap<String, ClusterConfig>,
     client_id: Option<String>,
 }
 
@@ -133,7 +131,7 @@ impl Config {
 
     /// create new config with a single local cluster
     pub fn new_with_local_cluster(domain: String) -> Self {
-        let cluster = Cluster::new(domain);
+        let cluster = ClusterConfig::new(domain);
         let mut config = Self::new();
 
         config.cluster.insert(LOCAL_PROFILE.to_owned(), cluster);
@@ -146,7 +144,7 @@ impl Config {
     }
 
     /// add new cluster
-    pub fn add_cluster(&mut self, cluster: Cluster, name: String) {
+    pub fn add_cluster(&mut self, cluster: ClusterConfig, name: String) {
         self.cluster.insert(name, cluster);
     }
 
@@ -172,12 +170,6 @@ impl Config {
     /// current profile
     pub fn current_profile_name(&self) -> Option<&str> {
         self.current_profile.as_ref().map(|c| c.as_ref())
-    }
-
-    pub fn current_profile(&self) -> Option<&Profile> {
-        self.current_profile
-            .as_ref()
-            .and_then(|p| self.profile.get(p))
     }
 
     /// set current profile, if profile doesn't exists return false
@@ -215,9 +207,9 @@ impl Config {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::config::{Config, Cluster, Profile};
+    /// # use fluvio::config::{Config, ClusterConfig, Profile};
     /// let mut config = Config::new();
-    /// let cluster = Cluster::new("https://cloud.fluvio.io".to_string());
+    /// let cluster = ClusterConfig::new("https://cloud.fluvio.io".to_string());
     /// config.add_cluster(cluster, "fluvio-cloud".to_string());
     /// let profile = Profile::new("fluvio-cloud".to_string());
     /// config.add_profile(profile, "fluvio-cloud".to_string());
@@ -225,7 +217,7 @@ impl Config {
     /// config.delete_cluster("fluvio-cloud").unwrap();
     /// assert!(config.cluster("fluvio-cloud").is_none());
     /// ```
-    pub fn delete_cluster(&mut self, cluster_name: &str) -> Option<Cluster> {
+    pub fn delete_cluster(&mut self, cluster_name: &str) -> Option<ClusterConfig> {
         self.cluster.remove(cluster_name)
     }
 
@@ -241,9 +233,9 @@ impl Config {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::config::{Config, Cluster, Profile};
+    /// # use fluvio::config::{Config, ClusterConfig, Profile};
     /// let mut config = Config::new();
-    /// let cluster = Cluster::new("https://cloud.fluvio.io".to_string());
+    /// let cluster = ClusterConfig::new("https://cloud.fluvio.io".to_string());
     /// config.add_cluster(cluster, "fluvio-cloud".to_string());
     /// let profile = Profile::new("fluvio-cloud".to_string());
     /// config.add_profile(profile, "fluvio-cloud".to_string());
@@ -267,34 +259,37 @@ impl Config {
         Ok(())
     }
 
-    pub fn mut_profile(&mut self, profile_name: &str) -> Option<&mut Profile> {
+    /// Returns a reference to the current Profile if there is one.
+    pub fn current_profile(&self) -> Option<&Profile> {
+        self.current_profile
+            .as_ref()
+            .and_then(|p| self.profile.get(p))
+    }
+
+    /// Returns a mutable reference to the current Profile if there is one.
+    pub fn profile_mut(&mut self, profile_name: &str) -> Option<&mut Profile> {
         self.profile.get_mut(profile_name)
     }
 
-    /// find cluster specified in the profile or current cluster
-    pub fn current_cluster_or_with_profile(&self, profile_name: Option<&str>) -> Option<&Cluster> {
-        if let Some(profile) = profile_name {
-            if let Some(profile_info) = self.profile.get(profile) {
-                self.cluster.get(&profile_info.cluster)
-            } else {
-                None
-            }
-        } else {
-            self.current_cluster()
-        }
-    }
-
-    /// find current cluster
-    pub fn current_cluster(&self) -> Option<&Cluster> {
+    /// Returns the ClusterConfig belonging to the current profile.
+    pub fn current_cluster(&self) -> Option<&ClusterConfig> {
         self.current_profile()
             .and_then(|profile| self.cluster.get(&profile.cluster))
     }
 
-    pub fn cluster(&self, cluster_name: &str) -> Option<&Cluster> {
+    /// Returns the ClusterConfig belonging to the named profile.
+    pub fn cluster_with_profile(&self, profile_name: &str) -> Option<&ClusterConfig> {
+        self.profile.get(profile_name)
+            .and_then(|profile| self.cluster.get(&profile.cluster))
+    }
+
+    /// Returns a reference to the named ClusterConfig.
+    pub fn cluster(&self, cluster_name: &str) -> Option<&ClusterConfig> {
         self.cluster.get(cluster_name)
     }
 
-    pub fn mut_cluster(&mut self, cluster_name: &str) -> Option<&mut Cluster> {
+    /// Returns a mutable reference to the named ClusterConfig.
+    pub fn cluster_mut(&mut self, cluster_name: &str) -> Option<&mut ClusterConfig> {
         self.cluster.get_mut(cluster_name)
     }
 
@@ -344,50 +339,12 @@ pub struct Replica {
     pub isolation: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct Cluster {
-    pub addr: String,
-    pub tls: Option<TlsConfig>,
-}
-
-impl From<String> for Cluster {
-    fn from(addr: String) -> Self {
-        Self {
-            addr,
-            ..Default::default()
-        }
-    }
-}
-
-impl Cluster {
-    /// default non tls local cluster
-    pub fn new(addr: String) -> Cluster {
-        Self {
-            addr,
-            ..Default::default()
-        }
-    }
-
-    pub fn addr(&self) -> &str {
-        &self.addr
-    }
-
-    pub fn set_addr(&mut self, addr: String) {
-        self.addr = addr;
-    }
-}
-
-impl From<Cluster> for ClientConfig {
-    fn from(cluster: Cluster) -> Self {
-        ClientConfig::new(cluster.addr, AllDomainConnector::default_tcp())
-    }
-}
-
 #[cfg(test)]
 pub mod test {
     use super::*;
     use std::path::PathBuf;
     use std::env::temp_dir;
+    use crate::config::TlsConfig;
 
     #[test]
     fn test_default_path_arg() {
@@ -449,12 +406,12 @@ pub mod test {
         };
 
         println!("temp: {:#?}", temp_dir());
-        config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(inline_tls_config);
+        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = Some(inline_tls_config);
         config
             .save_to(temp_dir().join("inline.toml"))
             .expect("save should succeed");
 
-        config.mut_cluster(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::NoVerification);
+        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::NoVerification);
         config
             .save_to(temp_dir().join("noverf.toml"))
             .expect("save should succeed");

--- a/src/client-rs/src/config/config.rs
+++ b/src/client-rs/src/config/config.rs
@@ -279,7 +279,8 @@ impl Config {
 
     /// Returns the ClusterConfig belonging to the named profile.
     pub fn cluster_with_profile(&self, profile_name: &str) -> Option<&ClusterConfig> {
-        self.profile.get(profile_name)
+        self.profile
+            .get(profile_name)
             .and_then(|profile| self.cluster.get(&profile.cluster))
     }
 

--- a/src/client-rs/src/lib.rs
+++ b/src/client-rs/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod params;
 
 pub use error::ClientError;
+pub use client::ClusterClient;
 pub use config::ClusterConfig;
 pub use producer::Producer;
 pub use consumer::Consumer;

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -8,6 +8,8 @@ use utils::bin::get_fluvio;
 use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
+use fluvio::config::ConfigFile;
+use fluvio::ClusterClient;
 
 /// verify consumer thru CLI
 pub async fn validate_consume_message(option: &TestOption) {
@@ -45,13 +47,16 @@ fn validate_consume_message_cli(option: &TestOption) {
 async fn validate_consume_message_api(option: &TestOption) {
     // futures::stream::StreamExt;
 
-    use fluvio::ClusterConfig;
     use fluvio::params::FetchOffset;;
     use fluvio::params::FetchLogOption;
     use fluvio::kf::api::ReplicaKey;
 
-    let config = ClusterConfig::lookup_profile(None).expect("connect");
-    let mut cluster = config.connect().await.expect("should connect");
+    let config = ConfigFile::load(None)
+        .expect("load config");
+    let cluster_config = config.config()
+        .current_cluster()
+        .expect("get current cluster");
+    let mut cluster = ClusterClient::connect(cluster_config.clone()).await.expect("should connect");
     let mut consumer = cluster
         .consumer(ReplicaKey::new(option.topic_name.to_owned(), 0))
         .await

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -51,12 +51,14 @@ async fn validate_consume_message_api(option: &TestOption) {
     use fluvio::params::FetchLogOption;
     use fluvio::kf::api::ReplicaKey;
 
-    let config = ConfigFile::load(None)
-        .expect("load config");
-    let cluster_config = config.config()
+    let config = ConfigFile::load(None).expect("load config");
+    let cluster_config = config
+        .config()
         .current_cluster()
         .expect("get current cluster");
-    let mut cluster = ClusterClient::connect(cluster_config.clone()).await.expect("should connect");
+    let mut cluster = ClusterClient::connect(cluster_config.clone())
+        .await
+        .expect("should connect");
     let mut consumer = cluster
         .consumer(ReplicaKey::new(option.topic_name.to_owned(), 0))
         .await

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -1,5 +1,7 @@
 use crate::TestOption;
 use super::message::*;
+use fluvio::config::ConfigFile;
+use fluvio::ClusterClient;
 
 pub async fn produce_message(option: &TestOption) {
     if option.produce.produce_iteration == 1 {
@@ -10,11 +12,14 @@ pub async fn produce_message(option: &TestOption) {
 }
 
 pub async fn produce_message_with_api(option: &TestOption) {
-    use fluvio::ClusterConfig;
     use fluvio::kf::api::ReplicaKey;
 
-    let config = ClusterConfig::lookup_profile(None).expect("connect");
-    let mut cluster = config.connect().await.expect("should connect");
+    let config = ConfigFile::load(None)
+        .expect("load config");
+    let cluster_config = config.config()
+        .current_cluster()
+        .expect("current cluster");
+    let mut cluster = ClusterClient::connect(cluster_config.clone()).await.expect("should connect");
     let replica: ReplicaKey = (option.topic_name.clone(), 0).into();
     let mut producer = cluster.producer(replica).await.expect("producer");
 

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -14,12 +14,11 @@ pub async fn produce_message(option: &TestOption) {
 pub async fn produce_message_with_api(option: &TestOption) {
     use fluvio::kf::api::ReplicaKey;
 
-    let config = ConfigFile::load(None)
-        .expect("load config");
-    let cluster_config = config.config()
-        .current_cluster()
-        .expect("current cluster");
-    let mut cluster = ClusterClient::connect(cluster_config.clone()).await.expect("should connect");
+    let config = ConfigFile::load(None).expect("load config");
+    let cluster_config = config.config().current_cluster().expect("current cluster");
+    let mut cluster = ClusterClient::connect(cluster_config.clone())
+        .await
+        .expect("should connect");
     let replica: ReplicaKey = (option.topic_name.clone(), 0).into();
     let mut producer = cluster.producer(replica).await.expect("producer");
 


### PR DESCRIPTION
This is part of my cleaning up the codebase surrounding `TlsConfig` in preparation for adding TLS support.

This PR:

* Removes the duplication between `client-rs/config::Cluster` and `client-rs/config::cluster::ClusterConfig` by removing `Cluster` and making `ClusterConfig` the default.

* Makes `ClusterClient` in charge of "connecting" itself using a `ClusterConfig, rather than forcing `ClusterConfig` to know how to do that. `ClusterConfig` is just a data structure now.