### PR TITLE
Fix obscure clippy lint

### DIFF
--- a/src/dataplane-protocol/src/error_code.rs
+++ b/src/dataplane-protocol/src/error_code.rs
@@ -52,10 +52,7 @@ impl Default for ErrorCode {
 
 impl ErrorCode {
     pub fn is_ok(&self) -> bool {
-        match self {
-            Self::None => true,
-            _ => false,
-        }
+        matches!(self, ErrorCode::None)
     }
 
     pub fn to_sentence(&self) -> String {

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -61,10 +61,7 @@ impl DefaultAsyncBuffer {
     /// Check if value is binary content
     pub fn is_binary(&self) -> bool {
         if let Some(value) = self.inner_value_ref() {
-            match inspect(value) {
-                ContentType::BINARY => true,
-                _ => false,
-            }
+            matches!(inspect(value), ContentType::BINARY)
         } else {
             false
         }


### PR DESCRIPTION
I was seeing a weird thing in CI where sometimes this lint would fail a build and sometimes not. I fixed it just so it's not a problem in the future.

This basically switches a few spots to using the [`matches!`](https://doc.rust-lang.org/beta/std/macro.matches.html) macro, which I just learned about. It's kinda neat!