### PR TITLE
Relax mut in admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -180,8 +180,7 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
 
     println!("waiting for spu to be provisioned");
 
-    let mut client = Fluvio::connect().await.expect("sc ");
-
+    let client = Fluvio::connect().await.expect("sc ");
     let mut admin = client.admin().await;
 
     // wait for list of spu

--- a/src/cli/src/custom/list.rs
+++ b/src/cli/src/custom/list.rs
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output_type) = opt.validate()?;
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let custom_spus = admin.list::<CustomSpuSpec, _>(vec![]).await?;

--- a/src/cli/src/custom/register.rs
+++ b/src/cli/src/custom/register.rs
@@ -68,9 +68,9 @@ impl RegisterCustomSpuOpt {
 pub async fn process_register_custom_spu(opt: RegisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, (name, spec)) = opt.validate()?;
 
-    let mut sc = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
 
-    let mut admin = sc.admin().await;
+    let mut admin = client.admin().await;
 
     admin.create(name, false, spec).await?;
 

--- a/src/cli/src/custom/unregister.rs
+++ b/src/cli/src/custom/unregister.rs
@@ -65,7 +65,7 @@ impl UnregisterCustomSpuOpt {
 pub async fn process_unregister_custom_spu(opt: UnregisterCustomSpuOpt) -> Result<(), CliError> {
     let (target_server, delete_key) = opt.validate()?;
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     admin.delete::<CustomSpuSpec, _>(delete_key).await?;

--- a/src/cli/src/group/create.rs
+++ b/src/cli/src/group/create.rs
@@ -82,7 +82,7 @@ pub async fn process_create_managed_spu_group(
 
     debug!("creating spg: {}, spec: {:#?}", name, spec);
 
-    let mut target = Fluvio::connect_with_config(&target_server).await?;
+    let target = Fluvio::connect_with_config(&target_server).await?;
 
     let mut admin = target.admin().await;
 

--- a/src/cli/src/group/delete.rs
+++ b/src/cli/src/group/delete.rs
@@ -43,7 +43,7 @@ pub async fn process_delete_managed_spu_group(
 ) -> Result<(), CliError> {
     let (target_server, name) = opt.validate()?;
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<SpuGroupSpec, _>(&name).await?;
     Ok(())

--- a/src/cli/src/group/list.rs
+++ b/src/cli/src/group/list.rs
@@ -39,7 +39,7 @@ pub async fn process_list_managed_spu_groups<O: Terminal>(
 ) -> Result<(), CliError> {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let lists = admin.list::<SpuGroupSpec, _>(vec![]).await?;

--- a/src/cli/src/partition/list.rs
+++ b/src/cli/src/partition/list.rs
@@ -40,7 +40,7 @@ impl ListPartitionOpt {
     {
         let (target_server, output) = self.validate()?;
 
-        let mut client = Fluvio::connect_with_config(&target_server).await?;
+        let client = Fluvio::connect_with_config(&target_server).await?;
         let mut admin = client.admin().await;
 
         let partitions = admin.list::<PartitionSpec, _>(vec![]).await?;

--- a/src/cli/src/spu/list.rs
+++ b/src/cli/src/spu/list.rs
@@ -50,7 +50,7 @@ where
 {
     let (target_server, output) = opt.validate()?;
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let spus = admin.list::<SpuSpec, _>(vec![]).await?;

--- a/src/cli/src/topic/create.rs
+++ b/src/cli/src/topic/create.rs
@@ -118,7 +118,7 @@ pub async fn process_create_topic(opt: CreateTopicOpt) -> Result<String, CliErro
 
     debug!("creating topic: {} spec: {:#?}", name, topic_spec);
 
-    let mut target = Fluvio::connect_with_config(&target_server).await?;
+    let target = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = target.admin().await;
 
     admin.create(name.clone(), dry_run, topic_spec).await?;

--- a/src/cli/src/topic/delete.rs
+++ b/src/cli/src/topic/delete.rs
@@ -41,7 +41,7 @@ pub async fn process_delete_topic(opt: DeleteTopicOpt) -> Result<String, CliErro
 
     debug!("deleting topic: {}", name);
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
     admin.delete::<TopicSpec, _>(&name).await?;
     Ok(format!("topic \"{}\" deleted", name))

--- a/src/cli/src/topic/describe.rs
+++ b/src/cli/src/topic/describe.rs
@@ -63,7 +63,7 @@ where
 
     debug!("describe topic: {}, {}", topic, output_type);
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![topic]).await?;

--- a/src/cli/src/topic/list.rs
+++ b/src/cli/src/topic/list.rs
@@ -66,7 +66,7 @@ where
 
     debug!("list topics {:#?} ", output_type);
 
-    let mut client = Fluvio::connect_with_config(&target_server).await?;
+    let client = Fluvio::connect_with_config(&target_server).await?;
     let mut admin = client.admin().await;
 
     let topics = admin.list::<TopicSpec, _>(vec![]).await?;

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -151,12 +151,12 @@ impl Fluvio {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn admin(&mut self) -> FluvioAdmin {
+    pub async fn admin(&self) -> FluvioAdmin {
         FluvioAdmin::new(self.create_serial_client().await)
     }
 
     /// create serial connection
-    async fn create_serial_client(&mut self) -> VersionedSerialSocket {
+    async fn create_serial_client(&self) -> VersionedSerialSocket {
         VersionedSerialSocket::new(
             self.socket.create_serial_socket().await,
             self.config.clone(),

--- a/src/cluster/src/install.rs
+++ b/src/cluster/src/install.rs
@@ -1099,7 +1099,7 @@ impl ClusterInstaller {
     )]
     async fn create_managed_spu_group(&self, cluster: &FluvioConfig) -> Result<(), ClusterError> {
         let name = self.config.group_name.clone();
-        let mut fluvio = Fluvio::connect_with_config(cluster).await?;
+        let fluvio = Fluvio::connect_with_config(cluster).await?;
         let mut admin = fluvio.admin().await;
         admin
             .create(name, false, self.config.spu_spec.clone())

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -39,7 +39,7 @@ impl TestRunner {
         }
 
         // wait until all partitions are provisioned
-        let mut client = Fluvio::connect().await.expect("should connect");
+        let client = Fluvio::connect().await.expect("should connect");
         let mut admin = client.admin().await;
 
         for _ in 0..60u16 {

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -38,7 +38,7 @@ mod offsets {
 
         let mut offsets = HashMap::new();
 
-        let mut client = Fluvio::connect().await.expect("should connect");
+        let client = Fluvio::connect().await.expect("should connect");
         let mut admin = client.admin().await;
 
         for i in 0..replication {


### PR DESCRIPTION
I thought I had merged this before but apparently not. With recent changes to `fluvio-socket`, we no longer require `&mut Fluvio` in order to create an admin instance, it can be relaxed to `&Fluvio`. This PR updates the client to reflect this and bumps the version to `0.2.1`.