### PR TITLE
fix futures timer issue on k8 by using smaller wait period

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,12 @@ jobs:
         if: startsWith(matrix.os,'ubuntu')
         run: |
           FLV_CMD=true make smoke-test-tls
+          make test-clean-up
       - name: smoke test tls
         if: startsWith(matrix.os, 'macOS')
         run: |
           FLV_CMD=true make smoke-test-tls DEFAULT_SPU=1
+          make test-clean-up
 
 
   k8_cluster_test:
@@ -225,4 +227,6 @@ jobs:
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: smoke test k8 tls
-        run: FLV_CMD=true make smoke-test-k8-tls
+        run: | 
+          FLV_CMD=true make smoke-test-k8-tls
+          make test-clean-up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: smoke test tls for linux
         if: startsWith(matrix.os,'ubuntu')
         run: |
-          FLV_CMD=true make smoke-test
+          FLV_CMD=true make smoke-test-tls
       - name: smoke test tls
         if: startsWith(matrix.os, 'macOS')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: smoke test tls for linux
         if: startsWith(matrix.os,'ubuntu')
         run: |
-          FLV_CMD=true make smoke-test-tls
+          FLV_CMD=true make smoke-test
       - name: smoke test tls
         if: startsWith(matrix.os, 'macOS')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v1
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
@@ -65,10 +61,6 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v2
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install ${{ matrix.rust }}
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -88,11 +80,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install ${{ matrix.rust }}
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
@@ -115,11 +102,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install ${{ matrix.rust }}
       - name: Install Helm
         run: dev-tools/ci-replace-helm.sh
         env:
@@ -183,7 +165,6 @@ jobs:
         uses: styfle/cancel-workflow-action@0.5.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install ${{ matrix.rust }}
       - name: Install Helm
         run: dev-tools/ci-replace-helm.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Cancel Workflow Action
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.5.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install ${{ matrix.rust }}
@@ -65,6 +65,11 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v2
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ${{ matrix.rust }}
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
@@ -83,6 +88,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ${{ matrix.rust }}
       - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
@@ -105,6 +115,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ${{ matrix.rust }}
       - name: Install Helm
         run: dev-tools/ci-replace-helm.sh
         env:
@@ -162,6 +177,11 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ${{ matrix.rust }}
       - name: Install Helm
         run: dev-tools/ci-replace-helm.sh
         env:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
 DEFAULT_SPU=1
-DEFAULT_ITERATION=1
+DEFAULT_ITERATION=100
 
 # install all tools required
 install_tools_mac:

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ build:
 smoke-test:	test-clean-up
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local-driver --log-dir /tmp
 
-smoke-test-tls:	build test-clean-up
+smoke-test-tls:	test-clean-up
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local-driver --log-dir /tmp
 
-smoke-test-k8:	build test-clean-up minikube_image
+smoke-test-k8:	test-clean-up minikube_image
 	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop
 
-smoke-test-k8-tls:	build test-clean-up minikube_image
+smoke-test-k8-tls:	test-clean-up minikube_image
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop
 
 test-clean-up:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CLI_BUILD=fluvio_cli
 FLUVIO_BIN=./target/debug/fluvio
 TEST_BIN=FLV_CMD=true ./target/debug/flv-test
 DEFAULT_SPU=1
