### PR TITLE
Consumer api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.1.3"
+source = "git+https://github.com/nicholastmosher/fluvio-socket?branch=stream#a6204a6c3300865cf7ff220f6ebc082fa0f0cd08"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1236,7 +1237,7 @@ dependencies = [
  "event-listener",
  "fluvio-future",
  "fluvio-protocol",
- "futures",
+ "futures-util",
  "log",
  "pin-project-lite",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-h1",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "fluvio",
  "fluvio-controlplane-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "fluvio",
- "futures",
+ "futures-lite",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ dependencies = [
  "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-types",
- "futures",
+ "futures-util",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "fluvio",
+ "futures",
 ]
 
 [[package]]
@@ -943,6 +944,7 @@ dependencies = [
  "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-types",
+ "futures",
  "serde",
  "serde_json",
  "thiserror",
@@ -1224,8 +1226,6 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1829f6aa18c3967380e5796dff883cbc841168d56629ba9001cf81552e837903"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1236,9 +1236,9 @@ dependencies = [
  "event-listener",
  "fluvio-future",
  "fluvio-protocol",
- "futures-util",
+ "futures",
  "log",
- "pin-utils",
+ "pin-project",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1389,7 +1389,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-system-util",
  "fluvio-types",
- "futures-util",
+ "futures",
  "k8-client",
  "k8-metadata-client",
  "structopt",
@@ -1442,9 +1442,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1467,15 +1467,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1517,24 +1517,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
  "fluvio-protocol",
  "futures",
  "log",
- "pin-project",
+ "pin-project-lite",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -941,7 +941,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-sc-schema",
- "fluvio-socket",
+ "fluvio-socket 0.2.0",
  "fluvio-spu-schema",
  "fluvio-types",
  "futures-util",
@@ -1059,7 +1059,7 @@ dependencies = [
  "crc32c",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket",
+ "fluvio-socket 0.1.3",
  "flv-util",
  "futures-util",
  "log",
@@ -1169,7 +1169,7 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-service",
- "fluvio-socket",
+ "fluvio-socket 0.1.3",
  "fluvio-stream-dispatcher",
  "fluvio-system-util",
  "fluvio-types",
@@ -1214,7 +1214,7 @@ dependencies = [
  "event-listener",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket",
+ "fluvio-socket 0.1.3",
  "futures-util",
  "log",
  "pin-utils",
@@ -1226,7 +1226,32 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.1.3"
-source = "git+https://github.com/nicholastmosher/fluvio-socket?branch=stream#a6204a6c3300865cf7ff220f6ebc082fa0f0cd08"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1829f6aa18c3967380e5796dff883cbc841168d56629ba9001cf81552e837903"
+dependencies = [
+ "async-channel",
+ "async-mutex",
+ "async-net",
+ "async-trait",
+ "bytes 0.5.6",
+ "chashmap",
+ "event-listener",
+ "fluvio-future",
+ "fluvio-protocol",
+ "futures-util",
+ "log",
+ "pin-utils",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-socket"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ce40bb7116cc1be8e3ab050cbba0b3f04760d64ef2009daf03acabd56354a7"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1263,7 +1288,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-service",
- "fluvio-socket",
+ "fluvio-socket 0.1.3",
  "fluvio-spu-schema",
  "fluvio-storage",
  "fluvio-system-util",
@@ -1304,7 +1329,7 @@ dependencies = [
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket",
+ "fluvio-socket 0.1.3",
  "fluvio-types",
  "flv-util",
  "futures-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arrayref"
@@ -116,9 +116,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "55576d57ea9e255e709ea13169645a9427987a6504791cf19b59908d5c922b3d"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -417,16 +417,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "c5aba2c74d15fe950254784fe497a999345606169c2288ccb771b72acdf41241"
 dependencies = [
  "async-channel",
+ "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
- "waker-fn",
 ]
 
 [[package]]
@@ -1490,9 +1490,9 @@ checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ec5fce115ef4d4cc77f46025232fba6a2f84381ff42337794147050aae971"
+checksum = "7c48d23e382e1f50ad68d16cd23dd3c467f420d4933b629c3f183f33e9f560d8"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -1973,9 +1973,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2096,9 +2096,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
  "autocfg",
@@ -2651,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "rustc_version"
@@ -3130,18 +3130,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [patch.crates-io]
-fluvio-socket = { path = "../fluvio-socket/crates/socket" }
+fluvio-socket = { git = "https://github.com/nicholastmosher/fluvio-socket", branch = "stream" }
 
 # profile to make image sizer smaller
 # comment out for now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ members = [
     "tests/runner",
 ]
 
-[patch.crates-io]
-fluvio-socket = { git = "https://github.com/nicholastmosher/fluvio-socket", branch = "stream" }
-
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ members = [
     "tests/runner",
 ]
 
+[patch.crates-io]
+fluvio-socket = { path = "../fluvio-socket/crates/socket" }
+
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]

--- a/examples/00-echo/Cargo.toml
+++ b/examples/00-echo/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 fluvio = { path = "../../src/client" }
-futures = "0.3.6"
+futures-lite = "1.10.1"
 async-std = "1.6.4"

--- a/examples/00-echo/Cargo.toml
+++ b/examples/00-echo/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 
 [dependencies]
 fluvio = { path = "../../src/client" }
+futures = "0.3.6"
 async-std = "1.6.4"

--- a/examples/00-echo/src/main.rs
+++ b/examples/00-echo/src/main.rs
@@ -89,6 +89,7 @@
 //! ```
 
 use std::time::Duration;
+use futures::StreamExt;
 use fluvio::{FluvioError, Offset};
 
 const TOPIC: &str = "echo";
@@ -121,7 +122,7 @@ async fn consume() -> Result<(), FluvioError> {
     let consumer = fluvio::consumer(TOPIC, 0).await?;
     let mut stream = consumer.stream(Offset::beginning()).await?;
 
-    while let Ok(event) = stream.next().await {
+    while let Some(Ok(event)) = stream.next().await {
         for batch in event.partition.records.batches {
             for record in batch.records {
                 if let Some(record) = record.value.inner_value() {

--- a/examples/00-echo/src/main.rs
+++ b/examples/00-echo/src/main.rs
@@ -122,16 +122,12 @@ async fn consume() -> Result<(), FluvioError> {
     let consumer = fluvio::consumer(TOPIC, 0).await?;
     let mut stream = consumer.stream(Offset::beginning()).await?;
 
-    while let Some(Ok(event)) = stream.next().await {
-        for batch in event.partition.records.batches {
-            for record in batch.records {
-                if let Some(record) = record.value.inner_value() {
-                    let string = String::from_utf8(record).unwrap();
-                    println!("Got record: {}", string);
-                    if string == "Done!" {
-                        return Ok(());
-                    }
-                }
+    while let Some(Ok(record)) = stream.next().await {
+        if let Some(bytes) = record.try_into_bytes() {
+            let string = String::from_utf8_lossy(&bytes);
+            println!("Got record: {}", string);
+            if string == "Done!" {
+                return Ok(());
             }
         }
     }

--- a/examples/00-echo/src/main.rs
+++ b/examples/00-echo/src/main.rs
@@ -89,7 +89,7 @@
 //! ```
 
 use std::time::Duration;
-use futures::StreamExt;
+use futures_lite::StreamExt;
 use fluvio::{FluvioError, Offset};
 
 const TOPIC: &str = "echo";

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -57,7 +57,7 @@ k8-config = { version = "1.3.0", features = ["context"] }
 k8-obj-core = { version = "1.1.0" }
 k8-obj-metadata = { version = "1.0.0" }
 k8-metadata-client = { version = "1.0.0" }
-fluvio = { version = "0.1.0", path = "../client" }
+fluvio = { version = "0.2.0", path = "../client" }
 fluvio-sc = { version = "0.1.0", path = "../sc", optional = true, features = ["k8"] }
 fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema", features = ["use_serde"] }
 fluvio-spu = { version = "0.1.0", path = "../spu", optional = true }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI"

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -92,7 +92,7 @@ where
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
         let mut log_stream = consumer
-            .stream_with_config(initial_offset, fetch_config)
+            ._stream_batches_with_config(initial_offset, fetch_config)
             .await?;
 
         while let Some(Ok(response)) = log_stream.next().await {

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -16,6 +16,7 @@ use crate::Terminal;
 
 use super::ConsumeLogConfig;
 use super::process_fetch_topic_response;
+use futures_lite::StreamExt;
 
 // -----------------------------------
 // SPU - Fetch Loop
@@ -94,7 +95,7 @@ where
             .stream_with_config(initial_offset, fetch_config)
             .await?;
 
-        while let Ok(response) = log_stream.next().await {
+        while let Some(Ok(response)) = log_stream.next().await {
             let partition = response.partition;
             debug!(
                 "got response: LSO: {} batchs: {}",

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -91,7 +91,6 @@ where
 
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
-        #[clippy::allow]
         let mut log_stream = consumer
             ._stream_batches_with_config(initial_offset, fetch_config)
             .await?;

--- a/src/cli/src/consume/fetch_log_loop.rs
+++ b/src/cli/src/consume/fetch_log_loop.rs
@@ -91,6 +91,7 @@ where
 
         process_fetch_topic_response(out.clone(), response, &opt).await?;
     } else {
+        #[clippy::allow]
         let mut log_stream = consumer
             ._stream_batches_with_config(initial_offset, fetch_config)
             .await?;

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -36,7 +36,7 @@ fluvio-future = { version = "0.1.2", features = ["tls"] }
 fluvio-types = { version = "0.1.0", path = "../types" }
 fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.1.0", path = "../spu-schema" }
-fluvio-socket = { version = "0.1.2" }
+fluvio-socket = { version = "0.2.0" }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -17,6 +17,7 @@ admin = ["fluvio-sc-schema/use_serde"]
 [dependencies]
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
+futures = "0.3.6"
 dirs = "1.0.2"
 toml = "0.5.5"
 async-rwlock = "1.1.0"

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -17,7 +17,7 @@ admin = ["fluvio-sc-schema/use_serde"]
 [dependencies]
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
-futures = "0.3.6"
+futures-util = "0.3.6"
 dirs = "1.0.2"
 toml = "0.5.5"
 async-rwlock = "1.1.0"

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -210,8 +210,9 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
+    /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
-    /// while let Ok(event) = stream.next().await {
+    /// while let Some(Ok(event)) = stream.next().await {
     ///     for batch in event.partition.records.batches {
     ///         for record in batch.records {
     ///             if let Some(record) = record.value.inner_value() {
@@ -257,11 +258,12 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
+    /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::default()
     ///     .with_max_bytes(1000);
     /// let mut stream = consumer.stream_with_config(Offset::beginning(), fetch_config).await?;
-    /// while let Ok(event) = stream.next().await {
+    /// while let Some(Ok(event)) = stream.next().await {
     ///     for batch in event.partition.records.batches {
     ///         for record in batch.records {
     ///             if let Some(record) = record.value.inner_value() {

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -284,7 +284,7 @@ impl PartitionConsumer {
         let flattened = stream.flat_map(|batch_result| {
             let batch = match batch_result {
                 Ok(batch) => batch,
-                Err(e) => return Either::Right(once(err(e.into()))),
+                Err(e) => return Either::Right(once(err(e))),
             };
 
             let records = batch
@@ -315,7 +315,6 @@ impl PartitionConsumer {
     /// on the internal structure of the fetch response. New clients should use the
     /// `stream` and `stream_with_config` methods.
     #[doc(hidden)]
-    #[deprecated(note = "please use 'stream' or 'stream_with_config' instead")]
     pub async fn _stream_batches_with_config(
         &self,
         offset: Offset,

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -1,4 +1,4 @@
-use futures::Stream;
+use futures_util::stream::Stream;
 use tracing::debug;
 
 use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest, DefaultStreamFetchResponse};
@@ -211,7 +211,7 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// use futures::StreamExt;
+    /// use futures::stream::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
     ///     if let Some(bytes) = record.try_into_bytes() {
@@ -255,7 +255,7 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// use futures::StreamExt;
+    /// use futures::stream::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::default()
     ///     .with_max_bytes(1000);
@@ -277,8 +277,8 @@ impl PartitionConsumer {
         offset: Offset,
         config: ConsumerConfig,
     ) -> Result<impl Stream<Item = Result<Record, FluvioError>>, FluvioError> {
-        use futures::future::{Either, err};
-        use futures::stream::{StreamExt, once, iter};
+        use futures_util::future::{Either, err};
+        use futures_util::stream::{StreamExt, once, iter};
 
         let stream = self._stream_batches_with_config(offset, config).await?;
         let flattened = stream.flat_map(|batch_result| {
@@ -343,7 +343,7 @@ impl PartitionConsumer {
             ..Default::default()
         };
 
-        use futures::StreamExt;
+        use futures_util::StreamExt;
         let stream = self.pool.create_stream(&replica, stream_request).await?;
         Ok(stream.map(|item| item.map_err(|e| e.into())))
     }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -229,7 +229,7 @@ impl PartitionConsumer {
     pub async fn stream(
         &self,
         offset: Offset,
-    ) -> Result<impl Stream<Item=Result<Record, FluvioError>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, FluvioError>>, FluvioError> {
         let stream = self
             .stream_with_config(offset, ConsumerConfig::default())
             .await?;
@@ -276,7 +276,7 @@ impl PartitionConsumer {
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item=Result<Record, FluvioError>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, FluvioError>>, FluvioError> {
         use futures::future::{Either, err};
         use futures::stream::{StreamExt, once, iter};
 
@@ -287,10 +287,17 @@ impl PartitionConsumer {
                 Err(e) => return Either::Right(once(err(e.into()))),
             };
 
-            let records = batch.partition.records.batches.into_iter()
+            let records = batch
+                .partition
+                .records
+                .batches
+                .into_iter()
                 .flat_map(|batch| {
                     let base_offset = batch.base_offset;
-                    batch.records.into_iter().enumerate()
+                    batch
+                        .records
+                        .into_iter()
+                        .enumerate()
                         .map(move |(relative, record)| {
                             Ok(Record {
                                 offset: base_offset + relative as i64,
@@ -313,7 +320,8 @@ impl PartitionConsumer {
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item=Result<DefaultStreamFetchResponse, FluvioError>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<DefaultStreamFetchResponse, FluvioError>>, FluvioError>
+    {
         let replica = ReplicaKey::new(&self.topic, self.partition);
         debug!(
             "starting fetch log once: {:#?} from replica: {}",

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -210,8 +210,11 @@ impl PartitionConsumer {
     /// ```no_run
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
+    /// # mod futures {
+    /// #     pub use futures_util::stream::StreamExt;
+    /// # }
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// use futures::stream::StreamExt;
+    /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
     ///     if let Some(bytes) = record.try_into_bytes() {
@@ -254,8 +257,11 @@ impl PartitionConsumer {
     /// ```no_run
     /// # use fluvio::{PartitionConsumer, FluvioError};
     /// # use fluvio::{Offset, ConsumerConfig};
+    /// # mod futures {
+    /// #     pub use futures_util::stream::StreamExt;
+    /// # }
     /// # async fn do_stream(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
-    /// use futures::stream::StreamExt;
+    /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::default()
     ///     .with_max_bytes(1000);

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -42,6 +42,7 @@
 //! ```no_run
 //! use std::time::Duration;
 //! use fluvio::{Offset, FluvioError};
+//! use futures::StreamExt;
 //!
 //! async_std::task::spawn(produce_records());
 //! if let Err(e) = async_std::task::block_on(consume_records()) {
@@ -61,7 +62,7 @@
 //!     let consumer = fluvio::consumer("echo", 0).await?;
 //!     let mut stream = consumer.stream(Offset::beginning()).await?;
 //!
-//!     while let Ok(event) = stream.next().await {
+//!     while let Some(Ok(event)) = stream.next().await {
 //!         for batch in event.partition.records.batches {
 //!             for record in batch.records {
 //!                 if let Some(record) = record.value.inner_value() {
@@ -139,9 +140,10 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// ```no_run
 /// # use fluvio::{ConsumerConfig, FluvioError, Offset};
 /// #  async fn do_consume() -> Result<(), FluvioError> {
+/// use futures::StreamExt;
 /// let consumer = fluvio::consumer("my-topic", 0).await?;
 /// let mut stream = consumer.stream(Offset::beginning()).await?;
-/// while let Ok(event) = stream.next().await {
+/// while let Some(Ok(event)) = stream.next().await {
 ///     for batch in event.partition.records.batches {
 ///         for record in batch.records {
 ///             if let Some(record) = record.value.inner_value() {

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -40,6 +40,9 @@
 //! [`Fluvio`] client object.
 //!
 //! ```no_run
+//! # mod futures {
+//! #     pub use futures_util::stream::StreamExt;
+//! # }
 //! use std::time::Duration;
 //! use fluvio::{Offset, FluvioError};
 //! use futures::StreamExt;
@@ -134,6 +137,9 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 ///
 /// ```no_run
 /// # use fluvio::{ConsumerConfig, FluvioError, Offset};
+/// # mod futures {
+/// #     pub use futures_util::stream::StreamExt;
+/// # }
 /// #  async fn do_consume() -> Result<(), FluvioError> {
 /// use futures::StreamExt;
 /// let consumer = fluvio::consumer("my-topic", 0).await?;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -62,15 +62,10 @@
 //!     let consumer = fluvio::consumer("echo", 0).await?;
 //!     let mut stream = consumer.stream(Offset::beginning()).await?;
 //!
-//!     while let Some(Ok(event)) = stream.next().await {
-//!         for batch in event.partition.records.batches {
-//!             for record in batch.records {
-//!                 if let Some(record) = record.value.inner_value() {
-//!                     let string = String::from_utf8(record)
-//!                         .expect("record should be a string");
-//!                     println!("Got record: {}", string);
-//!                 }
-//!             }
+//!     while let Some(Ok(record)) = stream.next().await {
+//!         if let Some(bytes) = record.try_into_bytes() {
+//!             let string = String::from_utf8_lossy(&bytes);
+//!             println!("Got record: {}", string);
 //!         }
 //!     }
 //!     Ok(())
@@ -143,15 +138,10 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// use futures::StreamExt;
 /// let consumer = fluvio::consumer("my-topic", 0).await?;
 /// let mut stream = consumer.stream(Offset::beginning()).await?;
-/// while let Some(Ok(event)) = stream.next().await {
-///     for batch in event.partition.records.batches {
-///         for record in batch.records {
-///             if let Some(record) = record.value.inner_value() {
-///                 let string = String::from_utf8(record)
-///                     .expect("record should be a string");
-///                 println!("Got record: {}", string);
-///             }
-///         }
+/// while let Some(Ok(record)) = stream.next().await {
+///     if let Some(bytes) = record.try_into_bytes() {
+///         let string = String::from_utf8_lossy(&bytes);
+///         println!("Got record: {}", string);
 ///     }
 /// }
 /// # Ok(())

--- a/src/client/src/sync/controller.rs
+++ b/src/client/src/sync/controller.rs
@@ -5,7 +5,7 @@ use std::io::ErrorKind;
 use std::fmt::Display;
 
 use tracing::{error, debug, instrument};
-use futures::StreamExt;
+use futures_util::stream::StreamExt;
 
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.57"
 thiserror = "1.0.20"
 
 # Fluvio dependencies
-fluvio = { version = "0.1.0", path = "../client" }
+fluvio = { version = "0.2.0", path = "../client" }
 fluvio-controlplane-metadata = { version = "0.1.0", path = "../controlplane-metadata", features = ["k8"] }
 fluvio-future = { version = "0.1.0" }
 flv-util = "0.5.2"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cluster"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.5.3"
-futures-util = { version = "0.3.5" }
+futures = "0.3.6"
+#futures-util = { version = "0.3.5" }
 structopt = "0.3.5"
 async-trait = "0.1.21"
 

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -76,26 +76,41 @@ async fn validate_consume_message_api(offsets: Offsets, option: &TestOption) {
             .expect("start from beginning");
 
         let mut total_records: u16 = 0;
-        'outer: while let Some(Ok(event)) = stream.next().await {
-            let batches = event.partition.records.batches;
-            println!("consumer: received batches {}", batches.len());
-            for batch in batches {
-                let mut offset = batch.base_offset;
-                for record in batch.records {
-                    if let Some(bytes) = record.value.inner_value() {
-                        validate_message(offset, &topic_name, option, &bytes);
-                        offset += 1;
-                        total_records += 1;
-                        println!(
-                            "   consumer: total records: {}, validated offset: {}",
-                            total_records, offset
-                        );
-                        assert_eq!(offset, base_offset + total_records as i64);
-                        if total_records == iteration {
-                            println!("<<consume test done for: {} >>>>", topic_name);
-                            break 'outer;
-                        }
-                    }
+        // 'outer: while let Some(Ok(event)) = stream.next().await {
+        //     for batch in batches {
+        //         let mut offset = batch.base_offset;
+        //         for record in batch.records {
+        //             if let Some(bytes) = record.value.inner_value() {
+        //                 validate_message(offset, &topic_name, option, &bytes);
+        //                 offset += 1;
+        //                 total_records += 1;
+        //                 println!(
+        //                     "   consumer: total records: {}, validated offset: {}",
+        //                     total_records, offset
+        //                 );
+        //                 assert_eq!(offset, base_offset + total_records as i64);
+        //                 if total_records == iteration {
+        //                     println!("<<consume test done for: {} >>>>", topic_name);
+        //                     break 'outer;
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+
+        while let Some(Ok(record)) = stream.next().await {
+            let offset = record.offset();
+            if let Some(bytes) = record.try_into_bytes() {
+                validate_message(offset, &topic_name, option, &bytes);
+                println!(
+                    "   consumer: total records: {}, validated offset: {}",
+                    total_records, offset
+                );
+                total_records += 1;
+                assert_eq!(offset, base_offset + total_records as i64);
+                if total_records == iteration {
+                    println!("<<consume test done for: {} >>>>", topic_name);
+                    break;
                 }
             }
         }

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -76,28 +76,6 @@ async fn validate_consume_message_api(offsets: Offsets, option: &TestOption) {
             .expect("start from beginning");
 
         let mut total_records: u16 = 0;
-        // 'outer: while let Some(Ok(event)) = stream.next().await {
-        //     for batch in batches {
-        //         let mut offset = batch.base_offset;
-        //         for record in batch.records {
-        //             if let Some(bytes) = record.value.inner_value() {
-        //                 validate_message(offset, &topic_name, option, &bytes);
-        //                 offset += 1;
-        //                 total_records += 1;
-        //                 println!(
-        //                     "   consumer: total records: {}, validated offset: {}",
-        //                     total_records, offset
-        //                 );
-        //                 assert_eq!(offset, base_offset + total_records as i64);
-        //                 if total_records == iteration {
-        //                     println!("<<consume test done for: {} >>>>", topic_name);
-        //                     break 'outer;
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
-
         while let Some(Ok(record)) = stream.next().await {
             let offset = record.offset();
             if let Some(bytes) = record.try_into_bytes() {
@@ -114,27 +92,6 @@ async fn validate_consume_message_api(offsets: Offsets, option: &TestOption) {
                 }
             }
         }
-
-        /*
-        println!("retrieving messages");
-        let response = consumer.fetch(Offset::beginning()).await.expect("records");
-        println!("message received");
-        let batches = response.records.batches;
-
-        assert_eq!(batches.len(), option.produce.produce_iteration as usize);
-        */
         println!("consume message validated!");
     }
-
-    /*
-    let mut log_stream = leader.fetch_logs(FetchOffset::Earliest(None), FetchLogOption::default());
-
-    if let Some(partition_response) = log_stream.next().await {
-        let records = partition_response.records;
-
-        println!("batch records: {}", records.batches.len());
-    } else {
-        assert!(false, "no response")
-    }
-    */
 }

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::collections::HashMap;
 
 use utils::bin::get_fluvio;
+use futures::StreamExt;
 
 use fluvio::{Fluvio, Offset};
 use crate::cli::TestOption;
@@ -75,7 +76,7 @@ async fn validate_consume_message_api(offsets: Offsets, option: &TestOption) {
             .expect("start from beginning");
 
         let mut total_records: u16 = 0;
-        'outer: while let Ok(event) = stream.next().await {
+        'outer: while let Some(Ok(event)) = stream.next().await {
             let batches = event.partition.records.batches;
             println!("consumer: received batches {}", batches.len());
             for batch in batches {


### PR DESCRIPTION
Implements #365 

This incorporates the changes from the `fluivo-socket` crate where `AsyncResponse` now implements `Stream`. It's important to note that `AsyncResponse` streams batches of records. The wrapper code in the consumer API is able to flat_map those batches into records so that consumers just see a nice record type. Basic consumer code will now look like this:

```rust
let mut stream = consumer.stream("my-topic", 0).await?;
while let Some(Ok(record)) = stream.next().await {
    if let Some(bytes) = record.try_into_bytes() {
        let string = String::from_utf8_lossy(&bytes);
        println!("Got record: {}", string);
    }
}
```

Right now, I'm not able to get the smoke tests to work, but I'm also not sure if that's due to my changes or not. You can try out the changes by checking out the `stream` branch of `fluvio-socket` adjacently to the `fluvio` repo so the dependency patch applies. I'd like to have somewhat of a deeper review on this PR (on the fluvio-socket side) to make sure I haven't broken anything.