### PR TITLE
Consolidate TLS configuration options

### DIFF
--- a/src/cli/src/profile/context.rs
+++ b/src/cli/src/profile/context.rs
@@ -1,4 +1,5 @@
 use std::io::Error as IoError;
+use std::convert::TryInto;
 
 use fluvio::config::*;
 
@@ -17,11 +18,11 @@ pub fn set_local_context(local_config: LocalOpt) -> Result<String, IoError> {
     match config.cluster_mut(LOCAL_PROFILE) {
         Some(cluster) => {
             cluster.addr = local_addr.clone();
-            cluster.tls = local_config.tls.try_into_inline()?;
+            cluster.tls = local_config.tls.try_into()?;
         }
         None => {
             let mut local_cluster = ClusterConfig::new(local_addr.clone());
-            local_cluster.tls = local_config.tls.try_into_inline()?;
+            local_cluster.tls = local_config.tls.try_into()?;
             config.add_cluster(local_cluster, LOCAL_PROFILE.to_owned());
         }
     };

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -1,5 +1,6 @@
-use tracing::*;
+use std::convert::TryInto;
 
+use tracing::*;
 use fluvio::config::*;
 use k8_client::K8Client;
 use k8_obj_core::service::ServiceSpec;
@@ -40,11 +41,11 @@ pub async fn set_k8_context(opt: K8Opt, external_addr: String) -> Result<Profile
     match config.cluster_mut(&profile_name) {
         Some(cluster) => {
             cluster.addr = external_addr;
-            cluster.tls = opt.tls.try_into_inline()?;
+            cluster.tls = opt.tls.try_into()?;
         }
         None => {
             let mut local_cluster = ClusterConfig::new(external_addr);
-            local_cluster.tls = opt.tls.try_into_inline()?;
+            local_cluster.tls = opt.tls.try_into()?;
             config.add_cluster(local_cluster, profile_name.clone());
         }
     };

--- a/src/client-rs/src/client/cluster.rs
+++ b/src/client-rs/src/client/cluster.rs
@@ -34,10 +34,7 @@ impl ClusterClient {
     }
 
     pub async fn connect(config: ClusterConfig) -> Result<ClusterClient, ClientError> {
-        let connector = match config.tls {
-            None => AllDomainConnector::default_tcp(),
-            Some(tls) => TryFrom::try_from(tls)?,
-        };
+        let connector = AllDomainConnector::try_from(config.tls)?;
         let config = ClientConfig::new(config.addr, connector);
         let inner_client = config.connect().await?;
         debug!("connected to cluster at: {}", inner_client.config().addr());

--- a/src/client-rs/src/config/cluster.rs
+++ b/src/client-rs/src/config/cluster.rs
@@ -5,16 +5,21 @@
 //!
 use serde::{Serialize, Deserialize};
 
-use super::tls::TlsConfig;
+use crate::config::TlsPolicy;
 
 /// Public configuration for the cluster.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ClusterConfig {
+    /// The address to connect to the cluster
     // TODO use a validated address type.
     // We don't want to have a "" address.
     pub addr: String,
-    pub tls: Option<TlsConfig>,
+    /// The TLS policy to use when connecting to the cluster
+    // If no TLS field is present in config file,
+    // use the default of NoTls
+    #[serde(default)]
+    pub tls: TlsPolicy,
 }
 
 impl ClusterConfig {
@@ -22,13 +27,13 @@ impl ClusterConfig {
     pub fn new<S: Into<String>>(addr: S) -> Self {
         Self {
             addr: addr.into(),
-            tls: None,
+            tls: TlsPolicy::Disabled,
         }
     }
 
     /// Add TLS configuration for this cluster.
-    pub fn with_tls(mut self, tls: TlsConfig) -> Self {
-        self.tls = Some(tls);
+    pub fn with_tls<T: Into<TlsPolicy>>(mut self, tls: T) -> Self {
+        self.tls = tls.into();
         self
     }
 }

--- a/src/client-rs/src/config/config.rs
+++ b/src/client-rs/src/config/config.rs
@@ -345,7 +345,7 @@ pub mod test {
     use super::*;
     use std::path::PathBuf;
     use std::env::temp_dir;
-    use crate::config::TlsConfig;
+    use crate::config::{TlsPolicy, TlsConfig, TlsCerts};
 
     #[test]
     fn test_default_path_arg() {
@@ -399,20 +399,20 @@ pub mod test {
     #[test]
     fn test_tls_save() {
         let mut config = Config::new_with_local_cluster("localhost:9003".to_owned());
-        let inline_tls_config = TlsConfig::WithCerts {
-            client_key: "ABCDEFF".to_owned(),
-            client_cert: "JJJJ".to_owned(),
+        let inline_tls_config = TlsConfig::Inline(TlsCerts {
+            key: "ABCDEFF".to_owned(),
+            cert: "JJJJ".to_owned(),
             ca_cert: "XXXXX".to_owned(),
             domain: "my_domain".to_owned(),
-        };
+        });
 
         println!("temp: {:#?}", temp_dir());
-        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = Some(inline_tls_config);
+        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = inline_tls_config.into();
         config
             .save_to(temp_dir().join("inline.toml"))
             .expect("save should succeed");
 
-        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = Some(TlsConfig::NoVerification);
+        config.cluster_mut(LOCAL_PROFILE).unwrap().tls = TlsPolicy::Disabled;
         config
             .save_to(temp_dir().join("noverf.toml"))
             .expect("save should succeed");

--- a/src/client-rs/src/config/tls.rs
+++ b/src/client-rs/src/config/tls.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::path::PathBuf;
@@ -13,81 +13,105 @@ use flv_future_aio::net::tls::AllDomainConnector;
 use flv_future_aio::net::tls::TlsDomainConnector;
 use flv_future_aio::net::tls::ConnectorBuilder;
 
+/// Describes whether or not to use TLS and how
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "cert_type", content = "cert")]
-pub enum TlsConfig {
-    /// Do not use TLS. Server must allow anonymous authentication
-    NoVerification,
-
-    /// TLS client config with inline keys and certs
-    WithCerts {
-        /// Client private key
-        client_key: String,
-        /// Client certificate
-        client_cert: String,
-        /// Certificate Authority cert
-        ca_cert: String,
-        /// Domain name
-        domain: String,
-    },
+#[serde(tag = "tls_policy")]
+pub enum TlsPolicy {
+    /// Do not use TLS
+    #[serde(rename = "disabled", alias = "disable")]
+    Disabled,
+    /// Use TLS, but do not verify certificates or domains
+    #[serde(rename = "no_verify", alias = "no_verification")]
+    NoVerify,
+    /// Use TLS and verify certificates and domains
+    #[serde(rename = "verify")]
+    Verify(TlsConfig),
 }
 
-impl Default for TlsConfig {
+impl Default for TlsPolicy {
     fn default() -> Self {
-        Self::NoVerification
+        Self::Disabled
     }
 }
 
-impl TryFrom<TlsConfigPaths> for TlsConfig {
-    type Error = IoError;
-
-    fn try_from(value: TlsConfigPaths) -> Result<Self, Self::Error> {
-        use std::fs::read;
-        match value {
-            TlsConfigPaths::NoVerification => Ok(Self::NoVerification),
-            TlsConfigPaths::WithPaths {
-                client_key,
-                client_cert,
-                ca_cert,
-                domain,
-            } => Ok(Self::WithCerts {
-                client_key: encode(&read(client_key)?),
-                client_cert: encode(&read(client_cert)?),
-                ca_cert: encode(&read(ca_cert)?),
-                domain,
-            }),
-        }
+impl From<TlsConfig> for TlsPolicy {
+    fn from(tls: TlsConfig) -> Self {
+        Self::Verify(tls)
     }
 }
 
-/// TLS client config with paths to keys and certs
+/// Describes the TLS configuration either inline or via file paths
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum TlsConfigPaths {
-    /// Do not use TLS. Server must allow anonymous authentication
-    NoVerification,
-
-    /// Paths to TLS client configs
-    WithPaths {
-        /// Path to client private key
-        client_key: PathBuf,
-
-        /// Path to client certificate
-        client_cert: PathBuf,
-
-        /// Path to Certificate Authority certificate
-        ca_cert: PathBuf,
-
-        /// Domain name
-        domain: String,
-    },
+#[serde(tag = "tls_source", content = "certs")]
+pub enum TlsConfig {
+    /// TLS client config with inline keys and certs
+    #[serde(rename = "inline")]
+    Inline(TlsCerts),
+    /// TLS client config with paths to keys and certs
+    #[serde(rename = "files", alias = "file")]
+    Files(TlsPaths),
 }
 
-impl TryFrom<TlsConfig> for AllDomainConnector {
+impl From<TlsCerts> for TlsConfig {
+    fn from(certs: TlsCerts) -> Self {
+        Self::Inline(certs)
+    }
+}
+
+impl From<TlsPaths> for TlsConfig {
+    fn from(paths: TlsPaths) -> Self {
+        Self::Files(paths)
+    }
+}
+
+/// TLS config with inline keys and certs
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TlsCerts {
+    /// Domain name
+    pub domain: String,
+    /// Client or Server private key
+    pub key: String,
+    /// Client or Server certificate
+    pub cert: String,
+    /// Certificate Authority cert
+    pub ca_cert: String,
+}
+
+impl TryFrom<TlsPaths> for TlsCerts {
     type Error = IoError;
 
-    fn try_from(config: TlsConfig) -> Result<Self, Self::Error> {
+    fn try_from(paths: TlsPaths) -> Result<Self, Self::Error> {
+        use std::fs::read;
+        Ok(Self {
+            domain: paths.domain,
+            key: encode(&read(paths.key)?),
+            cert: encode(&read(paths.cert)?),
+            ca_cert: encode(&read(paths.ca_cert)?),
+        })
+    }
+}
+
+/// TLS config with paths to keys and certs
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TlsPaths {
+    /// Domain name
+    pub domain: String,
+    /// Path to client or server private key
+    pub key: PathBuf,
+    /// Path to client or server certificate
+    pub cert: PathBuf,
+    /// Path to Certificate Authority certificate
+    pub ca_cert: PathBuf,
+}
+
+// TODO move this to AllDomainConnector
+impl TryFrom<TlsPolicy> for AllDomainConnector {
+    type Error = IoError;
+
+    fn try_from(config: TlsPolicy) -> Result<Self, Self::Error> {
         match config {
-            TlsConfig::NoVerification => {
+            TlsPolicy::Disabled => Ok(AllDomainConnector::default_tcp()),
+            TlsPolicy::NoVerify => {
                 info!("using anonymous tls");
                 Ok(AllDomainConnector::TlsAnonymous(
                     ConnectorBuilder::new()
@@ -96,21 +120,19 @@ impl TryFrom<TlsConfig> for AllDomainConnector {
                         .into(),
                 ))
             }
-            TlsConfig::WithCerts {
-                client_key,
-                client_cert,
-                ca_cert,
-                domain,
-                ..
-            } => {
-                info!("using inline cert");
-                let ca_cert = decode(ca_cert).map_err(|err| {
+            TlsPolicy::Verify(tls) => {
+                // Convert path certs to inline if necessary
+                let tls: TlsCerts = match tls {
+                    TlsConfig::Inline(certs) => certs,
+                    TlsConfig::Files(cert_paths) => cert_paths.try_into()?,
+                };
+                let ca_cert = decode(tls.ca_cert).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
-                let client_key = decode(client_key).map_err(|err| {
+                let client_key = decode(tls.key).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
-                let client_cert = decode(client_cert).map_err(|err| {
+                let client_cert = decode(tls.cert).map_err(|err| {
                     IoError::new(ErrorKind::InvalidInput, format!("base 64 decode: {}", err))
                 })?;
 
@@ -119,7 +141,7 @@ impl TryFrom<TlsConfig> for AllDomainConnector {
                         .load_client_certs_from_bytes(&client_cert, &client_key)?
                         .load_ca_cert_from_bytes(&ca_cert)?
                         .build(),
-                    domain,
+                    tls.domain,
                 )))
             }
         }

--- a/src/client-rs/test-data/tls/file.toml
+++ b/src/client-rs/test-data/tls/file.toml
@@ -6,10 +6,11 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-cert_type = "File"
+tls_policy = "verify"
+tls_type = "Paths"
 
 [cluster.local.tls.cert]
-client_key = "/tmp/client.key"
-client_cert = "/tmp/client.cert"
+key = "/tmp/client.key"
+cert = "/tmp/client.cert"
 ca_cert = "/tmp/ca.cert"
 domain = "my_domain"

--- a/src/client-rs/test-data/tls/inline.toml
+++ b/src/client-rs/test-data/tls/inline.toml
@@ -6,10 +6,11 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-cert_type = "Inline"
+tls_policy = "WithTls"
+tls_type = "Inline"
 
 [cluster.local.tls.cert]
-client_key = "ABCDEFF"
-client_cert = "JJJJ"
+key = "ABCDEFF"
+cert = "JJJJ"
 ca_cert = "XXXXX"
 domain = "my_domain"

--- a/src/client-rs/test-data/tls/no-verf.toml
+++ b/src/client-rs/test-data/tls/no-verf.toml
@@ -6,4 +6,4 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-cert_type = "NoVerification"
+tls_policy = "NoTls"


### PR DESCRIPTION
Previously, there was a mix of types that represented different TLS options, which made things less ergonomic and more confusing. For example:

* To not use TLS, you'd use `None::<TlsConfig>`
* To use TLS but without domain verification, you'd use `Some(TlsConfig::NoVerification)`
* To use TLS with verification, you'd use `Some(TlsConfig::WithCerts)`

I found the mix of the `Option` type into this scheme rather confusing, so I flattened it out and created some nice `From` implementations to make things more streamlined.

Now, at the top level we have `TlsPolicy`, which can be

* `Disabled`: meaning TLS is not used
* `NoVerify`: meaning that TLS is used but the certificates are not verified
* `Verify(TlsConfig)`: meaning that TLS is used and certificates are verified.

The presence of a `TlsConfig` always implies that you are working with verified TLS. The variants of `TlsConfig` describe how your certificates and keys are represented in configuration:

* `Inline(TlsCerts)`: TLS certificates and keys are held in memory as strings and serialized directly into the configuration object.
* `File(TlsPaths)`: TLS certificates and keys are referenced by paths into the filesystem. The paths are serialized into the config object.