### PR TITLE
Streamline cluster install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fluvio",
  "fluvio-controlplane-metadata",

--- a/src/cli/src/cluster/install/k8.rs
+++ b/src/cli/src/cluster/install/k8.rs
@@ -43,7 +43,7 @@ pub async fn install_core(opt: InstallCommand) -> Result<(), CliError> {
         }
         // If we're in develop mode (but no explicit chart location), use hardcoded local path
         None if opt.develop => {
-            builder = builder.with_local_chart("./k8-util/helm/fluvio-app");
+            builder = builder.with_local_chart("./k8-util/helm");
         }
         _ => (),
     }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cluster"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.20"
 fluvio = { version = "0.1.0", path = "../client" }
 fluvio-controlplane-metadata = { version = "0.1.0", path = "../controlplane-metadata", features = ["k8"] }
 fluvio-future = { version = "0.1.0" }
-flv-util = "0.5.0"
+flv-util = "0.5.2"
 k8-config = { version = "1.3.0", features = ["context"] }
 k8-client = "2.1.0"
 k8-obj-core = "1.1.0"

--- a/src/cluster/src/check.rs
+++ b/src/cluster/src/check.rs
@@ -64,7 +64,7 @@ pub enum CheckError {
     K8ConfigError {
         #[from]
         source: K8ConfigError,
-    }
+    },
 }
 
 // Getting server hostname from K8 context
@@ -75,12 +75,17 @@ pub fn check_cluster_server_host() -> Result<(), CheckError> {
         K8Config::KubeConfig(context) => context,
     };
 
-    let cluster_context = context.config.current_cluster()
+    let cluster_context = context
+        .config
+        .current_cluster()
         .ok_or(CheckError::NoActiveKubernetesContext)?;
     let server_url = cluster_context.cluster.server.to_owned();
-    let url = Url::parse(&server_url)
-        .map_err(|source| CheckError::BadKubernetesServerUrl { source })?;
-    let host = url.host().ok_or(CheckError::MissingKubernetesServerHost)?.to_string();
+    let url =
+        Url::parse(&server_url).map_err(|source| CheckError::BadKubernetesServerUrl { source })?;
+    let host = url
+        .host()
+        .ok_or(CheckError::MissingKubernetesServerHost)?
+        .to_string();
     if host.is_empty() {
         return Err(CheckError::MissingKubernetesServerHost);
     }
