### PR TITLE
Feature/alpha/rbac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     "examples/00-echo",
+    "src/auth",
+    "src/auth-schema",
     "src/cli",
     "src/client",
     "src/cluster",
@@ -20,8 +22,8 @@ members = [
 ]
 
 [patch.crates-io]
-fluvio-socket = { git = 'https://github.com/infinyon/fluvio-socket', rev = "b717c1e"  }
-fluvio-service = { git = 'https://github.com/infinyon/fluvio-socket', rev = "b717c1e" }
+fluvio-socket = { git = 'https://github.com/infinyon/fluvio-socket', rev = "3975110" }
+fluvio-service = { git = 'https://github.com/infinyon/fluvio-socket', rev = "3975110" }
 
 
 # profile to make image sizer smaller

--- a/src/auth-schema/Cargo.toml
+++ b/src/auth-schema/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fluvio-auth-schema"
+version = "0.1.0"
+authors = ["fluvio authors"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4.8"
+serde = { version = "1.0.0", features = ['derive'] }
+
+dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.2.0" }
+fluvio-service = { version = "0.2.0" }

--- a/src/auth-schema/src/lib.rs
+++ b/src/auth-schema/src/lib.rs
@@ -1,0 +1,11 @@
+mod request;
+
+pub use request::*;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/auth-schema/src/request.rs
+++ b/src/auth-schema/src/request.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::assign_op_pattern)]
+
+use std::fmt::Debug;
+
+use dataplane::bytes::Buf;
+use dataplane::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
+use dataplane::derive::{Encode, Decode};
+
+pub type AuthorizationScopes = Vec<String>;
+
+pub const AUTH_REQUEST_API_KEY: u16 = 8;
+
+// Auth Test Request & Response
+#[derive(Decode, Encode, Debug, Default)]
+pub struct AuthRequest {
+    pub principal: String,
+    pub scopes: AuthorizationScopes,
+}
+
+impl AuthRequest {
+    pub fn new(principal: String, scopes: AuthorizationScopes) -> Self {
+        AuthRequest { principal, scopes }
+    }
+}
+
+impl Request for AuthRequest {
+    const API_KEY: u16 = AUTH_REQUEST_API_KEY;
+    type Response = AuthResponse;
+}
+
+#[derive(Decode, Encode, Default, Debug)]
+pub struct AuthResponse {
+    pub success: bool,
+}
+
+#[derive(Debug)]
+pub enum AuthorizationApiRequest {
+    AuthRequest(RequestMessage<AuthRequest>),
+}
+
+// Added to satisfy Encode/Decode traits
+impl Default for AuthorizationApiRequest {
+    fn default() -> AuthorizationApiRequest {
+        AuthorizationApiRequest::AuthRequest(RequestMessage::default())
+    }
+}
+
+impl ApiMessage for AuthorizationApiRequest {
+    type ApiKey = u16;
+
+    fn decode_with_header<T>(src: &mut T, header: RequestHeader) -> Result<Self, std::io::Error>
+    where
+        Self: Default + Sized,
+        Self::ApiKey: Sized,
+        T: Buf,
+    {
+        match header.api_key() {
+            AUTH_REQUEST_API_KEY => api_decode!(AuthorizationApiRequest, AuthRequest, src, header),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "api auth header key should be set to {:?}",
+                    AUTH_REQUEST_API_KEY
+                ),
+            )),
+        }
+    }
+}

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "fluvio-auth"
+version = "0.1.0"
+authors = ["fluvio.io"]
+edition = "2018"
+
+[lib]
+name = "fluvio_auth"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1.41"
+log = "0.4.11"
+thiserror = "1.0.21"
+
+tracing = "0.1.21"
+tracing-futures = "0.2.4"
+
+futures-util = { version = "0.3.5" }
+
+fluvio-protocol = { version = "0.2.0" }
+fluvio-service = { version = "0.2.0" }
+fluvio-socket = { version = "0.3.0" }
+fluvio-stream-model = { path = "../stream-model", version = "0.2.0" }
+fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema" }
+fluvio-types = { version = "0.1.0", path = "../types" }
+fluvio-future = { version = "0.1.0", features = ["net"] }
+fluvio-auth-schema = { version = "0.1.0", path = "../auth-schema" }
+
+serde = { version = "1.0.103", features = ['derive'] }
+serde_json = "1.0.59"

--- a/src/auth/src/identity.rs
+++ b/src/auth/src/identity.rs
@@ -1,0 +1,81 @@
+use fluvio_auth_schema::AuthorizationScopes;
+
+use async_trait::async_trait;
+use futures_util::stream::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use fluvio_service::{SocketBuilder, IdentityContext};
+use fluvio_socket::InnerFlvSocket;
+use fluvio_protocol::api::{ResponseMessage};
+use fluvio_auth_schema::{AuthorizationApiRequest, AuthResponse};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthorizationIdentity {
+    pub principal: String,
+    pub scopes: AuthorizationScopes,
+}
+
+impl AuthorizationIdentity {
+    pub fn scopes(&self) -> &AuthorizationScopes {
+        &self.scopes
+    }
+}
+
+#[async_trait]
+impl IdentityContext for AuthorizationIdentity {
+    async fn create_from_connection<S>(
+        socket: &mut InnerFlvSocket<<S>::Stream>,
+    ) -> Result<Self, std::io::Error>
+    where
+        S: SocketBuilder,
+    {
+        let identity = {
+            let stream = &mut socket.get_mut_stream();
+
+            let mut api_stream = stream.api_stream::<AuthorizationApiRequest, _>();
+
+            if let Some(msg) = api_stream.next().await {
+                match msg {
+                    Ok(req_msg) => match req_msg {
+                        AuthorizationApiRequest::AuthRequest(req_msg) => AuthorizationIdentity {
+                            scopes: req_msg.request.scopes,
+                            principal: req_msg.request.principal,
+                        },
+                    },
+                    Err(_e) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Interrupted,
+                            "connection closed",
+                        ))
+                    }
+                }
+            } else {
+                tracing::trace!("client connect terminated");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "connection closed",
+                ));
+            }
+        };
+
+        let sink = &mut socket.get_mut_sink();
+
+        let response = AuthResponse { success: true };
+
+        let msg = ResponseMessage {
+            correlation_id: 0,
+            response,
+        };
+
+        let version = 1;
+
+        if let Ok(()) = sink.send_response(&msg, version).await {
+            Ok(identity)
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "connection interrupted during response",
+            ))
+        }
+    }
+}

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod identity;
+
+// #[cfg(test)]
+// mod tests;

