### PR TITLE
Fix kubectl secret panic

### DIFF
--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -791,6 +791,17 @@ impl ClusterInstaller {
         })?;
         debug!("Using TLS from paths: {:?}", paths);
 
+        // Try uninstalling secrets first to prevent duplication error
+        Command::new("kubectl")
+            .args(&["delete", "secret", "fluvio-ca", "--ignore-not-found=true"])
+            .args(&["--namespace", &self.config.namespace])
+            .inherit();
+
+        Command::new("kubectl")
+            .args(&["delete", "secret", "fluvio-tls", "--ignore-not-found=true"])
+            .args(&["--namespace", &self.config.namespace])
+            .inherit();
+
         Command::new("kubectl")
             .args(&["create", "secret", "generic", "fluvio-ca"])
             .args(&["--from-file", ca_cert])


### PR DESCRIPTION
I noticed that if a Fluvio installation got partially created and then cancelled, then when it tried to resume it would fail because `kubectl` would be installing secrets that already exist. This causes the installation to first try to delete secrets (ignoring if they don't exist), and then re-installing them.