@@ -105,7 +110,6 @@ pub fn check_helm_version(helm: &HelmClient, required: &str) -> Result<(), Check
 
 /// Check that the system chart is installed
 pub fn check_system_chart(helm: &HelmClient, sys_repo: &str) -> Result<(), CheckError> {
-
     // check installed system chart version
     let sys_charts = helm.get_installed_chart_by_name(sys_repo)?;
     if sys_charts.is_empty() {

--- a/src/cluster/src/check.rs
+++ b/src/cluster/src/check.rs
@@ -1,23 +1,85 @@
-use k8_config::{KubeContext};
-use url::Url;
+use std::net::IpAddr;
+use std::str::FromStr;
 
-use crate::ClusterError;
+use thiserror::Error;
+use k8_config::{KubeContext, ConfigError as K8ConfigError};
+use url::{Url, ParseError};
+use crate::helm::HelmError;
+
+#[derive(Error, Debug)]
+pub enum CheckError {
+    /// The fluvio-sys chart is not installed
+    #[error("The fluvio-sys chart is not installed")]
+    MissingSystemChart,
+
+    /// Fluvio is already correctly installed
+    #[error("The fluvio-app chart is already installed")]
+    AlreadyInstalled,
+
+    /// Need to update minikube context
+    #[error("The minikube context is not active or does not match your minikube ip")]
+    InvalidMinikubeContext,
+
+    /// There is no current kubernetest context
+    #[error("There is no active Kubernetes context")]
+    NoActiveKubernetesContext,
+
+    /// Failed to parse kubernetes cluster server URL
+    #[error("Failed to parse server url from Kubernetes context")]
+    BadKubernetesServerUrl {
+        #[from]
+        source: ParseError,
+    },
+
+    /// There are multiple fluvio-sys's installed
+    #[error("Cannot have multiple versions of fluvio-sys installed")]
+    MultipleSystemCharts,
+
+    /// The current kubernetes cluster must have a server hostname
+    #[error("Missing Kubernetes server host")]
+    MissingKubernetesServerHost,
+
+    /// The server address for the current cluster must be a hostname, not an IP
+    #[error("Kubernetes server must be a hostname, not an IP address")]
+    KubernetesServerIsIp,
+
+    /// The installed version of helm is incompatible
+    #[error("Must have helm version {required} or later. You have {installed}")]
+    IncompatibleHelmVersion {
+        /// The currently-installed helm version
+        installed: String,
+        /// The minimum required helm version
+        required: String,
+    },
+
+    /// There was a problem with the helm client during pre-check
+    #[error("Helm client error")]
+    HelmError {
+        #[from]
+        source: HelmError,
+    },
+
+    #[error("Kubernetes config error")]
+    K8ConfigError {
+        #[from]
+        source: K8ConfigError,
+    }
+}
 
 // Getting server hostname from K8 context
-pub(crate) fn get_cluster_server_host(kc_config: KubeContext) -> Result<String, ClusterError> {
-    if let Some(ctx) = kc_config.config.current_cluster() {
-        let server_url = ctx.cluster.server.to_owned();
-        let url = match Url::parse(&server_url) {
-            Ok(url) => url,
-            Err(e) => {
-                return Err(ClusterError::Other(format!(
-                    "error parsing server url {}",
-                    e.to_string()
-                )))
-            }
-        };
-        Ok(url.host().unwrap().to_string())
-    } else {
-        Err(ClusterError::Other("no context found".to_string()))
+pub(crate) fn check_cluster_server_host(kc_context: KubeContext) -> Result<(), CheckError> {
+    let cluster_context = kc_context.config.current_cluster()
+        .ok_or(CheckError::NoActiveKubernetesContext)?;
+    let server_url = cluster_context.cluster.server.to_owned();
+    let url = Url::parse(&server_url)
+        .map_err(|source| CheckError::BadKubernetesServerUrl { source })?;
+    let host = url.host().ok_or(CheckError::MissingKubernetesServerHost)?.to_string();
+    if host.is_empty() {
+        return Err(CheckError::MissingKubernetesServerHost);
     }
+    if IpAddr::from_str(&host).is_ok() {
+        return Err(CheckError::KubernetesServerIsIp);
+    }
+
+    Ok(())
 }

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -5,6 +5,7 @@ use fluvio::FluvioError;
 use k8_config::{ConfigError as K8ConfigError};
 use k8_client::{ClientError as K8ClientError};
 use crate::helm::HelmError;
+use crate::check::CheckError;
 
 /// The types of errors that can occur during cluster management
 #[derive(Error, Debug)]
@@ -44,23 +45,13 @@ pub enum ClusterError {
         /// The underlying Helm client error
         source: HelmError,
     },
-    /// The installed version of helm is incompatible
-    #[error("Must have helm version {required} or later. You have {installed}")]
-    IncompatibleHelmVersion {
-        /// The currently-installed helm version
-        installed: String,
-        /// The minimum required helm version
-        required: String,
+    /// An error that occurred during pre-installation checks
+    #[error("Fluvio pre-installation check failed")]
+    PreCheckError {
+        /// The pre-check error that occurred
+        #[from]
+        source: CheckError,
     },
-    /// The fluvio-sys chart is not installed
-    #[error("The fluvio-sys chart is not installed")]
-    MissingSystemChart,
-    /// Fluvio is already correctly installed
-    #[error("The fluvio-app chart is already installed")]
-    AlreadyInstalled,
-    /// Need to update minikube context
-    #[error("The minikube context is not active or does not match your minikube ip")]
-    InvalidMinikubeContext,
     /// Timed out when waiting for SC service.
     #[error("Timed out when waiting for SC service")]
     SCServiceTimeout,

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -55,6 +55,9 @@ pub enum ClusterError {
     /// The fluvio-sys chart is not installed
     #[error("The fluvio-sys chart is not installed")]
     MissingSystemChart,
+    /// Fluvio is already correctly installed
+    #[error("The fluvio-app chart is already installed")]
+    AlreadyInstalled,
     /// Need to update minikube context
     #[error("The minikube context is not active or does not match your minikube ip")]
     InvalidMinikubeContext,

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -39,7 +39,7 @@ const DEFAULT_CHART_APP_NAME: &str = "fluvio/fluvio-app";
 const DEFAULT_CHART_REMOTE: &str = "https://charts.fluvio.io";
 const DEFAULT_GROUP_NAME: &str = "main";
 const DEFAULT_CLOUD_NAME: &str = "minikube";
-const DEFAULT_HELM_VERSION: &str = "3.2.0";
+const DEFAULT_HELM_VERSION: &str = "3.3.4";
 
 /// Distinguishes between a Local and Remote helm chart
 #[derive(Debug)]

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -643,7 +643,11 @@ impl ClusterInstaller {
             // If Fluvio is already installed, skip install step
             Err(ClusterError::PreCheckError {
                 source: CheckError::AlreadyInstalled,
-            }) => (),
+            }) => {
+                debug!("Fluvio is already installed. Getting SC address");
+                let sc_address = self.wait_for_sc_service(&self.config.namespace).await?;
+                return Ok(sc_address);
+            },
             // If there were other unhandled errors, return them
             Err(unhandled) => return Err(unhandled),
         }

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -23,7 +23,10 @@ use k8_obj_metadata::InputObjectMeta;
 
 use crate::ClusterError;
 use crate::helm::{HelmClient, Chart, InstalledChart};
-use crate::check::{check_cluster_server_host, CheckError, check_helm_version, check_system_chart, check_already_installed};
+use crate::check::{
+    check_cluster_server_host, CheckError, check_helm_version, check_system_chart,
+    check_already_installed,
+};
 
 const DEFAULT_NAMESPACE: &str = "default";
 const DEFAULT_REGISTRY: &str = "infinyon";
@@ -570,7 +573,6 @@ impl ClusterInstaller {
     /// [`with_system_chart`]: ./struct.ClusterInstaller.html#method.with_system_chart
     /// [`with_update_context`]: ./struct.ClusterInstaller.html#method.with_update_context
     fn pre_install(&self) -> Result<(), ClusterError> {
-
         // Continue fixing pre-check errors until we resolve all problems
         // or there is an error that we cannot fix
         loop {
@@ -604,7 +606,6 @@ impl ClusterInstaller {
     /// Given a pre-check error, attempt to automatically correct it
     #[instrument(skip(self, error))]
     fn pre_install_fix(&self, error: CheckError) -> Result<(), ClusterError> {
-
         // Depending on what error occurred, try to fix the error.
         // If we handle the error successfully, return Ok(()) to indicate success
         // If we cannot handle this error, return it to bubble up
@@ -621,7 +622,7 @@ impl ClusterInstaller {
             unhandled => {
                 warn!("Pre-install was unable to autofix an error");
                 return Err(unhandled.into());
-            },
+            }
         }
 
         Ok(())
@@ -640,7 +641,9 @@ impl ClusterInstaller {
             // If all checks pass, perform the main installation
             Ok(()) => self.install_app()?,
             // If Fluvio is already installed, skip install step
-            Err(ClusterError::PreCheckError { source: CheckError::AlreadyInstalled }) => (),
+            Err(ClusterError::PreCheckError {
+                source: CheckError::AlreadyInstalled,
+            }) => (),
             // If there were other unhandled errors, return them
             Err(unhandled) => return Err(unhandled),
         }

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -647,7 +647,7 @@ impl ClusterInstaller {
                 debug!("Fluvio is already installed. Getting SC address");
                 let sc_address = self.wait_for_sc_service(&self.config.namespace).await?;
                 return Ok(sc_address);
-            },
+            }
             // If there were other unhandled errors, return them
             Err(unhandled) => return Err(unhandled),
         }

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -538,7 +538,7 @@ impl ClusterInstaller {
             cloud: DEFAULT_CLOUD_NAME.to_string(),
             save_profile: false,
             install_sys: true,
-            update_context: true,
+            update_context: false,
             spu_spec,
             rust_log: None,
             server_tls_policy: TlsPolicy::Disabled,

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -30,6 +30,8 @@ use crate::check::{
 
 const DEFAULT_NAMESPACE: &str = "default";
 const DEFAULT_REGISTRY: &str = "infinyon";
+const DEFAULT_APP_NAME: &str = "fluvio-app";
+const DEFAULT_SYS_NAME: &str = "fluvio-sys";
 const DEFAULT_CHART_SYS_REPO: &str = "fluvio-sys";
 const DEFAULT_CHART_SYS_NAME: &str = "fluvio/fluvio-sys";
 const DEFAULT_CHART_APP_REPO: &str = "fluvio";
@@ -714,7 +716,7 @@ impl ClusterInstaller {
                 )?;
             }
             ChartLocation::Local(chart_home) => {
-                let chart_location = chart_home.join("fluvio-sys");
+                let chart_location = chart_home.join(DEFAULT_SYS_NAME);
                 let chart_string = chart_location.to_string_lossy();
                 debug!(
                     chart_location = chart_string.as_ref(),
@@ -800,7 +802,7 @@ impl ClusterInstaller {
             }
             // For local, we do not use a repo but install from the chart location directly.
             ChartLocation::Local(chart_home) => {
-                let chart_location = chart_home.join("fluvio-app");
+                let chart_location = chart_home.join(DEFAULT_APP_NAME);
                 let chart_string = chart_location.to_string_lossy();
                 debug!(
                     chart_location = chart_string.as_ref(),


### PR DESCRIPTION
This adds better error messages to the `helm` client in such a way that it bubbles all the way up to the CLI. Before, if `helm` was not installed, if the user ran `fluvio cluster install`, they would be given the following error:

```bash
$ fluvio cluster install
error: No such file or directory (os error 2)
```

Now, it gives this error:

```bash
$ fluvio cluster install
error: Unable to find 'helm' executable
  Please make sure helm is installed and in your PATH.
  See https://helm.sh/docs/intro/install/ for more help
```

In addition, this PR makes the cluster installer attempt to fix some things if the precheck runs into errors:

- If fluvio-sys is not installed, it attempts to install it
- If the minikube context is not set right, it will set it