### PR TITLE
Create fluvio-cluster crate for programmatic installation with TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 target-docker
 .vscode/tasks.json
 .idea/
+VERSION

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rand 0.7.3",
  "sha2",
- "time 0.2.17",
+ "time 0.2.18",
  "version_check",
 ]
 
@@ -910,7 +910,7 @@ dependencies = [
  "flv-api-spu",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.2",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -919,6 +919,26 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "fluvio-cluster"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "fluvio",
+ "flv-future-aio",
+ "flv-metadata-cluster",
+ "flv-util 0.3.2",
+ "k8-client",
+ "k8-config",
+ "k8-obj-core",
+ "k8-obj-metadata",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -927,7 +947,7 @@ version = "2.0.0"
 dependencies = [
  "flv-metadata-cluster",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.2",
  "kf-protocol",
  "log",
  "serde",
@@ -956,13 +976,14 @@ dependencies = [
  "ctrlc",
  "dirs 1.0.5",
  "fluvio",
+ "fluvio-cluster",
  "flv-api-sc",
  "flv-future-aio",
  "flv-metadata-cluster",
  "flv-sc-k8",
  "flv-spu",
  "flv-types",
- "flv-util 0.3.1",
+ "flv-util 0.3.2",
  "futures",
  "http-types",
  "k8-client",
@@ -997,7 +1018,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.2",
  "futures",
  "k8-metadata-client",
  "log",
@@ -1014,7 +1035,7 @@ dependencies = [
  "async-rwlock",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.2",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -1054,7 +1075,7 @@ dependencies = [
  "flv-eventstream-model",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.3.1",
+ "flv-util 0.3.2",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -1079,7 +1100,7 @@ dependencies = [
  "flv-future-aio",
  "flv-metadata-cluster",
  "flv-types",
- "flv-util 0.3.1",
+ "flv-util 0.3.2",
  "futures",
  "internal-api",
  "k8-metadata-client",
@@ -1107,7 +1128,7 @@ dependencies = [
  "flv-sc-core",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.3.1",
+ "flv-util 0.3.2",
  "futures",
  "k8-client",
  "rand 0.7.3",
@@ -1137,7 +1158,7 @@ dependencies = [
  "flv-storage",
  "flv-tls-proxy",
  "flv-types",
- "flv-util 0.3.1",
+ "flv-util 0.3.2",
  "futures",
  "internal-api",
  "kf-protocol",
@@ -1164,7 +1185,7 @@ dependencies = [
  "bytes 0.5.6",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.2.1",
+ "flv-util 0.3.2",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -1238,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "flv-util"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a4e1a536df6e2a5149046ed83edf6ad31ac2efbeeed44c3b6711c4c56b7feb"
+checksum = "b5cf735c988038ec59ba1dd5515770ad67a35688328ed99fd867e133dfe8c69b"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
@@ -1645,9 +1666,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1872,7 +1893,7 @@ dependencies = [
  "event-listener",
  "flv-future-aio",
  "flv-types",
- "flv-util 0.1.1",
+ "flv-util 0.3.2",
  "futures",
  "kf-protocol",
  "kf-socket",
@@ -1894,7 +1915,7 @@ dependencies = [
  "chashmap",
  "event-listener",
  "flv-future-aio",
- "flv-util 0.1.1",
+ "flv-util 0.3.2",
  "futures",
  "kf-protocol",
  "log",
@@ -3044,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
@@ -3163,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7ec98a72285d12e0febb26f0847b12d54be24577618719df654c66cadab55d"
+checksum = "12785163ae8a1cbb52a5db39af4a5baabd3fe49f07f76f952f89d7e89e5ce531"
 dependencies = [
  "const_fn",
  "libc",
@@ -3277,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -3545,9 +3566,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3555,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3570,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3582,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -3592,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
@@ -3605,15 +3626,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ cargo-features = ["strip"]
 members = [
     "src/cli",
     "src/client-rs",
+    "src/cluster",
     "src/internal-api",
     "src/kf-socket",
     "src/kf-service",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -37,7 +37,7 @@ async-trait = "0.1.21"
 ctrlc = "3.1.3"
 futures = { version = "0.3.4", features = ['async-await'] }
 flv-future-aio = { version = "2.2.1" }
-flv-util = { version = "0.3.1" }
+flv-util = { version = "0.3.2" }
 fluvio = { path = "../client-rs"}
 flv-metadata-cluster = { path = "../metadata-cluster", features = ["use_serde", "k8"]}
 flv-api-sc = { version = "2.0.0", path = "../sc-api", features = ["use_serde"]}
@@ -50,6 +50,7 @@ utils = { path= "../utils"}
 flv-types = { path ="../types", version = "0.2.0" }
 flv-spu = { path = "../spu-server", optional = true }
 flv-sc-k8 = { path = "../sc-k8", optional = true }
+fluvio-cluster = { path = "../cluster" }
 rpassword = "5.0.0"
 dirs = "1.0.2"
 async-h1 = "2.1.2"

--- a/src/cli/src/cluster/install/helm.rs
+++ b/src/cli/src/cluster/install/helm.rs
@@ -5,27 +5,6 @@ use serde::Deserialize;
 
 use super::*;
 
-pub fn repo_add(chart_location: Option<&str>) {
-    // add repo
-    Command::new("helm")
-        .arg("repo")
-        .arg("add")
-        .arg("fluvio")
-        .arg(chart_location.unwrap_or("https://infinyon.github.io"))
-        .inherit();
-}
-
-pub fn repo_update() {
-    // add repo
-    Command::new("helm").arg("repo").arg("update").inherit();
-}
-
-#[derive(Debug, Deserialize)]
-struct Chart {
-    name: String,
-    version: String,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct SysChart {
     pub name: String,

--- a/src/cli/src/cluster/install/helm.rs
+++ b/src/cli/src/cluster/install/helm.rs
@@ -32,37 +32,6 @@ pub struct SysChart {
     pub app_version: String,
 }
 
-pub fn check_chart_version_exists(name: &str, version: &str) -> bool {
-    let versions = core_chart_versions(name, &version);
-    versions
-        .iter()
-        .filter(|chart| chart.name == name && chart.version == version)
-        .count()
-        > 0
-}
-
-fn core_chart_versions(name: &str, version: &str) -> Vec<Chart> {
-    let mut cmd = Command::new("helm");
-    cmd.arg("search")
-        .arg("repo")
-        .arg(name)
-        .arg("--version")
-        .arg(version)
-        .arg("--output")
-        .arg("json")
-        .print();
-
-    debug!("command {:?}", cmd);
-
-    let output = cmd
-        .output()
-        .expect("unable to query for versions of fluvio-core in helm repo");
-
-    debug!("command output {:?}", output);
-
-    serde_json::from_slice(&output.stdout).expect("invalid json from helm search")
-}
-
 pub fn installed_sys_charts(name: &str) -> Vec<SysChart> {
     let mut cmd = Command::new("helm");
     cmd.arg("list")

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -7,13 +7,9 @@ use std::io::ErrorKind;
 use std::net::IpAddr;
 use std::str::FromStr;
 use url::Url;
-use tracing::*;
 
 use super::*;
-use crate::target::ClusterTarget;
-use crate::tls::TlsOpt;
-
-const CORE_CHART_NAME: &str = "fluvio/fluvio-app";
+use fluvio_cluster::ClusterInstaller;
 
 fn get_cluster_server_host(kc_config: KubeContext) -> Result<String, IoError> {
     if let Some(ctx) = kc_config.config.current_cluster() {
@@ -115,225 +111,66 @@ fn pre_install_check() -> Result<(), CliError> {
 
 pub async fn install_core(opt: InstallCommand) -> Result<(), CliError> {
     pre_install_check().map_err(|err| CliError::Other(err.to_string()))?;
-    install_core_app(&opt)?;
 
-    if k8_util::wait_for_service_exist(&opt.k8_config.namespace)
-        .await
-        .map_err(|err| CliError::Other(err.to_string()))?
-        .is_some()
-    {
-        info!("fluvio is up");
+    let mut builder = ClusterInstaller::new()
+        .with_namespace(opt.k8_config.namespace)
+        .with_group_name(opt.k8_config.group_name)
+        .with_spu_replicas(opt.spu)
+        .with_save_profile(!opt.skip_profile_creation);
 
-        let external_addr =
-            match crate::profile::discover_fluvio_addr(Some(&opt.k8_config.namespace)).await? {
-                Some(sc_addr) => sc_addr,
-                None => {
-                    return Err(CliError::Other(
-                        "fluvio service is not deployed".to_string(),
-                    ))
-                }
-            };
-
-        debug!("found sc, addr is: {}", external_addr);
-
-        let tls_config = &opt.tls;
-        let tls = if tls_config.tls {
-            TlsOpt {
-                tls: true,
-                domain: tls_config.domain.clone(),
-                enable_client_cert: true,
-                client_key: tls_config.client_key.clone(),
-                client_cert: tls_config.client_cert.clone(),
-                ca_cert: tls_config.ca_cert.clone(),
-            }
-        } else {
-            TlsOpt::default()
-        };
-
-        if !opt.skip_profile_creation {
-            set_profile(
-                external_addr.clone(),
-                tls.clone(),
-                Some(opt.k8_config.namespace.clone()),
-            )
-            .await?;
+    match opt.k8_config.image_version {
+        // If an image tag is given, use it
+        Some(image_tag) => {
+            builder = builder.with_image_tag(image_tag.trim());
         }
-
-        if opt.spu > 0 {
-            use std::time::Duration;
-            use flv_future_aio::timer::sleep;
-
-            // wait little bit for sc to spin up
-
-            sleep(Duration::from_millis(2000)).await;
-
-            create_spg(
-                ClusterTarget {
-                    cluster: Some(external_addr),
-                    tls,
-                    ..Default::default()
-                },
-                &opt,
-            )
-            .await?;
-
-            if !k8_util::wait_for_spu(&opt.k8_config.namespace).await? {
-                println!("too long to wait for spu to be ready");
-                return Err(CliError::Other(
-                    "unable to detect fluvio service".to_owned(),
-                ));
-            }
-
-            // print spu
-            let _ = Command::new("kubectl")
-                .arg("get")
-                .arg("spu")
-                .print()
-                .inherit();
+        // If we're in develop mode (but no explicit tag), use current git hash
+        None if opt.develop => {
+            let output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
+            let git_hash = String::from_utf8(output.stdout).map_err(|e| {
+                IoError::new(
+                    ErrorKind::InvalidData,
+                    format!("failed to get git hash: {}", e),
+                )
+            })?;
+            builder = builder.with_image_tag(git_hash.trim());
         }
-
-        Ok(())
-    } else {
-        println!("unable to detect fluvio service");
-        println!("for minikube, check if you have tunnel up!");
-        Err(CliError::Other(
-            "unable to detect fluvio service".to_owned(),
-        ))
-    }
-}
-
-/// for tls, copy secrets
-fn copy_secrets(opt: &InstallCommand) {
-    println!("copy secrets");
-
-    let tls = &opt.tls;
-
-    // copy certificate as kubernetes secrets
-
-    Command::new("kubectl")
-        .arg("create")
-        .arg("secret")
-        .arg("generic")
-        .arg("fluvio-ca")
-        .arg("--from-file")
-        .arg(&tls.ca_cert.as_ref().expect("ca cert"))
-        .inherit();
-
-    Command::new("kubectl")
-        .arg("create")
-        .arg("secret")
-        .arg("tls")
-        .arg("fluvio-tls")
-        .arg("--cert")
-        .arg(&tls.server_cert.as_ref().expect("server cert"))
-        .arg("--key")
-        .arg(&tls.server_key.as_ref().expect("server key"))
-        .inherit();
-}
-
-/// install helm core chart
-fn install_core_app(opt: &InstallCommand) -> Result<(), CliError> {
-    if opt.tls.tls {
-        copy_secrets(opt);
+        _ => (),
     }
 
-    // chart version can be overriden
-    let chart_version = opt
-        .k8_config
-        .chart_version
-        .as_deref()
-        .unwrap_or(crate::VERSION);
-
-    // prepare chart if using release
-    if !opt.develop {
-        debug!("updating helm repo");
-        helm::repo_add(opt.k8_config.chart_location.as_deref());
-        helm::repo_update();
-
-        if !helm::check_chart_version_exists(CORE_CHART_NAME, chart_version) {
-            return Err(CliError::Other(format!(
-                "{}:{} not found in helm repo",
-                CORE_CHART_NAME,
-                crate::VERSION
-            )));
+    match opt.k8_config.chart_location {
+        // If a chart location is given, use it
+        Some(chart_location) => {
+            builder = builder.with_chart_location(chart_location);
         }
-    }
-
-    // compute image version
-    let image_version = if opt.develop {
-        // if it is develop, if image version is not specified default to git log hash
-        opt.k8_config.image_version.clone().unwrap_or_else(|| {
-            // get git version
-            let output = Command::new("git")
-                .args(&["log", "-1", "--pretty=format:\"%H\""])
-                .output()
-                .unwrap();
-            let version = String::from_utf8(output.stdout).unwrap();
-            version.trim_matches('"').to_owned()
-        })
-    } else {
-        opt.k8_config
-            .image_version
-            .clone()
-            .unwrap_or_else(|| chart_version.to_owned())
-    };
-
-    let k8_config = &opt.k8_config;
-    let ns = &k8_config.namespace;
-
-    println!("installing fluvio app with image: {}", image_version);
-
-    let fluvio_version = format!("image.tag={}", image_version);
-
-    let mut cmd = Command::new("helm");
-
-    let registry = k8_config.registry.as_deref().unwrap_or({
-        if opt.develop {
-            "localhost:5000/infinyon"
-        } else {
-            "infinyon"
+        // If we're in develop mode (but no explicit chart location), use hardcoded local path
+        None if opt.develop => {
+            builder = builder.with_chart_location("./k8-util/helm/fluvio-app");
         }
-    });
-
-    if opt.develop {
-        cmd.arg("install").arg(&k8_config.install_name).arg(
-            k8_config
-                .chart_location
-                .as_deref()
-                .unwrap_or("./k8-util/helm/fluvio-app"),
-        );
-    } else {
-        cmd.arg("install").arg(&k8_config.install_name).arg(
-            k8_config
-                .chart_location
-                .as_deref()
-                .unwrap_or(CORE_CHART_NAME),
-        );
+        _ => (),
     }
 
-    cmd.arg("--version")
-        .arg(chart_version)
-        .arg("--set")
-        .arg(fluvio_version)
-        .arg("--set")
-        .arg(format!("image.registry={}", registry))
-        .arg("-n")
-        .arg(ns)
-        .arg("--set")
-        .arg(format!("cloud={}", k8_config.cloud));
-
-    if opt.tls.tls {
-        cmd.arg("--set").arg("tls=true");
+    match opt.k8_config.registry {
+        // If a registry is given, use it
+        Some(registry) => {
+            builder = builder.with_image_registry(registry);
+        }
+        // If we're in develop mode (but no explicit registry), use localhost:5000 registry
+        None if opt.develop => {
+            builder = builder.with_image_registry("localhost:5000/infinyon");
+        }
+        _ => (),
     }
 
-    if let Some(log) = &opt.rust_log {
-        cmd.arg("--set").arg(format!("scLog={}", log));
+    if let Some(chart_version) = opt.k8_config.chart_version {
+        builder = builder.with_chart_version(chart_version);
     }
 
-    cmd.wait();
+    if let Some(rust_log) = opt.rust_log {
+        builder = builder.with_rust_log(rust_log);
+    }
 
-    println!("fluvio chart has been installed");
-
+    let installer = builder.build()?;
+    installer.install_fluvio().await?;
     Ok(())
 }
 
@@ -364,140 +201,4 @@ pub fn install_sys(opt: InstallCommand) {
         .arg(format!("cloud={}", opt.k8_config.cloud))
         .inherit();
     println!("fluvio sys chart has been installed");
-}
-
-/// switch to profile
-async fn set_profile(
-    external_addr: String,
-    tls: TlsOpt,
-    namespace: Option<String>,
-) -> Result<(), CliError> {
-    use crate::profile::set_k8_context;
-    use crate::profile::K8Opt;
-
-    let config = K8Opt {
-        namespace,
-        tls,
-        ..Default::default()
-    };
-
-    println!(
-        "updated profile: {:#?}",
-        set_k8_context(config, external_addr).await?
-    );
-
-    Ok(())
-}
-
-async fn create_spg(target: ClusterTarget, opt: &InstallCommand) -> Result<(), CliError> {
-    use crate::group::process_create_managed_spu_group;
-    use crate::group::CreateManagedSpuGroupOpt;
-
-    let group_name = &opt.k8_config.group_name;
-    let group_opt = CreateManagedSpuGroupOpt {
-        name: group_name.clone(),
-        replicas: opt.spu,
-        target,
-        ..Default::default()
-    };
-
-    process_create_managed_spu_group(group_opt).await?;
-
-    println!("group: {} with replica: {} created", group_name, opt.spu);
-
-    Ok(())
-}
-
-mod k8_util {
-
-    use std::time::Duration;
-
-    use flv_future_aio::timer::sleep;
-    use k8_client::ClientError;
-    use k8_client::K8Client;
-    use k8_obj_core::service::ServiceSpec;
-    use k8_obj_metadata::InputObjectMeta;
-    use k8_metadata_client::MetadataClient;
-    use k8_client::ClientError as K8ClientError;
-
-    use super::*;
-
-    /// print svc
-    fn print_svc(ns: &str) {
-        Command::new("kubectl")
-            .arg("get")
-            .arg("svc")
-            .arg("-n")
-            .arg(ns)
-            .inherit();
-    }
-
-    pub async fn wait_for_service_exist(ns: &str) -> Result<Option<String>, ClientError> {
-        let client = K8Client::default()?;
-
-        let input = InputObjectMeta::named("flv-sc-public", ns);
-
-        for i in 0..100u16 {
-            println!("checking to see if svc exists, count: {}", i);
-            match client.retrieve_item::<ServiceSpec, _>(&input).await {
-                Ok(svc) => {
-                    // check if load balancer status exists
-                    if let Some(addr) = svc.status.load_balancer.find_any_ip_or_host() {
-                        print!("found svc load balancer addr: {}", addr);
-                        print_svc(ns);
-                        return Ok(Some(format!("{}:9003", addr.to_owned())));
-                    } else {
-                        println!("svc exists but no load balancer exist yet, continue wait");
-                        sleep(Duration::from_millis(2000)).await;
-                    }
-                }
-                Err(err) => match err {
-                    K8ClientError::NotFound => {
-                        println!("no svc found, sleeping ");
-                        sleep(Duration::from_millis(2000)).await;
-                    }
-                    _ => panic!("error: {}", err),
-                },
-            };
-        }
-
-        // if we  can't  find any service print out kc get svc
-        print_svc(ns);
-
-        Ok(None)
-    }
-
-    /// wait until all spus are ready and have ingres
-    pub async fn wait_for_spu(ns: &str) -> Result<bool, ClientError> {
-        use flv_metadata_cluster::spu::SpuSpec;
-
-        let client = K8Client::default()?;
-
-        for i in 0..100u16 {
-            let items = client.retrieve_items::<SpuSpec, _>(ns).await?;
-            let spu_count = items.items.len();
-            // check for all items has ingress
-
-            let ready_spu = items
-                .items
-                .iter()
-                .filter(|spu_obj| {
-                    !spu_obj.spec.public_endpoint.ingress.is_empty() && spu_obj.status.is_online()
-                })
-                .count();
-
-            if spu_count == ready_spu {
-                println!("all spu: {} is ready", spu_count);
-                return Ok(true);
-            } else {
-                println!(
-                    "spu: {} out of {} ready, waiting: {}",
-                    ready_spu, spu_count, i
-                );
-                sleep(Duration::from_millis(2000)).await;
-            }
-        }
-
-        Ok(false)
-    }
 }

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -41,6 +41,7 @@ pub struct K8Install {
     #[structopt(long, default_value = "fluvio")]
     pub install_name: String,
 
+    /// Local path to a helm chart to install
     #[structopt(long)]
     pub chart_location: Option<String>,
 
@@ -130,7 +131,7 @@ where
     use local::install_local;
 
     if command.sys {
-        install_sys(command);
+        install_sys(command)?;
     } else if command.local {
         #[cfg(feature = "cluster_components")]
         install_local(command).await?;

--- a/src/cli/src/error/error.rs
+++ b/src/cli/src/error/error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io::Error as IoError;
 
 use fluvio::ClientError;
+use fluvio_cluster::ClusterError;
 use crate::profile::CloudError;
 
 #[derive(Debug)]
@@ -10,6 +11,7 @@ pub enum CliError {
     IoError(IoError),
     ClientError(ClientError),
     CloudError(CloudError),
+    ClusterError(ClusterError),
     K8ConfigError(k8_config::ConfigError),
     K8ClientError(k8_client::ClientError),
     Other(String),
@@ -39,6 +41,12 @@ impl From<CloudError> for CliError {
     }
 }
 
+impl From<ClusterError> for CliError {
+    fn from(error: ClusterError) -> Self {
+        Self::ClusterError(error)
+    }
+}
+
 impl From<k8_config::ConfigError> for CliError {
     fn from(error: k8_config::ConfigError) -> Self {
         Self::K8ConfigError(error)
@@ -58,6 +66,7 @@ impl fmt::Display for CliError {
             Self::IoError(err) => write!(f, "{}", err),
             Self::ClientError(err) => write!(f, "{}", err),
             Self::CloudError(err) => write!(f, "{}", err),
+            Self::ClusterError(err) => write!(f, "{}", err),
             Self::K8ConfigError(err) => write!(f, "{}", err),
             Self::K8ClientError(err) => write!(f, "{}", err),
             Self::Other(msg) => write!(f, "{}", msg),

--- a/src/cli/src/tls/mod.rs
+++ b/src/cli/src/tls/mod.rs
@@ -44,11 +44,11 @@ impl TryInto<TlsPolicy> for TlsOpt {
             }
             _ if !self.enable_client_cert => {
                 debug!("using no cert verification");
-                Ok(TlsPolicy::NoVerify)
+                Ok(TlsPolicy::Anonymous)
             }
             (Some(client_cert), Some(client_key), Some(ca_cert), Some(domain)) => {
                 debug!("using tls and client cert");
-                Ok(TlsPolicy::Verify(TlsConfig::Files(TlsPaths {
+                Ok(TlsPolicy::Verified(TlsConfig::Files(TlsPaths {
                     cert: client_cert,
                     key: client_key,
                     ca_cert,

--- a/src/client-rs/Cargo.toml
+++ b/src/client-rs/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"
 description = "The offical Fluvio driver for Rust"
 
-
 [dependencies]
 tracing = "0.1.19"
+tracing-futures = "0.2.4"
 dirs = "1.0.2"
 toml = "0.5.5"
 dashmap = "3.11.4"
@@ -23,10 +23,10 @@ async-channel = "1.1.0"
 event-listener = "2.2.0"
 async-mutex = "1.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-future-aio = { version = "2.2.1", features = ["tls"] }
+flv-future-aio = { version = "2.4.1", features = ["tls"] }
 kf-protocol = { version = "2.0.0" } 
 flv-types = { version = "0.2.0", path ="../types" }
-flv-util = "0.2.0"
+flv-util = "0.3.2"
 kf-socket = { version = "2.1.0", path = "../kf-socket" }
 flv-api-sc = { version = "2.0.0", path = "../sc-api", default-features=false}
 flv-api-spu = { version = "2.0.0", path = "../spu-api"}

--- a/src/client-rs/test-data/tls/file.toml
+++ b/src/client-rs/test-data/tls/file.toml
@@ -6,10 +6,10 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-tls_policy = "verify"
-tls_type = "Paths"
+tls_policy = "verified"
+tls_source = "files"
 
-[cluster.local.tls.cert]
+[cluster.local.tls.certs]
 key = "/tmp/client.key"
 cert = "/tmp/client.cert"
 ca_cert = "/tmp/ca.cert"

--- a/src/client-rs/test-data/tls/inline.toml
+++ b/src/client-rs/test-data/tls/inline.toml
@@ -6,10 +6,10 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-tls_policy = "WithTls"
-tls_type = "Inline"
+tls_policy = "verified"
+tls_source = "inline"
 
-[cluster.local.tls.cert]
+[cluster.local.tls.certs]
 key = "ABCDEFF"
 cert = "JJJJ"
 ca_cert = "XXXXX"

--- a/src/client-rs/test-data/tls/no-verf.toml
+++ b/src/client-rs/test-data/tls/no-verf.toml
@@ -6,4 +6,4 @@ cluster = "local"
 addr = "localhost:9003"
 
 [cluster.local.tls]
-tls_policy = "NoTls"
+tls_policy = "disabled"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "fluvio-cluster"
+version = "0.1.0"
+edition = "2018"
+license = "Apache-2.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+repository = "https://github.com/infinyon/fluvio"
+build = "build.rs"
+
+[lib]
+name = "fluvio_cluster"
+path = "src/lib.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1.19"
+tracing-futures = "0.2.4"
+serde = "1.0.115"
+serde_json = "1.0.57"
+fluvio = { path = "../client-rs" }
+flv-util = { version = "0.3.2" }
+flv-future-aio = "2.3.1"
+flv-metadata-cluster = { path = "../metadata-cluster", features = ["k8"] }
+k8-config = { version = "1.1.0", features = ["context"] }
+k8-client = "1.1.0"
+k8-obj-core = "1.1.0"
+k8-obj-metadata = "1.0.0"
+
+[dev-dependencies]
+# Needed for doc-tests
+async-std = "1.6.3"

--- a/src/cluster/LICENSE-APACHE
+++ b/src/cluster/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/cluster/build.rs
+++ b/src/cluster/build.rs
@@ -1,0 +1,8 @@
+use std::fs;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/VERSION");
+    println!("cargo:rerun-if-changed=../../VERSION");
+    println!("cargo:rerun-if-changed=build.rs");
+    fs::copy("../../VERSION", "src/VERSION").expect("version copy");
+}

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -1,0 +1,57 @@
+use std::io::Error as IoError;
+use serde::export::Formatter;
+use fluvio::ClientError;
+use flv_future_aio::io::Error;
+use k8_config::{ConfigError as K8ConfigError};
+use k8_client::{ClientError as K8ClientError};
+
+/// The types of errors that can occur during cluster management
+#[derive(Debug)]
+pub enum ClusterError {
+    /// An IO error occurred, such as opening a file or running a command.
+    IoError(IoError),
+    /// An error occurred with the Fluvio client.
+    ClientError(ClientError),
+    /// An error occurred with the Kubernetes config.
+    K8ConfigError(K8ConfigError),
+    /// An error occurred with the Kubernetes client.
+    K8ClientError(K8ClientError),
+    /// A different kind of error occurred.
+    Other(String),
+}
+
+impl std::fmt::Display for ClusterError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IoError(err) => write!(f, "{}", err),
+            Self::ClientError(err) => write!(f, "{}", err),
+            Self::K8ConfigError(err) => write!(f, "{}", err),
+            Self::K8ClientError(err) => write!(f, "{}", err),
+            Self::Other(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl From<IoError> for ClusterError {
+    fn from(err: Error) -> Self {
+        Self::IoError(err)
+    }
+}
+
+impl From<ClientError> for ClusterError {
+    fn from(err: ClientError) -> Self {
+        Self::ClientError(err)
+    }
+}
+
+impl From<K8ConfigError> for ClusterError {
+    fn from(err: K8ConfigError) -> Self {
+        Self::K8ConfigError(err)
+    }
+}
+
+impl From<K8ClientError> for ClusterError {
+    fn from(err: K8ClientError) -> Self {
+        Self::K8ClientError(err)
+    }
+}

--- a/src/cluster/src/helm.rs
+++ b/src/cluster/src/helm.rs
@@ -55,7 +55,8 @@ impl HelmClient {
             .collect();
 
         let mut command = Command::new("helm");
-        command.args(&["install", name, chart])
+        command
+            .args(&["install", name, chart])
             .args(&["--namespace", namespace])
             .args(sets);
 

--- a/src/cluster/src/helm.rs
+++ b/src/cluster/src/helm.rs
@@ -1,0 +1,122 @@
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+use flv_util::cmd::CommandExt;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct HelmClient {}
+
+impl HelmClient {
+    /// Creates a Rust client to manage our helm needs.
+    ///
+    /// This only succeeds if the helm command can be found.
+    pub fn new() -> Result<Self, IoError> {
+        let output = Command::new("helm").arg("version").print().output()?;
+
+        // Convert command output into a string
+        let out_str = String::from_utf8(output.stdout).map_err(|e| {
+            IoError::new(
+                ErrorKind::InvalidData,
+                format!("failed to parse helm output as string: {}", e),
+            )
+        })?;
+
+        // Check that the version command gives a version.
+        // In the future, we can parse the version string and check
+        // for compatible CLI client version.
+        if !out_str.contains("version") {
+            return Err(IoError::new(
+                ErrorKind::InvalidData,
+                "failed to get helm version",
+            ));
+        }
+
+        // If checks succeed, create Helm client
+        Ok(Self {})
+    }
+
+    /// Installs the given chart under the given name.
+    ///
+    /// The `opts` are passed to helm as `--set` arguments.
+    pub fn install(
+        &self,
+        namespace: &str,
+        name: &str,
+        chart: &str,
+        opts: &[(&str, &str)],
+    ) -> Result<(), IoError> {
+        let sets: Vec<_> = opts
+            .iter()
+            .flat_map(|(key, val)| vec!["--set".to_string(), format!("{}={}", key, val)])
+            .collect();
+
+        Command::new("helm")
+            .args(&["install", name, chart])
+            .args(&["-n", namespace])
+            .args(sets)
+            .inherit();
+        Ok(())
+    }
+
+    /// Adds a new helm repo with the given chart name and chart location
+    pub fn repo_add(&self, chart: &str, location: &str) -> Result<(), IoError> {
+        Command::new("helm")
+            .args(&["repo", "add", chart, location])
+            .stdout(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .inherit();
+        Ok(())
+    }
+
+    /// Updates the local helm repository
+    pub fn repo_update(&self) -> Result<(), IoError> {
+        Command::new("helm").args(&["repo", "update"]).inherit();
+        Ok(())
+    }
+
+    /// Searches the repo for the named helm chart
+    pub fn search_repo(&self, chart: &str) -> Result<Vec<Chart>, IoError> {
+        let output = Command::new("helm")
+            .args(&["search", "repo", chart, "--output", "json"])
+            .print()
+            .output()?;
+
+        serde_json::from_slice(&output.stdout).map_err(|_| {
+            IoError::new(
+                ErrorKind::InvalidData,
+                "failed to parse helm chart versions",
+            )
+        })
+    }
+
+    /// Checks that a given version of a given chart exists in the repo.
+    pub fn chart_version_exists(&self, name: &str, version: &str) -> Result<bool, IoError> {
+        let versions = self.search_repo(name)?;
+        let count = versions
+            .iter()
+            .filter(|chart| chart.name == name && chart.version == version)
+            .count();
+        Ok(count > 0)
+    }
+}
+
+/// A representation of a chart definition in a repo.
+#[derive(Debug, Deserialize)]
+pub struct Chart {
+    /// The chart name
+    name: String,
+    /// The chart version
+    version: String,
+}
+
+/// A representation of an installed chart.
+#[derive(Debug, Deserialize)]
+pub struct InstalledChart {
+    /// The chart name
+    pub name: String,
+    /// The version of the app this chart installed
+    pub app_version: String,
+}

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -532,8 +532,12 @@ impl ClusterInstaller {
         let install_settings = &[("cloud", &*self.config.cloud)];
         match &self.config.chart_location {
             ChartLocation::Remote(chart_location) => {
-                debug!(chart_location = &**chart_location, "Using remote helm chart:");
-                self.helm_client.repo_add(DEFAULT_CHART_APP_REPO, chart_location)?;
+                debug!(
+                    chart_location = &**chart_location,
+                    "Using remote helm chart:"
+                );
+                self.helm_client
+                    .repo_add(DEFAULT_CHART_APP_REPO, chart_location)?;
                 self.helm_client.repo_update()?;
                 self.helm_client.install(
                     &self.config.namespace,
@@ -545,7 +549,10 @@ impl ClusterInstaller {
             }
             ChartLocation::Local(chart_location) => {
                 let chart_location = chart_location.to_string_lossy();
-                debug!(chart_location = chart_location.as_ref(), "Using local helm chart:");
+                debug!(
+                    chart_location = chart_location.as_ref(),
+                    "Using local helm chart:"
+                );
                 self.helm_client.install(
                     &self.config.namespace,
                     DEFAULT_CHART_SYS_REPO,
@@ -563,7 +570,10 @@ impl ClusterInstaller {
     /// Install Fluvio Core chart on the configured cluster
     #[instrument(skip(self))]
     fn install_app(&self) -> Result<(), ClusterError> {
-        trace!("Installing fluvio with the following configuration: {:#?}", &self.config);
+        trace!(
+            "Installing fluvio with the following configuration: {:#?}",
+            &self.config
+        );
 
         // If configured with TLS, copy certs to server
         if let TlsPolicy::Verified(tls) = &self.config.server_tls_policy {
@@ -597,7 +607,8 @@ impl ClusterInstaller {
         match &self.config.chart_location {
             // For remote, we add a repo pointing to the chart location.
             ChartLocation::Remote(chart_location) => {
-                self.helm_client.repo_add(DEFAULT_CHART_APP_REPO, chart_location)?;
+                self.helm_client
+                    .repo_add(DEFAULT_CHART_APP_REPO, chart_location)?;
                 self.helm_client.repo_update()?;
                 if !self
                     .helm_client
@@ -608,7 +619,10 @@ impl ClusterInstaller {
                         &self.config.chart_name, &self.config.chart_version,
                     )));
                 }
-                debug!(chart_location = &**chart_location, "Using remote helm chart:");
+                debug!(
+                    chart_location = &**chart_location,
+                    "Using remote helm chart:"
+                );
                 self.helm_client.install(
                     &self.config.namespace,
                     DEFAULT_CHART_APP_REPO,
@@ -620,7 +634,10 @@ impl ClusterInstaller {
             // For local, we do not use a repo but install from the chart location directly.
             ChartLocation::Local(chart_location) => {
                 let chart_location = chart_location.to_string_lossy();
-                debug!(chart_location = chart_location.as_ref(), "Using local helm chart:");
+                debug!(
+                    chart_location = chart_location.as_ref(),
+                    "Using local helm chart:"
+                );
                 self.helm_client.install(
                     &self.config.namespace,
                     DEFAULT_CHART_APP_REPO,
@@ -628,7 +645,7 @@ impl ClusterInstaller {
                     Some(&self.config.chart_version),
                     &install_settings,
                 )?;
-            },
+            }
         }
 
         info!("Fluvio app chart has been installed");

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -877,18 +877,3 @@ impl ClusterInstaller {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_install_prod() {
-        let installer = ClusterInstaller::new()
-            .with_chart_version("0.6.0-latest")
-            .build()
-            .unwrap();
-        let result = async_std::task::block_on(installer.install_fluvio()).unwrap();
-        println!("{}", result);
-    }
-}

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -1,0 +1,795 @@
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+use std::borrow::Cow;
+use std::process::Command;
+use std::time::Duration;
+
+use tracing::{info, warn, debug, instrument};
+use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::metadata::spg::SpuGroupSpec;
+use fluvio::metadata::spu::SpuSpec;
+use fluvio::config::{TlsPolicy, TlsConfig, TlsPaths, ConfigFile, Profile};
+use flv_util::cmd::CommandExt;
+use flv_future_aio::timer::sleep;
+use k8_client::{K8Client, ClientError as K8ClientError};
+use k8_config::K8Config;
+use k8_client::metadata::MetadataClient;
+use k8_obj_core::service::ServiceSpec;
+use k8_obj_metadata::InputObjectMeta;
+
+use crate::ClusterError;
+use crate::helm::HelmClient;
+
+const DEFAULT_NAMESPACE: &str = "default";
+const DEFAULT_REGISTRY: &str = "infinyon";
+const DEFAULT_CHART_NAME: &str = "fluvio";
+const DEFAULT_CHART_LOCATION: &str = "https://infinyon.github.io";
+const DEFAULT_GROUP_NAME: &str = "main";
+const DEFAULT_CLOUD_NAME: &str = "minikube";
+
+/// A builder for cluster installation options
+#[derive(Debug)]
+pub struct ClusterInstallerBuilder {
+    /// The namespace to install under
+    namespace: String,
+    /// The image tag to use for Fluvio install
+    image_tag: Option<String>,
+    /// The docker registry to use
+    image_registry: String,
+    /// The name of the Fluvio helm chart to install
+    chart_name: String,
+    /// A specific version of the Fluvio helm chart to install
+    chart_version: String,
+    /// The location to find the helm chart
+    chart_location: String,
+    /// The name of the SPU group to create
+    group_name: String,
+    /// The name of the Fluvio cloud
+    cloud: String,
+    /// Whether to save an update to the Fluvio profile
+    save_profile: bool,
+    /// How much storage to allocate on SPUs
+    spu_spec: SpuGroupSpec,
+    /// The logging settings to set in the cluster
+    rust_log: Option<String>,
+    /// The TLS policy for the SC and SPU servers
+    server_tls_policy: TlsPolicy,
+    /// The TLS policy for the client
+    client_tls_policy: TlsPolicy,
+}
+
+impl ClusterInstallerBuilder {
+    /// Creates a [`ClusterInstaller`] with the current configuration.
+    ///
+    /// This may fail if there is a problem conencting to Kubernetes or
+    /// finding the `helm` executable on the local system.
+    ///
+    /// # Example
+    ///
+    /// The simplest flow to create a `ClusterInstaller` looks like the
+    /// following:
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .build()
+    ///     .expect("should create ClusterInstaller");
+    /// ```
+    ///
+    /// [`ClusterInstaller`]: ./struct.ClusterInstaller.html
+    pub fn build(self) -> Result<ClusterInstaller, ClusterError> {
+        Ok(ClusterInstaller {
+            config: self,
+            kube_client: K8Client::default()?,
+            helm_client: HelmClient::new()?,
+        })
+    }
+
+    /// Sets the Kubernetes namespace to install Fluvio into.
+    ///
+    /// The default namespace is "default".
+    pub fn with_namespace<S: Into<String>>(mut self, namespace: S) -> Self {
+        self.namespace = namespace.into();
+        self
+    }
+
+    /// Sets the docker image tag of the Fluvio image to install.
+    ///
+    /// If this is not specified, the installer will use the chart version
+    /// as the image tag. This should correspond to the image tags of the
+    /// official published Fluvio images.
+    ///
+    /// # Example
+    ///
+    /// Suppose you would like to install version `0.6.0` of Fluvio from
+    /// Docker Hub, where the image is tagged as `infinyon/fluvio-sc:0.6.0`.
+    /// You can do that like this:
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_image_tag("0.6.0")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_image_tag<S: Into<String>>(mut self, image_tag: S) -> Self {
+        self.image_tag = Some(image_tag.into());
+        self
+    }
+
+    /// Sets the docker image registry to use to download Fluvio images.
+    ///
+    /// This defaults to `infinyon` to pull from Infinyon's official Docker Hub
+    /// registry. This can be used to specify a private registry or a local
+    /// registry as a source of Fluvio images.
+    ///
+    /// # Example
+    ///
+    /// You can create a local Docker registry to publish images to during
+    /// development. Suppose you have a local registry running such as the following:
+    ///
+    /// ```bash
+    /// docker run -d -p 5000:5000 --restart=always --name registry registry:2
+    /// ```
+    ///
+    /// Suppose you tagged your image as `infinyon/fluvio-sc:0.1.0` and pushed it
+    /// to your `localhost:5000` registry. Your image is now located at
+    /// `localhost:5000/infinyon`. You can specify that to the installer like so:
+    ///
+    /// > **NOTE**: See [`with_image_tag`] to see how to specify the `0.1.0` shown here.
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_image_registry("localhost:5000/infinyon")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// Then, when you use `installer.install_fluvio()`, it will pull the images
+    /// from your local docker registry.
+    ///
+    /// [`with_image_tag`]: ./struct.ClusterInstaller.html#method.with_image_tag
+    pub fn with_image_registry<S: Into<String>>(mut self, image_registry: S) -> Self {
+        self.image_registry = image_registry.into();
+        self
+    }
+
+    /// Sets a specific version of the Fluvio helm chart to install.
+    ///
+    /// When working with published Fluvio images, the chart version will appear
+    /// to be a [Semver] version, such as `0.6.0`.
+    ///
+    /// When developing for Fluvio, chart versions are named after the git hash
+    /// of the revision a chart was built on.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_chart_version("0.6.0")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// [Semver]: https://docs.rs/semver/0.10.0/semver/
+    pub fn with_chart_version<S: Into<String>>(mut self, chart_version: S) -> Self {
+        self.chart_version = chart_version.into();
+        self
+    }
+
+    /// Sets a helm chart location to search for Fluvio charts.
+    ///
+    /// Official Fluvio charts are published at [`https://infinyon.github.io/`],
+    /// which is the default chart location.
+    ///
+    /// For Fluvio development, you may wish to specify a local chart location.
+    /// This can be done by specifying the filesystem path of the chart.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_chart_location("./k8-util/helm/fluvio-app")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// [`https://infinyon.github.io/`]: https://infinyon.github.io/
+    pub fn with_chart_location<S: Into<String>>(mut self, chart_location: S) -> Self {
+        self.chart_location = chart_location.into();
+        self
+    }
+
+    /// Sets a custom SPU group name. The default is `main`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_group_name("orange")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_group_name<S: Into<String>>(mut self, group_name: S) -> Self {
+        self.group_name = group_name.into();
+        self
+    }
+
+    /// Whether to save a profile of this installation to `~/.fluvio/config`. Defaults to `false`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_save_profile(true)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_save_profile(mut self, save_profile: bool) -> Self {
+        self.save_profile = save_profile;
+        self
+    }
+
+    /// Sets the number of SPU replicas that should be provisioned. Defaults to 1.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_spu_replicas(2)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_spu_replicas(mut self, spu_replicas: u16) -> Self {
+        self.spu_spec.replicas = spu_replicas;
+        self
+    }
+
+    /// Sets the [`RUST_LOG`] environment variable for the installation.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_rust_log("debug")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// [`RUST_LOG`]: https://docs.rs/tracing-subscriber/0.2.11/tracing_subscriber/filter/struct.EnvFilter.html
+    pub fn with_rust_log<S: Into<String>>(mut self, rust_log: S) -> Self {
+        self.rust_log = Some(rust_log.into());
+        self
+    }
+
+    /// Sets the TLS Policy that the client and server will use to communicate.
+    ///
+    /// By default, these are set to `TlsPolicy::Disabled`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::path::PathBuf;
+    /// use fluvio::config::TlsPaths;
+    /// use fluvio_cluster::ClusterInstaller;
+    ///
+    /// let cert_path = PathBuf::from("/tmp/certs");
+    /// let client = TlsPaths {
+    ///     domain: "fluvio.io".to_string(),
+    ///     ca_cert: cert_path.join("ca.crt"),
+    ///     cert: cert_path.join("client.crt"),
+    ///     key: cert_path.join("client.key"),
+    /// };
+    /// let server = TlsPaths {
+    ///     domain: "fluvio.io".to_string(),
+    ///     ca_cert: cert_path.join("ca.crt"),
+    ///     cert: cert_path.join("server.crt"),
+    ///     key: cert_path.join("server.key"),
+    /// };
+    ///
+    /// let installer = ClusterInstaller::new()
+    ///     .with_tls(client, server)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn with_tls<C: Into<TlsPolicy>, S: Into<TlsPolicy>>(
+        mut self,
+        client: C,
+        server: S,
+    ) -> Self {
+        let client_policy = client.into();
+        let server_policy = server.into();
+
+        use TlsPolicy::*;
+        use std::mem::discriminant;
+        match (&client_policy, &server_policy) {
+            // If the two policies do not have the same variant, they are probably incompatible
+            _ if discriminant(&client_policy) != discriminant(&server_policy) => {
+                warn!("Client TLS policy type is different than the Server TLS policy type!");
+            }
+            // If the client and server domains do not match, give a warning
+            (Verified(client), Verified(server)) if client.domain() != server.domain() => {
+                warn!(
+                    client_domain = client.domain(),
+                    server_domain = server.domain(),
+                    "Client TLS config has a different domain than the Server TLS config!"
+                );
+            }
+            _ => (),
+        }
+
+        self.client_tls_policy = client_policy;
+        self.server_tls_policy = server_policy;
+        self
+    }
+}
+
+/// Allows installing Fluvio on a Kubernetes cluster
+///
+/// Fluvio's Kubernetes components are distributed as [Helm Charts],
+/// which allow them to be easily installed on any Kubernetes
+/// cluster. A `ClusterInstaller` takes care of installing all of
+/// the pieces in the right order, with sane defaults.
+///
+/// [Helm Charts]: https://helm.sh/
+///
+/// # Example
+///
+/// If you want to try out Fluvio on Kubernetes, you can use [Minikube]
+/// as an installation target. This is the default target that the
+/// `ClusterInstaller` uses, so it doesn't require any complex setup.
+///
+/// [Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
+///
+/// ```no_run
+/// use fluvio_cluster::ClusterInstaller;
+/// let installer = ClusterInstaller::new()
+///     .build()
+///     .expect("should initialize installer");
+///
+/// // Installing Fluvio is asynchronous, so you'll need an async runtime
+/// let result = async_std::task::block_on(async {
+///     installer.install_fluvio().await
+/// });
+/// ```
+#[derive(Debug)]
+pub struct ClusterInstaller {
+    /// Configuration options for this installation
+    config: ClusterInstallerBuilder,
+    /// Shared Kubernetes client for install
+    kube_client: K8Client,
+    /// Helm client for performing installs
+    helm_client: HelmClient,
+}
+
+impl ClusterInstaller {
+    /// Creates a default [`ClusterInstallerBuilder`] which can build a `ClusterInstaller`
+    ///
+    /// # Example
+    ///
+    /// The easiest way to build a `ClusterInstaller` is as follows:
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new().build().unwrap();
+    /// ```
+    ///
+    /// Building a `ClusterInstaller` may fail if there is trouble connecting to
+    /// Kubernetes or if the `helm` executable is not locally installed.
+    ///
+    /// You may also set custom installation options before calling [`.build()`].
+    /// For example, if you wanted to specify a custom namespace and RUST_LOG,
+    /// you could use [`with_namespace`] and [`with_rust_log`]. See
+    /// [`ClusterInstallerBuilder`] for the full set of options.
+    ///
+    /// ```no_run
+    /// use fluvio_cluster::ClusterInstaller;
+    /// let installer = ClusterInstaller::new()
+    ///     .with_namespace("my_namespace")
+    ///     .with_rust_log("debug")
+    ///     .build()
+    ///     .expect("should build ClusterInstaller");
+    /// ```
+    ///
+    /// [`ClusterInstallerBuilder`]: ./struct.ClusterInstallerBuilder.html
+    /// [`.build()`]: ./struct.ClusterInstallerBuilder.html#build
+    /// [`with_namespace`]: ./struct.ClusterInstallerBuilder.html#method.with_namespace
+    /// [`with_rust_log`]: ./struct.ClusterInstallerBuilder.html#method.with_rust_log
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> ClusterInstallerBuilder {
+        let spu_spec = SpuGroupSpec {
+            replicas: 1,
+            min_id: 0,
+            ..SpuGroupSpec::default()
+        };
+
+        ClusterInstallerBuilder {
+            namespace: DEFAULT_NAMESPACE.to_string(),
+            image_tag: None,
+            image_registry: DEFAULT_REGISTRY.to_string(),
+            chart_version: crate::VERSION.to_string(),
+            chart_name: DEFAULT_CHART_NAME.to_string(),
+            chart_location: DEFAULT_CHART_LOCATION.to_string(),
+            group_name: DEFAULT_GROUP_NAME.to_string(),
+            cloud: DEFAULT_CLOUD_NAME.to_string(),
+            save_profile: false,
+            spu_spec,
+            rust_log: None,
+            server_tls_policy: TlsPolicy::Disabled,
+            client_tls_policy: TlsPolicy::Disabled,
+        }
+    }
+
+    /// Installs Fluvio according to the installer's configuration
+    ///
+    /// Returns the external address of the new cluster's SC
+    #[instrument(
+        skip(self),
+        fields(namespace = &*self.config.namespace),
+    )]
+    pub async fn install_fluvio(&self) -> Result<String, ClusterError> {
+        self.install_app()?;
+
+        let namespace = &self.config.namespace;
+        let sc_address = match self.wait_for_sc_service(namespace).await {
+            Ok(Some(addr)) => {
+                info!(addr = &*addr, "Fluvio SC is up");
+                addr
+            }
+            Ok(None) => {
+                warn!("Timed out when waiting for SC service");
+                return Err(ClusterError::Other(
+                    "Timed out when waiting for SC service".to_string(),
+                ));
+            }
+            Err(err) => {
+                warn!("Unable to detect Fluvio service. If you're running on Minikube, make sure you have the tunnel up!");
+                return Err(ClusterError::Other(format!(
+                    "Unable to detect Fluvio service: {}",
+                    err
+                )));
+            }
+        };
+
+        if self.config.save_profile {
+            self.update_profile(sc_address.clone())?;
+        }
+
+        if self.config.spu_spec.replicas > 0 {
+            // Wait a little bit for the SC to spin up
+            sleep(Duration::from_millis(2000)).await;
+
+            // Create a managed SPU cluster
+            let cluster = ClusterConfig::new(sc_address.clone())
+                .with_tls(self.config.client_tls_policy.clone());
+            self.create_managed_spu_group(cluster).await?;
+
+            // Wait for the SPU cluster to spin up
+            if !self.wait_for_spu(namespace).await? {
+                warn!("SPU took too long to get ready");
+                return Err(ClusterError::Other(
+                    "SPU took too long to get ready".to_string(),
+                ));
+            }
+        }
+
+        Ok(sc_address)
+    }
+
+    /// Install the Fluvio System chart on the configured cluster
+    #[instrument(skip(self))]
+    fn install_sys(&self) -> Result<(), ClusterError> {
+        self.helm_client
+            .repo_add("fluvio", &self.config.chart_location)?;
+        self.helm_client.repo_update()?;
+        self.helm_client.install(
+            &self.config.namespace,
+            "fluvio-sys",
+            "fluvio/fluvio-sys",
+            &[("cloud", &self.config.cloud)],
+        )?;
+        info!("Fluvio sys chart has been installed");
+        Ok(())
+    }
+
+    /// Install Fluvio Core chart on the configured cluster
+    #[instrument(skip(self))]
+    fn install_app(&self) -> Result<(), ClusterError> {
+        // If configured with TLS, copy certs to server
+        if let TlsPolicy::Verified(tls) = &self.config.server_tls_policy {
+            self.upload_tls_secrets(tls)?;
+        }
+
+        // If the chart location is remote, add helm repo
+        if self.config.chart_location.trim().starts_with("http") {
+            if !self
+                .helm_client
+                .chart_version_exists(&self.config.chart_name, &self.config.chart_version)?
+            {
+                return Err(ClusterError::Other(format!(
+                    "{}:{} not found in helm repo",
+                    &self.config.chart_name, &self.config.chart_version,
+                )));
+            }
+            debug!(
+                chart_location = &*self.config.chart_location,
+                "Using remote helm chart:"
+            );
+            self.helm_client
+                .repo_add("fluvio", &self.config.chart_location)?;
+            self.helm_client.repo_update()?;
+        } else {
+            debug!(
+                chart_location = &*self.config.chart_location,
+                "Using local helm chart:"
+            );
+        }
+
+        let fluvio_tag = self
+            .config
+            .image_tag
+            .as_ref()
+            .unwrap_or(&self.config.chart_version)
+            .to_owned();
+
+        let mut install_settings: Vec<(_, &str)> = vec![
+            ("fluvioVersion", &self.config.chart_version),
+            ("image.registry", &self.config.image_registry),
+            ("image.tag", &fluvio_tag),
+            ("cloud", &self.config.cloud),
+        ];
+
+        // If TLS is enabled, set it as a helm variable
+        if let TlsPolicy::Anonymous | TlsPolicy::Verified(_) = self.config.server_tls_policy {
+            install_settings.push(("tls", "true"));
+        }
+
+        // If RUST_LOG is defined, pass it to SC
+        if let Some(log) = &self.config.rust_log {
+            install_settings.push(("scLog", log));
+        }
+
+        // Install Fluvio via helm
+        self.helm_client.install(
+            &self.config.namespace,
+            &self.config.chart_name,
+            &self.config.chart_location,
+            &install_settings,
+        )?;
+
+        info!("Fluvio app chart has been installed");
+        Ok(())
+    }
+
+    /// Uploads TLS secrets to Kubernetes
+    fn upload_tls_secrets(&self, tls: &TlsConfig) -> Result<(), IoError> {
+        let paths: Cow<TlsPaths> = match tls {
+            TlsConfig::Files(paths) => Cow::Borrowed(paths),
+            TlsConfig::Inline(certs) => Cow::Owned(certs.try_into_temp_files()?),
+        };
+        self.upload_tls_secrets_from_files(paths.as_ref())?;
+        Ok(())
+    }
+
+    /// Looks up the external address of a Fluvio SC instance in the given namespace
+    #[instrument(skip(self, ns))]
+    async fn discover_sc_address(&self, ns: &str) -> Result<Option<String>, ClusterError> {
+        let result = self
+            .kube_client
+            .retrieve_item::<ServiceSpec, _>(&InputObjectMeta::named("flv-sc-public", ns))
+            .await;
+
+        let svc = match result {
+            Ok(svc) => svc,
+            Err(k8_client::ClientError::NotFound) => return Ok(None),
+            Err(err) => {
+                return Err(ClusterError::Other(format!(
+                    "unable to look up fluvio service in k8: {}",
+                    err
+                )))
+            }
+        };
+
+        let ingress_addr = svc
+            .status
+            .load_balancer
+            .ingress
+            .iter()
+            .find(|_| true)
+            .and_then(|ingress| ingress.host_or_ip().to_owned());
+
+        let address = ingress_addr.and_then(|addr| {
+            svc.spec
+                .ports
+                .iter()
+                .find(|_| true)
+                .and_then(|port| port.target_port)
+                .map(|target_port| format!("{}:{}", addr, target_port))
+        });
+
+        if let Some(address) = &address {
+            debug!(addr = &**address, "Discovered SC address");
+        }
+
+        Ok(address)
+    }
+
+    /// Wait until the Fluvio SC public service appears in Kubernetes
+    #[instrument(skip(self, ns))]
+    async fn wait_for_sc_service(&self, ns: &str) -> Result<Option<String>, ClusterError> {
+        let input = InputObjectMeta::named("flv-sc-public", ns);
+
+        for i in 0..100u16 {
+            match self
+                .kube_client
+                .retrieve_item::<ServiceSpec, _>(&input)
+                .await
+            {
+                Ok(svc) => {
+                    // check if load balancer status exists
+                    if let Some(addr) = svc.status.load_balancer.find_any_ip_or_host() {
+                        debug!(addr, "Found SC service load balancer");
+                        return Ok(Some(format!("{}:9003", addr.to_owned())));
+                    } else {
+                        debug!(
+                            attempt = i,
+                            "SC service exists but no load balancer exist yet, continue wait"
+                        );
+                        sleep(Duration::from_millis(2000)).await;
+                    }
+                }
+                Err(err) => match err {
+                    K8ClientError::NotFound => {
+                        debug!(attempt = i, "No SC service found, sleeping");
+                        sleep(Duration::from_millis(2000)).await;
+                    }
+                    _ => panic!("error: {}", err),
+                },
+            };
+        }
+
+        Ok(None)
+    }
+
+    /// Wait until all SPUs are ready and have ingress
+    #[instrument(skip(self, ns))]
+    async fn wait_for_spu(&self, ns: &str) -> Result<bool, ClusterError> {
+        // Try waiting for SPUs for 100 cycles
+        for i in 0..100u16 {
+            let items = self.kube_client.retrieve_items::<SpuSpec, _>(ns).await?;
+            let spu_count = items.items.len();
+
+            // Check that all items have ingress
+            let ready_spu = items
+                .items
+                .iter()
+                .filter(|spu_obj| {
+                    !spu_obj.spec.public_endpoint.ingress.is_empty() && spu_obj.status.is_online()
+                })
+                .count();
+
+            if spu_count == ready_spu {
+                info!(spu_count, "All SPUs are ready");
+                return Ok(true);
+            } else {
+                debug!(
+                    total_expected_spu = spu_count,
+                    ready_spu,
+                    attempt = i,
+                    "Not all SPUs are ready. Waiting",
+                );
+                sleep(Duration::from_millis(2000)).await;
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Install server-side TLS by uploading secrets to kubernetes
+    #[instrument(skip(self, paths))]
+    fn upload_tls_secrets_from_files(&self, paths: &TlsPaths) -> Result<(), IoError> {
+        let ca_cert = paths
+            .ca_cert
+            .to_str()
+            .ok_or_else(|| IoError::new(ErrorKind::InvalidInput, "ca_cert must be a valid path"))?;
+        let server_cert = paths.cert.to_str().ok_or_else(|| {
+            IoError::new(ErrorKind::InvalidInput, "server_cert must be a valid path")
+        })?;
+        let server_key = paths.key.to_str().ok_or_else(|| {
+            IoError::new(ErrorKind::InvalidInput, "server_key must be a valid path")
+        })?;
+        debug!("Using TLS from paths: {:?}", paths);
+
+        Command::new("kubectl")
+            .args(&["create", "secret", "generic", "fluvio-ca"])
+            .args(&["--from-file", ca_cert])
+            .args(&["--namespace", &self.config.namespace])
+            .inherit();
+
+        Command::new("kubectl")
+            .args(&["create", "secret", "tls", "fluvio-tls"])
+            .args(&["--cert", server_cert])
+            .args(&["--key", server_key])
+            .args(&["--namespace", &self.config.namespace])
+            .inherit();
+
+        Ok(())
+    }
+
+    /// Updates the Fluvio configuration with the newly installed cluster info.
+    fn update_profile(&self, external_addr: String) -> Result<(), ClusterError> {
+        let mut config_file = ConfigFile::load_default_or_new()?;
+        let config = config_file.mut_config();
+
+        let profile_name = self.compute_profile_name()?;
+
+        match config.cluster_mut(&profile_name) {
+            Some(cluster) => {
+                cluster.addr = external_addr;
+                cluster.tls = self.config.server_tls_policy.clone();
+            }
+            None => {
+                let mut local_cluster = ClusterConfig::new(external_addr);
+                local_cluster.tls = self.config.server_tls_policy.clone();
+                config.add_cluster(local_cluster, profile_name.clone());
+            }
+        }
+
+        match config.profile_mut(&profile_name) {
+            Some(profile) => {
+                profile.set_cluster(profile_name.clone());
+            }
+            None => {
+                let profile = Profile::new(profile_name.clone());
+                config.add_profile(profile, profile_name.clone());
+            }
+        };
+
+        config.set_current_profile(&profile_name);
+        config_file.save()?;
+        Ok(())
+    }
+
+    /// Determines a profile name from the name of the active Kubernetes context
+    fn compute_profile_name(&self) -> Result<String, ClusterError> {
+        let k8_config = K8Config::load()?;
+
+        let kc_config = match k8_config {
+            K8Config::Pod(_) => {
+                return Err(ClusterError::Other(
+                    "Pod config is not valid here".to_owned(),
+                ))
+            }
+            K8Config::KubeConfig(config) => config,
+        };
+
+        kc_config
+            .config
+            .current_context()
+            .ok_or_else(|| ClusterError::Other("No context fount".to_owned()))
+            .map(|ctx| ctx.name.to_owned())
+    }
+
+    /// Provisions a SPU group for the given cluster according to internal config
+    #[instrument(
+        skip(self, cluster),
+        fields(cluster_addr = &*cluster.addr)
+    )]
+    async fn create_managed_spu_group(&self, cluster: ClusterConfig) -> Result<(), ClusterError> {
+        let name = self.config.group_name.clone();
+        let mut target = ClusterSocket::connect(cluster).await?;
+        let mut admin = target.admin().await;
+        admin
+            .create(name, false, self.config.spu_spec.clone())
+            .await?;
+
+        Ok(())
+    }
+}

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -1,0 +1,29 @@
+//! Functionality for installing, managing, and deleting Fluvio clusters.
+//!
+//! The primary use of this crate is to install Fluvio clusters on
+//! Kubernetes using a [`ClusterInstaller`], which provides a fluid
+//! interface for cluster specification.
+//!
+//! # Example
+//!
+//! To install a basic Fluvio cluster, just do the following:
+//!
+//! ```no_run
+//! use fluvio_cluster::ClusterInstaller;
+//! let installer = ClusterInstaller::new().build().unwrap();
+//! async_std::task::block_on(installer.install_fluvio()).unwrap();
+//! ```
+//!
+//! [`ClusterInstaller`]: ./struct.ClusterInstaller.html
+
+#![warn(missing_docs)]
+
+mod helm;
+mod install;
+mod error;
+
+pub use install::ClusterInstaller;
+pub use install::ClusterInstallerBuilder;
+pub use error::ClusterError;
+
+const VERSION: &str = include_str!("VERSION");

--- a/src/event-stream-k8/Cargo.toml
+++ b/src/event-stream-k8/Cargo.toml
@@ -18,7 +18,7 @@ async-lock = "1.1.2"
 async-channel = "1.1.0"
 event-listener = "2.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-util = { version = "0.2.0"}
+flv-util = { version = "0.3.2" }
 flv-future-aio = { version = "2.3.0", features =["unstable"] }
 k8-metadata-client = { version = "1.0.1"}
 flv-types = { path ="../types", version = "0.2.0"}
@@ -26,4 +26,4 @@ flv-eventstream-model = { features = ["k8"], path = "../event-stream-model" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}
-flv-util = { version = "0.2.0", features=["fixture"]}
+flv-util = { version = "0.3.2", features = ["fixture"] }

--- a/src/event-stream-model/Cargo.toml
+++ b/src/event-stream-model/Cargo.toml
@@ -20,7 +20,7 @@ k8-obj-core = { version = "1.1.0", optional = true}
 k8-obj-app = { version = "1.1.0", optional = true }
 flv-future-aio = { version = "2.3.0"}
 flv-types = { path ="../types", version = "0.2.0" }
-flv-util = { version = "0.2.0"}
+flv-util = { version = "0.3.2" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}

--- a/src/kf-service/Cargo.toml
+++ b/src/kf-service/Cargo.toml
@@ -20,4 +20,4 @@ flv-types = { version = "0.2.0", path ="../types" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.2.1", features = ["fixture"] }
-flv-util = { version = "0.1.0" }
+flv-util = { version = "0.3.2" }

--- a/src/kf-socket/Cargo.toml
+++ b/src/kf-socket/Cargo.toml
@@ -24,8 +24,7 @@ async-trait = "0.1.21"
 kf-protocol = { version = "2.0.0" } 
 flv-future-aio = { version = "2.2.1", features = ["tls"] }
 
-
 [dev-dependencies]
 log = "0.4.8"
-flv-util = { version = "0.1.0", features = ["fixture"]}
+flv-util = { version = "0.3.2", features = ["fixture"]}
 flv-future-aio = { version = "2.2.1", features = ["fixture"] }

--- a/src/metadata-cluster/Cargo.toml
+++ b/src/metadata-cluster/Cargo.toml
@@ -22,7 +22,7 @@ k8-obj-app = { version = "1.1.0", optional = true }
 flv-future-aio = { version = "2.3.0"}
 kf-protocol =  "2.0.0" 
 flv-types = { path ="../types", version = "0.2.0" }
-flv-util = { version = "0.3.1" }
+flv-util = { version = "0.3.2" }
 flv-eventstream-model = { path = "../event-stream-model"}
 
 [dev-dependencies]

--- a/src/sc-api/Cargo.toml
+++ b/src/sc-api/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version ="1.0.0", features = ['derive'], optional = true }
 kf-protocol = { version = "2.0.0" } 
 flv-metadata-cluster = { version = "0.1.0", default-features = false, path = "../metadata-cluster"}
 flv-types = { version = "0.2.0", path ="../types" }
-flv-util = { version = "0.2.0"}
+flv-util = { version = "0.3.2" }

--- a/src/sc-core/Cargo.toml
+++ b/src/sc-core/Cargo.toml
@@ -20,7 +20,7 @@ async-lock = "1.1.2"
 async-channel = "1.1.0"
 event-listener = "2.4.0"
 tokio = { version = "0.2.21", features = ["macros"] }
-flv-util = { version = "0.3.0" }
+flv-util = { version = "0.3.2" }
 flv-future-aio = { version = "2.3.0", features =["tls","unstable"] }
 k8-metadata-client = { version = "1.0.1"}
 k8-obj-metadata = { version = "1.0.0" }
@@ -36,4 +36,4 @@ flv-eventstream-dispatcher = { path = "../event-stream-k8" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.3.0", features=["fixture"]}
-flv-util = { version = "0.3.0", features=["fixture"]}
+flv-util = { version = "0.3.2", features=["fixture"]}

--- a/src/sc-k8/Cargo.toml
+++ b/src/sc-k8/Cargo.toml
@@ -23,6 +23,6 @@ k8-client = { version = "1.1.1" }
 flv-tls-proxy = "0.1.0"
 flv-types = { path = "../types", version = "0.2.0" }
 flv-future-aio = { version = "2.2.1", features = ["tls"] }
-flv-util = { version = "0.3.0" }
+flv-util = { version = "0.3.2" }
 utils = { path = "../utils" }
 flv-sc-core = { path = "../sc-core" }

--- a/src/spu-server/Cargo.toml
+++ b/src/spu-server/Cargo.toml
@@ -30,7 +30,7 @@ regex = "1.3.1"
 tokio = { version = "0.2.21", features = ["macros"] }
 event-listener = "2.4.0"
 flv-future-aio = { version = "2.2.1" }
-flv-util = { version = "0.3.0" }
+flv-util = { version = "0.3.2" }
 kf-protocol = { version = "2.0.0" } 
 flv-tls-proxy = "0.1.0"
 kf-socket = {path = "../kf-socket"}

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/bin/cli.rs"
 doc = false
 required-features = ["cli"]
 
-
 [dependencies]
 tracing = "0.1.19"
 libc = "0.2.58"
@@ -25,13 +24,11 @@ kf-socket = { path = "../kf-socket"}
 flv-future-aio = { version = "2.2.1" }
 utils = { path= "../utils", optional = false }
 flv-types = { path ="../types", version = "0.2.0" }
-flv-util = { version = "0.2.0"}
+flv-util = { version = "0.3.2" }
 
 [dev-dependencies]
 flv-future-aio = { version = "2.2.1", features=["fixture"]}
-flv-util = { version = "0.2.0", features = ["fixture"]}
-
-
+flv-util = { version = "0.3.2", features = ["fixture"]}
 
 [features]
 cli = ["structopt"]


### PR DESCRIPTION
This PR implements #179 and is a required implementation detail of infinyon/fluvio-cloud-ops#21.

The biggest addition here is the new `fluvio-cluster` crate in `src/cluster`. It provides a clean programmatic interface for installing a Fluvio cluster on Kubernetes. It naturally supports TLS by installing server certificates onto the new Fluvio instance, as well as by optionally saving the client credentials to the local configuration.

There is more future work that can be done for `fluvio-cluster`, including:

* Adding a programmatic uninstall feature
* Rewriting the implementation of the `cli` crate to use `fluvio-cluster`
* Writing end-to-end tests for `fluvio-cluster`
  * This would be naturally achieved by making the `cli` use `fluvio-cluster`, as it would then be run with `smoke-test-tls`