### PR TITLE
add install fluvio github composite action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,54 @@
+name: 'fluvio'
+description: 'Installs Fluvio CLI from source with required dependencies (e.g. Helm, Rust) and starts a Local Cluster. Used for developing fluvio.'
+inputs:
+  spus:  # number of SPUs
+    description: 'number of SPUs to create for local cluster'
+    required: false
+    default: "1"
+  cluster-type:
+    description: 'Type of cluster (i.e. local or kubernetes)'
+    required: true
+    default: 'local'
+  rust-log:
+    description: "Add rust log options (e.g. debug, warn, info)"
+    required: false
+    default: 'info'
+  version:
+    description: "Use a specific version of the fluvio CLI (e.g. latest, 0.6.0)"
+    required: false
+    default: 'latest'
+  development:
+    description: "Use a debug release version of fluvio"
+    required: false
+    default: "true"
+  helm-version:
+    description: "Use a specific helm version"
+    required: false
+    default: 'v3.3.4'
+  minikube-version:
+    description: "Use a specific minikube version"
+    required: false
+    default: 'v1.13.1'
+runs:
+  using: "composite"
+  steps: 
+    - id: set-environment-variables
+      run: |
+        echo "::set-env name=SPU_NUMBER::${{ inputs.spus }}"
+        echo "::set-env name=CLUSTER_TYPE::${{ inputs.cluster-type }}"
+        echo "::set-env name=RUST_LOG::${{ inputs.rust-log }}"
+        echo "::set-env name=VERSION::${{ inputs.version }}"
+        echo "::set-env name=DEVELOPMENT::${{ inputs.development }}"
+        echo "::set-env name=HELM_VERSION::${{ inputs.helm-version }}"
+        echo "::set-env name=MINIKUBE_VERSION::${{ inputs.minikube-version }}"
+        echo "::set-env name=OS::${{ runner.os }}"
+      shell: bash
+    - id: install-helm
+      run: ${{ github.action_path }}/dev-tools/ci-replace-helm.sh
+      shell: bash
+    - id: install-minikube
+      run: ${{ github.action_path }}/dev-tools/action-install-minikube.sh
+      shell: bash
+    - id: fluvio-cluster
+      run: ${{ github.action_path }}/dev-tools/action-install-fluvio-cluster.sh
+      shell: bash

--- a/dev-tools/action-install-fluvio-cluster.sh
+++ b/dev-tools/action-install-fluvio-cluster.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This script is ran by the github actions to install fluvio in
+# GitHub Action Workflows.
+echo "Installing Fluvio Local Cluster"
+if [ "$DEVELOPMENT" = "true" ]; then
+        if [ "$VERSION" = "latest" ]; then 
+                echo "Installing from latest source"
+                # Download Fluvio Repo
+                # TODO! TEMPORARY; REPLACE ONCE BINARY IS RELEASED
+                # Use only in develop version
+                pushd /tmp/
+                git clone https://github.com/infinyon/fluvio.git
+                popd
+
+                pushd /tmp/fluvio
+                # Install Fluvio Src
+                cargo install --path ./src/cli
+                popd
+        else
+                echo "Release binary is not available; use 'latest'"
+        fi
+
+        # Set fluvio minikube context
+        fluvio cluster set-minikube-context
+
+        # Install Fluvio System Charts
+        fluvio cluster install --sys
+
+        # Run Fluvio Cluster Pre-Install Check
+        fluvio cluster check --pre-install
+
+        if [ "$CLUSTER_TYPE" = "local" ]; then
+                # Install Local Fluvio Cluster
+                fluvio cluster install --rust-log $RUST_LOG --log-dir /tmp --develop --local --spu $SPU_NUMBER
+        else
+                echo "Currently, only local cluster types are supported"
+        fi
+else
+        echo "Fluvio production version is currently not supported; use development"
+fi

--- a/dev-tools/action-install-minikube.sh
+++ b/dev-tools/action-install-minikube.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This script is ran by the github actions to install fluvio in
+# GitHub Action Workflows.
+echo "Installing Minikube"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "Installing for Linux"
+        PLATFORM=linux-amd64
+        # Install Minikube for ubuntu
+        # Pre-Installation Check 
+        # grep -E --color 'vmx|svm' /proc/cpuinfo
+
+        echo "Installing Minikube"
+        # Install Minikube
+        curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-${PLATFORM} \
+        && chmod +x minikube
+        sudo install minikube /usr/local/bin/
+
+        # Install conntrack
+        sudo apt install conntrack
+
+        # Start Minikube with `none` driver
+        sudo minikube start --driver=none -p minikube
+
+        # Update permissions for .kube and .minikube
+        sudo chown -R $USER $HOME/.kube $HOME/.minikube
+
+        # Run Minikube Tunnel
+        sudo nohup minikube tunnel >/tmp/tunnel.out 2>/tmp/tunnel.out &
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # Mac OSX
+        PLATFORM=darwin-amd64
+        echo "unsupported operating system; ignoring fluvio install"
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+        # POSIX compatibility layer and Linux environment emulation for Windows
+        echo "unsupported operating system; ignoring fluvio install"
+elif [[ "$OSTYPE" == "msys" ]]; then
+        # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+        echo "unsupported operating system; ignoring fluvio install"
+elif [[ "$OSTYPE" == "win32" ]]; then
+        # I'm not sure this can happen.
+        echo "unsupported operating system; ignoring fluvio install"
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+        # ...
+        echo "unsupported operating system; ignoring fluvio install"
+else
+        # Unknown.
+        echo "unsupported operating system; ignoring fluvio install"
+fi

--- a/dev-tools/ci-replace-helm.sh
+++ b/dev-tools/ci-replace-helm.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
-
+echo "Operating System: $OS"
 case $OS in
+        'Linux') PLATFORM=linux-amd64
+        ;;
         'ubuntu-latest') PLATFORM=linux-amd64
         ;;
         'macOS-latest') PLATFORM=darwin-amd64


### PR DESCRIPTION
This PR adds a composite github action for re-use in github workflows.

To use this github action in another workflow, you should be able to use the following:

```yaml
...
- name: Install Fluvio Local Cluster
   uses: infinyon/fluvio@latest
- name: Check Fluvio Installation
  run: |
    fluvio --help
```

We'll need to tag release once merged and publish to the github actions market place.

Not sure if we want to lock the version of the github action with the version of fluvio. I am using `latest` in the example above, and in the action.sh script it will always build from the fluvio repo master branch source.