### PR TITLE
Add better Offset API

### DIFF
--- a/src/cli/src/consume/cli.rs
+++ b/src/cli/src/consume/cli.rs
@@ -8,7 +8,6 @@ use structopt::StructOpt;
 
 use fluvio::FluvioConfig;
 use fluvio::dataplane::Offset;
-use fluvio::params::MAX_FETCH_BYTES;
 
 use crate::error::CliError;
 use crate::target::ClusterTarget;
@@ -64,7 +63,6 @@ impl ConsumeLogOpt {
     /// validate the configuration and generate target server and config which can be used
     pub fn validate(self) -> Result<(FluvioConfig, ConsumeLogConfig), CliError> {
         let target_server = self.target.load()?;
-        let max_bytes = self.max_bytes.unwrap_or(MAX_FETCH_BYTES as i32);
 
         // consume log specific configurations
         let consume_log_cfg = ConsumeLogConfig {
@@ -73,7 +71,7 @@ impl ConsumeLogOpt {
             from_beginning: self.from_beginning,
             disable_continuous: self.disable_continuous,
             offset: self.offset,
-            max_bytes,
+            max_bytes: self.max_bytes,
             output: self.output,
             suppress_unknown: self.suppress_unknown,
         };
@@ -91,7 +89,7 @@ pub struct ConsumeLogConfig {
     pub from_beginning: bool,
     pub disable_continuous: bool,
     pub offset: Option<Offset>,
-    pub max_bytes: i32,
+    pub max_bytes: Option<i32>,
     pub output: ConsumeOutputType,
     pub suppress_unknown: bool,
 }

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -62,9 +62,16 @@ where
         Ok(offset) => offset,
         Err(FluvioError::NegativeOffset(err)) => {
             // This should only apply in the `-B` case
-            return Err(CliError::InvalidArg(format!("Negative offsets are illegal: got {}", err)));
+            return Err(CliError::InvalidArg(format!(
+                "Negative offsets are illegal: got {}",
+                err
+            )));
         }
-        _ => return Err(CliError::Other("an unknown offset error occurred".to_string())),
+        _ => {
+            return Err(CliError::Other(
+                "an unknown offset error occurred".to_string(),
+            ))
+        }
     };
 
     let fetch_config = {

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -49,14 +49,12 @@ where
     let maybe_initial_offset = if opt.from_beginning {
         let big_offset = opt.offset.unwrap_or(0);
         // Try to convert to u32
-        u32::try_from(big_offset).ok()
-            .map(|num| Offset::from_beginning(num))
+        u32::try_from(big_offset).ok().map(Offset::from_beginning)
     } else if let Some(big_offset) = opt.offset {
         // if it is negative, we start from end
         if big_offset < 0 {
             // Try to convert to u32
-            u32::try_from(big_offset * -1).ok()
-                .map(|num| Offset::from_end(num))
+            u32::try_from(big_offset * -1).ok().map(Offset::from_end)
         } else {
             Offset::absolute(big_offset).ok()
         }
@@ -67,7 +65,7 @@ where
     let initial_offset = match maybe_initial_offset {
         Some(offset) => offset,
         None => {
-            return Err(CliError::InvalidArg(format!("Illegal offset. Relative offsets must be u32 and absolute offsets must be positive")));
+            return Err(CliError::InvalidArg("Illegal offset. Relative offsets must be u32 and absolute offsets must be positive".to_string()));
         }
     };
 

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -62,7 +62,9 @@ where
         Some(offset) => offset,
         None => {
             // This should only apply in the `-B` case
-            return Err(CliError::InvalidArg("Illegal offset, negative numbers not allowed".to_string()));
+            return Err(CliError::InvalidArg(
+                "Illegal offset, negative numbers not allowed".to_string(),
+            ));
         }
     };
 
@@ -75,7 +77,9 @@ where
     };
 
     if opt.disable_continuous {
-        let response = consumer.fetch_with_config(initial_offset, fetch_config).await?;
+        let response = consumer
+            .fetch_with_config(initial_offset, fetch_config)
+            .await?;
 
         debug!(
             "got a single response: LSO: {} batches: {}",
@@ -85,7 +89,9 @@ where
 
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
-        let mut log_stream = consumer.stream_with_config(initial_offset, fetch_config).await?;
+        let mut log_stream = consumer
+            .stream_with_config(initial_offset, fetch_config)
+            .await?;
 
         while let Ok(response) = log_stream.next().await {
             let partition = response.partition;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit="2102449"]
+#![type_length_limit = "2102449"]
 
 mod common;
 mod error;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit="2102494"]
+#![type_length_limit = "2102494"]
 
 mod common;
 mod error;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2100919"]
+#![type_length_limit="2102449"]
 
 mod common;
 mod error;

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2102449"]
+#![type_length_limit="2102494"]
 
 mod common;
 mod error;

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -123,11 +123,8 @@ impl Fluvio {
     /// let consumer_one = fluvio.partition_consumer("my-topic", 0).await?;
     /// let consumer_two = fluvio.partition_consumer("my-topic", 1).await?;
     ///
-    /// let offset_one = Offset::from_beginning(0).unwrap();
-    /// let records_one = consumer_one.fetch(offset_one).await?;
-    ///
-    /// let offset_two = Offset::from_beginning(0).unwrap();
-    /// let records_two = consumer_two.fetch(offset_two).await?;
+    /// let records_one = consumer_one.fetch(Offset::beginning()).await?;
+    /// let records_two = consumer_two.fetch(Offset::beginning()).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -94,6 +94,7 @@ impl Fluvio {
     /// # use fluvio::{Fluvio, FluvioError};
     /// # async fn do_produce_to_topic(fluvio: &Fluvio) -> Result<(), FluvioError> {
     /// let producer = fluvio.topic_producer("my-topic").await?;
+    /// producer.send_record("Hello, Fluvio!", 0).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -117,17 +118,16 @@ impl Fluvio {
     /// # Example
     ///
     /// ```no_run
-    /// # use fluvio::{Fluvio, FluvioError};
-    /// # use fluvio::params::{FetchOffset, FetchLogOption};
+    /// # use fluvio::{Fluvio, Offset, FluvioError};
     /// # async fn do_consume_from_partitions(fluvio: &Fluvio) -> Result<(), FluvioError> {
     /// let consumer_one = fluvio.partition_consumer("my-topic", 0).await?;
     /// let consumer_two = fluvio.partition_consumer("my-topic", 1).await?;
     ///
-    /// let offset_one = FetchOffset::Earliest(None);
-    /// let records_one = consumer_one.fetch(offset_one, FetchLogOption::default()).await?;
+    /// let offset_one = Offset::from_beginning(0).unwrap();
+    /// let records_one = consumer_one.fetch(offset_one).await?;
     ///
-    /// let offset_two = FetchOffset::Earliest(None);
-    /// let records_two = consumer_two.fetch(offset_two, FetchLogOption::default()).await?;
+    /// let offset_two = Offset::from_beginning(0).unwrap();
+    /// let records_two = consumer_two.fetch(offset_two).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -236,6 +236,7 @@ impl PartitionConsumer {
     ///
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
+    /// [`stream_with_config`]: struct.ConsumerConfig.html#method.stream_with_config
     pub async fn stream(
         &self,
         offset: Offset,

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -92,8 +92,13 @@ impl PartitionConsumer {
     ///
     /// [`Offset`]: struct.Offset.html
     /// [`fetch_with_config`]: struct.PartitionConsumer.html#method.fetch_with_config
-    pub async fn fetch(&self, offset: Offset) -> Result<FetchablePartitionResponse<RecordSet>, FluvioError> {
-        let records = self.fetch_with_config(offset, ConsumerConfig::default()).await?;
+    pub async fn fetch(
+        &self,
+        offset: Offset,
+    ) -> Result<FetchablePartitionResponse<RecordSet>, FluvioError> {
+        let records = self
+            .fetch_with_config(offset, ConsumerConfig::default())
+            .await?;
         Ok(records)
     }
 
@@ -152,7 +157,9 @@ impl PartitionConsumer {
 
         debug!("found spu leader {}", leader);
 
-        let offset = offset.to_absolute(&mut leader, &self.topic, self.partition).await?;
+        let offset = offset
+            .to_absolute(&mut leader, &self.topic, self.partition)
+            .await?;
 
         let partition = FetchPartition {
             partition_index: self.partition,
@@ -229,8 +236,13 @@ impl PartitionConsumer {
     ///
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
-    pub async fn stream(&self, offset: Offset) -> Result<AsyncResponse<DefaultStreamFetchRequest>, FluvioError> {
-        let result = self.stream_with_config(offset, ConsumerConfig::default()).await?;
+    pub async fn stream(
+        &self,
+        offset: Offset,
+    ) -> Result<AsyncResponse<DefaultStreamFetchRequest>, FluvioError> {
+        let result = self
+            .stream_with_config(offset, ConsumerConfig::default())
+            .await?;
         Ok(result)
     }
 
@@ -287,7 +299,9 @@ impl PartitionConsumer {
 
         let mut serial_socket = self.pool.create_serial_socket(&replica).await?;
         debug!("created serial socket {}", serial_socket);
-        let offset = offset.to_absolute(&mut serial_socket, &self.topic, self.partition).await?;
+        let offset = offset
+            .to_absolute(&mut serial_socket, &self.topic, self.partition)
+            .await?;
         drop(serial_socket);
 
         let stream_request = DefaultStreamFetchRequest {

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -34,8 +34,7 @@ use crate::spu::SpuPool;
 /// # use fluvio::{Fluvio, Offset, ConsumerConfig, FluvioError};
 /// # async fn do_create_consumer(fluvio: &Fluvio) -> Result<(), FluvioError> {
 /// let consumer = fluvio.partition_consumer("my-topic", 0).await?;
-/// let offset = Offset::from_beginning(0).unwrap();
-/// let records = consumer.fetch(offset).await?;
+/// let records = consumer.fetch(Offset::beginning()).await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -73,10 +72,7 @@ impl PartitionConsumer {
     /// ```no_run
     /// # use fluvio::{PartitionConsumer, Offset, ConsumerConfig, FluvioError};
     /// # async fn do_fetch(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// // Fetch records starting from the earliest ones saved
-    /// let offset = Offset::from_beginning(0).unwrap();
-    ///
-    /// let response = consumer.fetch(offset).await?;
+    /// let response = consumer.fetch(Offset::beginning()).await?;
     /// for batch in response.records.batches {
     ///     for record in batch.records {
     ///         if let Some(record) = record.value.inner_value() {
@@ -119,13 +115,11 @@ impl PartitionConsumer {
     /// ```no_run
     /// # use fluvio::{PartitionConsumer, FluvioError, Offset, ConsumerConfig};
     /// # async fn do_fetch(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// // Fetch records starting from the earliest ones saved
-    /// let offset = Offset::from_beginning(0).unwrap();
     /// // Use custom fetching configurations
     /// let fetch_config = ConsumerConfig::default()
     ///     .with_max_bytes(1000);
     ///
-    /// let response = consumer.fetch_with_config(offset, fetch_config).await?;
+    /// let response = consumer.fetch_with_config(Offset::beginning(), fetch_config).await?;
     /// for batch in response.records.batches {
     ///     for record in batch.records {
     ///         if let Some(record) = record.value.inner_value() {
@@ -216,9 +210,7 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// // Start streaming events from the beginning of the partition
-    /// let offset = Offset::from_beginning(0).unwrap();
-    /// let mut stream = consumer.stream(offset).await?;
+    /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Ok(event) = stream.next().await {
     ///     for batch in event.partition.records.batches {
     ///         for record in batch.records {
@@ -265,11 +257,10 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// // Start streaming events from the beginning of the partition
-    /// let offset = Offset::from_beginning(0).unwrap();
-    /// // Use the default streaming settings
-    /// let fetch_config = ConsumerConfig::default();
-    /// let mut stream = consumer.stream_with_config(offset, fetch_config).await?;
+    /// // Use a custom max_bytes value in the config
+    /// let fetch_config = ConsumerConfig::default()
+    ///     .with_max_bytes(1000);
+    /// let mut stream = consumer.stream_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Ok(event) = stream.next().await {
     ///     for batch in event.partition.records.batches {
     ///         for record in batch.records {

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -15,6 +15,7 @@ pub enum FluvioError {
     ApiError(ApiError),
     UnableToReadProfile,
     ConfigError(String),
+    NegativeOffset(i64),
 }
 
 impl From<IoError> for FluvioError {
@@ -48,6 +49,7 @@ impl fmt::Display for FluvioError {
             Self::ApiError(err) => write!(f, "{}", err),
             Self::UnableToReadProfile => write!(f, "No configuration has been provided"),
             Self::ConfigError(err) => write!(f, "Config error: {}", err),
+            Self::NegativeOffset(err) => write!(f, "Negative offsets are illegal. Got: {}", err),
         }
     }
 }

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -59,8 +59,7 @@
 //!
 //! async fn consume_records() -> Result<(), FluvioError> {
 //!     let consumer = fluvio::consumer("echo", 0).await?;
-//!     let offset = Offset::from_beginning(0).unwrap();
-//!     let mut stream = consumer.stream(offset).await?;
+//!     let mut stream = consumer.stream(Offset::beginning()).await?;
 //!
 //!     while let Ok(event) = stream.next().await {
 //!         for batch in event.partition.records.batches {
@@ -141,8 +140,7 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// # use fluvio::{ConsumerConfig, FluvioError, Offset};
 /// #  async fn do_consume() -> Result<(), FluvioError> {
 /// let consumer = fluvio::consumer("my-topic", 0).await?;
-/// let offset = Offset::from_beginning(0).unwrap();
-/// let mut stream = consumer.stream(offset).await?;
+/// let mut stream = consumer.stream(Offset::beginning()).await?;
 /// while let Ok(event) = stream.next().await {
 ///     for batch in event.partition.records.batches {
 ///         for record in batch.records {

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -41,8 +41,7 @@
 //!
 //! ```no_run
 //! use std::time::Duration;
-//! use fluvio::FluvioError;
-//! use fluvio::params::{FetchOffset, FetchLogOption};
+//! use fluvio::{Offset, FluvioError};
 //!
 //! async_std::task::spawn(produce_records());
 //! if let Err(e) = async_std::task::block_on(consume_records()) {
@@ -60,9 +59,8 @@
 //!
 //! async fn consume_records() -> Result<(), FluvioError> {
 //!     let consumer = fluvio::consumer("echo", 0).await?;
-//!     let offset = FetchOffset::Earliest(None);
-//!     let fetch_config = FetchLogOption::default();
-//!     let mut stream = consumer.stream(offset, fetch_config).await?;
+//!     let offset = Offset::from_beginning(0).unwrap();
+//!     let mut stream = consumer.stream(offset).await?;
 //!
 //!     while let Ok(event) = stream.next().await {
 //!         for batch in event.partition.records.batches {
@@ -89,6 +87,7 @@
 mod error;
 mod client;
 mod admin;
+mod params;
 mod consumer;
 mod producer;
 mod offset;
@@ -96,12 +95,11 @@ mod sync;
 mod spu;
 
 pub mod config;
-pub mod params;
 
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::TopicProducer;
-pub use consumer::PartitionConsumer;
+pub use consumer::{PartitionConsumer, ConsumerConfig};
 pub use offset::Offset;
 
 pub use crate::admin::FluvioAdmin;
@@ -140,11 +138,11 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// # Example
 ///
 /// ```no_run
-/// # use fluvio::FluvioError;
-/// use fluvio::params::{FetchOffset, FetchLogOption};
+/// # use fluvio::{ConsumerConfig, FluvioError, Offset};
 /// #  async fn do_consume() -> Result<(), FluvioError> {
 /// let consumer = fluvio::consumer("my-topic", 0).await?;
-/// let mut stream = consumer.stream(FetchOffset::Earliest(None), FetchLogOption::default()).await?;
+/// let offset = Offset::from_beginning(0).unwrap();
+/// let mut stream = consumer.stream(offset).await?;
 /// while let Ok(event) = stream.next().await {
 ///     for batch in event.partition.records.batches {
 ///         for record in batch.records {

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -91,6 +91,7 @@ mod client;
 mod admin;
 mod consumer;
 mod producer;
+mod offset;
 mod sync;
 mod spu;
 
@@ -101,6 +102,7 @@ pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::TopicProducer;
 pub use consumer::PartitionConsumer;
+pub use offset::Offset;
 
 pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;

--- a/src/client/src/offset.rs
+++ b/src/client/src/offset.rs
@@ -1,0 +1,267 @@
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+
+use tracing::{debug, trace};
+use dataplane::ReplicaKey;
+use fluvio_spu_schema::server::fetch_offset::FetchOffsetsRequest;
+use fluvio_spu_schema::server::fetch_offset::FetchOffsetPartitionResponse;
+
+use crate::FluvioError;
+use crate::client::SerialFrame;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum OffsetInner {
+    Absolute(i64),
+    FromBeginning(i64),
+    FromEnd(i64),
+}
+
+/// Describes the location of an event stored in a Fluvio partition
+///
+/// All Fluvio events are stored as a log inside a partition. A log
+/// is just an ordered list, and an `Offset` is just a way to select
+/// an item from that list. There are several ways that an `Offset`
+/// may identify an element from a log. Suppose you sent some
+/// multiples of `11` to your partition. The various offset types
+/// would look like this:
+///
+/// ```text
+///         Partition Log: [ 00, 11, 22, 33, 44, 55, 66 ]
+///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6
+///  FromBeginning Offset:    0,  1,  2,  3,  4,  5,  6
+///        FromEnd Offset:    6,  5,  4,  3,  2,  1,  0
+/// ```
+///
+/// When a new partition is created, it always starts counting new
+/// events at the `Absolute` offset of 0. An absolute offset is a
+/// unique index that represents the event's distance from the very
+/// beginning of the partition. The absolute offset of an event never
+/// changes.
+///
+/// Sometimes when a partition gets very large, Fluvio will begin
+/// deleting events from the beginning of the log in order to save
+/// space. Whenever it does this, it keeps track of the latest
+/// non-deleted event. This allows the `FromBeginning` offset to
+/// select an event which is a certain number of places in front of
+/// the deleted range. For example, let's say that the first two
+/// events from our partition were deleted. Our new offsets would
+/// look like this:
+///
+/// ```text
+///                          These events were deleted!
+///                          |
+///                          vvvvvv
+///         Partition Log: [ .., .., 22, 33, 44, 55, 66 ]
+///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6
+///  FromBeginning Offset:            0,  1,  2,  3,  4
+///        FromEnd Offset:    6,  5,  4,  3,  2,  1,  0
+/// ```
+///
+/// Just like the `FromBeginning` offset may change if events are deleted,
+/// the `FromEnd` offset will change when new events are added. Let's take
+/// a look:
+///
+/// ```text
+///                                        These events were added!
+///                                                               |
+///                                                      vvvvvvvvvv
+///         Partition Log: [ .., .., 22, 33, 44, 55, 66, 77, 88, 99 ]
+///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6,  7,  8,  9
+///  FromBeginning Offset:            0,  1,  2,  3,  4,  5,  6,  7
+///        FromEnd Offset:    9,  8,  7,  6,  5,  4,  3,  2,  1,  0
+/// ```
+///
+/// # Example
+///
+/// All offsets must be constructed with a positive index. Negative
+/// numbers are meaningless for offsets and therefore are not allowed.
+/// Trying to construct an offset with a negative number will yield `None`.
+///
+/// ```
+/// use fluvio::Offset;
+/// let absolute_offset = Offset::absolute(5).unwrap();
+/// let offset_from_beginning = Offset::from_beginning(100).unwrap();
+/// let offset_from_end = Offset::from_end(10).unwrap();
+///
+/// // Negative offsets will give None
+/// assert_eq!(Offset::absolute(-10), None);
+/// assert_eq!(Offset::from_beginning(-15), None);
+/// assert_eq!(Offset::from_end(-20), None);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Offset {
+    inner: OffsetInner,
+}
+
+impl Offset {
+    /// Creates an absolute offset with the given index
+    ///
+    /// The index must not be less than zero.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fluvio::Offset;
+    /// assert!(Offset::absolute(100).is_some());
+    /// assert!(Offset::absolute(0).is_some());
+    /// assert!(Offset::absolute(-10).is_none());
+    /// ```
+    pub fn absolute(index: i64) -> Option<Offset> {
+        if index < 0 {
+            return None;
+        }
+        Some(Self {
+            inner: OffsetInner::Absolute(index),
+        })
+    }
+
+    /// Creates a relative offset starting at the beginning of the saved log
+    ///
+    /// A relative `FromBeginning` offset will not always match an `Absolute`
+    /// offset. In order to save space, Fluvio may sometimes delete events
+    /// from the beginning of the log. When this happens, the `FromBeginning`
+    /// relative offset starts counting from the first non-deleted log entry.
+    ///
+    /// ```text
+    ///                          These events were deleted!
+    ///                          |
+    ///                          vvvvvv
+    ///         Partition Log: [ .., .., 22, 33, 44, 55, 66 ]
+    ///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6
+    ///  FromBeginning Offset:            0,  1,  2,  3,  4
+    /// ```
+    ///
+    /// The offset must not be less than zero.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fluvio::Offset;
+    /// assert!(Offset::from_beginning(10).is_some());
+    /// assert!(Offset::from_beginning(0).is_some());
+    /// assert!(Offset::from_beginning(-10).is_none());
+    /// ```
+    pub fn from_beginning(offset: i64) -> Option<Offset> {
+        if offset < 0 {
+            return None;
+        }
+        Some(Self {
+            inner: OffsetInner::FromBeginning(offset),
+        })
+    }
+
+    /// Creates a relative offset counting backwards from the end of the log
+    ///
+    /// A relative `FromEnd` offset will begin counting from the last
+    /// "stable committed" event entry in the log. Increasing the offset will
+    /// select events in reverse chronological order from the most recent event
+    /// towards the earliest event. Therefore, a relative `FromEnd` offset may
+    /// refer to different entries depending on when a query is made.
+    ///
+    /// For example, `Offset::from_end(3)` will refer to the event with content
+    /// `33` at this point in time:
+    ///
+    /// ```text
+    ///         Partition Log: [ .., .., 22, 33, 44, 55, 66 ]
+    ///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6
+    ///        FromEnd Offset:    6,  5,  4,  3,  2,  1,  0
+    /// ```
+    ///
+    /// But when these new events are added, `Offset::from_end(3)` will refer to
+    /// the event with content `66`:
+    ///
+    /// ```text
+    ///                                        These events were added!
+    ///                                                               |
+    ///                                                      vvvvvvvvvv
+    ///         Partition Log: [ .., .., 22, 33, 44, 55, 66, 77, 88, 99 ]
+    ///       Absolute Offset:    0,  1,  2,  3,  4,  5,  6,  7,  8,  9
+    ///        FromEnd Offset:    9,  8,  7,  6,  5,  4,  3,  2,  1,  0
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fluvio::Offset;
+    /// assert!(Offset::from_end(10).is_some());
+    /// assert!(Offset::from_end(0).is_some());
+    /// assert!(Offset::from_end(-10).is_none());
+    /// ```
+    pub fn from_end(offset: i64) -> Option<Offset> {
+        if offset < 0 {
+            return None;
+        }
+        Some(Self {
+            inner: OffsetInner::FromEnd(offset),
+        })
+    }
+
+    /// Converts this offset into an absolute offset
+    ///
+    /// If this offset is relative from the beginning (i.e. it was created
+    /// using the [`from_beginning`] function), then using `to_absolute` will
+    /// calculate the absolute offset by finding the first still-persisted
+    /// event offset and adding the relative offset to it.
+    ///
+    /// Similarly, if this offset is relative from the end (i.e. it was created
+    /// using the [`from_end`] function), then using `to_absolute` will calculate
+    /// the absolute offset by finding the last stably-committed event and subtracting
+    /// the relative offset from it.
+    ///
+    /// Calling `to_absolute` on an offset that is already absolute just returns
+    /// that same offset.
+    ///
+    /// Note that calculating relative offsets requires connecting to Fluvio, and
+    /// therefore it is `async` and returns a `Result`.
+    pub(crate) async fn to_absolute<F, S: Into<String>>(&self, client: &mut F, topic: S, partition: i32) -> Result<i64, FluvioError>
+        where F: SerialFrame,
+    {
+        let offset = match self.inner {
+            OffsetInner::Absolute(offset) => offset,
+            OffsetInner::FromBeginning(offset) => {
+                let replica = ReplicaKey::new(topic, partition);
+                let offsets = fetch_offsets(client, &replica).await?;
+                offsets.start_offset + offset
+            }
+            OffsetInner::FromEnd(offset) => {
+                let replica = ReplicaKey::new(topic, partition);
+                let offsets = fetch_offsets(client, &replica).await?;
+                offsets.last_stable_offset - offset
+            }
+        };
+
+        Ok(offset)
+    }
+}
+
+async fn fetch_offsets<F: SerialFrame>(
+    client: &mut F,
+    replica: &ReplicaKey,
+) -> Result<FetchOffsetPartitionResponse, FluvioError> {
+    debug!("fetching offset for replica: {}", replica);
+
+    let response = client
+        .send_receive(FetchOffsetsRequest::new(
+            replica.topic.to_owned(),
+            replica.partition,
+        ))
+        .await?;
+
+    trace!(
+        "receive fetch response replica: {}, {:#?}",
+        replica,
+        response
+    );
+
+    match response.find_partition(&replica) {
+        Some(partition_response) => {
+            debug!("replica: {}, fetch offset: {}", replica, partition_response);
+            Ok(partition_response)
+        }
+        None => Err(IoError::new(
+            ErrorKind::InvalidData,
+            format!("no replica offset for: {}", replica),
+        )
+            .into()),
+    }
+}

--- a/src/client/src/offset.rs
+++ b/src/client/src/offset.rs
@@ -213,8 +213,14 @@ impl Offset {
     ///
     /// Note that calculating relative offsets requires connecting to Fluvio, and
     /// therefore it is `async` and returns a `Result`.
-    pub(crate) async fn to_absolute<F, S: Into<String>>(&self, client: &mut F, topic: S, partition: i32) -> Result<i64, FluvioError>
-        where F: SerialFrame,
+    pub(crate) async fn to_absolute<F, S: Into<String>>(
+        &self,
+        client: &mut F,
+        topic: S,
+        partition: i32,
+    ) -> Result<i64, FluvioError>
+    where
+        F: SerialFrame,
     {
         let offset = match self.inner {
             OffsetInner::Absolute(offset) => offset,
@@ -262,6 +268,6 @@ async fn fetch_offsets<F: SerialFrame>(
             ErrorKind::InvalidData,
             format!("no replica offset for: {}", replica),
         )
-            .into()),
+        .into()),
     }
 }

--- a/src/client/src/offset.rs
+++ b/src/client/src/offset.rs
@@ -84,9 +84,9 @@ pub(crate) enum OffsetInner {
 /// let offset_from_end = Offset::from_end(10).unwrap();
 ///
 /// // Negative offsets will give None
-/// assert_eq!(Offset::absolute(-10), None);
-/// assert_eq!(Offset::from_beginning(-15), None);
-/// assert_eq!(Offset::from_end(-20), None);
+/// assert!(Offset::absolute(-10).is_err());
+/// assert!(Offset::from_beginning(-15).is_err());
+/// assert!(Offset::from_end(-20).is_err());
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Offset {
@@ -102,15 +102,15 @@ impl Offset {
     ///
     /// ```
     /// # use fluvio::Offset;
-    /// assert!(Offset::absolute(100).is_some());
-    /// assert!(Offset::absolute(0).is_some());
-    /// assert!(Offset::absolute(-10).is_none());
+    /// assert!(Offset::absolute(100).is_ok());
+    /// assert!(Offset::absolute(0).is_ok());
+    /// assert!(Offset::absolute(-10).is_err());
     /// ```
-    pub fn absolute(index: i64) -> Option<Offset> {
+    pub fn absolute(index: i64) -> Result<Offset, FluvioError> {
         if index < 0 {
-            return None;
+            return Err(FluvioError::NegativeOffset(index));
         }
-        Some(Self {
+        Ok(Self {
             inner: OffsetInner::Absolute(index),
         })
     }
@@ -137,15 +137,15 @@ impl Offset {
     ///
     /// ```
     /// # use fluvio::Offset;
-    /// assert!(Offset::from_beginning(10).is_some());
-    /// assert!(Offset::from_beginning(0).is_some());
-    /// assert!(Offset::from_beginning(-10).is_none());
+    /// assert!(Offset::from_beginning(10).is_ok());
+    /// assert!(Offset::from_beginning(0).is_ok());
+    /// assert!(Offset::from_beginning(-10).is_err());
     /// ```
-    pub fn from_beginning(offset: i64) -> Option<Offset> {
+    pub fn from_beginning(offset: i64) -> Result<Offset, FluvioError> {
         if offset < 0 {
-            return None;
+            return Err(FluvioError::NegativeOffset(offset));
         }
-        Some(Self {
+        Ok(Self {
             inner: OffsetInner::FromBeginning(offset),
         })
     }
@@ -183,15 +183,15 @@ impl Offset {
     ///
     /// ```
     /// # use fluvio::Offset;
-    /// assert!(Offset::from_end(10).is_some());
-    /// assert!(Offset::from_end(0).is_some());
-    /// assert!(Offset::from_end(-10).is_none());
+    /// assert!(Offset::from_end(10).is_ok());
+    /// assert!(Offset::from_end(0).is_ok());
+    /// assert!(Offset::from_end(-10).is_err());
     /// ```
-    pub fn from_end(offset: i64) -> Option<Offset> {
+    pub fn from_end(offset: i64) -> Result<Offset, FluvioError> {
         if offset < 0 {
-            return None;
+            return Err(FluvioError::NegativeOffset(offset));
         }
-        Some(Self {
+        Ok(Self {
             inner: OffsetInner::FromEnd(offset),
         })
     }

--- a/src/client/src/offset.rs
+++ b/src/client/src/offset.rs
@@ -80,13 +80,11 @@ pub(crate) enum OffsetInner {
 /// ```
 /// use fluvio::Offset;
 /// let absolute_offset = Offset::absolute(5).unwrap();
-/// let offset_from_beginning = Offset::from_beginning(100).unwrap();
-/// let offset_from_end = Offset::from_end(10).unwrap();
+/// let offset_from_beginning = Offset::from_beginning(100);
+/// let offset_from_end = Offset::from_end(10);
 ///
-/// // Negative offsets will give None
+/// // Negative values are not allowed for absolute offsets
 /// assert!(Offset::absolute(-10).is_err());
-/// assert!(Offset::from_beginning(-15).is_err());
-/// assert!(Offset::from_end(-20).is_err());
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Offset {

--- a/src/client/src/offset.rs
+++ b/src/client/src/offset.rs
@@ -38,14 +38,14 @@ pub(crate) enum OffsetInner {
 /// beginning of the partition. The absolute offset of an event never
 /// changes.
 ///
-/// Sometimes when a partition gets very large, Fluvio will begin
-/// deleting events from the beginning of the log in order to save
-/// space. Whenever it does this, it keeps track of the latest
-/// non-deleted event. This allows the `FromBeginning` offset to
-/// select an event which is a certain number of places in front of
-/// the deleted range. For example, let's say that the first two
-/// events from our partition were deleted. Our new offsets would
-/// look like this:
+/// Fluvio allows you to set a retention policy that determines how
+/// long your events should live. Once an event has outlived your
+/// retention policy, Fluvio may delete it to save resources. Whenever
+/// it does this, it keeps track of the latest non-deleted event. This
+/// allows the `FromBeginning` offset to select an event which is a
+/// certain number of places in front of the deleted range. For example,
+/// let's say that the first two events from our partition were deleted.
+/// Our new offsets would look like this:
 ///
 /// ```text
 ///                          These events were deleted!

--- a/src/client/src/params.rs
+++ b/src/client/src/params.rs
@@ -4,9 +4,6 @@
 //!
 
 use dataplane::Offset;
-use dataplane::Isolation;
-
-pub const MAX_FETCH_BYTES: u32 = 1000000;
 
 /// Fetch Logs parameters
 #[derive(Debug)]
@@ -40,10 +37,4 @@ pub struct PartitionParam {
     pub partition_idx: i32,
     pub offset: Offset,
     pub epoch: i32,
-}
-
-#[derive(Default)]
-pub struct FetchLogOption {
-    pub max_bytes: i32,
-    pub isolation: Isolation,
 }

--- a/src/client/src/params.rs
+++ b/src/client/src/params.rs
@@ -42,15 +42,6 @@ pub struct PartitionParam {
     pub epoch: i32,
 }
 
-#[derive(Debug)]
-pub enum FetchOffset {
-    Earliest(Option<i64>),
-    /// earliest + offset
-    Latest(Option<i64>),
-    /// latest - offset
-    Offset(i64),
-}
-
 #[derive(Default)]
 pub struct FetchLogOption {
     pub max_bytes: i32,

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 
 use utils::bin::get_fluvio;
 
-use fluvio::{Fluvio, Offset, ConsumerConfig};
+use fluvio::{Fluvio, Offset};
 use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
@@ -59,10 +59,7 @@ async fn validate_consume_message_api(option: &TestOption) {
 
         println!("retrieving messages");
         let response = consumer
-            .fetch_with_config(
-                Offset::from_beginning(0).unwrap(),
-                ConsumerConfig::default(),
-            )
+            .fetch(Offset::beginning())
             .await
             .expect("records");
         println!("message received");

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -58,10 +58,7 @@ async fn validate_consume_message_api(option: &TestOption) {
             .expect("consumer");
 
         println!("retrieving messages");
-        let response = consumer
-            .fetch(Offset::beginning())
-            .await
-            .expect("records");
+        let response = consumer.fetch(Offset::beginning()).await.expect("records");
         println!("message received");
         let batches = response.records.batches;
 

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 
 use utils::bin::get_fluvio;
 
-use fluvio::Fluvio;
+use fluvio::{Fluvio, Offset};
 use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
@@ -47,7 +47,6 @@ fn validate_consume_message_cli(option: &TestOption) {
 }
 
 async fn validate_consume_message_api(option: &TestOption) {
-    use fluvio::params::FetchOffset;
     use fluvio::params::FetchLogOption;
 
     let client = Fluvio::connect().await.expect("should connect");
@@ -62,7 +61,7 @@ async fn validate_consume_message_api(option: &TestOption) {
 
         println!("retrieving messages");
         let response = consumer
-            .fetch(FetchOffset::Earliest(None), FetchLogOption::default())
+            .fetch(Offset::from_beginning(0).unwrap(), FetchLogOption::default())
             .await
             .expect("records");
         println!("message received");

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -59,7 +59,10 @@ async fn validate_consume_message_api(option: &TestOption) {
 
         println!("retrieving messages");
         let response = consumer
-            .fetch_with_config(Offset::from_beginning(0).unwrap(), ConsumerConfig::default())
+            .fetch_with_config(
+                Offset::from_beginning(0).unwrap(),
+                ConsumerConfig::default(),
+            )
             .await
             .expect("records");
         println!("message received");

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 
 use utils::bin::get_fluvio;
 
-use fluvio::{Fluvio, Offset};
+use fluvio::{Fluvio, Offset, ConsumerConfig};
 use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
@@ -47,8 +47,6 @@ fn validate_consume_message_cli(option: &TestOption) {
 }
 
 async fn validate_consume_message_api(option: &TestOption) {
-    use fluvio::params::FetchLogOption;
-
     let client = Fluvio::connect().await.expect("should connect");
     let replication = option.replication();
 
@@ -61,7 +59,7 @@ async fn validate_consume_message_api(option: &TestOption) {
 
         println!("retrieving messages");
         let response = consumer
-            .fetch(Offset::from_beginning(0).unwrap(), FetchLogOption::default())
+            .fetch_with_config(Offset::from_beginning(0).unwrap(), ConsumerConfig::default())
             .await
             .expect("records");
         println!("message received");


### PR DESCRIPTION
This PR introduces a new API for Offsets that makes it impossible to construct illegal `Offset` values. This renames the previously-named `FetchOffset` into just `Offset`. The `Offset` type is essentially an enum with private variants, achieved by wrapping an `OffsetInner` enum inside the `Offset` struct with a private field. This makes it impossible for users to manually construct an Offset, they must use the validating constructors `Offset::absolute`, `Offset::from_beginning`, and `Offset::from_end` which only optionally produce an `Offset` when the argument is valid. This creates the invariant that if an `Offset` type exists, it is valid (e.g. there are no negative offsets).

Additionally, this PR renames `FetchLogOption` to `ConsumerConfig` since it is used both in fetching and streaming operations. I also noticed that it is a common pattern to just use `FetchLogOption::default()` in a lot of call sites, so I have separated the methods into `fetch/fetch_with_config` and `stream/stream_with_config`, where the shorter-named methods automatically use the default ConsumerConfig, and the `with_config` variants will accept a user-provided ConsumerConfig.

# TODO before merging:

- [ ] I need a good user-facing description of what the `max_bytes` configuration option does and why somebody would want to use it
- [ ] I need to know whether the user will ever need to specify a custom `Isolation` value. I have not seen any instances of this occurring, so as of now I have hidden it from the user (the default value is always used in ConsumerConfig). If we need to expose it, we should re-export it and give it documentation on how to use it.