### PR TITLE
fix object conflict issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,14 +520,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "9942f5f46d88ae2926edcd93a8a5b24151133cf6dc4e5f4c3fadb1c532ac8041"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "winapi",
 ]
 
 [[package]]
@@ -937,10 +939,10 @@ dependencies = [
  "futures-lite",
  "http-types",
  "k8-client",
- "k8-config",
- "k8-metadata-client",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-config 1.1.2",
+ "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs",
  "rand 0.7.3",
  "rpassword",
@@ -966,9 +968,9 @@ dependencies = [
  "fluvio-future",
  "flv-util",
  "k8-client",
- "k8-config",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-config 1.1.2",
+ "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.10.0",
  "serde",
  "serde_json",
@@ -1001,8 +1003,8 @@ dependencies = [
  "fluvio-types",
  "flv-util",
  "k8-obj-app",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "serde",
  "tracing",
@@ -1133,8 +1135,8 @@ dependencies = [
  "flv-util",
  "futures-util",
  "k8-client",
- "k8-metadata-client",
- "k8-obj-metadata",
+ "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "rand 0.7.3",
  "regex",
@@ -1284,7 +1286,7 @@ dependencies = [
  "fluvio-types",
  "flv-util",
  "futures",
- "k8-metadata-client",
+ "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "serde",
  "tokio",
@@ -1300,8 +1302,8 @@ dependencies = [
  "fluvio-future",
  "fluvio-types",
  "k8-obj-app",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "tracing",
 ]
@@ -1337,7 +1339,7 @@ dependencies = [
  "fluvio-types",
  "futures-util",
  "k8-client",
- "k8-metadata-client",
+ "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt",
  "utils",
 ]
@@ -1606,6 +1608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostfile"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2733206bcc0550a15b450c64d8aa859f486d7281c4c0c36ef904b361960d658"
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,9 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa62bbf9afa8e887da4137e9b3cb728f0852b18a8c2ea3198da9d056cbbfc9d9"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -1766,11 +1772,11 @@ dependencies = [
  "fluvio-future",
  "futures-util",
  "isahc",
- "k8-config",
- "k8-diff",
- "k8-metadata-client",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-config 1.2.0",
+ "k8-diff 0.1.0",
+ "k8-metadata-client 1.0.2",
+ "k8-obj-core 1.1.0",
+ "k8-obj-metadata 1.0.0",
  "openssl-sys",
  "pin-utils",
  "rand 0.7.3",
@@ -1797,6 +1803,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8-config"
+version = "1.2.0"
+dependencies = [
+ "dirs 2.0.2",
+ "hostfile",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tracing",
+]
+
+[[package]]
+name = "k8-diff"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "k8-diff"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,14 +1837,31 @@ dependencies = [
 [[package]]
 name = "k8-metadata-client"
 version = "1.0.2"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "http 0.1.21",
+ "k8-diff 0.1.0",
+ "k8-obj-metadata 1.0.0",
+ "pin-utils",
+ "serde",
+ "serde_json",
+ "serde_qs 0.5.2",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "k8-metadata-client"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d8d0eb309f2f0fbf05a0449aad056c6c41a8392929fe0c56fa690e71e45081f"
 dependencies = [
  "async-trait",
  "futures-util",
  "http 0.1.21",
- "k8-diff",
- "k8-obj-metadata",
+ "k8-diff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils",
  "serde",
  "serde_json",
@@ -1833,8 +1877,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1928f08244bb04c7ac1455f3fccb0e3ce193f25f61c06aed863371e46deb040"
 dependencies = [
  "http 0.1.21",
- "k8-obj-core",
- "k8-obj-metadata",
+ "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "serde",
  "serde_json",
@@ -1844,15 +1888,37 @@ dependencies = [
 [[package]]
 name = "k8-obj-core"
 version = "1.1.0"
+dependencies = [
+ "http 0.1.21",
+ "k8-obj-metadata 1.0.0",
+ "serde",
+ "serde_json",
+ "serde_qs 0.4.6",
+ "tracing",
+]
+
+[[package]]
+name = "k8-obj-core"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd20a0c2182b2e55fbbb90b3d887139164408efd9b720952a002d188a6580e0"
 dependencies = [
  "http 0.1.21",
- "k8-obj-metadata",
+ "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "serde",
  "serde_json",
  "serde_qs 0.4.6",
+]
+
+[[package]]
+name = "k8-obj-metadata"
+version = "1.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_qs 0.4.6",
+ "tracing",
 ]
 
 [[package]]
@@ -2099,9 +2165,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.10.2+1.1.1g"
+version = "111.11.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
 dependencies = [
  "cc",
 ]
@@ -2366,9 +2432,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "e4b93dba1818d32e781f9d008edd577bab215e83ef50e8a1ddf1ad301b19a09f"
 dependencies = [
  "unicode-xid 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9942f5f46d88ae2926edcd93a8a5b24151133cf6dc4e5f4c3fadb1c532ac8041"
+checksum = "d021fddb7bd3e734370acfa4a83f34095571d8570c039f1420d77540f68d5772"
 dependencies = [
  "libc",
  "num-integer",
@@ -620,7 +620,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rand 0.7.3",
  "sha2",
- "time 0.2.21",
+ "time 0.2.22",
  "version_check",
 ]
 
@@ -1108,7 +1108,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1278,7 +1278,7 @@ name = "fluvio-stream-dispatcher"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "async-lock",
+ "async-rwlock",
  "async-trait",
  "event-listener",
  "fluvio-future",
@@ -1316,7 +1316,7 @@ checksum = "fc9e4cb09caa5ff039928399ef5aa99206fd1b9a59df208cf6d94e2764fe5ce0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1449,7 +1449,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2235,7 +2235,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2266,7 +2266,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2339,7 +2339,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "version_check",
 ]
 
@@ -2368,9 +2368,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b93dba1818d32e781f9d008edd577bab215e83ef50e8a1ddf1ad301b19a09f"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2679,7 +2679,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2892,7 +2892,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2908,7 +2908,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2e31fb28e2a9f01f5ed6901b066c1ba2333c04b64dc61254142bafcb3feb2c"
+checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
 dependencies = [
  "const_fn",
  "libc",
@@ -3090,7 +3090,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.7",
  "standback",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3120,7 +3120,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3167,7 +3167,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3453,7 +3453,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "wasm-bindgen-shared",
 ]
 
@@ -3487,7 +3487,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,10 +939,10 @@ dependencies = [
  "futures-lite",
  "http-types",
  "k8-client",
- "k8-config 1.1.2",
- "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config",
+ "k8-metadata-client",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "prettytable-rs",
  "rand 0.7.3",
  "rpassword",
@@ -968,9 +968,9 @@ dependencies = [
  "fluvio-future",
  "flv-util",
  "k8-client",
- "k8-config 1.1.2",
- "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "semver 0.10.0",
  "serde",
  "serde_json",
@@ -1003,8 +1003,8 @@ dependencies = [
  "fluvio-types",
  "flv-util",
  "k8-obj-app",
- "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "log",
  "serde",
  "tracing",
@@ -1135,8 +1135,8 @@ dependencies = [
  "flv-util",
  "futures-util",
  "k8-client",
- "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-metadata-client",
+ "k8-obj-metadata",
  "log",
  "rand 0.7.3",
  "regex",
@@ -1286,7 +1286,7 @@ dependencies = [
  "fluvio-types",
  "flv-util",
  "futures",
- "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-metadata-client",
  "log",
  "serde",
  "tokio",
@@ -1302,8 +1302,8 @@ dependencies = [
  "fluvio-future",
  "fluvio-types",
  "k8-obj-app",
- "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "serde",
  "tracing",
 ]
@@ -1339,7 +1339,7 @@ dependencies = [
  "fluvio-types",
  "futures-util",
  "k8-client",
- "k8-metadata-client 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-metadata-client",
  "structopt",
  "utils",
 ]
@@ -1608,12 +1608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostfile"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2733206bcc0550a15b450c64d8aa859f486d7281c4c0c36ef904b361960d658"
-
-[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1758,8 @@ dependencies = [
 [[package]]
 name = "k8-client"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d6b194f528912e2c8c1e5d5adf756254d029622610e8623274ad0306528968"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -1772,11 +1768,11 @@ dependencies = [
  "fluvio-future",
  "futures-util",
  "isahc",
- "k8-config 1.2.0",
- "k8-diff 0.1.0",
- "k8-metadata-client 1.0.2",
- "k8-obj-core 1.1.0",
- "k8-obj-metadata 1.0.0",
+ "k8-config",
+ "k8-diff",
+ "k8-metadata-client",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "openssl-sys",
  "pin-utils",
  "rand 0.7.3",
@@ -1803,27 +1799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8-config"
-version = "1.2.0"
-dependencies = [
- "dirs 2.0.2",
- "hostfile",
- "serde",
- "serde_json",
- "serde_yaml",
- "tracing",
-]
-
-[[package]]
-name = "k8-diff"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "k8-diff"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,31 +1812,14 @@ dependencies = [
 [[package]]
 name = "k8-metadata-client"
 version = "1.0.2"
-dependencies = [
- "async-trait",
- "futures-util",
- "http 0.1.21",
- "k8-diff 0.1.0",
- "k8-obj-metadata 1.0.0",
- "pin-utils",
- "serde",
- "serde_json",
- "serde_qs 0.5.2",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "k8-metadata-client"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d8d0eb309f2f0fbf05a0449aad056c6c41a8392929fe0c56fa690e71e45081f"
 dependencies = [
  "async-trait",
  "futures-util",
  "http 0.1.21",
- "k8-diff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-diff",
+ "k8-obj-metadata",
  "pin-utils",
  "serde",
  "serde_json",
@@ -1877,24 +1835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1928f08244bb04c7ac1455f3fccb0e3ce193f25f61c06aed863371e46deb040"
 dependencies = [
  "http 0.1.21",
- "k8-obj-core 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-core",
+ "k8-obj-metadata",
  "log",
  "serde",
  "serde_json",
  "serde_qs 0.4.6",
-]
-
-[[package]]
-name = "k8-obj-core"
-version = "1.1.0"
-dependencies = [
- "http 0.1.21",
- "k8-obj-metadata 1.0.0",
- "serde",
- "serde_json",
- "serde_qs 0.4.6",
- "tracing",
 ]
 
 [[package]]
@@ -1904,21 +1850,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd20a0c2182b2e55fbbb90b3d887139164408efd9b720952a002d188a6580e0"
 dependencies = [
  "http 0.1.21",
- "k8-obj-metadata 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-obj-metadata",
  "log",
  "serde",
  "serde_json",
  "serde_qs 0.4.6",
-]
-
-[[package]]
-name = "k8-obj-metadata"
-version = "1.0.0"
-dependencies = [
- "serde",
- "serde_json",
- "serde_qs 0.4.6",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ members = [
     "tests/runner",
 ]
 
-[patch.crates-io]
-k8-client = { path = "../k8-api/src/k8-client" }
-
-
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ members = [
     "tests/runner",
 ]
 
+[patch.crates-io]
+k8-client = { path = "../k8-api/src/k8-client" }
+
+
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET_DARWIN=x86_64-apple-darwin
 CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
-DEFAULT_SPU=1
+DEFAULT_SPU=3
 DEFAULT_ITERATION=1
 
 # install all tools required

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET_DARWIN=x86_64-apple-darwin
 CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
-DEFAULT_SPU=3
+DEFAULT_SPU=1
 DEFAULT_ITERATION=1
 
 # install all tools required

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ smoke-test-tls:	build test-clean-up
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local-driver --log-dir /tmp
 
 smoke-test-k8:	build test-clean-up minikube_image
-	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop --log-dir /tmp
+	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop
 
 smoke-test-k8-tls:	build test-clean-up minikube_image
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop --log-dir /tmp
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop
 
 test-clean-up:
 	$(FLUVIO_BIN) cluster uninstall

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
 DEFAULT_SPU=1
-DEFAULT_ITERATION=100
+DEFAULT_ITERATION=1
 
 # install all tools required
 install_tools_mac:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET_DARWIN=x86_64-apple-darwin
 CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
-DEFAULT_SPU=3
+DEFAULT_SPU=1
 DEFAULT_ITERATION=100
 
 # install all tools required

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
 DEFAULT_SPU=3
+DEFAULT_ITERATION=100
 
 # install all tools required
 install_tools_mac:
@@ -24,16 +25,16 @@ build:
 #
 
 smoke-test:	test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --local-driver --log-dir /tmp
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local-driver --log-dir /tmp
 
 smoke-test-tls:	build test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --tls --local-driver --log-dir /tmp
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local-driver --log-dir /tmp
 
 smoke-test-k8:	build test-clean-up minikube_image
-	$(TEST_BIN)	--spu ${DEFAULT_SPU} --develop --log-dir /tmp
+	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop --log-dir /tmp
 
 smoke-test-k8-tls:	build test-clean-up minikube_image
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --tls --develop --log-dir /tmp
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop --log-dir /tmp
 
 test-clean-up:
 	$(FLUVIO_BIN) cluster uninstall

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -49,7 +49,7 @@ http-types = "2.4.0"
 
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.0", features = ["fs", "io","subscriber"] }
-k8-client = { version = "1.1.0" }
+k8-client = { version = "2.0.0" }
 k8-config = { version = "1.1.0", features = ["context"] }
 k8-obj-core = { version = "1.1.0" }
 k8-obj-metadata = { version = "1.0.0" }

--- a/src/cli/src/cluster/check.rs
+++ b/src/cli/src/cluster/check.rs
@@ -297,6 +297,7 @@ fn compute_user_name() -> Result<String, IoError> {
 
 async fn wait_for_service_exist(ns: &str) -> Result<Option<String>, ClientError> {
     use k8_metadata_client::MetadataClient;
+    use k8_client::http::StatusCode;
 
     let client = load_and_share()?;
 
@@ -313,7 +314,7 @@ async fn wait_for_service_exist(ns: &str) -> Result<Option<String>, ClientError>
                 }
             }
             Err(err) => match err {
-                K8ClientError::NotFound => {
+                K8ClientError::Client(status) if status == StatusCode::NOT_FOUND => {
                     sleep(Duration::from_millis(3000)).await;
                 }
                 _ => panic!("error: {}", err),

--- a/src/cli/src/cluster/mod.rs
+++ b/src/cli/src/cluster/mod.rs
@@ -85,6 +85,8 @@ mod k8_util {
 
     // wait for i8 objects appear
     pub async fn wait_for_delete<S: Spec>(client: SharedK8Client, input: &InputObjectMeta) {
+        use k8_client::http::StatusCode;
+
         for i in 0..100u16 {
             println!("checking to see if {} is deleted, count: {}", S::label(), i);
             match client.retrieve_item::<S, _>(input).await {
@@ -93,7 +95,7 @@ mod k8_util {
                     sleep(Duration::from_millis(10000)).await;
                 }
                 Err(err) => match err {
-                    K8ClientError::NotFound => {
+                    K8ClientError::Client(status) if status == StatusCode::NOT_FOUND => {
                         println!("no sc {} found, can proceed to setup ", S::label());
                         return;
                     }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2116804"]
+#![type_length_limit = "2117209"]
 
 mod common;
 mod error;

--- a/src/cli/src/partition/list.rs
+++ b/src/cli/src/partition/list.rs
@@ -43,10 +43,10 @@ impl ListPartitionOpt {
         let mut client = Fluvio::connect_with_config(&target_server).await?;
         let mut admin = client.admin().await;
 
-        let spus = admin.list::<PartitionSpec, _>(vec![]).await?;
+        let partitions = admin.list::<PartitionSpec, _>(vec![]).await?;
 
         // format and dump to screen
-        display::format_partition_response_output(out, spus, output)?;
+        display::format_partition_response_output(out, partitions, output)?;
         Ok("".to_owned())
     }
 }

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -75,6 +75,8 @@ pub async fn set_k8_context(opt: K8Opt, external_addr: String) -> Result<Profile
 
 /// find fluvio addr
 pub async fn discover_fluvio_addr(namespace: Option<&str>) -> Result<Option<String>, CliError> {
+    use k8_client::http::StatusCode;
+
     let ns = namespace.unwrap_or("default");
     let svc = match K8Client::default()?
         .retrieve_item::<ServiceSpec, _>(&InputObjectMeta::named("flv-sc-public", ns))
@@ -82,7 +84,7 @@ pub async fn discover_fluvio_addr(namespace: Option<&str>) -> Result<Option<Stri
     {
         Ok(svc) => svc,
         Err(err) => match err {
-            k8_client::ClientError::NotFound => return Ok(None),
+            k8_client::ClientError::Client(status) if status == StatusCode::NOT_FOUND => return Ok(None),
             _ => {
                 return Err(CliError::Other(format!(
                     "unable to look up fluvio service in k8: {}",

--- a/src/cli/src/profile/k8.rs
+++ b/src/cli/src/profile/k8.rs
@@ -84,7 +84,9 @@ pub async fn discover_fluvio_addr(namespace: Option<&str>) -> Result<Option<Stri
     {
         Ok(svc) => svc,
         Err(err) => match err {
-            k8_client::ClientError::Client(status) if status == StatusCode::NOT_FOUND => return Ok(None),
+            k8_client::ClientError::Client(status) if status == StatusCode::NOT_FOUND => {
+                return Ok(None)
+            }
             _ => {
                 return Err(CliError::Other(format!(
                     "unable to look up fluvio service in k8: {}",

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -28,7 +28,7 @@ fluvio-controlplane-metadata = { path = "../controlplane-metadata", features = [
 fluvio-future = { version = "0.1.0" }
 flv-util = "0.5.0"
 k8-config = { version = "1.1.0", features = ["context"] }
-k8-client = "1.1.0"
+k8-client = "2.0.0"
 k8-obj-core = "1.1.0"
 k8-obj-metadata = "1.0.0"
 

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -755,7 +755,9 @@ impl ClusterInstaller {
 
         let svc = match result {
             Ok(svc) => svc,
-            Err(k8_client::ClientError::Client(status)) if status == StatusCode::NOT_FOUND => return Ok(None),
+            Err(k8_client::ClientError::Client(status)) if status == StatusCode::NOT_FOUND => {
+                return Ok(None)
+            }
             Err(err) => {
                 return Err(ClusterError::Other(format!(
                     "unable to look up fluvio service in k8: {}",

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -42,7 +42,7 @@ fluvio-controlplane = { path = "../controlplane" }
 fluvio-controlplane-metadata = { features = ["k8"], path = "../controlplane-metadata" }
 fluvio-stream-dispatcher = { path = "../stream-dispatcher" }
 k8-client = { version = "2.0.0", optional = true }
-k8-metadata-client = { version = "1.0.1" }
+k8-metadata-client = { version = "1.0.0" }
 k8-obj-metadata = { version = "1.0.0" }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -41,7 +41,7 @@ fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema" }
 fluvio-controlplane = { path = "../controlplane" }
 fluvio-controlplane-metadata = { features = ["k8"], path = "../controlplane-metadata" }
 fluvio-stream-dispatcher = { path = "../stream-dispatcher" }
-k8-client = { version = "1.1.1", optional = true }
+k8-client = { version = "2.0.0", optional = true }
 k8-metadata-client = { version = "1.0.1" }
 k8-obj-metadata = { version = "1.0.0" }
 fluvio-protocol = { version = "0.2.0" }

--- a/src/sc/src/k8/service/controller.rs
+++ b/src/sc/src/k8/service/controller.rs
@@ -99,10 +99,14 @@ impl SpuServiceController {
             let svc_ingresses = svc_md.status.ingress();
 
             if let Some(mut spu) = self.spus.store().value(spu_id).await {
-                debug!("trying sync service: {}, with: spu: {}",svc_md.key(),spu_id);
-                trace!("svc ingress: {:#?}",svc_ingresses);
+                debug!(
+                    "trying sync service: {}, with: spu: {}",
+                    svc_md.key(),
+                    spu_id
+                );
+                trace!("svc ingress: {:#?}", svc_ingresses);
                 let spu_ingress = svc_ingresses.iter().map(convert).collect();
-                trace!("spu ingress: {:#?}",spu_ingress);
+                trace!("spu ingress: {:#?}", spu_ingress);
                 if spu_ingress != spu.spec.public_endpoint.ingress {
                     debug!(
                         "updating spu:{} public end point: {:#?}",
@@ -120,7 +124,11 @@ impl SpuServiceController {
                     debug!("detected no spu: {} ingress changes", spu_id);
                 }
             } else {
-                debug!("no sync service: {}, with: spu: {} because spu doesn't exist",svc_md.key(),spu_id);
+                debug!(
+                    "no sync service: {}, with: spu: {} because spu doesn't exist",
+                    svc_md.key(),
+                    spu_id
+                );
             }
         }
     }

--- a/src/sc/src/k8/service/meta.rs
+++ b/src/sc/src/k8/service/meta.rs
@@ -85,9 +85,9 @@ mod extended {
 
             if let Some(name) = labels.get("fluvio.io/spu-name") {
                 debug!("detected spu service: {}", name);
-                trace!("converting k8 spu service: {:#?}",k8_obj);
+                trace!("converting k8 spu service: {:#?}", k8_obj);
 
-                let ctx_result: Result<K8MetaItem,_> = k8_obj.metadata.clone().try_into();
+                let ctx_result: Result<K8MetaItem, _> = k8_obj.metadata.clone().try_into();
                 match ctx_result {
                     Ok(ctx_item) => {
                         let mut meta = MetadataStoreObject::new(
@@ -99,15 +99,12 @@ mod extended {
                         );
                         meta.set_ctx(ctx_item.into());
                         Ok(meta)
-                    },
-                    Err(err) => {
-                        Err(K8ConvertError::KeyConvertionError(IoError::new(
-                            ErrorKind::InvalidData,
-                            format!("error converting metadata: {:#?}", err),
-                        )))
                     }
+                    Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
+                        ErrorKind::InvalidData,
+                        format!("error converting metadata: {:#?}", err),
+                    ))),
                 }
-                
             } else {
                 debug!("skipping non acct fluvio {}", k8_obj.metadata.namespace);
                 Err(K8ConvertError::Skip(k8_obj))

--- a/src/sc/src/k8/service/meta.rs
+++ b/src/sc/src/k8/service/meta.rs
@@ -45,6 +45,7 @@ mod extended {
     // use std::io::ErrorKind;
 
     use tracing::debug;
+    use tracing::trace;
 
     use crate::dispatcher::k8::core::service::ServiceSpec;
     use crate::dispatcher::k8::core::service::ServiceStatus;
@@ -80,6 +81,7 @@ mod extended {
 
             if let Some(name) = labels.get("fluvio.io/spu-name") {
                 debug!("detected spu service: {}", name);
+                trace!("converting k8 spu service: {:#?}",k8_obj);
 
                 Ok(MetadataStoreObject::new(
                     name,

--- a/src/stream-dispatcher/Cargo.toml
+++ b/src/stream-dispatcher/Cargo.toml
@@ -18,7 +18,7 @@ tracing-futures = "0.2.0"
 serde = { version = "1.0.103", features = ['derive'] }
 futures = { version = "0.3.1" }
 async-trait = "0.1.21"
-async-lock = "1.1.2"
+async-rwlock = "1.3.0"
 async-channel = "1.1.0"
 event-listener = "2.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -216,7 +216,6 @@ where
     #[instrument(skip(self, action))]
     async fn process_ws_action(&mut self, action: WSAction<S>) {
         use crate::store::k8::K8MetaItem;
-        
 
         match action {
             WSAction::Apply(obj) => {
@@ -230,7 +229,8 @@ where
                     (spec, obj.inner().ctx().item().clone())
                 } else {
                     // create new ctx
-                    let meta = K8MetaItem::new(key.to_string(), self.namespace.named().to_owned()).into();
+                    let meta =
+                        K8MetaItem::new(key.to_string(), self.namespace.named().to_owned());
                     (spec, meta)
                 };
                 if let Err(err) = self.ws_update_service.update_spec(metadata, spec).await {
@@ -259,16 +259,15 @@ where
                 {
                     Ok(item) => {
                         //println!("updated status item: {:#?}", item);
-                        
+
                         use crate::store::actions::LSUpdate;
-                        
+
                         debug!(
                             "{} k8 update Status: {}, rev: {},stats: {:#?}",
                             S::LABEL,
                             item.metadata.name,
                             item.metadata.resource_version,
                             item.status,
-                            
                         );
 
                         match convert::k8_obj_to_kv_obj(item) {
@@ -277,11 +276,10 @@ where
 
                                 if self.ctx.store().apply_changes(changes).await.is_some() {
                                     self.ctx.event().notify(usize::MAX);
-                                } 
-                            },
-                            Err(err) => error!("{},error  converting back: {:#?}",S::LABEL,err)
+                                }
+                            }
+                            Err(err) => error!("{},error  converting back: {:#?}", S::LABEL, err),
                         }
-                        
                     }
                     Err(err) => {
                         error!(

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -229,8 +229,7 @@ where
                     (spec, obj.inner().ctx().item().clone())
                 } else {
                     // create new ctx
-                    let meta =
-                        K8MetaItem::new(key.to_string(), self.namespace.named().to_owned());
+                    let meta = K8MetaItem::new(key.to_string(), self.namespace.named().to_owned());
                     (spec, meta)
                 };
                 if let Err(err) = self.ws_update_service.update_spec(metadata, spec).await {

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -253,7 +253,7 @@ where
                             item.metadata.name,
                             updated_version
                         );
-                        let write_guard = self.ctx.store().write().await;
+                        let mut write_guard = self.ctx.store().write().await;
                         if let Some(obj) = write_guard.get_mut(&key) {
                             obj.inner_mut().ctx_mut().item_mut().update_revision(updated_version);
                         }

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -215,7 +215,7 @@ where
 
     #[instrument(skip(self, action))]
     async fn process_ws_action(&mut self, action: WSAction<S>) {
-        use crate::k8::metadata::ObjectMeta;
+        use crate::store::k8::K8MetaItem;
         
 
         match action {
@@ -230,7 +230,7 @@ where
                     (spec, obj.inner().ctx().item().clone())
                 } else {
                     // create new ctx
-                    let meta = ObjectMeta::new(key.to_string(), self.namespace.named().to_owned());
+                    let meta = K8MetaItem::new(key.to_string(), self.namespace.named().to_owned()).into();
                     (spec, meta)
                 };
                 if let Err(err) = self.ws_update_service.update_spec(metadata, spec).await {

--- a/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
@@ -70,7 +70,7 @@ where
 
             self.client.apply(new_k8).await.map(|_| ())
         } else {
-            let new_k8 = InputK8Obj::new(k8_spec, ctx.item_owned().into());
+            let new_k8 = InputK8Obj::new(k8_spec, ctx.item().inner().clone().into());
 
             trace!("adding k8 {:#?} ", new_k8);
 
@@ -101,7 +101,7 @@ where
         let k8_input: UpdateK8ObjStatus<S::K8Spec> = UpdateK8ObjStatus {
             api_version: S::K8Spec::api_version(),
             kind: S::K8Spec::kind(),
-            metadata: metadata.into(),
+            metadata: metadata.inner().clone().into(),
             status: k8_status,
             ..Default::default()
         };
@@ -125,7 +125,7 @@ where
         let k8_input: InputK8Obj<S::K8Spec> = InputK8Obj {
             api_version: S::K8Spec::api_version(),
             kind: S::K8Spec::kind(),
-            metadata: metadata.into(),
+            metadata: metadata.inner().clone().into(),
             spec: k8_spec,
             ..Default::default()
         };
@@ -135,7 +135,7 @@ where
 
     pub async fn delete(&self, meta: K8MetaItem) -> Result<(), C::MetadataClientError> {
         self.client
-            .delete_item::<S::K8Spec, _>(&meta)
+            .delete_item::<S::K8Spec, _>(meta.inner())
             .await
             .map(|_| ())
     }

--- a/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
@@ -10,7 +10,6 @@ use tracing::debug;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-
 use k8_metadata_client::MetadataClient;
 use k8_metadata_client::SharedClient;
 
@@ -23,7 +22,6 @@ use crate::k8::metadata::Spec as K8Spec;
 use crate::k8::metadata::UpdateK8ObjStatus;
 
 use crate::store::*;
-
 
 pub struct K8WSUpdateService<C, S> {
     client: SharedClient<C>,
@@ -139,5 +137,4 @@ where
             .await
             .map(|_| ())
     }
-
 }

--- a/src/stream-dispatcher/src/dispatcher/mod.rs
+++ b/src/stream-dispatcher/src/dispatcher/mod.rs
@@ -4,8 +4,6 @@ mod k8_ws_service;
 pub use k8_dispatcher::*;
 pub use k8_ws_service::*;
 
-
-
 /*
 mod delta{
 
@@ -15,7 +13,7 @@ mod delta{
 
     use crate::core::Spec;
 
-    /// WS ActionQueue 
+    /// WS ActionQueue
     pub struct WSActionQueue<S> where S: Spec {
 
         entries: RwLock<HashMap<S::IndexKey,S>>
@@ -28,11 +26,11 @@ mod delta{
             Self{}
         }
 
-        
+
     }
 
 
-    #[cfg(test)]    
+    #[cfg(test)]
     mod test {
 
         use super::WSActionQueue;

--- a/src/stream-dispatcher/src/dispatcher/mod.rs
+++ b/src/stream-dispatcher/src/dispatcher/mod.rs
@@ -3,23 +3,3 @@ mod k8_ws_service;
 
 pub use k8_dispatcher::*;
 pub use k8_ws_service::*;
-
-mod k8_actions {
-
-    use crate::core::Spec;
-    use crate::store::k8::K8MetaItem;
-    use crate::store::MetadataStoreObject;
-
-    /// Actions to update World States
-    #[allow(clippy::large_enum_variant)]
-    #[derive(Debug, PartialEq, Clone)]
-    pub enum K8Action<S>
-    where
-        S: Spec,
-    {
-        Apply(MetadataStoreObject<S, K8MetaItem>),
-        UpdateStatus((S::Status, K8MetaItem)),
-        UpdateSpec((S, K8MetaItem)),
-        Delete(K8MetaItem),
-    }
-}

--- a/src/stream-dispatcher/src/dispatcher/mod.rs
+++ b/src/stream-dispatcher/src/dispatcher/mod.rs
@@ -3,3 +3,59 @@ mod k8_ws_service;
 
 pub use k8_dispatcher::*;
 pub use k8_ws_service::*;
+
+
+
+/*
+mod delta{
+
+    use std::collections::HashMap;
+
+    use async_rwlock::RwLock;
+
+    use crate::core::Spec;
+
+    /// WS ActionQueue 
+    pub struct WSActionQueue<S> where S: Spec {
+
+        entries: RwLock<HashMap<S::IndexKey,S>>
+    }
+
+
+    impl WSActionQueue  {
+
+        pub fn new() -> Self {
+            Self{}
+        }
+
+        
+    }
+
+
+    #[cfg(test)]    
+    mod test {
+
+        use super::WSActionQueue;
+
+        struct TestSpec {
+            pub name: String
+        }
+
+        struct TestStatus {
+
+        }
+
+
+
+
+        fn test_insert() {
+
+            let fifo = WSActionQueue::new();
+
+
+        }
+
+    }
+
+}
+*/

--- a/src/stream-model/Cargo.toml
+++ b/src/stream-model/Cargo.toml
@@ -18,7 +18,7 @@ k8 = ["use_serde", "k8-obj-metadata", "k8-obj-core", "k8-obj-app"]
 [dependencies]
 tracing = "0.1.19"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
-async-rwlock = "1.1.0"
+async-rwlock = "1.3.0"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.1.0", features = ["net"] }

--- a/src/stream-model/src/core.rs
+++ b/src/stream-model/src/core.rs
@@ -14,6 +14,9 @@ mod context {
         type UId: PartialEq;
 
         fn uid(&self) -> &Self::UId;
+
+        /// update revision if make sense
+        fn update_revision(&mut self,revision: String);
     }
 
     impl MetadataItem for String {
@@ -21,6 +24,10 @@ mod context {
 
         fn uid(&self) -> &Self::UId {
             &self
+        }
+
+        fn update_revision(&mut self,_revision: String) {
+            // nothing
         }
     }
 
@@ -39,6 +46,10 @@ mod context {
     impl<C> MetadataContext<C> {
         pub fn item(&self) -> &C {
             &self.item
+        }
+
+        pub fn item_mut(&mut self) -> &mut C {
+            &mut self.item
         }
 
         pub fn item_owned(self) -> C {
@@ -77,6 +88,10 @@ pub mod k8 {
         type UId = String;
         fn uid(&self) -> &Self::UId {
             &self.uid
+        }
+
+        fn update_revision(&mut self,revision: String) {
+            self.resource_version = revision;
         }
     }
 }

--- a/src/stream-model/src/core.rs
+++ b/src/stream-model/src/core.rs
@@ -1,7 +1,6 @@
 pub use core_model::*;
 pub use context::*;
 
-
 mod context {
 
     use std::fmt;
@@ -15,7 +14,7 @@ mod context {
         fn uid(&self) -> &Self::UId;
 
         /// checkif item is newer
-        fn is_newer(&self,another: &Self) -> bool;
+        fn is_newer(&self, another: &Self) -> bool;
     }
 
     impl MetadataItem for String {
@@ -25,8 +24,7 @@ mod context {
             &self
         }
 
-
-        fn is_newer(&self,_another: &Self) -> bool {
+        fn is_newer(&self, _another: &Self) -> bool {
             true
         }
     }
@@ -78,14 +76,13 @@ mod context {
 
     impl<C> Display for MetadataContext<C>
     where
-        C: MetadataItem
+        C: MetadataItem,
     {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{:#?}", self.item)
         }
     }
 }
-
 
 mod core_model {
 

--- a/src/stream-model/src/core.rs
+++ b/src/stream-model/src/core.rs
@@ -1,8 +1,6 @@
 pub use core_model::*;
 pub use context::*;
 
-#[cfg(feature = "k8")]
-pub use k8::*;
 
 mod context {
 
@@ -88,27 +86,6 @@ mod context {
     }
 }
 
-#[cfg(feature = "k8")]
-pub mod k8 {
-
-
-    use crate::k8::metadata::ObjectMeta;
-
-    use super::*;
-
-    impl MetadataItem for ObjectMeta {
-        type UId = String;
-        fn uid(&self) -> &Self::UId {
-            &self.uid
-        }
-
-        fn is_newer(&self,another: &Self) -> bool {
-            self.resource_version > another.resource_version
-        }
-    }
-
-    
-}
 
 mod core_model {
 

--- a/src/stream-model/src/store/epoch_map.rs
+++ b/src/stream-model/src/store/epoch_map.rs
@@ -82,6 +82,10 @@ impl<T> EpochCounter<T> {
         &self.inner
     }
 
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     pub fn inner_owned(self) -> T {
         self.inner
     }
@@ -125,6 +129,12 @@ mod old_map {
 
         fn deref(&self) -> &Self::Target {
             &self.map
+        }
+    }
+
+    impl<K, V> DerefMut for EpochMap<K, V> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.map
         }
     }
 

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -36,6 +36,10 @@ impl K8MetaItem  {
         &self.inner
     }
 
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
 }
 
 impl Deref for K8MetaItem {
@@ -53,6 +57,7 @@ impl MetadataItem for K8MetaItem {
         &self.inner.uid
     }
 
+    #[inline]
     fn is_newer(&self, another: &Self) -> bool {
         self.revision > another.revision
     }
@@ -123,6 +128,7 @@ where
             let ctx_item_result: Result<K8MetaItem,_> = k8_obj.metadata.try_into();
             match ctx_item_result {
                 Ok(ctx_item) => {
+                 //   trace!("k8 revision: {}, meta revision: {}",ctx_item.revision(),ctx_item.inner().resource_version);
                     let ctx: MetadataContext<K8MetaItem> = ctx_item.into();
                     let local_kv =
                         MetadataStoreObject::new(key, local_spec, local_status).with_context(ctx);

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -16,19 +16,20 @@ use crate::core::{Spec, MetadataItem, MetadataContext};
 
 pub type K8MetadataContext = MetadataContext<K8MetaItem>;
 
-#[derive(Debug, Default,Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct K8MetaItem {
     revision: u64,
     inner: ObjectMeta,
 }
 
-impl K8MetaItem  {
-
-    pub fn new<S>(name: S,name_space: S) -> Self 
-    where S: Into<String> {
+impl K8MetaItem {
+    pub fn new<S>(name: S, name_space: S) -> Self
+    where
+        S: Into<String>,
+    {
         Self {
             revision: 0,
-            inner: ObjectMeta::new(name,name_space)
+            inner: ObjectMeta::new(name, name_space),
         }
     }
 
@@ -39,7 +40,6 @@ impl K8MetaItem  {
     pub fn revision(&self) -> u64 {
         self.revision
     }
-
 }
 
 impl Deref for K8MetaItem {
@@ -49,7 +49,6 @@ impl Deref for K8MetaItem {
         &self.inner
     }
 }
-
 
 impl MetadataItem for K8MetaItem {
     type UId = String;
@@ -67,14 +66,11 @@ impl TryFrom<ObjectMeta> for K8MetaItem {
     type Error = ParseIntError;
 
     fn try_from(value: ObjectMeta) -> Result<Self, Self::Error> {
-
         if value.resource_version.is_empty() {
-            return Ok(
-                Self {
-                    revision: 0,
-                    inner: value
-                }
-            )
+            return Ok(Self {
+                revision: 0,
+                inner: value,
+            });
         }
         let revision: u64 = value.resource_version.parse()?;
 
@@ -125,10 +121,10 @@ where
             let local_spec = k8_obj.spec.into();
             let local_status = k8_obj.status.into();
 
-            let ctx_item_result: Result<K8MetaItem,_> = k8_obj.metadata.try_into();
+            let ctx_item_result: Result<K8MetaItem, _> = k8_obj.metadata.try_into();
             match ctx_item_result {
                 Ok(ctx_item) => {
-                 //   trace!("k8 revision: {}, meta revision: {}",ctx_item.revision(),ctx_item.inner().resource_version);
+                    //   trace!("k8 revision: {}, meta revision: {}",ctx_item.revision(),ctx_item.inner().resource_version);
                     let ctx: MetadataContext<K8MetaItem> = ctx_item.into();
                     let local_kv =
                         MetadataStoreObject::new(key, local_spec, local_status).with_context(ctx);

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -2,18 +2,83 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::num::ParseIntError;
 use std::fmt::Display;
 use std::fmt::Debug;
+use std::ops::Deref;
 
 use crate::k8::metadata::Spec as K8Spec;
 use crate::k8::metadata::Status as K8Status;
 use crate::k8::metadata::ObjectMeta;
 use crate::k8::metadata::K8Obj;
-use crate::store::*;
-use crate::core::*;
+use crate::store::{MetadataStoreObject};
+use crate::core::{Spec, MetadataItem, MetadataContext};
 
-pub type K8MetaItem = ObjectMeta;
 pub type K8MetadataContext = MetadataContext<K8MetaItem>;
+
+#[derive(Debug, Default,Clone, PartialEq)]
+pub struct K8MetaItem {
+    revision: u64,
+    inner: ObjectMeta,
+}
+
+impl K8MetaItem  {
+
+    pub fn new<S>(name: S,name_space: S) -> Self 
+    where S: Into<String> {
+        Self {
+            revision: 0,
+            inner: ObjectMeta::new(name,name_space)
+        }
+    }
+
+    pub fn inner(&self) -> &ObjectMeta {
+        &self.inner
+    }
+
+}
+
+impl Deref for K8MetaItem {
+    type Target = ObjectMeta;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+
+impl MetadataItem for K8MetaItem {
+    type UId = String;
+    fn uid(&self) -> &Self::UId {
+        &self.inner.uid
+    }
+
+    fn is_newer(&self, another: &Self) -> bool {
+        self.revision > another.revision
+    }
+}
+
+impl TryFrom<ObjectMeta> for K8MetaItem {
+    type Error = ParseIntError;
+
+    fn try_from(value: ObjectMeta) -> Result<Self, Self::Error> {
+
+        if value.resource_version.is_empty() {
+            return Ok(
+                Self {
+                    revision: 0,
+                    inner: value
+                }
+            )
+        }
+        let revision: u64 = value.resource_version.parse()?;
+
+        Ok(Self {
+            revision,
+            inner: value,
+        })
+    }
+}
 
 #[derive(Debug)]
 pub enum K8ConvertError<S>
@@ -55,11 +120,20 @@ where
             let local_spec = k8_obj.spec.into();
             let local_status = k8_obj.status.into();
 
-            let ctx: MetadataContext<ObjectMeta> = k8_obj.metadata.into();
-            let local_kv =
-                MetadataStoreObject::new(key, local_spec, local_status).with_context(ctx);
+            let ctx_item_result: Result<K8MetaItem,_> = k8_obj.metadata.try_into();
+            match ctx_item_result {
+                Ok(ctx_item) => {
+                    let ctx: MetadataContext<K8MetaItem> = ctx_item.into();
+                    let local_kv =
+                        MetadataStoreObject::new(key, local_spec, local_status).with_context(ctx);
 
-            Ok(local_kv)
+                    Ok(local_kv)
+                }
+                Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
+                    ErrorKind::InvalidData,
+                    format!("error converting metadata: {:#?}", err),
+                ))),
+            }
         }
         Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
             ErrorKind::InvalidData,

--- a/src/stream-model/src/store/metadata.rs
+++ b/src/stream-model/src/store/metadata.rs
@@ -116,7 +116,6 @@ where
     pub fn is_newer(&self, another: &Self) -> bool {
         self.ctx.item().is_newer(another.ctx().item())
     }
-
 }
 
 impl<S, C> Into<(S::IndexKey, S, S::Status)> for MetadataStoreObject<S, C>

--- a/src/stream-model/src/store/metadata.rs
+++ b/src/stream-model/src/store/metadata.rs
@@ -89,6 +89,10 @@ where
         &self.ctx
     }
 
+    pub fn ctx_mut(&mut self) -> &mut MetadataContext<C> {
+        &mut self.ctx
+    }
+
     pub fn ctx_owned(&self) -> MetadataContext<C> {
         self.ctx.clone()
     }

--- a/src/stream-model/src/store/metadata.rs
+++ b/src/stream-model/src/store/metadata.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::core::*;
+use crate::core::{Spec, MetadataContext, MetadataItem};
 
 pub type DefaultMetadataObject<S> = MetadataStoreObject<S, String>;
 
@@ -112,6 +112,11 @@ where
             None => false,
         }
     }
+
+    pub fn is_newer(&self, another: &Self) -> bool {
+        self.ctx.item().is_newer(another.ctx().item())
+    }
+
 }
 
 impl<S, C> Into<(S::IndexKey, S, S::Status)> for MetadataStoreObject<S, C>

--- a/src/stream-model/src/store/store.rs
+++ b/src/stream-model/src/store/store.rs
@@ -298,8 +298,8 @@ where
             match dry_run_change {
                 LSUpdate::Mod(new_kv_value) => {
                     if let Some(old_value) = read_guard.get(new_kv_value.key()) {
-                        if old_value.inner() != &new_kv_value {
-                            // existing but different, transform into mod
+                        if new_kv_value.is_newer(old_value) {
+                            // only replace if new kv is newer than old
                             actual_changes.push(LSUpdate::Mod(new_kv_value));
                         }
                     } else {
@@ -330,6 +330,7 @@ where
             match change {
                 LSUpdate::Mod(new_kv_value) => {
                     if write_guard.insert_meta(new_kv_value).is_some() {
+                        
                         mod_cnt += 1;
                     } else {
                         // there was no existing, so this is new

--- a/src/stream-model/src/store/store.rs
+++ b/src/stream-model/src/store/store.rs
@@ -329,7 +329,6 @@ where
         for change in actual_changes.into_iter() {
             match change {
                 LSUpdate::Mod(new_kv_value) => {
-    
                     if write_guard.insert_meta(new_kv_value).is_some() {
                         mod_cnt += 1;
                     } else {

--- a/src/stream-model/src/store/store.rs
+++ b/src/stream-model/src/store/store.rs
@@ -79,7 +79,7 @@ where
 
     /// write guard, this is private, use sync API to make changes
     #[inline(always)]
-    async fn write<'a>(
+    pub async fn write<'a>(
         &'_ self,
     ) -> RwLockWriteGuard<'_, EpochMap<S::IndexKey, MetadataStoreObject<S, C>>> {
         self.0.write().await

--- a/src/stream-model/src/store/store.rs
+++ b/src/stream-model/src/store/store.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 
 use tracing::debug;
 use tracing::error;
+use tracing::trace;
 use async_rwlock::RwLock;
 use async_rwlock::RwLockReadGuard;
 use async_rwlock::RwLockWriteGuard;
@@ -329,8 +330,8 @@ where
         for change in actual_changes.into_iter() {
             match change {
                 LSUpdate::Mod(new_kv_value) => {
+    
                     if write_guard.insert_meta(new_kv_value).is_some() {
-                        
                         mod_cnt += 1;
                     } else {
                         // there was no existing, so this is new

--- a/src/stream-model/src/store/store.rs
+++ b/src/stream-model/src/store/store.rs
@@ -7,7 +7,6 @@ use std::hash::Hash;
 
 use tracing::debug;
 use tracing::error;
-use tracing::trace;
 use async_rwlock::RwLock;
 use async_rwlock::RwLockReadGuard;
 use async_rwlock::RwLockWriteGuard;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,70 @@
+# Local test
+This run test with SC and SPU running in your dev machine.
+
+## Setting up
+
+```
+cargo build
+alias flvd=./target/debug/fluvio
+
+```
+
+
+# Running simple test
+
+This run a simple smoke test with a single record
+
+```
+$ flvt --local-driver --log-dir /tmp
+```
+
+Displaying current offsets:
+```
+$ flvd partition list
+ TOPIC   PARTITION  LEADER  REPLICAS  RESOLUTION  HW  LEO  LSR  FOLLOWER OFFSETS 
+ topic0  0          5001    []        Online      1   1    0    [] 
+```
+
+Run a test with sending 10 records:
+```
+flvt  --produce-iteration 10  -d
+
+no setup
+no topic initialized
+start testing...
+found topic: topic0 offset: 1
+starting fetch stream for: topic0 at: 1, expected new records: 10
+consumer: received batches 0
+produced message topic: topic0, offset: 1,len: 108
+consumer: received batches 1
+   consumer: total records: 1, validated offset: 2
+produced message topic: topic0, offset: 2,len: 108
+consumer: received batches 1
+   consumer: total records: 2, validated offset: 3
+produced message topic: topic0, offset: 3,len: 108
+consumer: received batches 1
+   consumer: total records: 3, validated offset: 4
+produced message topic: topic0, offset: 4,len: 108
+consumer: received batches 1
+   consumer: total records: 4, validated offset: 5
+produced message topic: topic0, offset: 5,len: 108
+consumer: received batches 1
+   consumer: total records: 5, validated offset: 6
+produced message topic: topic0, offset: 6,len: 108
+consumer: received batches 1
+   consumer: total records: 6, validated offset: 7
+produced message topic: topic0, offset: 7,len: 108
+consumer: received batches 1
+   consumer: total records: 7, validated offset: 8
+produced message topic: topic0, offset: 8,len: 108
+consumer: received batches 1
+   consumer: total records: 8, validated offset: 9
+produced message topic: topic0, offset: 9,len: 108
+consumer: received batches 1
+   consumer: total records: 9, validated offset: 10
+produced message topic: topic0, offset: 10,len: 109
+consumer: received batches 1
+   consumer: total records: 10, validated offset: 11
+<<consume test done for: topic0 >>>>
+consume message validated!
+```

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -17,5 +17,5 @@ fluvio-types = { path = "../../src/types", version = "0.1.0" }
 fluvio-controlplane-metadata = { features = ["k8"], path = "../../src/controlplane-metadata" }
 dataplane = { version = "0.1.0", path = "../../src/dataplane-protocol", package = "fluvio-dataplane-protocol" }
 utils = { path = "../../src/utils" }
-k8-client = { version = "1.1.1" }
+k8-client = { version = "2.0.0" }
 k8-metadata-client = { version = "1.0.1" }

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -11,7 +11,7 @@ structopt = "0.3.5"
 async-trait = "0.1.21"
 
 # Fluvio dependencies
-fluvio-future = { version = "0.1.0", features = ["subscriber","fixture"] }
+fluvio-future = { version = "0.1.0", features = ["task","timer","subscriber","fixture"] }
 fluvio = { path = "../../src/client" }
 fluvio-types = { path = "../../src/types", version = "0.1.0" }
 fluvio-controlplane-metadata = { features = ["k8"], path = "../../src/controlplane-metadata" }

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -34,9 +34,6 @@ pub struct TestOption {
     #[structopt(long)]
     disable_consume: bool,
 
-    /// disable set up topics
-    #[structopt(long)]
-    disable_topic_setup: bool,
 
     #[structopt(short, long)]
     /// replication count, number of spu will be same as replication count, unless overridden
@@ -88,11 +85,11 @@ impl TestOption {
 
     // do the setup (without cleanup)
     pub fn setup(&self) -> bool {
-        self.disable_install
+        !self.disable_install
     }
 
     pub fn init_topic(&self) -> bool {
-        !self.disable_topic_setup
+        !self.disable_install
     }
 
     pub fn terminate_after_consumer_test(&self) -> bool {

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -34,7 +34,6 @@ pub struct TestOption {
     #[structopt(long)]
     disable_consume: bool,
 
-
     #[structopt(short, long)]
     /// replication count, number of spu will be same as replication count, unless overridden
     replication: Option<u16>,

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -22,14 +22,13 @@ fn main() {
     let test_runner = TestRunner::new(option.clone());
 
     run_block_on(async move {
-
         if option.setup() {
             let mut setup = Setup::new(option);
             setup.setup().await;
         } else {
             println!("no setup");
         }
-        
+
         test_runner.run_test().await;
     });
 }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -19,12 +19,17 @@ fn main() {
 
     let option = TestOption::parse_cli_or_exit();
 
-    let mut setup = Setup::new(option.clone());
-    let test_runner = TestRunner::new(option);
+    let test_runner = TestRunner::new(option.clone());
 
-    run_block_on(async {
-        setup.setup().await;
+    run_block_on(async move {
 
+        if option.setup() {
+            let mut setup = Setup::new(option);
+            setup.setup().await;
+        } else {
+            println!("no setup");
+        }
+        
         test_runner.run_test().await;
     });
 }

--- a/tests/runner/src/setup.rs
+++ b/tests/runner/src/setup.rs
@@ -38,6 +38,6 @@ impl Setup {
 
         self.env_driver.install_cluster().await;
 
-        sleep(Duration::from_millis(2000)).await;
+        sleep(Duration::from_millis(5000)).await;
     }
 }

--- a/tests/runner/src/setup.rs
+++ b/tests/runner/src/setup.rs
@@ -38,6 +38,6 @@ impl Setup {
 
         self.env_driver.install_cluster().await;
 
-        sleep(Duration::from_millis(5000)).await;
+        sleep(Duration::from_millis(2000)).await;
     }
 }

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -69,7 +69,7 @@ impl TestRunner {
         // we need to test what happens topic gets created before spu
         if self.option.init_topic() {
             self.setup_topic().await;
-            sleep(Duration::from_secs(3)).await; // sleep 5 second in just case
+            sleep(Duration::from_secs(5)).await; // sleep 5 second in just case
         } else {
             println!("no topic initialized");
         }

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -69,11 +69,11 @@ impl TestRunner {
         // we need to test what happens topic gets created before spu
         if self.option.init_topic() {
             self.setup_topic().await;
+            sleep(Duration::from_secs(3)).await; // sleep 5 second in just case
         } else {
             println!("no topic initialized");
         }
 
-        sleep(Duration::from_secs(5)).await; // sleep 5 second in just case
 
         let test_driver = create_test_driver(self.option.clone());
 

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -74,7 +74,6 @@ impl TestRunner {
             println!("no topic initialized");
         }
 
-
         let test_driver = create_test_driver(self.option.clone());
 
         test_driver.run().await;

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -54,11 +54,12 @@ fn validate_consume_message_cli(option: &TestOption,offsets: Offsets) {
 async fn validate_consume_message_api(offsets: Offsets,option: &TestOption) {
     let client = Fluvio::connect().await.expect("should connect");
     let replication = option.replication();
+    let iteration = option.produce.produce_iteration;
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
         let base_offset = offsets.get(&topic_name).expect("offsets");
-        println!("starting fetch stream for: {} at: {}",topic_name,base_offset);
+        println!("starting fetch stream for: {} at: {}, expected new records: {}",topic_name,base_offset,iteration);
         
         let consumer = client
             .partition_consumer(topic_name.clone(), 0)
@@ -68,7 +69,7 @@ async fn validate_consume_message_api(offsets: Offsets,option: &TestOption) {
         let mut stream = consumer.stream(Offset::absolute(*base_offset).unwrap()).await.expect("start from beginning");
 
         let mut total_records: u16 = 0;
-        while let Ok(event) = stream.next().await {
+        'outer: while let Ok(event) = stream.next().await {
             let batches = event.partition.records.batches;
             println!("consumer: received batches {}",batches.len() );
             for batch in batches {
@@ -78,10 +79,11 @@ async fn validate_consume_message_api(offsets: Offsets,option: &TestOption) {
                        validate_message(offset,&topic_name,option, &bytes); 
                        offset += 1;   
                        total_records += 1;
-                       println!("consumer: records: {}, validated offset: {}",total_records,offset); 
+                       println!("   consumer: total records: {}, validated offset: {}",total_records,offset); 
                        assert_eq!(offset, base_offset + total_records as i64);  
-                       if total_records  == option.produce.produce_iteration {
-                           break;
+                       if total_records  == iteration {
+                           println!("<<consume test done for: {} >>>>",topic_name);
+                           break 'outer;
                        }             
                     }
                 }

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -1,7 +1,8 @@
-// test client
+// test consumer
 
 use std::io;
 use std::io::Write;
+use std::collections::HashMap;
 
 use utils::bin::get_fluvio;
 
@@ -10,28 +11,32 @@ use crate::cli::TestOption;
 use crate::util::CommandUtil;
 use super::message::*;
 
-/// verify consumer thru CLI
-pub async fn validate_consume_message(option: &TestOption) {
+type Offsets = HashMap<String,i64>;
+
+/// verify consumers
+pub async fn validate_consume_message(option: &TestOption,offsets: Offsets) {
     if option.produce.produce_iteration == 1 {
-        validate_consume_message_cli(option);
+        validate_consume_message_cli(option,offsets);
     } else {
         validate_consume_message_api(option).await;
     }
 }
 
-fn validate_consume_message_cli(option: &TestOption) {
+fn validate_consume_message_cli(option: &TestOption,offsets: Offsets) {
     let replication = option.replication();
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
+        let offset = offsets.get(&topic_name).expect("topic offset");
         let output = get_fluvio()
             .expect("fluvio not founded")
             .arg("consume")
             .arg(&topic_name)
             .arg("--partition")
             .arg("0")
-            .arg("-B")
             .arg("-d")
+            .arg("-o")
+            .arg(offset.to_string())
             .print()
             .output()
             .expect("no output");
@@ -40,7 +45,7 @@ fn validate_consume_message_cli(option: &TestOption) {
         io::stderr().write_all(&output.stderr).unwrap();
 
         let msg = output.stdout.as_slice();
-        validate_message(0, option, &msg[0..msg.len() - 1]);
+        validate_message(*offset, &topic_name,option, &msg[0..msg.len() - 1]);
 
         println!("topic: {}, consume message validated!", topic_name);
     }
@@ -56,6 +61,19 @@ async fn validate_consume_message_api(option: &TestOption) {
             .partition_consumer(topic_name, 0)
             .await
             .expect("consumer");
+
+        let mut stream = consumer.stream(Offset::beginning()).await.expect("start from beginning");
+
+        while let Ok(event) = stream.next().await {
+            for batch in event.partition.records.batches {
+                for record in batch.records {
+                    if let Some(record) = record.value.inner_value() {
+                        let string = String::from_utf8(record).unwrap();
+                        
+                    }
+                }
+            }
+        }
 
         println!("retrieving messages");
         let response = consumer.fetch(Offset::beginning()).await.expect("records");

--- a/tests/runner/src/tests/smoke/message.rs
+++ b/tests/runner/src/tests/smoke/message.rs
@@ -26,13 +26,14 @@ pub fn validate_message(offset: i64, topic: &str, option: &TestOption, data: &[u
     let prefix = message.as_bytes();
     let prefix_len = prefix.len();
 
+    assert_eq!(data.len(), option.produce.record_size + prefix_len);
+
     // check prefix
     for i in 0..prefix_len {
         assert_eq!(data[i],prefix[i]);
     }
 
-    
-    assert_eq!(data.len(), option.produce.record_size + prefix_len);
+
     for i in 0..option.produce.record_size {
         assert_eq!(data[i+prefix_len], VALUE);
     }

--- a/tests/runner/src/tests/smoke/message.rs
+++ b/tests/runner/src/tests/smoke/message.rs
@@ -7,7 +7,7 @@ const VALUE: u8 = 65;
 pub fn generate_message(offset: i64, topic: &str, option: &TestOption) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(option.produce.record_size);
 
-    let message = format!("{}:{}",topic,offset);
+    let message = format!("{}:{}", topic, offset);
     for p in message.as_bytes() {
         bytes.push(*p);
     }
@@ -21,8 +21,7 @@ pub fn generate_message(offset: i64, topic: &str, option: &TestOption) -> Vec<u8
 /// validate the message
 #[allow(clippy::needless_range_loop)]
 pub fn validate_message(offset: i64, topic: &str, option: &TestOption, data: &[u8]) {
-
-    let message = format!("{}:{}",topic,offset);
+    let message = format!("{}:{}", topic, offset);
     let prefix = message.as_bytes();
     let prefix_len = prefix.len();
 
@@ -30,11 +29,10 @@ pub fn validate_message(offset: i64, topic: &str, option: &TestOption, data: &[u
 
     // check prefix
     for i in 0..prefix_len {
-        assert_eq!(data[i],prefix[i]);
+        assert_eq!(data[i], prefix[i]);
     }
 
-
     for i in 0..option.produce.record_size {
-        assert_eq!(data[i+prefix_len], VALUE);
+        assert_eq!(data[i + prefix_len], VALUE);
     }
 }

--- a/tests/runner/src/tests/smoke/message.rs
+++ b/tests/runner/src/tests/smoke/message.rs
@@ -4,9 +4,13 @@ const VALUE: u8 = 65;
 
 /// generate test data based on iteration and option
 #[allow(clippy::all)]
-pub fn generate_message(_index: u16, option: &TestOption) -> Vec<u8> {
+pub fn generate_message(offset: i64, topic: &str, option: &TestOption) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(option.produce.record_size);
 
+    let message = format!("{}:{}",topic,offset);
+    for p in message.as_bytes() {
+        bytes.push(*p);
+    }
     for _ in 0..option.produce.record_size {
         bytes.push(VALUE);
     }
@@ -16,9 +20,20 @@ pub fn generate_message(_index: u16, option: &TestOption) -> Vec<u8> {
 
 /// validate the message
 #[allow(clippy::needless_range_loop)]
-pub fn validate_message(_index: u16, option: &TestOption, data: &[u8]) {
-    assert_eq!(data.len(), option.produce.record_size);
+pub fn validate_message(offset: i64, topic: &str, option: &TestOption, data: &[u8]) {
+
+    let message = format!("{}:{}",topic,offset);
+    let prefix = message.as_bytes();
+    let prefix_len = prefix.len();
+
+    // check prefix
+    for i in 0..prefix_len {
+        assert_eq!(data[i],prefix[i]);
+    }
+
+    
+    assert_eq!(data.len(), option.produce.record_size + prefix_len);
     for i in 0..option.produce.record_size {
-        assert_eq!(data[i], VALUE);
+        assert_eq!(data[i+prefix_len], VALUE);
     }
 }

--- a/tests/runner/src/tests/smoke/mod.rs
+++ b/tests/runner/src/tests/smoke/mod.rs
@@ -8,7 +8,6 @@ use super::TestDriver;
 
 mod runner {
 
-
     use async_trait::async_trait;
 
     use crate::TestOption;
@@ -25,12 +24,8 @@ mod runner {
         }
 
         async fn produce_and_consume_cli(&self) {
-
-
-
             let start_offsets = super::produce::produce_message(&self.option).await;
-            super::consume::validate_consume_message(&self.option,start_offsets).await;
-            
+            super::consume::validate_consume_message(&self.option, start_offsets).await;
         }
     }
 
@@ -38,11 +33,8 @@ mod runner {
     impl TestDriver for SmokeTestRunner {
         /// run tester
         async fn run(&self) {
-           
-
             println!("start testing...");
 
-            
             self.produce_and_consume_cli().await;
         }
     }

--- a/tests/runner/src/tests/smoke/mod.rs
+++ b/tests/runner/src/tests/smoke/mod.rs
@@ -8,8 +8,6 @@ use super::TestDriver;
 
 mod runner {
 
-    use std::time::Duration;
-    use fluvio_future::timer::sleep;
 
     use async_trait::async_trait;
 
@@ -27,19 +25,12 @@ mod runner {
         }
 
         async fn produce_and_consume_cli(&self) {
-            if self.option.produce() {
-                super::produce::produce_message(&self.option).await;
-            } else {
-                println!("produce skipped");
-            }
 
-            sleep(Duration::from_secs(5)).await;
 
-            if self.option.test_consumer() {
-                super::consume::validate_consume_message(&self.option).await;
-            } else {
-                println!("consume test skipped");
-            }
+
+            let start_offsets = super::produce::produce_message(&self.option).await;
+            super::consume::validate_consume_message(&self.option,start_offsets).await;
+            
         }
     }
 
@@ -47,30 +38,11 @@ mod runner {
     impl TestDriver for SmokeTestRunner {
         /// run tester
         async fn run(&self) {
-            //use futures::future::join_all;
-            //use futures::future::join;
-
-            //use fluvio_future::task::run_block_on;
-
-            //let mut listen_consumer_test = vec ![];
+           
 
             println!("start testing...");
 
-            /*
-            if self.0.test_consumer() {
-                for i in 0..self.0.replication() {
-                    listen_consumer_test.push(consume::validate_consumer_listener(i,&self.0));
-                }
-            }
-            */
-
-            /*
-            run_block_on(
-                join(
-                    self.produce_and_consume_cli(&target),
-                    join_all(listen_consumer_test)
-                ));
-            */
+            
             self.produce_and_consume_cli().await;
         }
     }

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -86,12 +86,14 @@ pub async fn produce_message_with_api(offsets: Offsets, option: TestOption) {
         let producer = client.topic_producer(&topic_name).await.expect("producer");
 
         for i in 0..option.produce.produce_iteration {
-            let message = generate_message(base_offset + i as i64, &topic_name, &option);
+            let offset = base_offset + i as i64;
+            let message = generate_message(offset, &topic_name, &option);
+            let len = message.len();
             producer
                 .send_record(message, 0)
                 .await
                 .expect("message sent");
-            println!("topic: {}, message sent: {}", topic_name, i);
+            println!("produced message topic: {}, offset: {},len: {}", topic_name, offset,len);
         }
     }
 }

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -93,7 +93,10 @@ pub async fn produce_message_with_api(offsets: Offsets, option: TestOption) {
                 .send_record(message, 0)
                 .await
                 .expect("message sent");
-            println!("produced message topic: {}, offset: {},len: {}", topic_name, offset,len);
+            println!(
+                "produced message topic: {}, offset: {},len: {}",
+                topic_name, offset, len
+            );
         }
     }
 }

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -1,25 +1,92 @@
+use std::collections::HashMap;
+
 use fluvio::Fluvio;
+use fluvio_future::task::spawn;
+
 use crate::TestOption;
 use super::message::*;
 
-pub async fn produce_message(option: &TestOption) {
+type Offsets = HashMap<String, i64>;
+
+pub async fn produce_message(option: &TestOption) -> Offsets {
+    // get initial offsets for each of the topic
+    let offsets = offsets::find_offsets(&option).await;
+
     if option.produce.produce_iteration == 1 {
-        cli::produce_message_with_cli(option).await;
+        cli::produce_message_with_cli(option, offsets.clone()).await;
     } else {
-        produce_message_with_api(option).await;
+        spawn(produce_message_with_api(offsets.clone(), option.clone()));
+    }
+
+    offsets
+}
+
+mod offsets {
+
+    use std::collections::HashMap;
+
+    use fluvio::{Fluvio, FluvioAdmin};
+
+    use fluvio_controlplane_metadata::partition::PartitionSpec;
+    use fluvio_controlplane_metadata::partition::ReplicaKey;
+
+    use super::TestOption;
+
+    pub async fn find_offsets(option: &TestOption) -> HashMap<String, i64> {
+        let replication = option.replication();
+
+        let mut offsets = HashMap::new();
+
+        let mut client = Fluvio::connect().await.expect("should connect");
+        let mut admin = client.admin().await;
+
+        for i in 0..replication {
+            let topic_name = option.topic_name(i);
+            // find last offset
+            let offset = last_leo(&mut admin, &topic_name).await;
+            println!("found topic: {} offset: {}", topic_name, offset);
+            offsets.insert(topic_name, offset);
+        }
+
+        offsets
+    }
+
+    async fn last_leo(admin: &mut FluvioAdmin, topic: &str) -> i64 {
+        use std::convert::TryInto;
+
+        let partitions = admin
+            .list::<PartitionSpec, _>(vec![])
+            .await
+            .expect("get partitions status");
+
+        for partition in partitions {
+            let replica: ReplicaKey = partition
+                .name
+                .clone()
+                .try_into()
+                .expect("canot parse partition");
+
+            if replica.topic == topic && replica.partition == 0 {
+                return partition.status.leader.leo;
+            }
+        }
+
+        panic!("cannot found partition 0 for topic: {}", topic);
     }
 }
 
-pub async fn produce_message_with_api(option: &TestOption) {
+pub async fn produce_message_with_api(offsets: Offsets, option: TestOption) {
     let client = Fluvio::connect().await.expect("should connect");
     let replication = option.replication();
 
     for i in 0..replication {
         let topic_name = option.topic_name(i);
+
+        let base_offset = *offsets.get(&topic_name).expect("offsets");
         let producer = client.topic_producer(&topic_name).await.expect("producer");
 
         for i in 0..option.produce.produce_iteration {
-            let message = generate_message(i, option);
+            let message = generate_message(base_offset + i as i64, &topic_name, &option);
             producer
                 .send_record(message, 0)
                 .await
@@ -40,26 +107,33 @@ mod cli {
 
     use super::*;
 
-    pub async fn produce_message_with_cli(option: &TestOption) {
+    pub async fn produce_message_with_cli(option: &TestOption, offsets: Offsets) {
         println!("starting produce");
 
         let produce_count = option.produce.produce_iteration;
         for i in 0..produce_count {
-            produce_message(i, option);
+            produce_message_replication(i, &offsets, option);
             //sleep(Duration::from_millis(10)).await
         }
     }
 
-    fn produce_message(_index: u16, option: &TestOption) {
+    fn produce_message_replication(iteration: u16, offsets: &Offsets, option: &TestOption) {
         let replication = option.replication();
 
         for i in 0..replication {
-            produce_message_inner(&option.topic_name(i), option);
+            produce_message_inner(iteration, &option.topic_name(i), offsets, option);
         }
     }
 
-    fn produce_message_inner(topic_name: &str, option: &TestOption) {
+    fn produce_message_inner(
+        _iteration: u16,
+        topic_name: &str,
+        offsets: &Offsets,
+        option: &TestOption,
+    ) {
         use std::io;
+
+        let base_offset = *offsets.get(topic_name).expect("offsets");
 
         let mut child = get_fluvio()
             .expect("no fluvio")
@@ -72,7 +146,7 @@ mod cli {
             .expect("no child");
 
         let stdin = child.stdin.as_mut().expect("Failed to open stdin");
-        let msg = generate_message(0, option);
+        let msg = generate_message(base_offset, topic_name, option);
         stdin
             .write_all(msg.as_slice())
             .expect("Failed to write to stdin");


### PR DESCRIPTION
this PR resolves object conflict issue in: #301.

This happens whenever status updates are arriving faster than around trip to k8.
The status from SPU doesn't have resource version, it assume last update is latest.
Since status cache doesn't have latest update from k8, update will be using outdated resourceVersion.

The PR contains
-  Use k8-client 2.0.0 which handles 409 error correctly
-  Use resourceVersion to compare if cache need to be replaced
-  Update cache after k8 status update instead of waiting for k8 watch stream.  This may result in duplicate events from k8 stream which will be ignored since latest version if already in the cache
- Improve consumer testing by starting from last instead of beginning