### PR TITLE
ensure dockerfile is correctly named and binaries are copied

### DIFF
--- a/k8-util/docker/fluvio/Makefile
+++ b/k8-util/docker/fluvio/Makefile
@@ -7,9 +7,10 @@ all: push
 copy_binaries:
 	mkdir -p target
 	cp	${BIN_DIR}/spu-server target
+	cp	${BIN_DIR}/sc-k8-server target
 
 build:	copy_binaries
-	docker build -f Dockerfile.spu  -t $(NAME):$(TAG)  ./target
+	docker build -f Dockerfile.fluvio  -t $(NAME):$(TAG)  ./target
 
 push:	build
 	docker push $(NAME):$(TAG)


### PR DESCRIPTION
Looks like this file was not saved and committed along with the other make fluvio image changes; This PR now adds the binaries for both spu server and sc k8 server and targets the correct `Dockerfile.fluvio` image. Fixes https://github.com/infinyon/fluvio/runs/1038457585?check_suite_focus=true