### PR TITLE
Fix cluster IO import to std::io

### DIFF
--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -2,7 +2,6 @@ use std::io::Error as IoError;
 use serde::export::Formatter;
 
 use fluvio::FluvioError;
-use fluvio_future::io::Error;
 use k8_config::{ConfigError as K8ConfigError};
 use k8_client::{ClientError as K8ClientError};
 
@@ -34,7 +33,7 @@ impl std::fmt::Display for ClusterError {
 }
 
 impl From<IoError> for ClusterError {
-    fn from(err: Error) -> Self {
+    fn from(err: IoError) -> Self {
         Self::IoError(err)
     }
 }


### PR DESCRIPTION
I noticed that the cluster crate's error type uses `fluvio_futures::io::Error` which is just a very roundabout re-export of `std::io::Error`. I imagine it was incorrectly added by IDE inference. Better to depend directly on `std::io::Error`.