### PR TITLE
Only update /etc/hosts when necessary. Prevent duplicate /etc/hosts entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostfile"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2733206bcc0550a15b450c64d8aa859f486d7281c4c0c36ef904b361960d658"
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,15 +1793,17 @@ dependencies = [
 
 [[package]]
 name = "k8-config"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ffdf19d8d09733044a611dfa660be0cc2a07e190bcdc2e9bf2eb08a84af0d7"
+checksum = "83fd3c29e5808dad171aa1dc92ac56cb734b8d1e24fade735e0373a8d12a7945"
 dependencies = [
  "dirs 2.0.2",
- "log",
+ "hostfile",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tera",
+ "tracing",
 ]
 
 [[package]]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -50,7 +50,7 @@ http-types = "2.4.0"
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.0", features = ["fs", "io","subscriber"] }
 k8-client = { version = "2.0.0" }
-k8-config = { version = "1.1.0", features = ["context"] }
+k8-config = { version = "1.2.0", features = ["context"] }
 k8-obj-core = { version = "1.1.0" }
 k8-obj-metadata = { version = "1.0.0" }
 k8-metadata-client = { version = "1.0.0" }

--- a/src/cli/src/cluster/minikube.rs
+++ b/src/cli/src/cluster/minikube.rs
@@ -14,20 +14,18 @@ pub struct SetMinikubeContext {
 mod context {
 
     use super::*;
+    use k8_config::context::MinikubeContext;
 
     /// Performs following
     ///     add  IP address to /etc/host
     ///     create new kubectl cluster and context which uses minikube name
     pub fn process_minikube_context(ctx: SetMinikubeContext) -> Result<String, CliError> {
-        use k8_config::context::Option;
-        use k8_config::context::create_dns_context;
+        let mut context = MinikubeContext::try_from_system()?;
 
-        let mut option = Option::default();
         if let Some(name) = ctx.name {
-            option.ctx_name = name;
+            context = context.with_name(name);
         }
-
-        create_dns_context(option);
+        context.save()?;
 
         Ok("".to_owned())
     }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -27,7 +27,7 @@ fluvio = { path = "../client" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", features = ["k8"] }
 fluvio-future = { version = "0.1.0" }
 flv-util = "0.5.0"
-k8-config = { version = "1.1.0", features = ["context"] }
+k8-config = { version = "1.2.0", features = ["context"] }
 k8-client = "2.0.0"
 k8-obj-core = "1.1.0"
 k8-obj-metadata = "1.0.0"


### PR DESCRIPTION
Fixes `fluvio cluster set-minikube-context` so that it:

- Only tries to update `/etc/hosts` when the `minikubeCA` does not match `minikube ip`
- Does not create duplicate entries in `/etc/hosts` when it does need to update.