-DEFAULT_ITERATION=100
+DEFAULT_ITERATION=10
 
 # install all tools required
 install_tools_mac:

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -160,7 +160,9 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
     // wait for list of spu
     for _ in 0..30u16 {
         let spus = admin.list::<SpuSpec, _>(vec![]).await.expect("no spu list");
-        let live_spus = spus.iter().filter(|spu| spu.status.is_online()).count();
+        let live_spus = spus.iter().filter(|spu| spu.status.is_online()
+            && !spu.spec.public_endpoint.ingress.is_empty()
+        ).count();
         if live_spus == spu as usize {
             println!("{} spus provisioned", spus.len());
             return Ok(());

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -123,6 +123,8 @@ where
     use k8::install_sys;
     use k8::install_core;
 
+    let spu = command.spu;
+
     #[cfg(feature = "cluster_components")]
     use local::install_local;
 
@@ -131,9 +133,43 @@ where
     } else if command.local {
         #[cfg(feature = "cluster_components")]
         install_local(command).await?;
+        confirm_spu(spu).await?;
     } else {
         install_core(command).await?;
     }
 
     Ok("".to_owned())
+}
+
+/// check to ensure spu are all running
+async fn confirm_spu(spu: u16) -> Result<(),CliError> {
+
+    use std::time::Duration;
+
+    use fluvio_future::timer::sleep;
+    use fluvio::Fluvio;
+    use fluvio_cluster::ClusterError;
+    use fluvio_controlplane_metadata::spu::SpuSpec;
+
+    let mut client = Fluvio::connect().await.expect("sc ");
+    
+    let mut admin = client.admin().await;
+
+    let spus = admin.list::<SpuSpec, _>(vec![]).await.expect("no spu list");
+
+    assert_eq!(spus.len(),spu as usize);
+
+    for _ in 0..30u16 {
+    
+        let live_spus = spus.iter().filter(|spu| spu.status.is_online()).count();
+        if live_spus == spu as usize {
+            return Ok(());
+        } else {
+            println!("{} out of spu: {} up, waiting 1 sec",live_spus,spus.len());
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    println!("waited too long,bailing out");
+    Err(CliError::ClusterError(ClusterError::Other(format!("not able to provision:{} spu",spu))))
 }

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -160,9 +160,10 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
     // wait for list of spu
     for _ in 0..30u16 {
         let spus = admin.list::<SpuSpec, _>(vec![]).await.expect("no spu list");
-        let live_spus = spus.iter().filter(|spu| spu.status.is_online()
-            && !spu.spec.public_endpoint.ingress.is_empty()
-        ).count();
+        let live_spus = spus
+            .iter()
+            .filter(|spu| spu.status.is_online() && !spu.spec.public_endpoint.ingress.is_empty())
+            .count();
         if live_spus == spu as usize {
             println!("{} spus provisioned", spus.len());
             return Ok(());

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2117209"]
+#![type_length_limit = "2200000"]
 
 mod common;
 mod error;

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -592,7 +592,10 @@ impl ClusterInstaller {
             self.create_managed_spu_group(&cluster).await?;
 
             // Wait for the SPU cluster to spin up
-            if !self.wait_for_spu(namespace,self.config.spu_spec.replicas).await? {
+            if !self
+                .wait_for_spu(namespace, self.config.spu_spec.replicas)
+                .await?
+            {
                 warn!("SPU took too long to get ready");
                 return Err(ClusterError::Other(
                     "SPU took too long to get ready".to_string(),
@@ -813,7 +816,7 @@ impl ClusterInstaller {
                             attempt = i,
                             "SC service exists but no load balancer exist yet, continue wait"
                         );
-                        println!("waiting for sc service up come up: {}",i);
+                        println!("waiting for sc service up come up: {}", i);
                         sleep(Duration::from_millis(1000)).await;
                     }
                 }
@@ -833,7 +836,7 @@ impl ClusterInstaller {
 
     /// Wait until all SPUs are ready and have ingress
     #[instrument(skip(self, ns))]
-    async fn wait_for_spu(&self, ns: &str,spu: u16) -> Result<bool, ClusterError> {
+    async fn wait_for_spu(&self, ns: &str, spu: u16) -> Result<bool, ClusterError> {
         // Try waiting for SPUs for 100 cycles
         for i in 0..30u16 {
             let items = self.kube_client.retrieve_items::<SpuSpec, _>(ns).await?;
@@ -858,7 +861,7 @@ impl ClusterInstaller {
                     attempt = i,
                     "Not all SPUs are ready. Waiting",
                 );
-                println!("{} of {} spu ready",ready_spu,spu);
+                println!("{} of {} spu ready", ready_spu, spu);
                 sleep(Duration::from_millis(1000)).await;
             }
         }

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -833,7 +833,7 @@ impl ClusterInstaller {
     #[instrument(skip(self, ns))]
     async fn wait_for_spu(&self, ns: &str) -> Result<bool, ClusterError> {
         // Try waiting for SPUs for 100 cycles
-        for i in 0..100u16 {
+        for i in 0..30u16 {
             let items = self.kube_client.retrieve_items::<SpuSpec, _>(ns).await?;
             let spu_count = items.items.len();
 
@@ -856,7 +856,7 @@ impl ClusterInstaller {
                     attempt = i,
                     "Not all SPUs are ready. Waiting",
                 );
-                sleep(Duration::from_millis(2000)).await;
+                sleep(Duration::from_millis(1000)).await;
             }
         }
 

--- a/src/sc/src/k8/mod.rs
+++ b/src/sc/src/k8/mod.rs
@@ -8,23 +8,29 @@
 mod operator;
 mod service;
 
-use fluvio_future::task::main;
 use k8_client::new_shared;
 
 use operator::run_k8_operators;
 
 use crate::cli::ScOpt;
-use crate::init::start_main_loop;
+
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main_k8_loop(opt: ScOpt) {
+
+    use std::time::Duration;
+
+    use fluvio_future::task::run_block_on;
+    use fluvio_future::timer::sleep;
+
+    use crate::init::start_main_loop;
     // parse configuration (program exits on error)
     let (sc_config, k8_config, tls_option) = opt.parse_cli_or_exit();
 
     println!("starting sc server with k8: {}", VERSION);
 
-    main(async move {
+    run_block_on(async move {
         // init k8 service
         let k8_client = new_shared(k8_config).expect("problem creating k8 client");
         let namespace = sc_config.namespace.clone();
@@ -45,6 +51,11 @@ pub fn main_k8_loop(opt: ScOpt) {
         }
 
         println!("Streaming Controller started successfully");
+
+        // do inifinite loop
+        loop {
+            sleep(Duration::from_secs(60)).await;
+        }
     });
 }
 

--- a/src/sc/src/k8/mod.rs
+++ b/src/sc/src/k8/mod.rs
@@ -14,11 +14,9 @@ use operator::run_k8_operators;
 
 use crate::cli::ScOpt;
 
-
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main_k8_loop(opt: ScOpt) {
-
     use std::time::Duration;
 
     use fluvio_future::task::run_block_on;

--- a/src/spu/src/start.rs
+++ b/src/spu/src/start.rs
@@ -1,4 +1,3 @@
-use fluvio_future::task::main;
 use fluvio_storage::FileReplica;
 
 use crate::config::{SpuConfig, SpuOpt};
@@ -15,12 +14,16 @@ type FileReplicaContext = GlobalContext<FileReplica>;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main_loop(opt: SpuOpt) {
+    use std::time::Duration;
+
+    use fluvio_future::task::run_block_on;
+    use fluvio_future::timer::sleep;
     // parse configuration (program exits on error)
     let (spu_config, tls_acceptor_option) = opt.process_spu_cli_or_exit();
 
     println!("starting spu server (id:{})", spu_config.id);
 
-    main(async move {
+    run_block_on(async move {
         let (_ctx, internal_server, public_server) =
             create_services(spu_config.clone(), true, true);
 
@@ -32,6 +35,11 @@ pub fn main_loop(opt: SpuOpt) {
         }
 
         println!("SPU Version: {} started successfully", VERSION);
+
+        // infinite loop
+        loop {
+            sleep(Duration::from_secs(60)).await;
+        }
     });
 }
 

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -38,10 +38,14 @@ pub struct TestOption {
     /// replication count, number of spu will be same as replication count, unless overridden
     replication: Option<u16>,
 
-    /// topic name used for testing
+    /// base topic name used.  if replication > 1, then topic name will be named: topic<replication>
     #[structopt(short("t"), long, default_value = "topic")]
     pub topic_name: String,
 
+    /// if this is turn on, consumer waits for producer to finish before starts consumption
+    /// if iterations are long then consumer may receive large number of batches 
+    #[structopt(long)]
+    pub consumer_wait: bool,
     /// number of spu
     #[structopt(short, long, default_value = "1")]
     pub spu: u16,

--- a/tests/runner/src/cli.rs
+++ b/tests/runner/src/cli.rs
@@ -43,7 +43,7 @@ pub struct TestOption {
     pub topic_name: String,
 
     /// if this is turn on, consumer waits for producer to finish before starts consumption
-    /// if iterations are long then consumer may receive large number of batches 
+    /// if iterations are long then consumer may receive large number of batches
     #[structopt(long)]
     pub consumer_wait: bool,
     /// number of spu

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
     use setup::Setup;
     use test_runner::TestRunner;
 
+    println!("Start running fluvio test runner");
     fluvio_future::subscriber::init_logger();
 
     let option = TestOption::parse_cli_or_exit();

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -44,24 +44,27 @@ impl TestRunner {
 
         for _ in 0..60u16 {
             use fluvio_controlplane_metadata::partition::PartitionSpec;
-            
+
             let partitions = admin
                 .list::<PartitionSpec, _>(vec![])
                 .await
                 .expect("get partitions status");
 
-            let live_partitions = partitions.iter().filter(| par | 
-                par.status.is_online()
-            ).count();
+            let live_partitions = partitions
+                .iter()
+                .filter(|par| par.status.is_online())
+                .count();
 
             if live_partitions != replication as usize {
-                println!("partition {} of out of {} is ready, sleeping",live_partitions,replication);
+                println!(
+                    "partition {} of out of {} is ready, sleeping",
+                    live_partitions, replication
+                );
                 sleep(Duration::from_secs(1)).await;
-            }  else {
-                println!("all {} partitions are live",live_partitions);
+            } else {
+                println!("all {} partitions are live", live_partitions);
                 break;
-            }      
-            
+            }
         }
 
         // print topic and partition status

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -2,26 +2,21 @@ use std::collections::HashMap;
 
 use fluvio::Fluvio;
 
-
 use crate::TestOption;
 use super::message::*;
 
 type Offsets = HashMap<String, i64>;
 
 pub async fn produce_message(option: &TestOption) -> Offsets {
-
-    use fluvio_future::task::spawn;    // get initial offsets for each of the topic
+    use fluvio_future::task::spawn; // get initial offsets for each of the topic
     let offsets = offsets::find_offsets(&option).await;
 
     if option.produce.produce_iteration == 1 {
         cli::produce_message_with_cli(option, offsets.clone()).await;
+    } else if option.consumer_wait {
+        produce_message_with_api(offsets.clone(), option.clone()).await;
     } else {
-        if option.consumer_wait {
-            produce_message_with_api(offsets.clone(), option.clone()).await
-        } else {
-            spawn(produce_message_with_api(offsets.clone(), option.clone()));
-        }
-        
+        spawn(produce_message_with_api(offsets.clone(), option.clone()));
     }
 
     offsets


### PR DESCRIPTION
fix issue when panic during futures task on sc.  it seems that running 1 hour delay can panic.  reduce sleep time to 60 seconds which seems to be done the trick.

Instead of waiting using heuristics waits, actual status are used for waiting for provisioning
- local and k8 spus
- topics

Also, cancel is applied for all workflows

