### PR TITLE
Fix/pvc remove app spu

### DIFF
--- a/k8-util/crd/config/gp2-storageclass-spu.yaml
+++ b/k8-util/crd/config/gp2-storageclass-spu.yaml
@@ -4,8 +4,6 @@ metadata:
   name: fluvio-spu
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-  labels:
-    storageclass: fluvio-spu
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2

--- a/k8-util/crd/config/gp2-storageclass-spu.yaml
+++ b/k8-util/crd/config/gp2-storageclass-spu.yaml
@@ -4,6 +4,8 @@ metadata:
   name: fluvio-spu
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+  labels:
+    storageclass: fluvio-spu
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2

--- a/k8-util/crd/config/local-storageclass.yaml
+++ b/k8-util/crd/config/local-storageclass.yaml
@@ -2,7 +2,5 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fluvio-spu
-  labels:
-    storageclass: fluvio-spu
 provisioner:  kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer

--- a/k8-util/crd/config/local-storageclass.yaml
+++ b/k8-util/crd/config/local-storageclass.yaml
@@ -2,5 +2,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fluvio-spu
+  labels:
+    storageclass: fluvio-spu
 provisioner:  kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer

--- a/k8-util/crd/config/minikube-storageclass-spu.yaml
+++ b/k8-util/crd/config/minikube-storageclass-spu.yaml
@@ -2,7 +2,5 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fluvio-spu
-  labels:
-    storageclass: fluvio-spu
 provisioner: k8s.io/minikube-hostpath
 reclaimPolicy: Retain

--- a/k8-util/crd/config/minikube-storageclass-spu.yaml
+++ b/k8-util/crd/config/minikube-storageclass-spu.yaml
@@ -2,5 +2,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fluvio-spu
+  labels:
+    storageclass: fluvio-spu
 provisioner: k8s.io/minikube-hostpath
 reclaimPolicy: Retain

--- a/k8-util/crd/config/persistent_volume_claim_spu.yaml
+++ b/k8-util/crd/config/persistent_volume_claim_spu.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fluvio-pvc
-  labels:
-    storageclass: fluvio-spu
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8-util/crd/config/persistent_volume_claim_spu.yaml
+++ b/k8-util/crd/config/persistent_volume_claim_spu.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fluvio-pvc
+  labels:
+    storageclass: fluvio-spu
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8-util/helm/fluvio-sys/templates/local-pv.yaml
+++ b/k8-util/helm/fluvio-sys/templates/local-pv.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: fluvio-spu-pv
-  labels:
-    storageclass: fluvio-spu
 spec:
   capacity:
     storage: {{ .Values.localPVStorageSize }}

--- a/k8-util/helm/fluvio-sys/templates/storage.yaml
+++ b/k8-util/helm/fluvio-sys/templates/storage.yaml
@@ -2,8 +2,6 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: fluvio-spu
-  labels:
-    storageclass: fluvio-spu
   annotations:
     {{- if eq .Values.cloud "aws" }}
     storageclass.kubernetes.io/is-default-class: "true"

--- a/src/cli/src/cluster/uninstall.rs
+++ b/src/cli/src/cluster/uninstall.rs
@@ -51,7 +51,6 @@ where
     remove_objects("topics", ns, None);
     remove_objects("persistentvolumeclaims", ns, Some("fluvio-spu"));
     remove_objects("persistentvolumes", ns, Some("fluvio-spu"));
-    remove_objects("storageclasses", ns, Some("fluvio-spu"));
 
     // delete secrets
     Command::new("kubectl")

--- a/src/cli/src/cluster/uninstall.rs
+++ b/src/cli/src/cluster/uninstall.rs
@@ -51,6 +51,7 @@ where
     remove_objects("topics", ns, None);
     remove_objects("persistentvolumeclaims", ns, Some("fluvio-spu"));
     remove_objects("persistentvolumes", ns, Some("fluvio-spu"));
+    remove_objects("storageclasses", ns, Some("fluvio-spu"));
 
     // delete secrets
     Command::new("kubectl")

--- a/src/cli/src/cluster/uninstall.rs
+++ b/src/cli/src/cluster/uninstall.rs
@@ -49,8 +49,7 @@ where
     remove_objects("spugroups", ns, None);
     remove_objects("spus", ns, None);
     remove_objects("topics", ns, None);
-    remove_objects("persistentvolumeclaims", ns, Some("fluvio-spu"));
-    remove_objects("persistentvolumes", ns, Some("fluvio-spu"));
+    remove_objects("persistentvolumeclaims", ns, Some("app=spu"));
 
     // delete secrets
     Command::new("kubectl")


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio/issues/280

I removed `storageclass` label and used the existing `app: spu` label for the pvc. 

Deleting the pvc successfully removes the pv, so I have removed the extraneous remote_objects command for pv.