### PR TITLE
Fix/ci/docker/toolchain

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,55 +15,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
-      - name: Start minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
-        with:
-          minikube version: "v1.12.3"
-          kubernetes version: "v1.18.8"
-          github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test Minikube
-        run: |
-          kubectl get nodes
-          kubectl config view
-          helm version
-          minikube status
-      - name: Run minikube tunnel
-        run: |
-          minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
-          sleep 10
-          echo "tunnel status"
-          cat /tmp/tunnel.out
-      - name: Build
-        run: |
-          cargo build
-      - name: setup context
-        run: |
-          ./target/debug/fluvio cluster set-minikube-context
-          kubectl config view
-          helm list
-      - name: install fluvio system chart
-        run: |
-          FLV_CMD=true ./target/debug/fluvio cluster install --sys
-      - name: smoke test
-        run: |
-          FLV_CMD=true make smoke-test
-      - name: smoke test tls
-        run: |
-          FLV_CMD=true make smoke-test-tls
-      - name: setup smoke test k8
+      - name: Install Musl Tools
         run: |
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
-          ./dev-tools/minikube-docker.sh 
-          docker run -d -p 5000:5000 --restart=always --name registry registry:2
-      - name: smoke test k8
-        run: |
           export TARGET_CC=musl-gcc
-          FLV_CMD=true make smoke-test-k8
-      - name: smoke test k8 tls
-        run: |
-          export TARGET_CC=musl-gcc
-          FLV_CMD=true make smoke-test-k8-tls
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Publish Fluvio Image

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,55 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
+      - name: Start minikube
+        uses: manusa/actions-setup-minikube@v2.0.0
+        with:
+          minikube version: "v1.12.3"
+          kubernetes version: "v1.18.8"
+          github token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test Minikube
+        run: |
+          kubectl get nodes
+          kubectl config view
+          helm version
+          minikube status
+      - name: Run minikube tunnel
+        run: |
+          minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
+          sleep 10
+          echo "tunnel status"
+          cat /tmp/tunnel.out
+      - name: Build
+        run: |
+          cargo build
+      - name: setup context
+        run: |
+          ./target/debug/fluvio cluster set-minikube-context
+          kubectl config view
+          helm list
+      - name: install fluvio system chart
+        run: |
+          FLV_CMD=true ./target/debug/fluvio cluster install --sys
+      - name: smoke test
+        run: |
+          FLV_CMD=true make smoke-test
+      - name: smoke test tls
+        run: |
+          FLV_CMD=true make smoke-test-tls
+      - name: setup smoke test k8
+        run: |
+          sudo apt install -y musl-tools
+          sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
+          ./dev-tools/minikube-docker.sh 
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+      - name: smoke test k8
+        run: |
+          export TARGET_CC=musl-gcc
+          FLV_CMD=true make smoke-test-k8
+      - name: smoke test k8 tls
+        run: |
+          export TARGET_CC=musl-gcc
+          FLV_CMD=true make smoke-test-k8-tls
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Publish Fluvio Image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,55 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
+      - name: Start minikube
+        uses: manusa/actions-setup-minikube@v2.0.0
+        with:
+          minikube version: "v1.12.3"
+          kubernetes version: "v1.18.8"
+          github token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test Minikube
+        run: |
+          kubectl get nodes
+          kubectl config view
+          helm version
+          minikube status
+      - name: Run minikube tunnel
+        run: |
+          minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
+          sleep 10
+          echo "tunnel status"
+          cat /tmp/tunnel.out
+      - name: Build
+        run: |
+          cargo build
+      - name: setup context
+        run: |
+          ./target/debug/fluvio cluster set-minikube-context
+          kubectl config view
+          helm list
+      - name: install fluvio system chart
+        run: |
+          FLV_CMD=true ./target/debug/fluvio cluster install --sys
+      - name: smoke test
+        run: |
+          FLV_CMD=true make smoke-test
+      - name: smoke test tls
+        run: |
+          FLV_CMD=true make smoke-test-tls
+      - name: setup smoke test k8
+        run: |
+          sudo apt install -y musl-tools
+          sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
+          ./dev-tools/minikube-docker.sh 
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+      - name: smoke test k8
+        run: |
+          export TARGET_CC=musl-gcc
+          FLV_CMD=true make smoke-test-k8
+      - name: smoke test k8 tls
+        run: |
+          export TARGET_CC=musl-gcc
+          FLV_CMD=true make smoke-test-k8-tls
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Publish Fluvio Image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,55 +13,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
-      - name: Start minikube
-        uses: manusa/actions-setup-minikube@v2.0.0
-        with:
-          minikube version: "v1.12.3"
-          kubernetes version: "v1.18.8"
-          github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test Minikube
-        run: |
-          kubectl get nodes
-          kubectl config view
-          helm version
-          minikube status
-      - name: Run minikube tunnel
-        run: |
-          minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
-          sleep 10
-          echo "tunnel status"
-          cat /tmp/tunnel.out
-      - name: Build
-        run: |
-          cargo build
-      - name: setup context
-        run: |
-          ./target/debug/fluvio cluster set-minikube-context
-          kubectl config view
-          helm list
-      - name: install fluvio system chart
-        run: |
-          FLV_CMD=true ./target/debug/fluvio cluster install --sys
-      - name: smoke test
-        run: |
-          FLV_CMD=true make smoke-test
-      - name: smoke test tls
-        run: |
-          FLV_CMD=true make smoke-test-tls
-      - name: setup smoke test k8
+      - name: Install Musl Tools
         run: |
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
-          ./dev-tools/minikube-docker.sh 
-          docker run -d -p 5000:5000 --restart=always --name registry registry:2
-      - name: smoke test k8
-        run: |
           export TARGET_CC=musl-gcc
-          FLV_CMD=true make smoke-test-k8
-      - name: smoke test k8 tls
-        run: |
-          export TARGET_CC=musl-gcc
-          FLV_CMD=true make smoke-test-k8-tls
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Publish Fluvio Image

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ make publish_fluvio_image:
 	curl \
 	-X POST \
 	-H "Accept: application/vnd.github.v3+json" \
+	-H "Authorization: $(GITHUB_ACCESS_TOKEN)" \
 	https://api.github.com/repos/infinyon/fluvio/actions/workflows/2333005/dispatches \
 	-d '{"ref":"master"}'
 


### PR DESCRIPTION
This updates the publish/nightly ci workflows to run through the smoke test before publishing.

TODO: Look into a github actions that can call into another github actions workflow step (re-using the same steps)