--- a/src/cli/Cargo.lock
+++ b/src/cli/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arrayref"
@@ -110,15 +110,15 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -141,20 +141,19 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "1.5.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca4f8ff117c37c278a2f7415ce9be55560b846b5bc4412aaa5d29c1c3dae2"
+checksum = "e3572236ba37147ca2b674a0bd5afd20aec0cd925ab125ab6fad6543960f9002"
 dependencies = [
- "async-lock 2.3.0",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "1.4.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124ac8c265e407641c3362b8f4d39cdb4e243885b71eef087be27199790f5a3a"
+checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
 dependencies = [
  "async-executor",
  "async-io",
@@ -165,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "async-h1"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be805a675002e0918f7f85d72add747fcb69132d86b731bcf1f0626a2661241c"
+checksum = "7ca2b5cfe1804f48bb8dfb1b2391e6e9a3fbf89e07514dce3bddb03eb4d529db"
 dependencies = [
  "async-std",
  "byte-pool",
@@ -181,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.10"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+checksum = "e8cf20dd2c6d20ef09876e189b44f213e66e846972cb303eef28d9dfbe790928"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -209,15 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,22 +217,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "async-std",
- "native-tls",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "async-net"
-version = "1.5.0"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
+checksum = "14a5335056541826f855bf95b936df9788adbacf94b15ef7104029f7fff3e82a"
 dependencies = [
  "async-io",
  "blocking",
@@ -289,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-tls"
@@ -314,7 +292,7 @@ checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -342,12 +320,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -380,12 +358,6 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -445,23 +417,23 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
 dependencies = [
  "async-channel",
- "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
+ "waker-fn",
 ]
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -521,21 +493,15 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chashmap"
@@ -680,22 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +673,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "crossbeam-utils",
  "maybe-uninit",
 ]
@@ -735,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -773,19 +723,19 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.7"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
+checksum = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 dependencies = [
- "nix 0.18.0",
+ "nix",
  "winapi",
 ]
 
 [[package]]
 name = "curl"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+checksum = "78baca05127a115136a9898e266988fc49ca7ea2c839f60fc6e1fc9df1599168"
 dependencies = [
  "curl-sys",
  "libc",
@@ -798,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.38+curl-7.73.0"
+version = "0.4.36+curl-7.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ecfb4f59997fd40023d62a9f1e506e768b2baeb59a1d311eb9751cdcd7e3f"
+checksum = "68cad94adeb0c16558429c3c34a607acc9ea58e09a7b66310aabc9788fc5d721"
 dependencies = [
  "cc",
  "libc",
@@ -818,32 +768,6 @@ name = "data-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
-
-[[package]]
-name = "der-oid-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66558629d772c3be040566b7be07be8c8f5aecee95e4a092dfe2efc313277ad"
-dependencies = [
- "nom",
- "num-bigint",
- "num-traits",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "der-parser"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caca07c50eaae94d43e21f4d14eca5543b6f5f5ce64715e9b7665ac5f5185b4e"
-dependencies = [
- "der-oid-macro",
- "nom",
- "num-bigint",
- "num-traits",
- "proc-macro-hack",
- "rusticata-macros",
-]
 
 [[package]]
 name = "deunicode"
@@ -886,7 +810,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "dirs-sys",
 ]
 
@@ -914,15 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
-name = "echo"
-version = "0.1.0"
-dependencies = [
- "async-std",
- "fluvio",
- "futures-lite",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,7 +849,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1003,12 +918,11 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.2.1"
+version = "0.1.0"
 dependencies = [
  "async-channel",
  "async-mutex",
  "async-rwlock",
- "async-std",
  "async-trait",
  "base64 0.12.3",
  "dirs 1.0.5",
@@ -1017,10 +931,9 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-sc-schema",
- "fluvio-socket 0.3.0",
+ "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-types",
- "futures-util",
  "serde",
  "serde_json",
  "thiserror",
@@ -1031,41 +944,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-auth"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "fluvio-auth-schema",
- "fluvio-future",
- "fluvio-protocol",
- "fluvio-sc-schema",
- "fluvio-service",
- "fluvio-socket 0.3.0",
- "fluvio-stream-model",
- "fluvio-types",
- "futures-util",
- "log",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "fluvio-auth-schema"
-version = "0.1.0"
-dependencies = [
- "fluvio-dataplane-protocol",
- "fluvio-protocol",
- "fluvio-service",
- "log",
- "serde",
-]
-
-[[package]]
 name = "fluvio-cli"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "async-h1",
  "async-trait",
@@ -1105,12 +985,11 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
- "which",
 ]
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.1.3"
+version = "0.1.0"
 dependencies = [
  "fluvio",
  "fluvio-controlplane-metadata",
@@ -1131,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -1143,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
@@ -1169,7 +1048,6 @@ dependencies = [
  "crc32c",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket 0.2.1",
  "flv-util",
  "futures-util",
  "log",
@@ -1177,13 +1055,12 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9eac52925a38cf92788318aeef688303f07d2ae17d021e2a8cacf194839ced4"
+checksum = "e5a6dc548919905c5ebc5ad51e9b078e1fde7a0cce3c4d08d143814204afd910"
 dependencies = [
  "async-fs",
  "async-io",
- "async-native-tls",
  "async-net",
  "async-std",
  "async-tls",
@@ -1192,10 +1069,8 @@ dependencies = [
  "futures-lite",
  "log",
  "memmap",
- "native-tls",
- "nix 0.17.0",
- "openssl",
- "pin-project 0.4.27",
+ "nix",
+ "pin-project",
  "pin-utils",
  "rustls 0.18.1",
  "thiserror",
@@ -1262,20 +1137,19 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "fluvio-sc"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "async-channel",
- "async-lock 1.1.5",
+ "async-lock",
  "async-trait",
  "base64 0.11.0",
  "chashmap",
  "event-listener",
- "fluvio-auth",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -1283,13 +1157,11 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-service",
- "fluvio-socket 0.3.0",
+ "fluvio-socket",
  "fluvio-stream-dispatcher",
- "fluvio-stream-model",
  "fluvio-system-util",
  "fluvio-types",
  "flv-tls-proxy",
- "flv-util",
  "futures-util",
  "k8-client",
  "k8-metadata-client",
@@ -1298,7 +1170,6 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "serde",
- "serde_json",
  "structopt",
  "tokio",
  "toml",
@@ -1310,7 +1181,6 @@ dependencies = [
 name = "fluvio-sc-schema"
 version = "0.1.0"
 dependencies = [
- "fluvio-auth-schema",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-protocol",
@@ -1323,20 +1193,18 @@ dependencies = [
 
 [[package]]
 name = "fluvio-service"
-version = "0.2.0"
-source = "git+https://github.com/infinyon/fluvio-socket?rev=3975110#3975110751fc9475b93c5e698f35cacfd607da81"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02eaf670c4291c757e2ca67e37b02423e13181489f6c9763e5514572064cc939"
 dependencies = [
  "async-trait",
  "event-listener",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket 0.3.0",
+ "fluvio-socket",
  "futures-util",
  "log",
  "pin-utils",
- "serde",
- "serde_json",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1344,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.2.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9800e3f19f797488fb526831d306f99567861f1d82bd78891189e425a3c72d78"
+checksum = "1829f6aa18c3967380e5796dff883cbc841168d56629ba9001cf81552e837903"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1359,30 +1227,7 @@ dependencies = [
  "fluvio-protocol",
  "futures-util",
  "log",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-socket"
-version = "0.3.0"
-source = "git+https://github.com/infinyon/fluvio-socket?rev=3975110#3975110751fc9475b93c5e698f35cacfd607da81"
-dependencies = [
- "async-channel",
- "async-mutex",
- "async-net",
- "async-trait",
- "bytes 0.5.6",
- "chashmap",
- "event-listener",
- "fluvio-future",
- "fluvio-protocol",
- "futures-util",
- "log",
- "pin-project-lite",
+ "pin-utils",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1391,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "async-channel",
  "async-rwlock",
@@ -1400,17 +1245,15 @@ dependencies = [
  "chashmap",
  "chrono",
  "event-listener",
- "fluvio-auth",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-service",
- "fluvio-socket 0.3.0",
+ "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-storage",
- "fluvio-stream-model",
  "fluvio-system-util",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1420,7 +1263,6 @@ dependencies = [
  "pin-utils",
  "regex",
  "serde",
- "serde_json",
  "serde_yaml",
  "structopt",
  "tokio",
@@ -1443,27 +1285,25 @@ dependencies = [
 
 [[package]]
 name = "fluvio-storage"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-protocol",
- "fluvio-socket 0.3.0",
+ "fluvio-socket",
  "fluvio-types",
- "flv-util",
  "futures-lite",
  "libc",
  "pin-utils",
  "serde",
- "structopt",
  "tracing",
 ]
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "async-channel",
  "async-rwlock",
@@ -1472,8 +1312,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-stream-model",
  "fluvio-types",
- "flv-util",
- "futures-lite",
+ "futures",
  "k8-metadata-client",
  "log",
  "serde",
@@ -1484,10 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.2.0"
+version = "0.1.1"
 dependencies = [
  "async-rwlock",
- "fluvio-future",
  "fluvio-types",
  "k8-obj-app",
  "k8-obj-core",
@@ -1514,7 +1352,7 @@ checksum = "fc9e4cb09caa5ff039928399ef5aa99206fd1b9a59df208cf6d94e2764fe5ce0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -1525,41 +1363,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "flv-test"
-version = "1.0.1"
-dependencies = [
- "async-trait",
- "bytes 0.5.6",
- "fluvio",
- "fluvio-controlplane-metadata",
- "fluvio-dataplane-protocol",
- "fluvio-future",
- "fluvio-system-util",
- "fluvio-types",
- "futures-lite",
- "k8-client",
- "k8-metadata-client",
- "log",
- "structopt",
-]
-
-[[package]]
 name = "flv-tls-proxy"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5b118f6a53f4536bea378533c252a1c8a9163e81719467f2abd6878e3d1d11"
+checksum = "de1cc4cb2dfb7d71a935b562e09b9b1b5e3a74214320b11a279887c1b150aa45"
 dependencies = [
- "async-trait",
  "fluvio-future",
- "fluvio-protocol",
- "fluvio-socket 0.2.1",
  "futures-lite",
  "futures-util",
  "log",
  "pin-project-lite",
- "serde",
- "serde_json",
- "x509-parser",
 ]
 
 [[package]]
@@ -1579,21 +1392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,31 +1408,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.7"
+name = "futures"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.2"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+checksum = "5b2ec5fce115ef4d4cc77f46025232fba6a2f84381ff42337794147050aae971"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1647,61 +1472,49 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi",
 ]
 
 [[package]]
@@ -1729,7 +1542,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1751,9 +1564,9 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1797,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -1854,15 +1667,13 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.6.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc9a434e0182abff944d7d44190f02d141f269a3f31c45ac5368dc548bb934b"
+checksum = "50e703a631784b7881751ebff731cd645eb4c7f9b6288c19178ba9e1c4788d39"
 dependencies = [
  "anyhow",
- "async-channel",
  "async-std",
  "cookie",
- "futures-lite",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1941,7 +1752,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2128,23 +1939,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 0.1.10",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2189,20 +1987,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2278,37 +2063,19 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
  "autocfg",
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nb-connect"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
 dependencies = [
  "libc",
  "winapi",
@@ -2322,43 +2089,9 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2392,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -2415,20 +2148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
-dependencies = [
- "bitflags",
- "cfg-if 0.1.10",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,9 +2155,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.12.0+1.1.1h"
+version = "111.11.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
 dependencies = [
  "cc",
 ]
@@ -2517,7 +2236,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi",
  "libc",
  "redox_syscall",
@@ -2576,7 +2295,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -2592,49 +2311,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
-dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2644,17 +2343,17 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "7215a098a80ab8ebd6349db593dc5faf741781bad0c4b7c5701fea6af548d52c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "log",
  "wepoll-sys",
@@ -2667,7 +2366,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "universal-hash",
 ]
 
@@ -2700,7 +2399,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
  "version_check",
 ]
 
@@ -2854,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2876,18 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "ring"
@@ -2928,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc_version"
@@ -2939,15 +2629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a9050636e8a1b487ba1fbe99114021cd7594dde3ce6ed95bfc1691e5b5367b"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -2977,17 +2658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.46",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,12 +2683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,29 +2696,6 @@ checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3083,29 +2724,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -3197,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3205,12 +2846,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -3261,7 +2901,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi",
@@ -3281,18 +2921,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
-version = "0.2.11"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
+checksum = "33a71ea1ea5f8747d1af1979bfb7e65c3a025a70609f04ceb78425bc5adad8e6"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"
@@ -3318,7 +2952,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3334,7 +2968,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3351,9 +2985,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3362,15 +2996,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3392,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -3408,20 +3042,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "rand 0.7.3",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -3477,22 +3097,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3550,7 +3170,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.7",
  "standback",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3580,7 +3200,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3600,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
@@ -3613,7 +3233,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3628,7 +3248,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
 ]
 
 [[package]]
@@ -3656,7 +3276,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project",
  "tracing",
 ]
 
@@ -3683,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -3697,7 +3317,6 @@ dependencies = [
  "sharded-slab",
  "smallvec 1.4.2",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3900,7 +3519,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -3915,7 +3534,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
  "wasm-bindgen-shared",
 ]
 
@@ -3925,7 +3544,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3949,7 +3568,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4000,21 +3619,11 @@ dependencies = [
 
 [[package]]
 name = "wepoll-sys"
-version = "3.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "which"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
-dependencies = [
- "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -4047,25 +3656,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x509-parser"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76245c48460d72a3e17ad3a01855c3cae98601bb992091c1c1421c77d1cb27c"
-dependencies = [
- "base64 0.13.0",
- "chrono",
- "data-encoding",
- "der-oid-macro",
- "der-parser",
- "lazy_static",
- "nom",
- "num-bigint",
- "rusticata-macros",
- "rustversion",
- "thiserror",
-]
 
 [[package]]
 name = "yaml-rust"

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -39,7 +39,7 @@ fluvio-future = { version = "0.1.4" }
 fluvio-types = { version = "0.1.0", path = "../types" }
 fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.1.0", path = "../spu-schema" }
-fluvio-socket = { version = "0.3.0" }
+fluvio-socket = { version = "0.3.0", features = [ "native_tls" ] }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 

--- a/src/controlplane-metadata/src/spu/mod.rs
+++ b/src/controlplane-metadata/src/spu/mod.rs
@@ -88,6 +88,15 @@ mod custom_metadata {
         Id(i32),
     }
 
+    impl From<&CustomSpuKey> for String {
+        fn from(key: &CustomSpuKey) -> Self {
+            match key {
+                CustomSpuKey::Name(name) => name.to_owned(),
+                CustomSpuKey::Id(id) => id.to_string(),
+            }
+        }
+    }
+
     impl CustomSpuKey {
         fn type_string(&self) -> &'static str {
             match self {

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -20,4 +20,4 @@ fluvio-protocol = { version = "0.2.0", features = ["derive", "api", "store"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { version = "0.2.0", default-features = false }
+fluvio-socket = { version = "0.2.0" }

--- a/src/dataplane-protocol/src/error_code.rs
+++ b/src/dataplane-protocol/src/error_code.rs
@@ -23,6 +23,7 @@ pub enum ErrorCode {
 
     OffsetOutOfRange = 1,
     NotLeaderForPartition = 6,
+    PermissionDenied = 13,
     StorageError = 56,
 
     // Spu errors

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -24,4 +24,5 @@ thiserror = "1.0.20"
 fluvio-types = { version = "0.1.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.2.0", default-features = false, path = "../controlplane-metadata" }
 fluvio-protocol = { version = "0.2.0" }
+fluvio-auth-schema = { version = "0.1.0", path = "../auth-schema" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc-schema/src/request.rs
+++ b/src/sc-schema/src/request.rs
@@ -4,30 +4,27 @@
 //! Maps SC Api Requests with their associated Responses.
 //!
 
-use std::convert::TryInto;
+use std::convert::{TryInto};
 use std::io::Error as IoError;
 
 use tracing::debug;
 
 use dataplane::bytes::Buf;
-
-use dataplane::api::ApiMessage;
+use dataplane::api::{ApiMessage};
 use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 
 use dataplane::api::api_decode;
-use dataplane::derive::Encode;
+use dataplane::derive::{Encode};
 
 use super::versions::ApiVersionsRequest;
 use super::objects::*;
-
 use super::AdminPublicApiKey;
 
 #[derive(Debug, Encode)]
 pub enum AdminPublicRequest {
     // Mixed
     ApiVersionsRequest(RequestMessage<ApiVersionsRequest>),
-
     CreateRequest(RequestMessage<CreateRequest>),
     DeleteRequest(RequestMessage<DeleteRequest>),
     ListRequest(RequestMessage<ListRequest>),

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.19"
 tracing-futures = "0.2.4"
 toml = "0.5.5"
 serde = { version = "1.0.103", features = ['derive'] }
+serde_json = "1.0.59"
 futures-util = { version = "0.3.5" }
 chashmap = "2.2.0"
 base64 = "0.11.0"
@@ -38,9 +39,11 @@ tokio = { version = "0.2.21", features = ["macros"] }
 structopt = "0.3.17"
 
 # Fluvio dependencies
+fluvio-auth = { version = "0.1.0", path = "../auth" }
 fluvio-future = { version = "0.1.0", features = ["tls","subscriber"] }
 fluvio-types = { path = "../types", version = "0.1.0" }
 fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema" }
+fluvio-stream-model = { path = "../stream-model", version = "0.2.0" }
 fluvio-controlplane = { version = "0.2.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.2.0", features = ["k8"], path = "../controlplane-metadata" }
 fluvio-stream-dispatcher = { version = "0.2.0", path = "../stream-dispatcher" }

--- a/src/sc/src/config/sc_config.rs
+++ b/src/sc/src/config/sc_config.rs
@@ -7,6 +7,7 @@ use std::io::Error as IoError;
 
 use fluvio_types::defaults::SC_PUBLIC_PORT;
 use fluvio_types::defaults::SC_PRIVATE_PORT;
+use crate::services::auth::basic::Policy;
 
 // -----------------------------------
 // Traits
@@ -23,6 +24,7 @@ pub struct ScConfig {
     pub private_endpoint: String,
     pub run_k8_dispatchers: bool,
     pub namespace: String,
+    pub policy: Policy,
 }
 
 impl ::std::default::Default for ScConfig {
@@ -32,6 +34,7 @@ impl ::std::default::Default for ScConfig {
             private_endpoint: format!("0.0.0.0:{}", SC_PRIVATE_PORT),
             run_k8_dispatchers: true,
             namespace: "default".to_owned(),
+            policy: Policy::default(),
         }
     }
 }

--- a/src/sc/src/core/context.rs
+++ b/src/sc/src/core/context.rs
@@ -3,7 +3,7 @@
 //!
 //! Metadata stores a copy of the data from KV store in local memory.
 //!
-use std::sync::Arc;
+use std::sync::{Arc};
 
 use crate::config::ScConfig;
 use crate::stores::spu::*;
@@ -12,6 +12,8 @@ use crate::stores::topic::*;
 use crate::stores::spg::*;
 use crate::stores::*;
 use crate::controllers::spus::SpuStatusChannel;
+
+use crate::services::auth::basic::ScAuthorizationContext;
 
 pub type SharedContext = Arc<Context>;
 
@@ -82,4 +84,9 @@ impl Context {
     pub fn namespace(&self) -> &str {
         &self.config.namespace
     }
+}
+
+pub struct AuthenticatedContext {
+    pub global_ctx: SharedContext,
+    pub auth: ScAuthorizationContext,
 }

--- a/src/sc/src/services/auth/basic.rs
+++ b/src/sc/src/services/auth/basic.rs
@@ -1,0 +1,120 @@
+use async_trait::async_trait;
+
+use std::fs::read;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::convert::TryFrom;
+
+use serde::{Serialize, Deserialize};
+
+use fluvio_auth::identity::AuthorizationIdentity;
+use fluvio_service::auth::{Authorization, AuthorizationError};
+
+pub type Role = String;
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize)]
+pub enum Action {
+    Create,
+    Read,
+    Update,
+    Delete,
+    All,
+}
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize)]
+pub enum Object {
+    Spu,
+    CustomSpu,
+    SpuGroup,
+    Topic,
+    Partition,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Policy(pub HashMap<Role, HashMap<Object, Vec<Action>>>);
+
+impl From<HashMap<Role, HashMap<Object, Vec<Action>>>> for Policy {
+    fn from(map: HashMap<Role, HashMap<Object, Vec<Action>>>) -> Self {
+        Self(map)
+    }
+}
+
+impl TryFrom<PathBuf> for Policy {
+    type Error = std::io::Error;
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        let file = read(path)?;
+        let policy: Policy = serde_json::from_slice(&file)?;
+        Ok(policy)
+    }
+}
+
+impl Policy {
+    pub async fn evaluate(
+        &self,
+        request: ScAuthorizationContextRequest,
+        identity: &AuthorizationIdentity,
+    ) -> Result<bool, AuthorizationError> {
+        // For each scope provided in the identity,
+        // check if there is a match;
+        let is_allowed = identity.scopes().iter().any(|scope| {
+            self.0
+                .get(&scope.to_lowercase())
+                .map(|objects| {
+                    objects
+                        .get(&request.1)
+                        .map(|actions| {
+                            actions
+                                .iter()
+                                .any(|action| action == &request.0 || action == &Action::All)
+                        })
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        });
+
+        Ok(is_allowed)
+    }
+}
+
+impl Default for Policy {
+    // default only allows the `Root` role to have full permissions;
+    fn default() -> Self {
+        let mut root_policy = HashMap::new();
+
+        root_policy.insert(Object::Spu, vec![Action::All]);
+        root_policy.insert(Object::CustomSpu, vec![Action::All]);
+        root_policy.insert(Object::SpuGroup, vec![Action::All]);
+        root_policy.insert(Object::Topic, vec![Action::All]);
+        root_policy.insert(Object::Partition, vec![Action::All]);
+
+        let mut policy = HashMap::new();
+
+        policy.insert(String::from("Root"), root_policy);
+
+        Self(policy)
+    }
+}
+
+pub type ObjectName = String;
+
+pub struct ScAuthorizationContext {
+    pub identity: AuthorizationIdentity,
+    pub policy: Policy,
+}
+
+pub type ScAuthorizationContextRequest = (Action, Object, Option<ObjectName>);
+
+#[async_trait]
+impl Authorization<Policy, AuthorizationIdentity> for ScAuthorizationContext {
+    type Request = ScAuthorizationContextRequest;
+    fn create_authorization_context(identity: AuthorizationIdentity, config: Policy) -> Self {
+        ScAuthorizationContext {
+            identity,
+            policy: config,
+        }
+    }
+
+    async fn enforce(&self, request: Self::Request) -> Result<bool, AuthorizationError> {
+        Ok(self.policy.evaluate(request, &self.identity).await?)
+    }
+}

--- a/src/sc/src/services/auth/mod.rs
+++ b/src/sc/src/services/auth/mod.rs
@@ -1,0 +1,4 @@
+pub mod basic;
+
+#[cfg(test)]
+mod test;

--- a/src/sc/src/services/auth/test.rs
+++ b/src/sc/src/services/auth/test.rs
@@ -1,0 +1,39 @@
+use std::fs::File;
+use std::path::PathBuf;
+use std::convert::TryFrom;
+use std::collections::HashMap;
+
+use super::basic::{Action, Object, Policy};
+
+#[test]
+fn test_policy_serialization() {
+    let mut policy = Policy::default();
+
+    let mut default_role = HashMap::new();
+
+    default_role.insert(Object::Topic, vec![Action::All]);
+    default_role.insert(Object::Partition, vec![Action::All]);
+    default_role.insert(Object::SpuGroup, vec![Action::Read]);
+    default_role.insert(Object::CustomSpu, vec![Action::Read]);
+    default_role.insert(Object::Spu, vec![Action::Read]);
+
+    policy.0.insert(String::from("Default"), default_role);
+
+    let tmp_file_path = PathBuf::from("/tmp/policy.json");
+    let tmp = File::create(tmp_file_path.clone()).expect("failed to create policy file");
+    serde_json::to_writer(&tmp, &policy).expect("failed to serialize policy to json file");
+
+    let recovered_policy =
+        Policy::try_from(tmp_file_path).expect("failed to parse policy from file");
+
+    assert_eq!(
+        policy, recovered_policy,
+        "serialized and deserialized policies from file should match"
+    )
+}
+
+#[test]
+fn test_policy_enforcement() {
+    // let identity =
+    // let auth = AuthorizationTest::create_authorization_context(identity: Self::IdentityContext, config: Policy)
+}

--- a/src/sc/src/services/mod.rs
+++ b/src/sc/src/services/mod.rs
@@ -1,7 +1,8 @@
 // pub mod send_channels;
-
 mod public_api;
 mod private_api;
+
+pub mod auth;
 
 pub use public_api::start_public_server;
 pub use private_api::start_internal_server;

--- a/src/sc/src/services/public_api/create.rs
+++ b/src/sc/src/services/public_api/create.rs
@@ -9,7 +9,7 @@ use crate::core::*;
 /// Handler for create topic request
 pub async fn handle_create_request(
     request: RequestMessage<CreateRequest>,
-    ctx: SharedContext,
+    auth_context: &AuthenticatedContext,
 ) -> Result<ResponseMessage<Status>, IoError> {
     let (header, req) = request.get_header_request();
 
@@ -18,17 +18,17 @@ pub async fn handle_create_request(
 
     let status = match req.spec {
         AllCreatableSpec::Topic(topic) => {
-            super::topic::handle_create_topics_request(name, dry_run, topic, ctx.clone()).await?
+            super::topic::handle_create_topics_request(name, dry_run, topic, auth_context).await?
         }
         AllCreatableSpec::SpuGroup(group) => {
-            super::spg::handle_create_spu_group_request(name, group, dry_run, ctx.clone()).await?
+            super::spg::handle_create_spu_group_request(name, group, dry_run, auth_context).await?
         }
         AllCreatableSpec::CustomSpu(custom) => {
             super::spu::RegisterCustomSpu::handle_register_custom_spu_request(
                 name,
                 custom,
                 dry_run,
-                ctx.clone(),
+                auth_context,
             )
             .await
         }

--- a/src/sc/src/services/public_api/delete.rs
+++ b/src/sc/src/services/public_api/delete.rs
@@ -16,17 +16,17 @@ use crate::core::*;
 /// Handler for delete topic request
 pub async fn handle_delete_request(
     request: RequestMessage<DeleteRequest>,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<ResponseMessage<Status>, Error> {
     let (header, req) = request.get_header_request();
 
     let status = match req {
-        DeleteRequest::Topic(name) => super::topic::handle_delete_topic(name, ctx.clone()).await?,
+        DeleteRequest::Topic(name) => super::topic::handle_delete_topic(name, auth_ctx).await?,
         DeleteRequest::CustomSpu(key) => {
-            super::spu::handle_un_register_custom_spu_request(key, ctx.clone()).await?
+            super::spu::handle_un_register_custom_spu_request(key, auth_ctx).await?
         }
         DeleteRequest::SpuGroup(name) => {
-            super::spg::handle_delete_spu_group(name, ctx.clone()).await?
+            super::spg::handle_delete_spu_group(name, auth_ctx).await?
         }
     };
 

--- a/src/sc/src/services/public_api/list.rs
+++ b/src/sc/src/services/public_api/list.rs
@@ -8,24 +8,26 @@ use crate::core::*;
 
 pub async fn handle_list_request(
     request: RequestMessage<ListRequest>,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<ResponseMessage<ListResponse>, Error> {
     debug!("handling list request");
     let (header, req) = request.get_header_request();
 
     let response = match req {
         ListRequest::Topic(filter) => {
-            super::topic::handle_fetch_topics_request(filter, &ctx).await?
+            super::topic::handle_fetch_topics_request(filter, &auth_ctx).await?
         }
-        ListRequest::Spu(filter) => super::spu::handle_fetch_spus_request(filter, &ctx).await?,
+        ListRequest::Spu(filter) => {
+            super::spu::handle_fetch_spus_request(filter, &auth_ctx).await?
+        }
         ListRequest::SpuGroup(filter) => {
-            super::spg::handle_fetch_spu_groups_request(filter, &ctx).await?
+            super::spg::handle_fetch_spu_groups_request(filter, &auth_ctx).await?
         }
         ListRequest::CustomSpu(filter) => {
-            super::spu::handle_fetch_custom_spu_request(filter, &ctx).await?
+            super::spu::handle_fetch_custom_spu_request(filter, &auth_ctx).await?
         }
         ListRequest::Partition(filter) => {
-            super::partition::handle_fetch_request(filter, &ctx).await?
+            super::partition::handle_fetch_request(filter, &auth_ctx).await?
         }
     };
 

--- a/src/sc/src/services/public_api/mod.rs
+++ b/src/sc/src/services/public_api/mod.rs
@@ -16,7 +16,7 @@ mod context {
     use tracing::info;
     use tracing::instrument;
 
-    use fluvio_service::FlvApiServer;
+    use fluvio_service::{FlvApiServer};
 
     use crate::core::*;
     use super::public_server::PublicService;
@@ -30,7 +30,6 @@ mod context {
     pub fn start_public_server(ctx: SharedContext) {
         let addr = ctx.config().public_endpoint.clone();
         info!("start public api service");
-
         let server = FlvApiServer::new(addr, ctx, PublicService::new());
         server.run();
     }

--- a/src/sc/src/services/public_api/spg/create.rs
+++ b/src/sc/src/services/public_api/spg/create.rs
@@ -4,25 +4,41 @@
 //! Converts Spu Gruups API request into KV request and sends to KV store for processing.
 //!
 
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 use tracing::{debug, trace};
 
+use dataplane::ErrorCode;
 use fluvio_sc_schema::Status;
-use fluvio_sc_schema::spg::*;
+use fluvio_service::auth::Authorization;
+use fluvio_controlplane_metadata::spg::SpuGroupSpec;
 
 use crate::core::*;
+use crate::services::auth::basic::{Action, Object};
 
 /// Handler for spu groups request
 pub async fn handle_create_spu_group_request(
     name: String,
     spec: SpuGroupSpec,
     _dry_run: bool,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<Status, Error> {
     debug!("creating spu group: {}", name);
+    let auth_request = (Action::Create, Object::SpuGroup, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            return Ok(Status::new(
+                name.clone(),
+                ErrorCode::PermissionDenied,
+                Some(String::from("permission denied")),
+            ));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
 
-    let status = process_custom_spu_request(&ctx, name, spec).await;
+    let status = process_custom_spu_request(&auth_ctx.global_ctx, name, spec).await;
     trace!("create spu-group response {:#?}", status);
 
     Ok(status)
@@ -30,8 +46,6 @@ pub async fn handle_create_spu_group_request(
 
 /// Process custom spu, converts spu spec to K8 and sends to KV store
 async fn process_custom_spu_request(ctx: &Context, name: String, spg_spec: SpuGroupSpec) -> Status {
-    use dataplane::ErrorCode;
-
     if let Err(err) = ctx.spgs().create_spec(name.clone(), spg_spec).await {
         let error = Some(err.to_string());
         Status::new(name, ErrorCode::SpuError, error)

--- a/src/sc/src/services/public_api/spg/delete.rs
+++ b/src/sc/src/services/public_api/spg/delete.rs
@@ -1,20 +1,46 @@
 use tracing::debug;
 use tracing::trace;
 
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
+use fluvio_service::auth::Authorization;
 use fluvio_sc_schema::Status;
 
 use crate::core::*;
+use crate::services::auth::basic::{Action, Object};
 
 /// Handler for delete spu group request
-pub async fn handle_delete_spu_group(name: String, ctx: SharedContext) -> Result<Status, Error> {
+pub async fn handle_delete_spu_group(
+    name: String,
+    auth_ctx: &AuthenticatedContext,
+) -> Result<Status, Error> {
     use dataplane::ErrorCode;
 
     debug!("delete spg group: {}", name);
 
-    let status = if ctx.spgs().store().value(&name).await.is_some() {
-        if let Err(err) = ctx.spgs().delete(name.clone()).await {
+    let auth_request = (Action::Delete, Object::SpuGroup, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            return Ok(Status::new(
+                name.clone(),
+                ErrorCode::PermissionDenied,
+                Some(String::from("permission denied")),
+            ));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    let status = if auth_ctx
+        .global_ctx
+        .spgs()
+        .store()
+        .value(&name)
+        .await
+        .is_some()
+    {
+        if let Err(err) = auth_ctx.global_ctx.spgs().delete(name.clone()).await {
             Status::new(name.clone(), ErrorCode::SpuError, Some(err.to_string()))
         } else {
             Status::new_ok(name)

--- a/src/sc/src/services/public_api/spg/fetch.rs
+++ b/src/sc/src/services/public_api/spg/fetch.rs
@@ -1,20 +1,35 @@
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 use tracing::debug;
 use tracing::trace;
 
+use fluvio_service::auth::Authorization;
 use fluvio_sc_schema::objects::*;
 use fluvio_sc_schema::spg::SpuGroupSpec;
 use fluvio_controlplane_metadata::store::*;
 
-use crate::core::Context;
+use crate::core::AuthenticatedContext;
+use crate::services::auth::basic::{Action, Object};
 
 pub async fn handle_fetch_spu_groups_request(
     filters: Vec<NameFilter>,
-    ctx: &Context,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<ListResponse, Error> {
     debug!("fetching spu groups");
-    let spgs: Vec<Metadata<SpuGroupSpec>> = ctx
+
+    let auth_request = (Action::Read, Object::SpuGroup, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            // If permission denied, return empty list;
+            return Ok(ListResponse::SpuGroup(vec![]));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    let spgs: Vec<Metadata<SpuGroupSpec>> = auth_ctx
+        .global_ctx
         .spgs()
         .store()
         .read()

--- a/src/sc/src/services/public_api/spu/fetch.rs
+++ b/src/sc/src/services/public_api/spu/fetch.rs
@@ -1,19 +1,35 @@
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 use tracing::{trace, debug};
 
+use fluvio_service::auth::Authorization;
 use fluvio_sc_schema::objects::*;
 use fluvio_sc_schema::spu::SpuSpec;
 use fluvio_sc_schema::spu::CustomSpuSpec;
 use fluvio_controlplane_metadata::store::*;
-use crate::core::Context;
+
+use crate::core::AuthenticatedContext;
+use crate::services::auth::basic::{Action, Object};
 
 pub async fn handle_fetch_custom_spu_request(
     filters: Vec<String>,
-    ctx: &Context,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<ListResponse, Error> {
     debug!("fetching custom spu list");
-    let spus: Vec<Metadata<SpuSpec>> = ctx
+
+    let auth_request = (Action::Read, Object::CustomSpu, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            // If permission denied, return empty list;
+            return Ok(ListResponse::CustomSpu(vec![]));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    let spus: Vec<Metadata<SpuSpec>> = auth_ctx
+        .global_ctx
         .spus()
         .store()
         .read()
@@ -45,11 +61,21 @@ pub async fn handle_fetch_custom_spu_request(
 
 pub async fn handle_fetch_spus_request(
     filters: Vec<String>,
-    ctx: &Context,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<ListResponse, Error> {
     debug!("fetching spu list");
 
-    let spus: Vec<Metadata<SpuSpec>> = ctx
+    let auth_request = (Action::Read, Object::Spu, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            // If permission denied, return empty list;
+            return Ok(ListResponse::Spu(vec![]));
+        }
+    }
+
+    let spus: Vec<Metadata<SpuSpec>> = auth_ctx
+        .global_ctx
         .spus()
         .store()
         .read()

--- a/src/sc/src/services/public_api/spu/unregister_custom_spus_req.rs
+++ b/src/sc/src/services/public_api/spu/unregister_custom_spus_req.rs
@@ -5,28 +5,45 @@
 //! and send K8 a delete message.
 //!
 use tracing::{debug, trace};
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 use dataplane::ErrorCode;
 use fluvio_sc_schema::Status;
 use fluvio_sc_schema::spu::*;
+use fluvio_service::auth::Authorization;
 
 use crate::stores::spu::*;
 use crate::core::*;
+use crate::services::auth::basic::{Action, Object};
 
 /// Handler for delete custom spu request
 pub async fn handle_un_register_custom_spu_request(
     key: CustomSpuKey,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<Status, Error> {
-    let spu_store = ctx.spus().store();
+    let auth_request = (Action::Delete, Object::CustomSpu, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            let name: String = String::from(&key);
+            return Ok(Status::new(
+                name,
+                ErrorCode::PermissionDenied,
+                Some(String::from("permission denied")),
+            ));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    let spu_store = auth_ctx.global_ctx.spus().store();
     let status = match key {
         CustomSpuKey::Name(spu_name) => {
             debug!("api request: delete custom-spu with name '{}'", spu_name);
 
             // spu-name must exist
             if let Some(spu) = spu_store.value(&spu_name).await {
-                un_register_custom_spu(&ctx, spu.inner_owned()).await
+                un_register_custom_spu(&auth_ctx, spu.inner_owned()).await
             } else {
                 // spu does not exist
                 Status::new(
@@ -41,7 +58,7 @@ pub async fn handle_un_register_custom_spu_request(
 
             // spu-id must exist
             if let Some(spu) = spu_store.get_by_id(spu_id).await {
-                un_register_custom_spu(&ctx, spu).await
+                un_register_custom_spu(&auth_ctx, spu).await
             } else {
                 // spu does not exist
                 Status::new(
@@ -59,7 +76,7 @@ pub async fn handle_un_register_custom_spu_request(
 }
 
 /// Generate for delete custom spu operation and return result.
-async fn un_register_custom_spu(ctx: &Context, spu: SpuAdminMd) -> Status {
+async fn un_register_custom_spu(auth_ctx: &AuthenticatedContext, spu: SpuAdminMd) -> Status {
     let spu_name = spu.key_owned();
 
     // must be Custom Spu
@@ -72,7 +89,7 @@ async fn un_register_custom_spu(ctx: &Context, spu: SpuAdminMd) -> Status {
     }
 
     // delete custom spec and return result
-    if let Err(err) = ctx.spus().delete(spu_name.clone()).await {
+    if let Err(err) = auth_ctx.global_ctx.spus().delete(spu_name.clone()).await {
         Status::new(
             spu_name,
             ErrorCode::SpuError,

--- a/src/sc/src/services/public_api/topic/create.rs
+++ b/src/sc/src/services/public_api/topic/create.rs
@@ -9,34 +9,52 @@
 //! Assigned Topics allow the users to apply their custom-defined replica assignment.
 //!
 
-use std::io::Error as IoError;
+use std::io::{Error as IoError, ErrorKind};
 
 use tracing::{debug, trace};
 
 use dataplane::ErrorCode;
 
 use fluvio_sc_schema::Status;
-use fluvio_sc_schema::topic::*;
+use fluvio_service::auth::Authorization;
+use fluvio_controlplane_metadata::topic::TopicSpec;
 
 use crate::core::*;
 use crate::controllers::topics::generate_replica_map;
 use crate::controllers::topics::update_replica_map_for_assigned_topic;
 use crate::controllers::topics::validate_computed_topic_parameters;
 use crate::controllers::topics::validate_assigned_topic_parameters;
+use crate::services::auth::basic::{Action, Object};
 
 /// Handler for create topic request
 pub async fn handle_create_topics_request(
     name: String,
     dry_run: bool,
     topic_spec: TopicSpec,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
 ) -> Result<Status, IoError> {
     debug!("api request: create topic '{}'", name);
+    let auth_request = (Action::Create, Object::Topic, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            return Ok(Status::new(
+                name.clone(),
+                ErrorCode::PermissionDenied,
+                Some(String::from("permission denied")),
+            ));
+        }
+    } else {
+        return Err(IoError::new(
+            ErrorKind::Interrupted,
+            "authorization io error",
+        ));
+    }
 
     // validate topic request
-    let mut status = validate_topic_request(&name, &topic_spec, &ctx).await;
+    let mut status = validate_topic_request(&name, &topic_spec, &auth_ctx.global_ctx).await;
     if !dry_run {
-        status = process_topic_request(&ctx, name, topic_spec).await;
+        status = process_topic_request(auth_ctx, name, topic_spec).await;
     }
 
     trace!("create topics request response {:#?}", status);
@@ -110,8 +128,12 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
 }
 
 /// Process topic, converts topic spec to K8 and sends to KV store
-async fn process_topic_request(ctx: &Context, name: String, topic_spec: TopicSpec) -> Status {
-    if let Err(err) = create_topic(ctx, name.clone(), topic_spec).await {
+async fn process_topic_request(
+    auth_ctx: &AuthenticatedContext,
+    name: String,
+    topic_spec: TopicSpec,
+) -> Status {
+    if let Err(err) = create_topic(auth_ctx, name.clone(), topic_spec).await {
         let error = Some(err.to_string());
         Status::new(name, ErrorCode::TopicError, error)
     } else {
@@ -119,6 +141,15 @@ async fn process_topic_request(ctx: &Context, name: String, topic_spec: TopicSpe
     }
 }
 
-async fn create_topic(ctx: &Context, name: String, topic: TopicSpec) -> Result<(), IoError> {
-    ctx.topics().create_spec(name, topic).await.map(|_| ())
+async fn create_topic(
+    auth_ctx: &AuthenticatedContext,
+    name: String,
+    topic: TopicSpec,
+) -> Result<(), IoError> {
+    auth_ctx
+        .global_ctx
+        .topics()
+        .create_spec(name, topic)
+        .await
+        .map(|_| ())
 }

--- a/src/sc/src/services/public_api/topic/delete.rs
+++ b/src/sc/src/services/public_api/topic/delete.rs
@@ -5,19 +5,50 @@
 //! and send K8 a delete message.
 //!
 use tracing::{debug, trace};
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 
 use dataplane::ErrorCode;
 use fluvio_sc_schema::Status;
+use fluvio_service::auth::Authorization;
 
 use crate::core::*;
+use crate::services::auth::basic::{Action, Object};
 
 /// Handler for delete topic request
-pub async fn handle_delete_topic(topic_name: String, ctx: SharedContext) -> Result<Status, Error> {
+pub async fn handle_delete_topic(
+    topic_name: String,
+    auth_ctx: &AuthenticatedContext,
+) -> Result<Status, Error> {
     debug!("api request: delete topic '{}'", topic_name);
 
-    let status = if ctx.topics().store().value(&topic_name).await.is_some() {
-        if let Err(err) = ctx.topics().delete(topic_name.clone()).await {
+    let auth_request = (Action::Delete, Object::Topic, None);
+    if let Ok(authorized) = auth_ctx.auth.enforce(auth_request).await {
+        if !authorized {
+            trace!("authorization failed");
+            return Ok(Status::new(
+                topic_name.clone(),
+                ErrorCode::PermissionDenied,
+                Some(String::from("permission denied")),
+            ));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    let status = if auth_ctx
+        .global_ctx
+        .topics()
+        .store()
+        .value(&topic_name)
+        .await
+        .is_some()
+    {
+        if let Err(err) = auth_ctx
+            .global_ctx
+            .topics()
+            .delete(topic_name.clone())
+            .await
+        {
             Status::new(
                 topic_name.clone(),
                 ErrorCode::TopicError,

--- a/src/sc/src/services/public_api/watch.rs
+++ b/src/sc/src/services/public_api/watch.rs
@@ -20,13 +20,13 @@ use fluvio_controlplane_metadata::store::Epoch;
 use fluvio_controlplane_metadata::partition::PartitionSpec;
 use fluvio_controlplane_metadata::spu::SpuSpec;
 
-use crate::core::SharedContext;
+use crate::core::AuthenticatedContext;
 use crate::stores::StoreContext;
 
 /// handle watch request by spawning watch controller for each store
 pub fn handle_watch_request<T>(
     request: RequestMessage<WatchRequest>,
-    ctx: SharedContext,
+    auth_ctx: &AuthenticatedContext,
     sink: InnerExclusiveFlvSink<T>,
     end_event: Arc<Event>,
 ) where
@@ -41,7 +41,7 @@ pub fn handle_watch_request<T>(
             epoch,
             sink,
             end_event,
-            ctx.spus().clone(),
+            auth_ctx.global_ctx.spus().clone(),
             header,
         ),
         WatchRequest::SpuGroup(_) => unimplemented!(),
@@ -49,7 +49,7 @@ pub fn handle_watch_request<T>(
             epoch,
             sink,
             end_event,
-            ctx.partitions().clone(),
+            auth_ctx.global_ctx.partitions().clone(),
             header,
         ),
     }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = { version = "0.3.5", features = ["sink"] }
 async-trait = "0.1.21"
 serde_yaml = "0.8.8"
 serde = { version = "1.0.103", features = ['derive'] }
+serde_json = "1.0.59"
 chrono = { version = "0.4.6", features = ["serde"] }
 chashmap = "2.2.0"
 pin-utils = "0.1.0-alpha.4"
@@ -38,11 +39,13 @@ event-listener = "2.4.0"
 
 
 # Fluvio dependencies
+fluvio-auth = { version = "0.1.0", path = "../auth" }
 fluvio-types = { path = "../types", version = "0.1.0" }
 fluvio-storage = { path = "../storage", version = "0.1.0" }
 fluvio-controlplane = { path = "../controlplane", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.2.0" }
 fluvio-spu-schema = { path = "../spu-schema", version = "0.1.0" }
+fluvio-stream-model = { path = "../stream-model", version = "0.2.0" }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-socket = { version = "0.3.0" }

--- a/src/spu/src/services/auth/basic.rs
+++ b/src/spu/src/services/auth/basic.rs
@@ -1,0 +1,120 @@
+use async_trait::async_trait;
+
+use std::fs::read;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::convert::TryFrom;
+
+use serde::{Serialize, Deserialize};
+
+use fluvio_auth::identity::AuthorizationIdentity;
+use fluvio_service::auth::{Authorization, AuthorizationError};
+
+pub type Role = String;
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize)]
+pub enum Action {
+    Create,
+    Read,
+    Update,
+    Delete,
+    All,
+}
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize)]
+pub enum Object {
+    Spu,
+    CustomSpu,
+    SpuGroup,
+    Topic,
+    Partition,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Policy(pub HashMap<Role, HashMap<Object, Vec<Action>>>);
+
+impl From<HashMap<Role, HashMap<Object, Vec<Action>>>> for Policy {
+    fn from(map: HashMap<Role, HashMap<Object, Vec<Action>>>) -> Self {
+        Self(map)
+    }
+}
+
+impl TryFrom<PathBuf> for Policy {
+    type Error = std::io::Error;
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        let file = read(path)?;
+        let policy: Policy = serde_json::from_slice(&file)?;
+        Ok(policy)
+    }
+}
+
+impl Policy {
+    pub async fn evaluate(
+        &self,
+        request: SpuAuthorizationContextRequest,
+        identity: &AuthorizationIdentity,
+    ) -> Result<bool, AuthorizationError> {
+        // For each scope provided in the identity,
+        // check if there is a match;
+        let is_allowed = identity.scopes().iter().any(|scope| {
+            self.0
+                .get(&scope.to_lowercase())
+                .map(|objects| {
+                    objects
+                        .get(&request.1)
+                        .map(|actions| {
+                            actions
+                                .iter()
+                                .any(|action| action == &request.0 || action == &Action::All)
+                        })
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        });
+
+        Ok(is_allowed)
+    }
+}
+
+impl Default for Policy {
+    // default only allows the `Root` role to have full permissions;
+    fn default() -> Self {
+        let mut root_policy = HashMap::new();
+
+        root_policy.insert(Object::Spu, vec![Action::All]);
+        root_policy.insert(Object::CustomSpu, vec![Action::All]);
+        root_policy.insert(Object::SpuGroup, vec![Action::All]);
+        root_policy.insert(Object::Topic, vec![Action::All]);
+        root_policy.insert(Object::Partition, vec![Action::All]);
+
+        let mut policy = HashMap::new();
+
+        policy.insert(String::from("Root"), root_policy);
+
+        Self(policy)
+    }
+}
+
+pub type ObjectName = String;
+
+pub struct SpuAuthorizationContext {
+    pub identity: AuthorizationIdentity,
+    pub policy: Policy,
+}
+
+pub type SpuAuthorizationContextRequest = (Action, Object, Option<ObjectName>);
+
+#[async_trait]
+impl Authorization<Policy, AuthorizationIdentity> for SpuAuthorizationContext {
+    type Request = SpuAuthorizationContextRequest;
+    fn create_authorization_context(identity: AuthorizationIdentity, config: Policy) -> Self {
+        SpuAuthorizationContext {
+            identity,
+            policy: config,
+        }
+    }
+
+    async fn enforce(&self, request: Self::Request) -> Result<bool, AuthorizationError> {
+        Ok(self.policy.evaluate(request, &self.identity).await?)
+    }
+}

--- a/src/spu/src/services/auth/mod.rs
+++ b/src/spu/src/services/auth/mod.rs
@@ -1,0 +1,1 @@
+pub mod basic;

--- a/src/spu/src/services/internal/mod.rs
+++ b/src/spu/src/services/internal/mod.rs
@@ -5,18 +5,26 @@ mod fetch_stream_request;
 
 use tracing::info;
 
+use fluvio_auth::identity::AuthorizationIdentity;
 use fluvio_service::FlvApiServer;
 use service_impl::InternalService;
 
 use crate::core::DefaultSharedGlobalContext;
+use crate::services::auth::basic::Policy;
 
 pub use self::fetch_stream_request::FetchStreamRequest;
 pub use self::fetch_stream_request::FetchStreamResponse;
 pub use self::api::SPUPeerApiEnum;
 pub use self::api::SpuPeerRequest;
 
-pub(crate) type InternalApiServer =
-    FlvApiServer<SpuPeerRequest, SPUPeerApiEnum, DefaultSharedGlobalContext, InternalService>;
+pub(crate) type InternalApiServer = FlvApiServer<
+    SpuPeerRequest,
+    SPUPeerApiEnum,
+    DefaultSharedGlobalContext,
+    InternalService,
+    AuthorizationIdentity,
+    Policy,
+>;
 
 // start server
 pub fn create_internal_server(addr: String, ctx: DefaultSharedGlobalContext) -> InternalApiServer {

--- a/src/spu/src/services/internal/service_impl.rs
+++ b/src/spu/src/services/internal/service_impl.rs
@@ -2,17 +2,18 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use fluvio_auth::identity::AuthorizationIdentity;
 use fluvio_service::api_loop;
-use fluvio_service::FlvService;
+use fluvio_service::{FlvService};
 use fluvio_socket::FlvSocket;
 use fluvio_socket::FlvSocketError;
 use fluvio_future::net::TcpStream;
 
 use super::SpuPeerRequest;
 use super::SPUPeerApiEnum;
-
 use super::fetch_stream::handle_fetch_stream_request;
 use crate::core::DefaultSharedGlobalContext;
+use crate::services::auth::basic::{SpuAuthorizationContext, Policy};
 
 #[derive(Debug)]
 pub struct InternalService {}
@@ -24,13 +25,16 @@ impl InternalService {
 }
 
 #[async_trait]
-impl FlvService<TcpStream> for InternalService {
+impl FlvService<TcpStream, AuthorizationIdentity, Policy> for InternalService {
     type Context = DefaultSharedGlobalContext;
     type Request = SpuPeerRequest;
+    type IdentityContext = AuthorizationIdentity;
+    type Authorization = SpuAuthorizationContext;
 
     async fn respond(
         self: Arc<Self>,
         context: DefaultSharedGlobalContext,
+        _identity: Self::IdentityContext,
         socket: FlvSocket,
     ) -> Result<(), FlvSocketError> {
         let (sink, mut stream) = socket.split();

--- a/src/spu/src/services/mod.rs
+++ b/src/spu/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod public;
 
+pub mod auth;
 pub mod internal;
 
 pub use self::internal::create_internal_server;

--- a/src/spu/src/services/public/mod.rs
+++ b/src/spu/src/services/public/mod.rs
@@ -7,6 +7,7 @@ mod stream_fetch;
 
 use tracing::info;
 
+use fluvio_auth::identity::AuthorizationIdentity;
 use fluvio_service::FlvApiServer;
 use service_impl::PublicService;
 use fluvio_spu_schema::server::SpuServerRequest;
@@ -14,11 +15,18 @@ use fluvio_spu_schema::server::SpuServerApiKey;
 use dataplane::ReplicaKey;
 
 use crate::core::DefaultSharedGlobalContext;
+use crate::services::auth::basic::Policy;
 
 pub type OffsetReplicaList = std::collections::HashSet<ReplicaKey>;
 
-pub(crate) type PublicApiServer =
-    FlvApiServer<SpuServerRequest, SpuServerApiKey, DefaultSharedGlobalContext, PublicService>;
+pub(crate) type PublicApiServer = FlvApiServer<
+    SpuServerRequest,
+    SpuServerApiKey,
+    DefaultSharedGlobalContext,
+    PublicService,
+    AuthorizationIdentity,
+    Policy,
+>;
 
 // start server
 pub fn create_public_server(addr: String, ctx: DefaultSharedGlobalContext) -> PublicApiServer {

--- a/src/spu/src/services/public/service_impl.rs
+++ b/src/spu/src/services/public/service_impl.rs
@@ -17,6 +17,7 @@ use fluvio_socket::InnerFlvSink;
 use fluvio_socket::FlvSocketError;
 use fluvio_service::call_service;
 use fluvio_service::FlvService;
+use fluvio_auth::identity::AuthorizationIdentity;
 use fluvio_spu_schema::server::SpuServerApiKey;
 use fluvio_spu_schema::server::SpuServerRequest;
 use fluvio_future::zero_copy::ZeroCopyWrite;
@@ -28,6 +29,8 @@ use super::fetch_handler::handle_fetch_request;
 use super::offset_request::handle_offset_request;
 use super::stream_fetch::StreamFetchHandler;
 use super::OffsetReplicaList;
+use crate::services::auth::basic::Policy;
+use crate::services::auth::basic::SpuAuthorizationContext;
 
 #[derive(Debug)]
 pub struct PublicService {}
@@ -39,16 +42,19 @@ impl PublicService {
 }
 
 #[async_trait]
-impl<S> FlvService<S> for PublicService
+impl<S> FlvService<S, AuthorizationIdentity, Policy> for PublicService
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Context = DefaultSharedGlobalContext;
     type Request = SpuServerRequest;
+    type IdentityContext = AuthorizationIdentity;
+    type Authorization = SpuAuthorizationContext;
 
     async fn respond(
         self: Arc<Self>,
         context: DefaultSharedGlobalContext,
+        _identity: Self::IdentityContext,
         socket: InnerFlvSocket<S>,
     ) -> Result<(), FlvSocketError>
     where

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.103", features = ['derive'] }
 
 # Fluvio dependencies
 fluvio-types = { path = "../types", version = "0.1.0" }
+fluvio-socket = { version = "0.3.0" }
 fluvio-future = { version = "0.1.0", features = ["fs","mmap"] }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }


### PR DESCRIPTION
WIP: opening as a draft for early feedback and discussion.

For this initial version, I've opted for using a basic `role`, `object`, `action` based RBAC policy, where the role is either `root` or `default`.

## Basic Types

```rust
// Policy Mapping
pub type Policy = HashMap<Role, HashMap<Object, Vec<Action>>>;


// Authorization tuple to find enforcement policy;
pub type AuthRequest = (Role, Object, Action);
```

## Auth Trait

```rust

#[async_trait]
pub trait Auth {    
    async fn enforce(&self, request: AuthRequest, role: Role) -> Result<bool, AuthError>;
    async fn set_role(&mut self, role: Role) -> Result<(), AuthError>;
    fn get_role(&self) -> Option<&Role>;
}
```

## Basic Implementation of Auth Trait


```rust
#[async_trait]
impl Auth for BasicAuth {
    async fn set_role(&mut self, role: Role) -> Result<(), AuthError> {
        self.role = Some(role);
        Ok(())
    }

    fn get_role(&self) -> Option<&Role> {
        self.role.as_ref()
    }

    async fn enforce(&self, request: AuthRequest, role: Role) -> Result<bool, AuthError> {

        let is_role_match = request.0 == role;
        
        let is_allowed = self
            .policy
            .get(&request.0)
            .map(|role| {
                role
                    .get(&request.1)
                    .map(|actions| actions.iter().any(|action| action == &request.2))
                    .unwrap_or(false)
            })
            .unwrap_or(false);

        Ok(is_role_match && is_allowed)
    }
}
```

## Use in API SharedContext

```rust

if let Ok(authorized) = ctx.authorize((Role::Root, Object::SpuGroup, Action::Create)).await {
        if !authorized {
            trace!("authorization failed for role: {:?}", ctx.role());
            // ... handle auth error;
        }
    };
```