### PR TITLE
Rename SocketCluster to Fluvio and ClusterConfig to FluvioConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,16 +136,29 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "0.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
+checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
+ "async-task 4.0.1",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd4f132a18f3fe7329c7b907047684f1b06174a900c559b661b2da8bb9cad5f"
+dependencies = [
+ "async-executor",
  "async-io",
  "futures-lite",
- "multitask",
- "parking 1.0.6",
- "scoped-tls",
- "waker-fn",
+ "num_cpus",
+ "once_cell",
 ]
 
 [[package]]
@@ -166,21 +179,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "0.1.11"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
+checksum = "64c629684e697f58c0e99e5e2d84a840e3b336afbcfdbac7b44c3b1e222c2fd8"
 dependencies = [
- "cfg-if",
  "concurrent-queue",
+ "fastrand",
  "futures-lite",
- "libc",
+ "log",
+ "nb-connect",
  "once_cell",
- "parking 2.0.0",
+ "parking",
  "polling",
- "socket2",
  "vec-arena",
- "wepoll-sys-stjepang",
- "winapi",
+ "waker-fn",
 ]
 
 [[package]]
@@ -203,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "async-rwlock"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8978b5ae008b5177da07a1bf1bfbe428f9bdb970c3fca0e92ed1c1930d7f34"
+checksum = "806b1cc0828c2b1611ccbdd743fc0cc7af09009e62c95a0501c1e5da7b142a22"
 dependencies = [
  "async-mutex",
  "event-listener",
@@ -213,21 +225,21 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
+checksum = "3c92085acfce8b32e5b261d0b59b8f3309aee69fea421ea3f271f8b93225754f"
 dependencies = [
- "async-executor",
+ "async-global-executor",
  "async-io",
  "async-mutex",
- "async-task",
+ "async-task 3.0.0",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-lite",
- "futures-timer 3.0.2",
+ "gloo-timers",
  "kv-log-macro",
  "log",
  "memchr",
@@ -246,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
+name = "async-task"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6725e96011a83fae25074a8734932e8d67763522839be7473dcfe8a0d6a378b1"
+
+[[package]]
 name = "async-test-derive"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +272,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -277,7 +295,7 @@ checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -402,12 +420,13 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
+checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
 dependencies = [
  "async-channel",
  "atomic-waker",
+ "fastrand",
  "futures-lite",
  "once_cell",
  "waker-fn",
@@ -477,9 +496,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cfg-if"
@@ -617,7 +636,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rand 0.7.3",
  "sha2",
- "time 0.2.18",
+ "time 0.2.21",
  "version_check",
 ]
 
@@ -854,19 +873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +907,7 @@ dependencies = [
  "async-channel",
  "async-mutex",
  "async-rwlock",
+ "async-std",
  "async-trait",
  "base64 0.12.3",
  "dashmap",
@@ -912,7 +919,7 @@ dependencies = [
  "fluvio-spu-schema",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "kf-socket",
  "serde",
@@ -941,7 +948,7 @@ dependencies = [
  "fluvio-spu",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "http-types",
  "k8-client",
@@ -973,7 +980,7 @@ dependencies = [
  "fluvio",
  "fluvio-controlplane-metadata",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "k8-client",
  "k8-config",
  "k8-obj-core",
@@ -1008,7 +1015,7 @@ dependencies = [
  "fluvio-stream-model",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -1026,7 +1033,7 @@ dependencies = [
  "crc32c",
  "fluvio-protocol",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "kf-socket",
  "log",
@@ -1054,7 +1061,7 @@ checksum = "a9e7db93c435c1357e2bd83914e32942515608588239d4a326b835b2e2f7c4e4"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
- "flv-util 0.4.0",
+ "flv-util",
  "log",
 ]
 
@@ -1090,7 +1097,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1112,7 +1119,7 @@ dependencies = [
  "fluvio-types",
  "flv-future-aio",
  "flv-tls-proxy",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "k8-client",
  "k8-metadata-client",
@@ -1139,7 +1146,7 @@ dependencies = [
  "fluvio-dataplane-protocol",
  "fluvio-protocol",
  "fluvio-types",
- "flv-util 0.4.0",
+ "flv-util",
  "log",
  "serde",
  "tracing",
@@ -1165,7 +1172,7 @@ dependencies = [
  "fluvio-types",
  "flv-future-aio",
  "flv-tls-proxy",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "kf-service",
  "kf-socket",
@@ -1204,7 +1211,7 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "kf-socket",
  "libc",
@@ -1226,7 +1233,7 @@ dependencies = [
  "fluvio-stream-model",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "k8-metadata-client",
  "log",
@@ -1243,7 +1250,7 @@ dependencies = [
  "async-rwlock",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "k8-obj-app",
  "k8-obj-core",
  "k8-obj-metadata",
@@ -1260,25 +1267,25 @@ dependencies = [
 
 [[package]]
 name = "flv-future-aio"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45c13326a094e19de2d0d42d30236a01bfcc041c28a4a617afc9605564a22b4"
+checksum = "f97affbe276a743321d92577bc939bcb247bbe532557c5618f7319d7357d1fbb"
 dependencies = [
  "async-std",
  "async-test-derive",
  "async-tls",
  "async-trait",
  "bytes 0.5.6",
- "flv-util 0.2.1",
+ "flv-util",
  "futures",
- "futures-timer 2.0.2",
- "log",
+ "futures-timer",
  "memmap",
  "nix",
  "pin-project",
  "pin-utils",
  "rustls 0.17.0",
  "tokio",
+ "tracing",
  "webpki",
 ]
 
@@ -1310,17 +1317,6 @@ dependencies = [
  "async-std",
  "flv-future-aio",
  "futures",
- "log",
-]
-
-[[package]]
-name = "flv-util"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d86d88e0fd6a90e453fb257f9f65819b6b1179fc888fadff6bb1aba1eb84707"
-dependencies = [
- "chrono",
- "env_logger 0.7.1",
  "log",
 ]
 
@@ -1396,15 +1392,15 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "0.1.11"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97999970129b808f0ccba93211201d431fcc12d7e1ffae03a61b5cedd1a7ced2"
+checksum = "5b77e08e656f472d8ea84c472fa8b0a7a917883048e1cf2d4e34a323cd0aaf63"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
- "parking 2.0.0",
+ "parking",
  "pin-project-lite",
  "waker-fn",
 ]
@@ -1418,7 +1414,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1441,16 +1437,6 @@ name = "futures-timer"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
 
 [[package]]
 name = "futures-util"
@@ -1493,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1565,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -1847,7 +1833,7 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-types",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "kf-socket",
  "log",
@@ -1869,7 +1855,7 @@ dependencies = [
  "event-listener",
  "fluvio-protocol",
  "flv-future-aio",
- "flv-util 0.4.0",
+ "flv-util",
  "futures",
  "log",
  "pin-utils",
@@ -1895,9 +1881,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1997,7 +1983,7 @@ dependencies = [
  "base64 0.10.1",
  "bitflags",
  "enum_to_u8_slice_derive",
- "env_logger 0.6.2",
+ "env_logger",
  "lazy_static",
  "libc",
  "parking_lot 0.9.0",
@@ -2012,22 +1998,22 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
+ "autocfg",
 ]
 
 [[package]]
-name = "multitask"
-version = "0.2.0"
+name = "nb-connect"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
+checksum = "e847c76b390f44529c2071ef06d0b52fbb4bdb04cc8987a5cfa63954c000abca"
 dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2136,12 +2122,6 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
-
-[[package]]
-name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
@@ -2244,7 +2224,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2275,7 +2255,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2298,9 +2278,9 @@ checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "polling"
-version = "0.1.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fffa183f6bd5f1a8a3e1f60ce2f8d5621e350eed84a62d6daaa5b9d1aaf6fbd"
+checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2348,7 +2328,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "version_check",
 ]
 
@@ -2377,9 +2357,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2632,12 +2612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,29 +2652,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2858,9 +2826,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2913,7 +2881,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2929,7 +2897,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2965,7 +2933,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2987,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -3078,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12785163ae8a1cbb52a5db39af4a5baabd3fe49f07f76f952f89d7e89e5ce531"
+checksum = "2c2e31fb28e2a9f01f5ed6901b066c1ba2333c04b64dc61254142bafcb3feb2c"
 dependencies = [
  "const_fn",
  "libc",
@@ -3111,7 +3079,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.7",
  "standback",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3141,7 +3109,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3187,7 +3155,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3222,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -3232,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3401,9 +3369,9 @@ checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec-arena"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb18268690309760d59ee1a9b21132c126ba384f374c59a94db4bc03adeb561"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -3473,7 +3441,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -3507,7 +3475,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3558,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "wepoll-sys-stjepang"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
+checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
 dependencies = [
  "cc",
 ]

--- a/src/cli/src/consume/cli.rs
+++ b/src/cli/src/consume/cli.rs
@@ -6,8 +6,8 @@
 
 use structopt::StructOpt;
 
+use fluvio::FluvioConfig;
 use fluvio::dataplane::Offset;
-use fluvio::ClusterConfig;
 use fluvio::params::MAX_FETCH_BYTES;
 
 use crate::error::CliError;
@@ -62,7 +62,7 @@ pub struct ConsumeLogOpt {
 
 impl ConsumeLogOpt {
     /// validate the configuration and generate target server and config which can be used
-    pub fn validate(self) -> Result<(ClusterConfig, ConsumeLogConfig), CliError> {
+    pub fn validate(self) -> Result<(FluvioConfig, ConsumeLogConfig), CliError> {
         let target_server = self.target.load()?;
         let max_bytes = self.max_bytes.unwrap_or(MAX_FETCH_BYTES as i32);
 

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -65,9 +65,7 @@ where
     };
 
     if opt.disable_continuous {
-        let response = consumer
-            .fetch(initial_offset, fetch_option)
-            .await?;
+        let response = consumer.fetch(initial_offset, fetch_option).await?;
 
         debug!(
             "got a single response: LSO: {} batches: {}",
@@ -77,9 +75,7 @@ where
 
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
-        let mut log_stream = consumer
-            .stream(initial_offset, fetch_option)
-            .await?;
+        let mut log_stream = consumer.stream(initial_offset, fetch_option).await?;
 
         while let Ok(response) = log_stream.next().await {
             let partition = response.partition;

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -66,7 +66,7 @@ where
 
     if opt.disable_continuous {
         let response = consumer
-            .fetch_logs_once(initial_offset, fetch_option)
+            .fetch(initial_offset, fetch_option)
             .await?;
 
         debug!(
@@ -78,7 +78,7 @@ where
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
         let mut log_stream = consumer
-            .fetch_logs_as_stream(initial_offset, fetch_option)
+            .stream(initial_offset, fetch_option)
             .await?;
 
         while let Ok(response) = log_stream.next().await {

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -10,7 +10,7 @@ use std::io::ErrorKind;
 use tracing::debug;
 
 use fluvio::params::*;
-use fluvio::Consumer;
+use fluvio::PartitionConsumer;
 
 use crate::error::CliError;
 use crate::Terminal;
@@ -26,7 +26,7 @@ use super::process_fetch_topic_response;
 #[allow(clippy::neg_multiply)]
 pub async fn fetch_log_loop<O>(
     out: std::sync::Arc<O>,
-    mut consumer: Consumer,
+    mut consumer: PartitionConsumer,
     opt: ConsumeLogConfig,
 ) -> Result<(), CliError>
 where

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -26,7 +26,7 @@ use super::process_fetch_topic_response;
 #[allow(clippy::neg_multiply)]
 pub async fn fetch_log_loop<O>(
     out: std::sync::Arc<O>,
-    mut consumer: PartitionConsumer,
+    consumer: PartitionConsumer,
     opt: ConsumeLogConfig,
 ) -> Result<(), CliError>
 where

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -10,7 +10,7 @@ use std::io::ErrorKind;
 use tracing::debug;
 
 use fluvio::params::*;
-use fluvio::PartitionConsumer;
+use fluvio::Consumer;
 
 use crate::error::CliError;
 use crate::Terminal;
@@ -26,7 +26,7 @@ use super::process_fetch_topic_response;
 #[allow(clippy::neg_multiply)]
 pub async fn fetch_log_loop<O>(
     out: std::sync::Arc<O>,
-    mut consumer: PartitionConsumer,
+    mut consumer: Consumer,
     opt: ConsumeLogConfig,
 ) -> Result<(), CliError>
 where

--- a/src/cli/src/consume/mod.rs
+++ b/src/cli/src/consume/mod.rs
@@ -36,7 +36,7 @@ mod process {
         debug!("spu  leader consume config: {:#?}", cfg);
 
         let mut target = Fluvio::connect_with_config(&target_server).await?;
-        let consumer = target.partition_consumer(&cfg.topic, cfg.partition).await?;
+        let consumer = target.consumer(&cfg.topic, cfg.partition).await?;
         fetch_log_loop(out, consumer, cfg).await?;
 
         Ok("".to_owned())

--- a/src/cli/src/consume/mod.rs
+++ b/src/cli/src/consume/mod.rs
@@ -13,7 +13,6 @@ use logs_output::process_fetch_topic_response;
 pub use process::process_consume_log;
 
 mod process {
-
     use tracing::debug;
 
     use crate::CliError;
@@ -35,8 +34,8 @@ mod process {
 
         debug!("spu  leader consume config: {:#?}", cfg);
 
-        let mut target = Fluvio::connect_with_config(&target_server).await?;
-        let consumer = target.consumer(&cfg.topic, cfg.partition).await?;
+        let target = Fluvio::connect_with_config(&target_server).await?;
+        let consumer = target.partition_consumer(&cfg.topic, cfg.partition).await?;
         fetch_log_loop(out, consumer, cfg).await?;
 
         Ok("".to_owned())

--- a/src/cli/src/custom/list.rs
+++ b/src/cli/src/custom/list.rs
@@ -5,7 +5,7 @@
 //!
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::spu::CustomSpuSpec;
 use fluvio::metadata::spu::SpuSpec;
 use fluvio::metadata::objects::Metadata;
@@ -33,7 +33,7 @@ pub struct ListCustomSpusOpt {
 
 impl ListCustomSpusOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, OutputType), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, OutputType), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.output.as_output()))
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output_type) = opt.validate()?;
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let custom_spus = admin.list::<CustomSpuSpec, _>(vec![]).await?;

--- a/src/cli/src/custom/register.rs
+++ b/src/cli/src/custom/register.rs
@@ -8,9 +8,9 @@ use std::convert::TryFrom;
 
 use structopt::StructOpt;
 
-use flv_util::socket_helpers::ServerAddress;
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::spu::CustomSpuSpec;
+use flv_util::socket_helpers::ServerAddress;
 
 use crate::error::CliError;
 use crate::target::ClusterTarget;
@@ -43,7 +43,7 @@ pub struct RegisterCustomSpuOpt {
 
 impl RegisterCustomSpuOpt {
     /// Validate cli options. Generate target-server and register custom spu config.
-    fn validate(self) -> Result<(ClusterConfig, (String, CustomSpuSpec)), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, (String, CustomSpuSpec)), CliError> {
         let target = self.target.load()?;
 
         // register custom spu config
@@ -68,7 +68,7 @@ impl RegisterCustomSpuOpt {
 pub async fn process_register_custom_spu(opt: RegisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, (name, spec)) = opt.validate()?;
 
-    let mut sc = ClusterSocket::connect(target_server).await?;
+    let mut sc = Fluvio::connect_with_config(&target_server).await?;
 
     let mut admin = sc.admin().await;
 

--- a/src/cli/src/custom/unregister.rs
+++ b/src/cli/src/custom/unregister.rs
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 
 use fluvio::metadata::spu::CustomSpuSpec;
 use fluvio::metadata::spu::CustomSpuKey;
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 
 use crate::target::ClusterTarget;
 use crate::error::CliError;
@@ -40,7 +40,7 @@ pub struct UnregisterCustomSpuOpt {
 
 impl UnregisterCustomSpuOpt {
     /// Validate cli options. Generate target-server and unregister custom spu config.
-    fn validate(self) -> Result<(ClusterConfig, CustomSpuKey), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, CustomSpuKey), CliError> {
         let target_server = self.target.load()?;
 
         // custom spu
@@ -68,7 +68,7 @@ impl UnregisterCustomSpuOpt {
 pub async fn process_unregister_custom_spu(opt: UnregisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, delete_key) = opt.validate()?;
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     admin.delete::<CustomSpuSpec, _>(delete_key).await?;

--- a/src/cli/src/error/error.rs
+++ b/src/cli/src/error/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::Error as IoError;
 
-use fluvio::ClientError;
+use fluvio::FluvioError;
 use fluvio_cluster::ClusterError;
 use crate::profile::CloudError;
 
@@ -9,7 +9,7 @@ use crate::profile::CloudError;
 pub enum CliError {
     InvalidArg(String),
     IoError(IoError),
-    ClientError(ClientError),
+    ClientError(FluvioError),
     CloudError(CloudError),
     ClusterError(ClusterError),
     K8ConfigError(k8_config::ConfigError),
@@ -29,8 +29,8 @@ impl From<IoError> for CliError {
     }
 }
 
-impl From<ClientError> for CliError {
-    fn from(error: ClientError) -> Self {
+impl From<FluvioError> for CliError {
+    fn from(error: FluvioError) -> Self {
         Self::ClientError(error)
     }
 }

--- a/src/cli/src/group/create.rs
+++ b/src/cli/src/group/create.rs
@@ -7,7 +7,7 @@
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::spg::*;
 
 use crate::error::CliError;
@@ -45,7 +45,7 @@ pub struct CreateManagedSpuGroupOpt {
 
 impl CreateManagedSpuGroupOpt {
     /// Validate cli options. Generate target-server and create spu group config.
-    fn validate(self) -> Result<(ClusterConfig, (String, SpuGroupSpec)), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, (String, SpuGroupSpec)), CliError> {
         let target_server = self.target.load()?;
 
         let storage = self.storage_size.map(|storage_size| StorageConfig {
@@ -82,7 +82,7 @@ pub async fn process_create_managed_spu_group(
 
     debug!("creating spg: {}, spec: {:#?}", name, spec);
 
-    let mut target = ClusterSocket::connect(target_server).await?;
+    let mut target = Fluvio::connect_with_config(&target_server).await?;
 
     let mut admin = target.admin().await;
 

--- a/src/cli/src/group/delete.rs
+++ b/src/cli/src/group/delete.rs
@@ -5,7 +5,7 @@
 //!
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::spg::SpuGroupSpec;
 use crate::error::CliError;
 use crate::target::ClusterTarget;
@@ -26,7 +26,7 @@ pub struct DeleteManagedSpuGroupOpt {
 
 impl DeleteManagedSpuGroupOpt {
     /// Validate cli options. Generate target-server and delete spu group configuration.
-    fn validate(self) -> Result<(ClusterConfig, String), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, String), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.name))
@@ -43,7 +43,7 @@ pub async fn process_delete_managed_spu_group(
 ) -> Result<(), CliError> {
     let (target_server, name) = opt.validate()?;
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<SpuGroupSpec, _>(&name).await?;
     Ok(())

--- a/src/cli/src/group/list.rs
+++ b/src/cli/src/group/list.rs
@@ -5,7 +5,7 @@
 
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio_controlplane_metadata::spg::SpuGroupSpec;
 
 use crate::output::OutputType;
@@ -25,7 +25,7 @@ pub struct ListManagedSpuGroupsOpt {
 
 impl ListManagedSpuGroupsOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, OutputType), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, OutputType), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.output.as_output()))
@@ -39,7 +39,7 @@ pub async fn process_list_managed_spu_groups<O: Terminal>(
 ) -> Result<(), CliError> {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let lists = admin.list::<SpuGroupSpec, _>(vec![]).await?;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -55,8 +55,8 @@ mod target {
     use std::convert::TryInto;
     use structopt::StructOpt;
 
+    use fluvio::FluvioConfig;
     use fluvio::config::ConfigFile;
-    use fluvio::ClusterConfig;
     use crate::tls::TlsOpt;
     use crate::CliError;
 
@@ -76,7 +76,7 @@ mod target {
 
     impl ClusterTarget {
         /// try to create sc config
-        pub fn load(self) -> Result<ClusterConfig, CliError> {
+        pub fn load(self) -> Result<FluvioConfig, CliError> {
             let tls = self.tls.try_into()?;
 
             use fluvio::config::TlsPolicy::*;
@@ -105,7 +105,7 @@ mod target {
                     Ok(cluster.clone())
                 }
                 (None, Some(cluster)) => {
-                    let cluster = ClusterConfig::new(cluster).with_tls(tls);
+                    let cluster = FluvioConfig::new(cluster).with_tls(tls);
                     Ok(cluster)
                 }
                 (None, None) => {

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit="2100919"]
+#![type_length_limit = "2100919"]
 
 mod common;
 mod error;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "1113484"]
+#![type_length_limit="2100919"]
 
 mod common;
 mod error;

--- a/src/cli/src/partition/list.rs
+++ b/src/cli/src/partition/list.rs
@@ -6,8 +6,7 @@
 
 use structopt::StructOpt;
 
-use fluvio::ClusterConfig;
-use fluvio::ClusterSocket;
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio_controlplane_metadata::partition::*;
 
 use crate::error::CliError;
@@ -28,7 +27,7 @@ pub struct ListPartitionOpt {
 
 impl ListPartitionOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, OutputType), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, OutputType), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.output.as_output()))
@@ -41,7 +40,7 @@ impl ListPartitionOpt {
     {
         let (target_server, output) = self.validate()?;
 
-        let mut client = ClusterSocket::connect(target_server).await?;
+        let mut client = Fluvio::connect_with_config(&target_server).await?;
         let mut admin = client.admin().await;
 
         let spus = admin.list::<PartitionSpec, _>(vec![]).await?;

--- a/src/cli/src/produce/mod.rs
+++ b/src/cli/src/produce/mod.rs
@@ -107,7 +107,7 @@ where
 
     let mut target = Fluvio::connect_with_config(&target_server).await?;
 
-    let producer = target.partition_producer(&cfg.topic, cfg.partition).await?;
+    let producer = target.producer(&cfg.topic, cfg.partition).await?;
 
     debug!("got producer");
     if let Some(records) = file_records {

--- a/src/cli/src/produce/mod.rs
+++ b/src/cli/src/produce/mod.rs
@@ -131,7 +131,7 @@ mod produce {
     use flv_future_aio::io::BufReader;
     use flv_future_aio::io::AsyncBufReadExt;
     use fluvio_types::{print_cli_err, print_cli_ok};
-    use fluvio::PartitionProducer;
+    use fluvio::Producer;
 
     use crate::t_println;
 
@@ -140,7 +140,7 @@ mod produce {
     pub type RecordTuples = Vec<(String, Vec<u8>)>;
 
     pub async fn produce_file_records<O: Terminal>(
-        mut producer: PartitionProducer,
+        mut producer: Producer,
         out: std::sync::Arc<O>,
         _cfg: ProduceLogConfig,
         file: FileRecord,
@@ -155,7 +155,7 @@ mod produce {
 
     /// Dispatch records based on the content of the record tuples variable
     pub async fn produce_from_stdin<O: Terminal>(
-        mut producer: PartitionProducer,
+        mut producer: Producer,
         _out: std::sync::Arc<O>,
         opt: ProduceLogConfig,
     ) -> Result<(), CliError> {
@@ -178,7 +178,7 @@ mod produce {
 
     /// Process record and print success or error
     /// TODO: Add version handling for SPU
-    async fn process_record(spu: &mut PartitionProducer, record: Vec<u8>) {
+    async fn process_record(spu: &mut Producer, record: Vec<u8>) {
         match spu.send_record(record).await {
             Ok(()) => {
                 debug!("record send success");

--- a/src/cli/src/profile/context.rs
+++ b/src/cli/src/profile/context.rs
@@ -21,7 +21,7 @@ pub fn set_local_context(local_config: LocalOpt) -> Result<String, IoError> {
             cluster.tls = local_config.tls.try_into()?;
         }
         None => {
-            let mut local_cluster = ClusterConfig::new(local_addr.clone());
+            let mut local_cluster = FluvioConfig::new(local_addr.clone());
             local_cluster.tls = local_config.tls.try_into()?;
             config.add_cluster(local_cluster, LOCAL_PROFILE.to_owned());
         }

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -44,7 +44,7 @@ pub async fn set_k8_context(opt: K8Opt, external_addr: String) -> Result<Profile
             cluster.tls = opt.tls.try_into()?;
         }
         None => {
-            let mut local_cluster = ClusterConfig::new(external_addr);
+            let mut local_cluster = FluvioConfig::new(external_addr);
             local_cluster.tls = opt.tls.try_into()?;
             config.add_cluster(local_cluster, profile_name.clone());
         }

--- a/src/cli/src/profile/sync/cloud/login_agent.rs
+++ b/src/cli/src/profile/sync/cloud/login_agent.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
 use http_types::{Response, Request, StatusCode, Error as HttpError, Url};
 
-use fluvio::ClusterConfig;
+use fluvio::FluvioConfig;
 use fluvio_types::defaults::CLI_CONFIG_PATH;
 use url::ParseError;
 use super::http::execute;
@@ -87,7 +87,7 @@ impl LoginAgent {
     ///
     /// Will fail if there is no saved session, or if the token
     /// in the saved session is expired.
-    pub async fn download_profile(&mut self) -> Result<ClusterConfig, CloudError> {
+    pub async fn download_profile(&mut self) -> Result<FluvioConfig, CloudError> {
         // Check whether we have credentials in session or on disk
         let creds = match self.session.as_ref() {
             // First, try to get the token from the agent session
@@ -115,7 +115,7 @@ impl LoginAgent {
             path = "/api/v1/downloadProfile"
         )
     )]
-    async fn try_download_profile(&self, creds: &Credentials) -> Result<ClusterConfig, CloudError> {
+    async fn try_download_profile(&self, creds: &Credentials) -> Result<FluvioConfig, CloudError> {
         let mut response = download_profile(&self.remote, creds).await?;
         trace!("Response: {:#?}", &response);
         debug!(status = response.status() as u16);
@@ -123,8 +123,8 @@ impl LoginAgent {
         match response.status() {
             StatusCode::Ok => {
                 debug!("Successfully authenticated with token");
-                let cluster: ClusterConfig = response.body_json().await?;
-                Ok(cluster)
+                let config: FluvioConfig = response.body_json().await?;
+                Ok(config)
             }
             _ => {
                 warn!("Failed to download profile");

--- a/src/cli/src/profile/sync/cloud/mod.rs
+++ b/src/cli/src/profile/sync/cloud/mod.rs
@@ -8,11 +8,13 @@ pub use login_agent::CloudError;
 
 use tracing::info;
 
+use fluvio::FluvioConfig;
+use fluvio::config::{ConfigFile, Profile};
+
 use crate::Terminal;
 use crate::CliError;
 use crate::t_print;
 use crate::profile::sync::cloud::login_agent::LoginAgent;
-use fluvio::config::{ClusterConfig, ConfigFile, Profile};
 
 #[derive(Debug, StructOpt)]
 pub struct CloudOpt {
@@ -79,7 +81,7 @@ where
 
 fn save_cluster<O: Terminal>(
     _out: std::sync::Arc<O>,
-    cluster: ClusterConfig,
+    cluster: FluvioConfig,
 ) -> Result<String, CliError> {
     let mut config_file = ConfigFile::load_default_or_new()?;
     let config = config_file.mut_config();

--- a/src/cli/src/spu/list.rs
+++ b/src/cli/src/spu/list.rs
@@ -6,7 +6,7 @@
 
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio_controlplane_metadata::spu::SpuSpec;
 
 use crate::error::CliError;
@@ -32,7 +32,7 @@ pub struct ListSpusOpt {
 
 impl ListSpusOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, OutputType), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, OutputType), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.output.as_output()))
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let spus = admin.list::<SpuSpec, _>(vec![]).await?;

--- a/src/cli/src/topic/create.rs
+++ b/src/cli/src/topic/create.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::error::CliError;
@@ -74,7 +74,7 @@ pub struct CreateTopicOpt {
 
 impl CreateTopicOpt {
     /// Validate cli options. Generate target-server and create-topic configuration.
-    fn validate(self) -> Result<(ClusterConfig, (String, TopicSpec)), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, (String, TopicSpec)), CliError> {
         use fluvio::metadata::topic::PartitionMaps;
         use fluvio::metadata::topic::TopicReplicaParam;
         use load::PartitionLoad;
@@ -118,7 +118,7 @@ pub async fn process_create_topic(opt: CreateTopicOpt) -> Result<String, CliErro
 
     debug!("creating topic: {} spec: {:#?}", name, topic_spec);
 
-    let mut target = ClusterSocket::connect(target_server).await?;
+    let mut target = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = target.admin().await;
 
     admin.create(name.clone(), dry_run, topic_spec).await?;

--- a/src/cli/src/topic/delete.rs
+++ b/src/cli/src/topic/delete.rs
@@ -7,11 +7,10 @@
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::config::ClusterConfig;
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::topic::TopicSpec;
 use crate::error::CliError;
 use crate::target::ClusterTarget;
-use fluvio::ClusterSocket;
 
 #[derive(Debug, StructOpt)]
 pub struct DeleteTopicOpt {
@@ -24,7 +23,7 @@ pub struct DeleteTopicOpt {
 
 impl DeleteTopicOpt {
     /// Validate cli options. Generate target-server and delete-topic configuration.
-    fn validate(self) -> Result<(ClusterConfig, String), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, String), CliError> {
         let target_server = self.target.load()?;
 
         // return server separately from config
@@ -42,7 +41,7 @@ pub async fn process_delete_topic(opt: DeleteTopicOpt) -> Result<String, CliErro
 
     debug!("deleting topic: {}", name);
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<TopicSpec, _>(&name).await?;
     Ok(format!("topic \"{}\" deleted", name))

--- a/src/cli/src/topic/describe.rs
+++ b/src/cli/src/topic/describe.rs
@@ -7,7 +7,7 @@
 use tracing::debug;
 use structopt::StructOpt;
 
-use fluvio::{ClusterConfig, ClusterSocket};
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::target::ClusterTarget;
@@ -36,7 +36,7 @@ pub struct DescribeTopicsOpt {
 
 impl DescribeTopicsOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, (String, OutputType)), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, (String, OutputType)), CliError> {
         let target_server = self.target.load()?;
 
         // transfer config parameters
@@ -63,7 +63,7 @@ where
 
     debug!("describe topic: {}, {}", topic, output_type);
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![topic]).await?;

--- a/src/cli/src/topic/list.rs
+++ b/src/cli/src/topic/list.rs
@@ -8,8 +8,7 @@ use structopt::StructOpt;
 
 use tracing::debug;
 
-use fluvio::ClusterSocket;
-use fluvio::ClusterConfig;
+use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::Terminal;
@@ -44,7 +43,7 @@ pub struct ListTopicsOpt {
 
 impl ListTopicsOpt {
     /// Validate cli options and generate config
-    fn validate(self) -> Result<(ClusterConfig, OutputType), CliError> {
+    fn validate(self) -> Result<(FluvioConfig, OutputType), CliError> {
         let target_server = self.target.load()?;
 
         Ok((target_server, self.output.unwrap_or_default()))
@@ -67,7 +66,7 @@ where
 
     debug!("list topics {:#?} ", output_type);
 
-    let mut client = ClusterSocket::connect(target_server).await?;
+    let mut client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![]).await?;

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -37,3 +37,6 @@ flv-future-aio = { version = "2.4.1", features = ["tls"] }
 kf-socket = { version = "3.0.0", path = "../kf-socket" }
 fluvio-protocol = { version = "0.1.0" }
 dataplane = { path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+
+[dev-dependencies]
+async-std = "1.6.4"

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -26,7 +26,8 @@ use crate::config::ConfigFile;
 ///
 /// If you _are_ writing an application whose purpose is to manage a
 /// Fluvio cluster for you, you can gain access to the `FluvioAdmin`
-/// client via the regular `Fluvio` client.
+/// client via the regular [`Fluvio`] client, or through the [`connect`]
+/// or [`connect_with_config`] functions.
 ///
 /// # Example
 ///
@@ -40,6 +41,10 @@ use crate::config::ConfigFile;
 /// # Ok(())
 /// # }
 /// ```
+///
+/// [`Fluvio`]: ./struct.Fluvio.html
+/// [`connect`]: ./struct.FluvioAdmin.html#method.connect
+/// [`connect_with_config`]: ./struct.FluvioAdmin.html#method.connect_with_config
 pub struct FluvioAdmin(VersionedSerialSocket);
 
 impl FluvioAdmin {

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -31,9 +31,9 @@ use crate::FluvioError;
 /// administrator for the cluster you are connected to.
 ///
 /// ```no_run
-/// # use fluvio_experimental::{Fluvio, FluvioError};
+/// # use fluvio::{Fluvio, FluvioError};
 /// # async fn do_get_admin(fluvio: &mut Fluvio) -> Result<(), FluvioError> {
-/// let admin = fluvio.admin().await?;
+/// let admin = fluvio.admin().await;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -47,7 +47,7 @@ impl FluvioAdmin {
         Self(client)
     }
 
-    /// Creates a new admin connection using default configurations
+    /// Creates a new admin connection using the current profile from `~/.fluvio/config`
     ///
     /// This will attempt to read a Fluvio cluster configuration from
     /// your `~/.fluvio/config` file, or create one with default settings

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -8,12 +8,38 @@ use fluvio_sc_schema::AdminRequest;
 use kf_socket::*;
 
 use crate::client::*;
-use crate::ClientError;
+use crate::FluvioError;
 
-/// adminstration interface
-pub struct AdminClient(VersionedSerialSocket);
+/// An interface for managing a Fluvio cluster
+///
+/// Most applications will not require administrator functionality. The
+/// `FluvioAdmin` interface is used to create, edit, and manage Topics
+/// and other operational items. Think of the difference between regular
+/// clients of a Database and its administrators. Regular clients may be
+/// applications which are reading and writing data to and from tables
+/// that exist in the database. Database administrators would be the
+/// ones actually creating, editing, or deleting tables. The same thing
+/// goes for Fluvio administrators.
+///
+/// If you _are_ writing an application whose purpose is to manage a
+/// Fluvio cluster for you, you can gain access to the `FluvioAdmin`
+/// client via the regular `Fluvio` client.
+///
+/// # Example
+///
+/// Note that this may fail if you are not authorized as a Fluvio
+/// administrator for the cluster you are connected to.
+///
+/// ```no_run
+/// # use fluvio_experimental::{Fluvio, FluvioError};
+/// # async fn do_get_admin(fluvio: &mut Fluvio) -> Result<(), FluvioError> {
+/// let admin = fluvio.admin().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct FluvioAdmin(VersionedSerialSocket);
 
-impl AdminClient {
+impl FluvioAdmin {
     pub(crate) fn new(client: VersionedSerialSocket) -> Self {
         Self(client)
     }
@@ -31,7 +57,7 @@ impl AdminClient {
         name: String,
         dry_run: bool,
         spec: S,
-    ) -> Result<(), ClientError>
+    ) -> Result<(), FluvioError>
     where
         S: Into<AllCreatableSpec>,
     {
@@ -48,7 +74,7 @@ impl AdminClient {
 
     /// delete object by key
     /// key is depend on spec, most are string but some allow multiple types
-    pub async fn delete<S, K>(&mut self, key: K) -> Result<(), ClientError>
+    pub async fn delete<S, K>(&mut self, key: K) -> Result<(), FluvioError>
     where
         S: DeleteSpec,
         K: Into<S::DeleteKey>,
@@ -58,7 +84,7 @@ impl AdminClient {
         Ok(())
     }
 
-    pub async fn list<S, F>(&mut self, filters: F) -> Result<Vec<Metadata<S>>, ClientError>
+    pub async fn list<S, F>(&mut self, filters: F) -> Result<Vec<Metadata<S>>, FluvioError>
     where
         S: ListSpec + Encoder + Decoder,
         S::Status: Encoder + Decoder,

--- a/src/client/src/client/client.rs
+++ b/src/client/src/client/client.rs
@@ -157,6 +157,7 @@ impl ClientConfig {
     }
 
     /// set client id
+    #[allow(unused)]
     pub fn set_client_id<S>(mut self, id: S) -> Self
     where
         S: Into<String>,

--- a/src/client/src/client/client.rs
+++ b/src/client/src/client/client.rs
@@ -11,7 +11,7 @@ use fluvio_spu_schema::server::versions::{ApiVersions, ApiVersionsRequest};
 use kf_socket::*;
 use flv_future_aio::net::tls::AllDomainConnector;
 
-use crate::ClientError;
+use crate::FluvioError;
 
 /// Frame with request and response
 #[async_trait]
@@ -82,7 +82,7 @@ impl VersionedSocket {
     pub async fn connect(
         mut socket: AllKfSocket,
         config: ClientConfig,
-    ) -> Result<Self, ClientError> {
+    ) -> Result<Self, FluvioError> {
         // now get versions
         // Query for API versions
         let mut req_msg = RequestMessage::new_request(ApiVersionsRequest::default());
@@ -169,7 +169,7 @@ impl ClientConfig {
         self.addr = domain
     }
 
-    pub(crate) async fn connect(self) -> Result<VersionedSocket, ClientError> {
+    pub(crate) async fn connect(self) -> Result<VersionedSocket, FluvioError> {
         let socket = AllKfSocket::connect_with_connector(&self.addr, &self.connector).await?;
         VersionedSocket::connect(socket, self).await
     }

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -134,7 +134,11 @@ impl Fluvio {
     ) -> Result<PartitionConsumer, FluvioError> {
         let topic = topic.into();
         debug!(topic = &*topic, "Creating consumer");
-        Ok(PartitionConsumer::new(topic, partition, self.spu_pool.clone()))
+        Ok(PartitionConsumer::new(
+            topic,
+            partition,
+            self.spu_pool.clone(),
+        ))
     }
 
     /// Provides an interface for managing a Fluvio cluster

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -80,7 +80,7 @@ impl Fluvio {
     }
 
     /// create new producer for topic/partition
-    pub async fn partition_producer<S: Into<String>>(
+    pub async fn producer<S: Into<String>>(
         &mut self,
         topic: S,
         partition: i32,
@@ -91,7 +91,7 @@ impl Fluvio {
     }
 
     /// create new consumer for topic/partition
-    pub async fn partition_consumer<S: Into<String>>(
+    pub async fn consumer<S: Into<String>>(
         &mut self,
         topic: S,
         partition: i32,

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -60,7 +60,7 @@ impl Fluvio {
     /// # }
     /// ```
     pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
-        let connector = AllDomainConnector::try_from(&config.tls)?;
+        let connector = AllDomainConnector::try_from(config.tls.clone())?;
         let config = ClientConfig::new(&config.addr, connector);
         let inner_client = config.connect().await?;
         debug!("connected to cluster at: {}", inner_client.config().addr());

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -24,7 +24,11 @@ pub struct Fluvio {
 }
 
 impl Fluvio {
-    /// Creates a new Fluvio client with default configurations
+    /// Creates a new Fluvio client using the current profile from `~/.fluvio/config`
+    ///
+    /// If there is no current profile or the `~/.fluvio/config` file does not exist,
+    /// then this will create a new profile with default settings and set it as
+    /// current, then try to connect to the cluster using those settings.
     ///
     /// # Example
     ///

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -38,8 +38,10 @@ impl Fluvio {
     /// ```
     pub async fn connect() -> Result<Self, FluvioError> {
         let config_file = ConfigFile::load_default_or_new()?;
-        let cluster_config = config_file.config().current_cluster()
-            .ok_or(FluvioError::ConfigError(format!("failed to load cluster config")))?;
+        let cluster_config = config_file
+            .config()
+            .current_cluster()
+            .ok_or_else(|| FluvioError::ConfigError("failed to load cluster config".to_string()))?;
         Self::connect_with_config(cluster_config).await
     }
 
@@ -78,14 +80,22 @@ impl Fluvio {
     }
 
     /// create new producer for topic/partition
-    pub async fn partition_producer<S: Into<String>>(&mut self, topic: S, partition: i32) -> Result<PartitionProducer, FluvioError> {
+    pub async fn partition_producer<S: Into<String>>(
+        &mut self,
+        topic: S,
+        partition: i32,
+    ) -> Result<PartitionProducer, FluvioError> {
         let replica = ReplicaKey::new(topic, partition);
         debug!("creating producer, replica: {}", replica);
         Ok(PartitionProducer::new(replica, self.spu_pool.clone()))
     }
 
     /// create new consumer for topic/partition
-    pub async fn partition_consumer<S: Into<String>>(&mut self, topic: S, partition: i32) -> Result<PartitionConsumer, FluvioError> {
+    pub async fn partition_consumer<S: Into<String>>(
+        &mut self,
+        topic: S,
+        partition: i32,
+    ) -> Result<PartitionConsumer, FluvioError> {
         let replica = ReplicaKey::new(topic, partition);
         debug!("creating consumer, replica: {}", replica);
         Ok(PartitionConsumer::new(replica, self.spu_pool.clone()))
@@ -98,7 +108,7 @@ impl Fluvio {
     /// ```no_run
     /// # use fluvio::{Fluvio, FluvioError};
     /// # async fn do_get_admin(fluvio: &mut Fluvio) -> Result<(), FluvioError> {
-    /// let admin = fluvio.admin().await?;
+    /// let admin = fluvio.admin().await;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -4,8 +4,8 @@ use kf_socket::AllMultiplexerSocket;
 use dataplane::ReplicaKey;
 
 use crate::admin::FluvioAdmin;
-use crate::PartitionProducer;
-use crate::PartitionConsumer;
+use crate::Producer;
+use crate::Consumer;
 use crate::FluvioError;
 use crate::FluvioConfig;
 use crate::sync::MetadataStores;
@@ -84,10 +84,10 @@ impl Fluvio {
         &mut self,
         topic: S,
         partition: i32,
-    ) -> Result<PartitionProducer, FluvioError> {
+    ) -> Result<Producer, FluvioError> {
         let replica = ReplicaKey::new(topic, partition);
         debug!("creating producer, replica: {}", replica);
-        Ok(PartitionProducer::new(replica, self.spu_pool.clone()))
+        Ok(Producer::new(replica, self.spu_pool.clone()))
     }
 
     /// create new consumer for topic/partition
@@ -95,10 +95,10 @@ impl Fluvio {
         &mut self,
         topic: S,
         partition: i32,
-    ) -> Result<PartitionConsumer, FluvioError> {
+    ) -> Result<Consumer, FluvioError> {
         let replica = ReplicaKey::new(topic, partition);
         debug!("creating consumer, replica: {}", replica);
-        Ok(PartitionConsumer::new(replica, self.spu_pool.clone()))
+        Ok(Consumer::new(replica, self.spu_pool.clone()))
     }
 
     /// Provides an interface for managing a Fluvio cluster

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -3,48 +3,107 @@ use tracing::debug;
 use kf_socket::AllMultiplexerSocket;
 use dataplane::ReplicaKey;
 
-use crate::admin::AdminClient;
-use crate::{Producer, ClusterConfig};
-use crate::Consumer;
-use crate::ClientError;
+use crate::admin::FluvioAdmin;
+use crate::PartitionProducer;
+use crate::PartitionConsumer;
+use crate::FluvioError;
+use crate::FluvioConfig;
 use crate::sync::MetadataStores;
 use crate::spu::SpuPool;
 
 use super::*;
 use flv_future_aio::net::tls::AllDomainConnector;
 use std::convert::TryFrom;
+use crate::config::ConfigFile;
 
-/// socket to Cluster
-pub struct ClusterSocket {
+/// An interface for interacting with Fluvio streaming
+pub struct Fluvio {
     socket: AllMultiplexerSocket,
     config: ClientConfig,
     versions: Versions,
-    spu_pool: Option<SpuPool>,
+    spu_pool: SpuPool,
 }
 
-impl ClusterSocket {
-    /// private creation with  raw client
-    /// this  wraps with multiplexor
-    pub(crate) fn new(client: VersionedSocket) -> Self {
-        let (socket, config, versions) = client.split();
-        Self {
-            socket: AllMultiplexerSocket::new(socket),
-            config,
-            versions,
-            spu_pool: None,
-        }
+impl Fluvio {
+    /// Creates a new Fluvio client with default configurations
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use fluvio::{Fluvio, FluvioError};
+    /// # async fn do_connect() -> Result<(), FluvioError> {
+    /// let fluvio = Fluvio::connect().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect() -> Result<Self, FluvioError> {
+        let config_file = ConfigFile::load_default_or_new()?;
+        let cluster_config = config_file.config().current_cluster()
+            .ok_or(FluvioError::ConfigError(format!("failed to load cluster config")))?;
+        Self::connect_with_config(cluster_config).await
     }
 
-    /// create connection to Cluster
-    /// depends on policy, this will result in plain connection or TLS connection
-    pub async fn connect(config: ClusterConfig) -> Result<Self, ClientError> {
-        let connector = AllDomainConnector::try_from(config.tls)?;
-        let config = ClientConfig::new(config.addr, connector);
+    /// Creates a new Fluvio client with the given configuration
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use fluvio::{Fluvio, FluvioError, FluvioConfig};
+    /// use fluvio::config::ConfigFile;
+    /// # async fn do_connect_with_config() -> Result<(), FluvioError> {
+    /// let config_file = ConfigFile::load_default_or_new()?;
+    /// let config = config_file.config().current_cluster().unwrap();
+    /// let fluvio = Fluvio::connect_with_config(&config).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
+        let connector = AllDomainConnector::try_from(&config.tls)?;
+        let config = ClientConfig::new(&config.addr, connector);
         let inner_client = config.connect().await?;
         debug!("connected to cluster at: {}", inner_client.config().addr());
-        let cluster = Self::new(inner_client);
-        //cluster.start_metadata_watch().await?;
-        Ok(cluster)
+
+        let (socket, config, versions) = inner_client.split();
+        let mut socket = AllMultiplexerSocket::new(socket);
+
+        let metadata = MetadataStores::new(&mut socket).await?;
+        let spu_pool = SpuPool::new(config.clone(), metadata);
+
+        Ok(Self {
+            socket,
+            config,
+            versions,
+            spu_pool,
+        })
+    }
+
+    /// create new producer for topic/partition
+    pub async fn partition_producer<S: Into<String>>(&mut self, topic: S, partition: i32) -> Result<PartitionProducer, FluvioError> {
+        let replica = ReplicaKey::new(topic, partition);
+        debug!("creating producer, replica: {}", replica);
+        Ok(PartitionProducer::new(replica, self.spu_pool.clone()))
+    }
+
+    /// create new consumer for topic/partition
+    pub async fn partition_consumer<S: Into<String>>(&mut self, topic: S, partition: i32) -> Result<PartitionConsumer, FluvioError> {
+        let replica = ReplicaKey::new(topic, partition);
+        debug!("creating consumer, replica: {}", replica);
+        Ok(PartitionConsumer::new(replica, self.spu_pool.clone()))
+    }
+
+    /// Provides an interface for managing a Fluvio cluster
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use fluvio::{Fluvio, FluvioError};
+    /// # async fn do_get_admin(fluvio: &mut Fluvio) -> Result<(), FluvioError> {
+    /// let admin = fluvio.admin().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn admin(&mut self) -> FluvioAdmin {
+        FluvioAdmin::new(self.create_serial_client().await)
     }
 
     /// create serial connection
@@ -54,42 +113,5 @@ impl ClusterSocket {
             self.config.clone(),
             self.versions.clone(),
         )
-    }
-
-    /// create new admin client
-    pub async fn admin(&mut self) -> AdminClient {
-        AdminClient::new(self.create_serial_client().await)
-    }
-
-    /// create new producer for topic/partition
-    pub async fn producer(&mut self, replica: ReplicaKey) -> Result<Producer, ClientError> {
-        debug!("creating producer, replica: {}", replica);
-        if let Some(pool) = &self.spu_pool {
-            Ok(Producer::new(replica, pool.clone()))
-        } else {
-            let pool = self.init_spu_pool().await?;
-            Ok(Producer::new(replica, pool))
-        }
-    }
-
-    /// initialize spu pool and return clone of the pool
-    async fn init_spu_pool(&mut self) -> Result<SpuPool, ClientError> {
-        debug!("init metadata store");
-        let metadata = MetadataStores::new(&mut self.socket).await?;
-        let pool = SpuPool::new(self.config.clone(), metadata);
-        self.spu_pool.replace(pool.clone());
-        Ok(pool)
-    }
-
-    /// create new consumer for topic/partition
-    pub async fn consumer(&mut self, replica: ReplicaKey) -> Result<Consumer, ClientError> {
-        debug!("creating consumer, replica: {}", replica);
-
-        if let Some(pool) = &self.spu_pool {
-            Ok(Consumer::new(replica, pool.clone()))
-        } else {
-            let pool = self.init_spu_pool().await?;
-            Ok(Consumer::new(replica, pool))
-        }
     }
 }

--- a/src/client/src/config/cluster.rs
+++ b/src/client/src/config/cluster.rs
@@ -7,11 +7,11 @@ use serde::{Serialize, Deserialize};
 
 use crate::config::TlsPolicy;
 
-/// Public configuration for the cluster.
+/// Public configuration for Fluvio.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct ClusterConfig {
-    /// The address to connect to the cluster
+pub struct FluvioConfig {
+    /// The address to connect to the Fluvio cluster
     // TODO use a validated address type.
     // We don't want to have a "" address.
     pub addr: String,
@@ -22,7 +22,7 @@ pub struct ClusterConfig {
     pub tls: TlsPolicy,
 }
 
-impl ClusterConfig {
+impl FluvioConfig {
     /// Create a new cluster configuration with no TLS.
     pub fn new<S: Into<String>>(addr: S) -> Self {
         Self {

--- a/src/client/src/config/tls.rs
+++ b/src/client/src/config/tls.rs
@@ -92,7 +92,7 @@ impl From<TlsPaths> for TlsConfig {
 /// stringified contents of a `TlsCerts` should have text resembling
 /// the following:
 ///
-/// ```ignore
+/// ```text
 /// -----BEGIN RSA PRIVATE KEY-----
 /// MIIJKAIBAAKCAgEAsqV4GUKER1wy4sbNvd6gHMp745L4x+ilVElk1ucWGT2akzA6
 /// TEvDiAKFF4txkEaLTECh1dUev6rB5HnboWxd5gdg1K4ck2wrZ3Jv2OTA0unXAkoA
@@ -104,7 +104,7 @@ impl From<TlsPaths> for TlsConfig {
 ///
 /// And certificates should look something like this:
 ///
-/// ```ignore
+/// ```text
 /// -----BEGIN CERTIFICATE-----
 /// MIIGezCCBGOgAwIBAgIUTYr3REzVKe5JZl2JzLR+rKbv05UwDQYJKoZIhvcNAQEL
 /// BQAwYTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZh

--- a/src/client/src/config/tls.rs
+++ b/src/client/src/config/tls.rs
@@ -194,10 +194,10 @@ pub struct TlsPaths {
 }
 
 // TODO move this to AllDomainConnector
-impl TryFrom<TlsPolicy> for AllDomainConnector {
+impl TryFrom<&TlsPolicy> for AllDomainConnector {
     type Error = IoError;
 
-    fn try_from(config: TlsPolicy) -> Result<Self, Self::Error> {
+    fn try_from(config: &TlsPolicy) -> Result<Self, Self::Error> {
         match config {
             TlsPolicy::Disabled => Ok(AllDomainConnector::default_tcp()),
             TlsPolicy::Anonymous => {
@@ -216,10 +216,10 @@ impl TryFrom<TlsPolicy> for AllDomainConnector {
                 );
                 Ok(AllDomainConnector::TlsDomain(TlsDomainConnector::new(
                     ConnectorBuilder::new()
-                        .load_client_certs(tls.cert, tls.key)?
-                        .load_ca_cert(tls.ca_cert)?
+                        .load_client_certs(&tls.cert, &tls.key)?
+                        .load_ca_cert(&tls.ca_cert)?
                         .build(),
-                    tls.domain,
+                    tls.domain.clone(),
                 )))
             }
             TlsPolicy::Verified(TlsConfig::Inline(tls)) => {
@@ -232,7 +232,7 @@ impl TryFrom<TlsPolicy> for AllDomainConnector {
                         .load_client_certs_from_bytes(tls.cert.as_bytes(), tls.key.as_bytes())?
                         .load_ca_cert_from_bytes(tls.ca_cert.as_bytes())?
                         .build(),
-                    tls.domain,
+                    tls.domain.clone(),
                 )))
             }
         }

--- a/src/client/src/config/tls.rs
+++ b/src/client/src/config/tls.rs
@@ -194,10 +194,10 @@ pub struct TlsPaths {
 }
 
 // TODO move this to AllDomainConnector
-impl TryFrom<&TlsPolicy> for AllDomainConnector {
+impl TryFrom<TlsPolicy> for AllDomainConnector {
     type Error = IoError;
 
-    fn try_from(config: &TlsPolicy) -> Result<Self, Self::Error> {
+    fn try_from(config: TlsPolicy) -> Result<Self, Self::Error> {
         match config {
             TlsPolicy::Disabled => Ok(AllDomainConnector::default_tcp()),
             TlsPolicy::Anonymous => {
@@ -219,7 +219,7 @@ impl TryFrom<&TlsPolicy> for AllDomainConnector {
                         .load_client_certs(&tls.cert, &tls.key)?
                         .load_ca_cert(&tls.ca_cert)?
                         .build(),
-                    tls.domain.clone(),
+                    tls.domain,
                 )))
             }
             TlsPolicy::Verified(TlsConfig::Inline(tls)) => {
@@ -232,7 +232,7 @@ impl TryFrom<&TlsPolicy> for AllDomainConnector {
                         .load_client_certs_from_bytes(tls.cert.as_bytes(), tls.key.as_bytes())?
                         .load_ca_cert_from_bytes(tls.ca_cert.as_bytes())?
                         .build(),
-                    tls.domain.clone(),
+                    tls.domain,
                 )))
             }
         }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -22,12 +22,12 @@ use crate::client::SerialFrame;
 use crate::spu::SpuPool;
 
 /// consume message from replica leader
-pub struct PartitionConsumer {
+pub struct Consumer {
     replica: ReplicaKey,
     pool: SpuPool,
 }
 
-impl PartitionConsumer {
+impl Consumer {
     pub(crate) fn new(replica: ReplicaKey, pool: SpuPool) -> Self {
         Self { replica, pool }
     }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -58,7 +58,11 @@ pub struct PartitionConsumer {
 
 impl PartitionConsumer {
     pub(crate) fn new(topic: String, partition: i32, pool: SpuPool) -> Self {
-        Self { topic, partition, pool }
+        Self {
+            topic,
+            partition,
+            pool,
+        }
     }
 
     /// Fetches events from a particular offset in a given partition
@@ -102,9 +106,7 @@ impl PartitionConsumer {
 
         debug!("received fetch logs for {}", &replica);
 
-        if let Some(partition_response) =
-            response.find_partition(&self.topic, self.partition)
-        {
+        if let Some(partition_response) = response.find_partition(&self.topic, self.partition) {
             debug!(
                 "found partition response with: {} batches: {} bytes",
                 partition_response.records.batches.len(),

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -33,21 +33,21 @@ impl Consumer {
     }
 
     /// fetch logs once
-    pub async fn fetch_logs_once(
+    pub async fn fetch(
         &mut self,
-        offset_option: FetchOffset,
+        offset: FetchOffset,
         option: FetchLogOption,
     ) -> Result<FetchablePartitionResponse<RecordSet>, FluvioError> {
         debug!(
             "starting fetch log once: {:#?} from replica: {}",
-            offset_option, self.replica,
+            offset, self.replica,
         );
 
         let mut leader = self.pool.create_serial_socket(&self.replica).await?;
 
         debug!("found spu leader {}", leader);
 
-        let offset = calc_offset(&mut leader, &self.replica, offset_option).await?;
+        let offset = calc_offset(&mut leader, &self.replica, offset).await?;
 
         let partition = FetchPartition {
             partition_index: self.replica.partition,
@@ -91,7 +91,7 @@ impl Consumer {
 
     /// fetch logs as stream
     /// this will fetch continously
-    pub async fn fetch_logs_as_stream(
+    pub async fn stream(
         &mut self,
         offset_option: FetchOffset,
         option: FetchLogOption,

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -82,7 +82,10 @@ impl PartitionConsumer {
             );
             Ok(partition_response)
         } else {
-            Err(FluvioError::PartitionNotFound(self.replica.topic.clone(), self.replica.partition))
+            Err(FluvioError::PartitionNotFound(
+                self.replica.topic.clone(),
+                self.replica.partition,
+            ))
         }
     }
 

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -1,49 +1,51 @@
 use std::fmt;
 use std::io::Error as IoError;
 
-use dataplane::ReplicaKey;
 use kf_socket::KfSocketError;
 use fluvio_sc_schema::ApiError;
 
+/// Possible errors that may arise when using Fluvio
 #[derive(Debug)]
-pub enum ClientError {
+pub enum FluvioError {
     TopicNotFound(String),
-    PartitionNotFound(ReplicaKey),
+    PartitionNotFound(String, i32),
     Other(String),
     IoError(IoError),
     KfSocketError(KfSocketError),
     ApiError(ApiError),
     UnableToReadProfile,
+    ConfigError(String),
 }
 
-impl From<IoError> for ClientError {
+impl From<IoError> for FluvioError {
     fn from(error: IoError) -> Self {
         Self::IoError(error)
     }
 }
 
-impl From<KfSocketError> for ClientError {
+impl From<KfSocketError> for FluvioError {
     fn from(error: KfSocketError) -> Self {
         Self::KfSocketError(error)
     }
 }
 
-impl From<ApiError> for ClientError {
+impl From<ApiError> for FluvioError {
     fn from(error: ApiError) -> Self {
         Self::ApiError(error)
     }
 }
 
-impl fmt::Display for ClientError {
+impl fmt::Display for FluvioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::TopicNotFound(topic) => write!(f, "topic: {} not found", topic),
-            Self::PartitionNotFound(replica) => write!(f, "partition <{}> not found", replica),
+            Self::PartitionNotFound(topic, partition) => write!(f, "partition <{}-{}> not found", topic, partition),
             Self::Other(msg) => write!(f, "{}", msg),
             Self::IoError(err) => write!(f, "{}", err),
             Self::KfSocketError(err) => write!(f, "{:#?}", err),
             Self::ApiError(err) => write!(f, "{}", err),
             Self::UnableToReadProfile => write!(f, "No configuration has been provided"),
+            Self::ConfigError(err) => write!(f, "Config error: {}", err),
         }
     }
 }

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -39,7 +39,9 @@ impl fmt::Display for FluvioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::TopicNotFound(topic) => write!(f, "topic: {} not found", topic),
-            Self::PartitionNotFound(topic, partition) => write!(f, "partition <{}-{}> not found", topic, partition),
+            Self::PartitionNotFound(topic, partition) => {
+                write!(f, "partition <{}-{}> not found", topic, partition)
+            }
             Self::Other(msg) => write!(f, "{}", msg),
             Self::IoError(err) => write!(f, "{}", err),
             Self::KfSocketError(err) => write!(f, "{:#?}", err),

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -44,11 +44,9 @@
 //! use fluvio::{Fluvio, FluvioError};
 //! use fluvio::params::{FetchOffset, FetchLogOption};
 //!
-//! fn main() {
-//!     async_std::task::spawn(produce_records());
-//!     if let Err(e) = async_std::task::block_on(consume_records()) {
-//!         println!("Error: {}", e);
-//!     }
+//! async_std::task::spawn(produce_records());
+//! if let Err(e) = async_std::task::block_on(consume_records()) {
+//!     println!("Error: {}", e);
 //! }
 //!
 //! async fn produce_records() -> Result<(), FluvioError> {
@@ -79,7 +77,6 @@
 //!     }
 //!     Ok(())
 //! }
-//!
 //! ```
 //!
 //! [Fluvio CLI]: https://nightly.fluvio.io/docs/cli/
@@ -162,7 +159,10 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// ```
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
-pub async fn consumer<S: Into<String>>(topic: S, partition: i32) -> Result<PartitionConsumer, FluvioError> {
+pub async fn consumer<S: Into<String>>(
+    topic: S,
+    partition: i32,
+) -> Result<PartitionConsumer, FluvioError> {
     let fluvio = Fluvio::connect().await?;
     let consumer = fluvio.partition_consumer(topic, partition).await?;
     Ok(consumer)

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -62,8 +62,8 @@ pub mod params;
 
 pub use error::FluvioError;
 pub use config::FluvioConfig;
-pub use producer::Producer;
-pub use consumer::Consumer;
+pub use producer::TopicProducer;
+pub use consumer::PartitionConsumer;
 
 pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -1,3 +1,52 @@
+//! The official Rust client library for writing streaming applications with Fluvio
+//!
+//! Fluvio is a high performance, low latency data streaming platform built for developers.
+//!
+//! When writing streaming applications, two of your core behaviors are producing messages
+//! and consuming messages. When you produce a message, you send it to a Fluvio cluster
+//! where it is recorded and saved for later usage. When you consume a message, you are
+//! reading a previously-stored message from that same Fluvio cluster. Let's get started
+//! with a quick example where we produce and consume some messages.
+//!
+//! # Prerequisites
+//!
+//! [Install Fluvio](#installation)
+//!
+//! # Fluvio Echo
+//!
+//! The easiest way to see Fluvio in action is to produce some messages and to consume
+//! them right away. In this sense, we can use Fluvio to make an "echo service".
+//!
+//! All messages in Fluvio are sent in a sort of category called a `Topic`. You can think
+//! of a Topic as a named folder where you want to store some files, which would be your
+//! messages. If you're familiar with relational databases, you can think of a Topic as
+//! being similar to a database table, but for streaming.
+//!
+//! As the application developer, you get to decide what Topics you create and which
+//! messages you send to them. For the echo example, we'll create a Topic called `echo`.
+//!
+//! # Example
+//!
+//! The easiest way to create a Fluvio Topic is by using the [Fluvio CLI].
+//!
+//! ```bash
+//! $ fluvio topic create echo
+//! topic "echo" created
+//! ```
+//!
+//! To produce some records, you'll need to initialize the Fluvio client
+//!
+//! ```no_run
+//! # use fluvio::{Fluvio, FluvioError};
+//! # async fn do_init_fluvio() -> Result<(), FluvioError> {
+//! let fluvio = Fluvio::connect().await?;
+//! # }
+//! ```
+#![cfg_attr(
+feature = "nightly",
+doc(include = "../../../website/kubernetes/INSTALL.md")
+)]
+
 mod error;
 mod client;
 mod admin;
@@ -9,11 +58,13 @@ mod spu;
 pub mod config;
 pub mod params;
 
-pub use error::ClientError;
-pub use client::ClusterSocket;
-pub use config::ClusterConfig;
-pub use producer::Producer;
-pub use consumer::Consumer;
+pub use error::FluvioError;
+pub use config::FluvioConfig;
+pub use producer::PartitionProducer;
+pub use consumer::PartitionConsumer;
+
+pub use crate::admin::FluvioAdmin;
+pub use crate::client::Fluvio;
 
 /// re-export metadata from sc-api
 pub mod metadata {

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -40,11 +40,12 @@
 //! # use fluvio::{Fluvio, FluvioError};
 //! # async fn do_init_fluvio() -> Result<(), FluvioError> {
 //! let fluvio = Fluvio::connect().await?;
+//! # Ok(())
 //! # }
 //! ```
 #![cfg_attr(
-feature = "nightly",
-doc(include = "../../../website/kubernetes/INSTALL.md")
+    feature = "nightly",
+    doc(include = "../../../website/kubernetes/INSTALL.md")
 )]
 
 mod error;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -1,4 +1,4 @@
-//! The official Rust client library for writing streaming applications with Fluvio
+//! The Rust client library for writing streaming applications with Fluvio
 //!
 //! Fluvio is a high performance, low latency data streaming platform built for developers.
 //!
@@ -23,7 +23,8 @@
 //! being similar to a database table, but for streaming.
 //!
 //! As the application developer, you get to decide what Topics you create and which
-//! messages you send to them. For the echo example, we'll create a Topic called `echo`.
+//! messages you send to them. We need to set up a Topic before running our code. For the
+//! echo example, we'll call our topic `echo`.
 //!
 //! # Example
 //!

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ```no_run
 //! use std::time::Duration;
-//! use fluvio::{Fluvio, FluvioError};
+//! use fluvio::FluvioError;
 //! use fluvio::params::{FetchOffset, FetchLogOption};
 //!
 //! async_std::task::spawn(produce_records());

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -61,8 +61,8 @@ pub mod params;
 
 pub use error::FluvioError;
 pub use config::FluvioConfig;
-pub use producer::PartitionProducer;
-pub use consumer::PartitionConsumer;
+pub use producer::Producer;
+pub use consumer::Consumer;
 
 pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -35,15 +35,55 @@
 //! topic "echo" created
 //! ```
 //!
-//! To produce some records, you'll need to initialize the Fluvio client
+//! There are convenience methods that let you get up-and-started quickly using default
+//! configurations. Later if you want to customize your setup, you can directly use the
+//! [`Fluvio`] client object.
 //!
 //! ```no_run
-//! # use fluvio::{Fluvio, FluvioError};
-//! # async fn do_init_fluvio() -> Result<(), FluvioError> {
-//! let fluvio = Fluvio::connect().await?;
-//! # Ok(())
-//! # }
+//! use std::time::Duration;
+//! use fluvio::{Fluvio, FluvioError};
+//! use fluvio::params::{FetchOffset, FetchLogOption};
+//!
+//! fn main() {
+//!     async_std::task::spawn(produce_records());
+//!     if let Err(e) = async_std::task::block_on(consume_records()) {
+//!         println!("Error: {}", e);
+//!     }
+//! }
+//!
+//! async fn produce_records() -> Result<(), FluvioError> {
+//!     let producer = fluvio::producer("echo").await?;
+//!     for i in 0..10u8 {
+//!         producer.send_record(format!("Hello, Fluvio {}!", i), 0).await?;
+//!         async_std::task::sleep(Duration::from_secs(1)).await;
+//!     }
+//!     Ok(())
+//! }
+//!
+//! async fn consume_records() -> Result<(), FluvioError> {
+//!     let consumer = fluvio::consumer("echo", 0).await?;
+//!     let offset = FetchOffset::Earliest(None);
+//!     let fetch_config = FetchLogOption::default();
+//!     let mut stream = consumer.stream(offset, fetch_config).await?;
+//!
+//!     while let Ok(event) = stream.next().await {
+//!         for batch in event.partition.records.batches {
+//!             for record in batch.records {
+//!                 if let Some(record) = record.value.inner_value() {
+//!                     let string = String::from_utf8(record)
+//!                         .expect("record should be a string");
+//!                     println!("Got record: {}", string);
+//!                 }
+//!             }
+//!         }
+//!     }
+//!     Ok(())
+//! }
+//!
 //! ```
+//!
+//! [Fluvio CLI]: https://nightly.fluvio.io/docs/cli/
+//! [`Fluvio`]: ./struct.Fluvio.html
 #![cfg_attr(
     feature = "nightly",
     doc(include = "../../../website/kubernetes/INSTALL.md")

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -23,7 +23,7 @@ impl Producer {
 
     /// send records to spu leader for replica
     pub async fn send_record<B: AsRef<[u8]>>(&mut self, buffer: B) -> Result<(), FluvioError> {
-        let record = buffer.as_ref().to_owned();
+        let record = buffer.as_ref();
         debug!(
             "sending records: {} bytes to: {}",
             record.len(),
@@ -42,7 +42,7 @@ impl Producer {
 async fn send_record_raw<F: SerialFrame>(
     mut leader: F,
     replica: &ReplicaKey,
-    record: Vec<u8>,
+    record: &[u8],
 ) -> Result<(), FluvioError> {
     use dataplane::produce::DefaultProduceRequest;
     use dataplane::produce::DefaultPartitionRequest;

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -21,10 +21,7 @@ pub struct TopicProducer {
 
 impl TopicProducer {
     pub(crate) fn new(topic: String, pool: SpuPool) -> Self {
-        Self {
-            topic,
-            pool,
-        }
+        Self { topic, pool }
     }
 
     /// Sends an event to a specific partition within this producer's topic
@@ -43,14 +40,14 @@ impl TopicProducer {
         skip(self, buffer),
         fields(topic = &*self.topic),
     )]
-    pub async fn send_record<B: AsRef<[u8]>>(&self, buffer: B, partition: i32) -> Result<(), FluvioError> {
+    pub async fn send_record<B: AsRef<[u8]>>(
+        &self,
+        buffer: B,
+        partition: i32,
+    ) -> Result<(), FluvioError> {
         let record = buffer.as_ref();
         let replica = ReplicaKey::new(&self.topic, partition);
-        debug!(
-            "sending records: {} bytes to: {}",
-            record.len(),
-            &replica
-        );
+        debug!("sending records: {} bytes to: {}", record.len(), &replica);
 
         let spu_client = self.pool.create_serial_socket(&replica).await?;
 

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -11,12 +11,12 @@ use crate::spu::SpuPool;
 use crate::client::SerialFrame;
 
 /// produce message to replica leader
-pub struct PartitionProducer {
+pub struct Producer {
     replica: ReplicaKey,
     pool: SpuPool,
 }
 
-impl PartitionProducer {
+impl Producer {
     pub(crate) fn new(replica: ReplicaKey, pool: SpuPool) -> Self {
         Self { replica, pool }
     }

--- a/src/client/src/spu/spu_pool.rs
+++ b/src/client/src/spu/spu_pool.rs
@@ -10,7 +10,7 @@ use dataplane::api::RequestMessage;
 use fluvio_types::SpuId;
 use kf_socket::AllMultiplexerSocket;
 use kf_socket::AsyncResponse;
-use crate::ClientError;
+use crate::FluvioError;
 use crate::client::ClientConfig;
 use crate::sync::MetadataStores;
 use crate::client::VersionedSerialSocket;
@@ -36,7 +36,7 @@ impl SpuSocket {
     async fn create_stream<R: Request>(
         &mut self,
         request: R,
-    ) -> Result<AsyncResponse<R>, ClientError> {
+    ) -> Result<AsyncResponse<R>, FluvioError> {
         let req_msg = RequestMessage::new_request(request);
         self.socket
             .create_stream(req_msg, DEFAULT_STREAM_QUEUE_SIZE)
@@ -64,7 +64,7 @@ impl SpuPool {
     }
 
     /// create new spu socket
-    async fn connect_to_leader(&self, leader: SpuId) -> Result<SpuSocket, ClientError> {
+    async fn connect_to_leader(&self, leader: SpuId) -> Result<SpuSocket, FluvioError> {
         let spu = self.metadata.spus().look_up_by_id(leader).await?;
 
         debug!("connecting to spu: {}", spu.spec);
@@ -85,7 +85,7 @@ impl SpuPool {
     pub async fn create_serial_socket(
         &self,
         replica: &ReplicaKey,
-    ) -> Result<VersionedSerialSocket, ClientError> {
+    ) -> Result<VersionedSerialSocket, FluvioError> {
         let partition = self.metadata.partitions().lookup_by_key(replica).await?;
 
         let leader_id = partition.spec.leader;
@@ -109,7 +109,7 @@ impl SpuPool {
         &self,
         replica: &ReplicaKey,
         request: R,
-    ) -> Result<AsyncResponse<R>, ClientError> {
+    ) -> Result<AsyncResponse<R>, FluvioError> {
         let partition = self.metadata.partitions().lookup_by_key(replica).await?;
 
         let leader_id = partition.spec.leader;

--- a/src/client/src/sync/mod.rs
+++ b/src/client/src/sync/mod.rs
@@ -16,7 +16,7 @@ mod context {
     use event_listener::EventListener;
     use async_rwlock::RwLockReadGuard;
 
-    use crate::ClientError;
+    use crate::FluvioError;
     use crate::metadata::core::Spec;
     use crate::metadata::store::LocalStore;
     use crate::metadata::store::EpochMap;
@@ -58,7 +58,7 @@ mod context {
         pub async fn lookup_by_key(
             &self,
             key: &S::IndexKey,
-        ) -> Result<MetadataStoreObject<S, String>, ClientError>
+        ) -> Result<MetadataStoreObject<S, String>, FluvioError>
         where
             S: 'static,
             S::IndexKey: Display,
@@ -72,7 +72,7 @@ mod context {
         pub async fn lookup_and_wait<'a, F>(
             &'a self,
             search: F,
-        ) -> Result<MetadataStoreObject<S, String>, ClientError>
+        ) -> Result<MetadataStoreObject<S, String>, FluvioError>
         where
             S: 'static,
             S::IndexKey: Display,
@@ -105,7 +105,7 @@ mod context {
 
                         _ = sleep(time_left) => {
                             warn!("store {}: look up timeout expired",S::LABEL);
-                            return Err(ClientError::IoError(IoError::new(
+                            return Err(FluvioError::IoError(IoError::new(
                                 ErrorKind::TimedOut,
                                 format!("{} store lookup failed due to timeout",S::LABEL),
                             )))
@@ -136,7 +136,7 @@ mod context {
         pub async fn look_up_by_id(
             &self,
             id: i32,
-        ) -> Result<MetadataStoreObject<SpuSpec, String>, ClientError> {
+        ) -> Result<MetadataStoreObject<SpuSpec, String>, FluvioError> {
             self.lookup_and_wait(|g| {
                 for spu in g.values() {
                     if spu.spec.id == id {

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -1,6 +1,6 @@
 use std::io::Error as IoError;
 use serde::export::Formatter;
-use fluvio::ClientError;
+use fluvio::FluvioError;
 use flv_future_aio::io::Error;
 use k8_config::{ConfigError as K8ConfigError};
 use k8_client::{ClientError as K8ClientError};
@@ -11,7 +11,7 @@ pub enum ClusterError {
     /// An IO error occurred, such as opening a file or running a command.
     IoError(IoError),
     /// An error occurred with the Fluvio client.
-    ClientError(ClientError),
+    ClientError(FluvioError),
     /// An error occurred with the Kubernetes config.
     K8ConfigError(K8ConfigError),
     /// An error occurred with the Kubernetes client.
@@ -38,8 +38,8 @@ impl From<IoError> for ClusterError {
     }
 }
 
-impl From<ClientError> for ClusterError {
-    fn from(err: ClientError) -> Self {
+impl From<FluvioError> for ClusterError {
+    fn from(err: FluvioError) -> Self {
         Self::ClientError(err)
     }
 }

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -84,12 +84,6 @@ impl DefaultAsyncBuffer {
     }
 }
 
-impl From<Option<Vec<u8>>> for DefaultAsyncBuffer {
-    fn from(val: Option<Vec<u8>>) -> Self {
-        Self::new(val)
-    }
-}
-
 impl AsyncBuffer for DefaultAsyncBuffer {
     fn len(&self) -> usize {
         match self.0 {
@@ -125,6 +119,13 @@ impl From<String> for DefaultAsyncBuffer {
 
 impl From<Vec<u8>> for DefaultAsyncBuffer {
     fn from(value: Vec<u8>) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<'a> From<&'a [u8]> for DefaultAsyncBuffer {
+    fn from(bytes: &'a [u8]) -> Self {
+        let value = bytes.to_owned();
         Self(Some(value))
     }
 }
@@ -327,6 +328,17 @@ where
     fn from(value: Vec<u8>) -> Self {
         let mut record = Record::default();
         record.value = value.into();
+        record
+    }
+}
+
+impl<'a, B> From<&'a [u8]> for Record<B>
+where
+    B: From<&'a [u8]> + Default,
+{
+    fn from(slice: &'a [u8]) -> Self {
+        let mut record = Record::default();
+        record.value = B::from(slice);
         record
     }
 }

--- a/src/sc/src/controllers/partitions/reducer.rs
+++ b/src/sc/src/controllers/partitions/reducer.rs
@@ -18,7 +18,7 @@ type PartitionWSAction = WSAction<PartitionSpec>;
 
 /// Given This is a generated partition from TopicController, It will try to allocate assign replicas
 /// to live SPU.
-/// ```ignore
+/// ```text
 ///     Spec
 ///           name: Topic0-0
 ///           replication: 2

--- a/src/storage/src/fixture.rs
+++ b/src/storage/src/fixture.rs
@@ -26,7 +26,7 @@ pub fn create_batch_with_producer(producer: i64, records: u16) -> DefaultBatch {
     for _ in 0..records {
         let mut record = DefaultRecord::default();
         let bytes: Vec<u8> = vec![10, 20];
-        record.value = Some(bytes).into();
+        record.value = bytes.into();
         batches.add_record(record);
     }
 

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -147,7 +147,7 @@ mod tests {
         for _ in 0..records {
             let mut record = DefaultRecord::default();
             let bytes: Vec<u8> = vec![10, 20];
-            record.value = Some(bytes).into();
+            record.value = bytes.into();
             batches.add_record(record);
         }
         batches

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -57,7 +57,7 @@ async fn validate_consume_message_api(option: &TestOption) {
     for i in 0..replication {
         let topic_name = option.topic_name(i);
         let mut consumer = client
-            .partition_consumer(topic_name, 0)
+            .consumer(topic_name, 0)
             .await
             .expect("consumer");
 

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -56,10 +56,7 @@ async fn validate_consume_message_api(option: &TestOption) {
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let mut consumer = client
-            .consumer(topic_name, 0)
-            .await
-            .expect("consumer");
+        let mut consumer = client.consumer(topic_name, 0).await.expect("consumer");
 
         println!("retrieving messages");
         let response = consumer

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -50,13 +50,12 @@ async fn validate_consume_message_api(option: &TestOption) {
     use fluvio::params::FetchOffset;
     use fluvio::params::FetchLogOption;
 
-    let mut client = Fluvio::connect().await.expect("should connect");
-
+    let client = Fluvio::connect().await.expect("should connect");
     let replication = option.replication();
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let mut consumer = client.consumer(topic_name, 0).await.expect("consumer");
+        let consumer = client.partition_consumer(topic_name, 0).await.expect("consumer");
 
         println!("retrieving messages");
         let response = consumer

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -63,7 +63,7 @@ async fn validate_consume_message_api(option: &TestOption) {
 
         println!("retrieving messages");
         let response = consumer
-            .fetch_logs_once(FetchOffset::Earliest(None), FetchLogOption::default())
+            .fetch(FetchOffset::Earliest(None), FetchLogOption::default())
             .await
             .expect("records");
         println!("message received");

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,11 +5,10 @@ use std::io::Write;
 
 use utils::bin::get_fluvio;
 
+use fluvio::Fluvio;
 use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
-use fluvio::config::ConfigFile;
-use fluvio::ClusterSocket;
 
 /// verify consumer thru CLI
 pub async fn validate_consume_message(option: &TestOption) {
@@ -48,18 +47,10 @@ fn validate_consume_message_cli(option: &TestOption) {
 }
 
 async fn validate_consume_message_api(option: &TestOption) {
-    // futures::stream::StreamExt;
-
-    use fluvio::params::FetchOffset;;
+    use fluvio::params::FetchOffset;
     use fluvio::params::FetchLogOption;
-    use dataplane::ReplicaKey;
 
-    let config = ConfigFile::load(None).expect("load config");
-    let cluster_config = config
-        .config()
-        .current_cluster()
-        .expect("get current cluster");
-    let mut cluster = ClusterSocket::connect(cluster_config.clone())
+    let mut client = Fluvio::connect()
         .await
         .expect("should connect");
 
@@ -67,8 +58,8 @@ async fn validate_consume_message_api(option: &TestOption) {
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let mut consumer = cluster
-            .consumer(ReplicaKey::new(topic_name.to_owned(), 0))
+        let mut consumer = client
+            .partition_consumer(topic_name, 0)
             .await
             .expect("consumer");
 

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -55,7 +55,10 @@ async fn validate_consume_message_api(option: &TestOption) {
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let consumer = client.partition_consumer(topic_name, 0).await.expect("consumer");
+        let consumer = client
+            .partition_consumer(topic_name, 0)
+            .await
+            .expect("consumer");
 
         println!("retrieving messages");
         let response = consumer

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -50,9 +50,7 @@ async fn validate_consume_message_api(option: &TestOption) {
     use fluvio::params::FetchOffset;
     use fluvio::params::FetchLogOption;
 
-    let mut client = Fluvio::connect()
-        .await
-        .expect("should connect");
+    let mut client = Fluvio::connect().await.expect("should connect");
 
     let replication = option.replication();
 

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -18,7 +18,7 @@ pub async fn produce_message_with_api(option: &TestOption) {
     for i in 0..replication {
         let topic_name = option.topic_name(i);
         let mut producer = client
-            .partition_producer(&topic_name, 0)
+            .producer(&topic_name, 0)
             .await
             .expect("producer");
 

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -11,9 +11,7 @@ pub async fn produce_message(option: &TestOption) {
 }
 
 pub async fn produce_message_with_api(option: &TestOption) {
-    let mut client = Fluvio::connect()
-        .await
-        .expect("should connect");
+    let mut client = Fluvio::connect().await.expect("should connect");
 
     let replication = option.replication();
 

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -17,10 +17,7 @@ pub async fn produce_message_with_api(option: &TestOption) {
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let mut producer = client
-            .producer(&topic_name, 0)
-            .await
-            .expect("producer");
+        let mut producer = client.producer(&topic_name, 0).await.expect("producer");
 
         for i in 0..option.produce.produce_iteration {
             let message = generate_message(i, option);

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -11,19 +11,16 @@ pub async fn produce_message(option: &TestOption) {
 }
 
 pub async fn produce_message_with_api(option: &TestOption) {
-    let mut client = Fluvio::connect().await.expect("should connect");
-
+    let client = Fluvio::connect().await.expect("should connect");
     let replication = option.replication();
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
-        let mut producer = client.producer(&topic_name, 0).await.expect("producer");
+        let producer = client.topic_producer(&topic_name).await.expect("producer");
 
         for i in 0..option.produce.produce_iteration {
             let message = generate_message(i, option);
-
-            producer.send_record(message).await.expect("message sent");
-
+            producer.send_record(message, 0).await.expect("message sent");
             println!("topic: {}, message sent: {}", topic_name, i);
         }
     }

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -20,7 +20,10 @@ pub async fn produce_message_with_api(option: &TestOption) {
 
         for i in 0..option.produce.produce_iteration {
             let message = generate_message(i, option);
-            producer.send_record(message, 0).await.expect("message sent");
+            producer
+                .send_record(message, 0)
+                .await
+                .expect("message sent");
             println!("topic: {}, message sent: {}", topic_name, i);
         }
     }


### PR DESCRIPTION
This is the first set of API changes decided upon as part of the [interface experiment](https://github.com/infinyon/fluvio/pull/285) last week. The primary change here is to make the top-level client structs represent Fluvio with their names.

Name changes:
- `ClusterSocket` -> `Fluvio`
- `ClusterConfig` -> `FluvioConfig`
- `AdminClient` -> `FluvioAdmin`
- ~`Producer` -> `PartitionProducer` (to represent that messages are sent to a specific partition in a topic)~
- ~`Consumer` -> `PartitionConsumer` (to represent that messages are received from a specific partition in a topic)~

These changes also introduce cargo doc examples for how to initialize and use those structs.