### PR TITLE
Add external subcommand execution to fluvio-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -3685,6 +3686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -47,6 +47,7 @@ http-types = "2.4.0"
 thiserror = "1.0.20"
 eyre = "0.6.1"
 color-eyre = "0.5.5"
+which = "4.0.2"
 
 # Fluvio dependencies
 

--- a/src/cli/src/bin/main.rs
+++ b/src/cli/src/bin/main.rs
@@ -4,7 +4,8 @@ fn main() -> Result<()> {
     fluvio_future::subscriber::init_tracer(None);
     color_eyre::install()?;
 
-    let output = fluvio_cli::run_cli()?;
+    let args: Vec<_> = std::env::args().collect();
+    let output = fluvio_cli::run_cli(&args)?;
     if !output.is_empty() {
         println!("{}", output)
     }

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -7,7 +7,7 @@ use crate::profile::CloudError;
 
 #[derive(Error, Debug)]
 pub enum CliError {
-    #[error("IO error")]
+    #[error(transparent)]
     IoError {
         #[from]
         source: IoError,
@@ -39,6 +39,11 @@ pub enum CliError {
     },
     #[error("Invalid argument: {0}")]
     InvalidArg(String),
+    #[error("Error finding executable")]
+    WhichError {
+        #[from]
+        source: which::Error,
+    },
     #[error("Unknown error: {0}")]
     Other(String),
 }

--- a/src/cli/src/root_cli.rs
+++ b/src/cli/src/root_cli.rs
@@ -230,7 +230,10 @@ fn process_external_subcommand(mut args: Vec<String>) -> Result<String, CliError
     let subcommand_path = match CanonicalPath::new(&external_subcommand) {
         Ok(path) => path,
         Err(WhichError::CannotFindBinaryPath) => {
-            println!("Unable to find plugin '{}'. Make sure it is executable and in your PATH.", &external_subcommand);
+            println!(
+                "Unable to find plugin '{}'. Make sure it is executable and in your PATH.",
+                &external_subcommand
+            );
             std::process::exit(1);
         }
         other => other?,
@@ -238,7 +241,11 @@ fn process_external_subcommand(mut args: Vec<String>) -> Result<String, CliError
 
     // Print the fully-qualified command to debug
     let args_string = args.join(" ");
-    debug!("Launching external subcommand: {} {}", subcommand_path.as_path().display(), &args_string);
+    debug!(
+        "Launching external subcommand: {} {}",
+        subcommand_path.as_path().display(),
+        &args_string
+    );
 
     // Execute the command with the provided arguments
     let status = Command::new(subcommand_path.as_path())

--- a/src/cli/src/root_cli.rs
+++ b/src/cli/src/root_cli.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 use structopt::clap::{AppSettings, Shell};
 use structopt::StructOpt;
+use tracing::debug;
 
 use fluvio_future::task::run_block_on;
 
@@ -118,13 +119,17 @@ enum Root {
         settings = &[AppSettings::Hidden]
     )]
     Completions(CompletionShell),
+
+    #[structopt(external_subcommand)]
+    External(Vec<String>),
 }
 
-pub fn run_cli() -> eyre::Result<String> {
+pub fn run_cli(args: &[String]) -> eyre::Result<String> {
     run_block_on(async move {
         let terminal = Arc::new(PrintTerminal::new());
 
-        let output = match Root::from_args() {
+        let root_args: Root = Root::from_iter(args);
+        let output = match root_args {
             Root::Consume(consume) => process_consume_log(terminal.clone(), consume).await?,
             Root::Produce(produce) => process_produce_record(terminal.clone(), produce).await?,
             Root::SPU(spu) => process_spu(terminal.clone(), spu).await?,
@@ -138,6 +143,7 @@ pub fn run_cli() -> eyre::Result<String> {
             Root::Run(opt) => process_run(opt)?,
             Root::Version(_) => process_version_cmd()?,
             Root::Completions(shell) => process_completions_cmd(shell)?,
+            Root::External(args) => process_external_subcommand(args)?,
         };
         Ok(output)
     })
@@ -209,5 +215,39 @@ fn process_completions_cmd(shell: CompletionShell) -> Result<String, CliError> {
             app.gen_completions_to(opt.name, Shell::Fish, &mut std::io::stdout());
         }
     }
+    Ok("".to_string())
+}
+
+fn process_external_subcommand(mut args: Vec<String>) -> Result<String, CliError> {
+    use std::process::Command;
+    use which::{CanonicalPath, Error as WhichError};
+
+    // The external subcommand's name is given as the first argument, take it.
+    let cmd = args.remove(0);
+
+    // Check for a matching external command in the environment
+    let external_subcommand = format!("fluvio-{}", cmd);
+    let subcommand_path = match CanonicalPath::new(&external_subcommand) {
+        Ok(path) => path,
+        Err(WhichError::CannotFindBinaryPath) => {
+            println!("Unable to find plugin '{}'. Make sure it is executable and in your PATH.", &external_subcommand);
+            std::process::exit(1);
+        }
+        other => other?,
+    };
+
+    // Print the fully-qualified command to debug
+    let args_string = args.join(" ");
+    debug!("Launching external subcommand: {} {}", subcommand_path.as_path().display(), &args_string);
+
+    // Execute the command with the provided arguments
+    let status = Command::new(subcommand_path.as_path())
+        .args(&args)
+        .status()?;
+
+    if let Some(code) = status.code() {
+        std::process::exit(code);
+    }
+
     Ok("".to_string())
 }


### PR DESCRIPTION
This uses the `external_subcommand` feature of clap/structopt in order to try to find and pass arguments to subcommands. For any subcommand `foo`, if `fluvio foo` is not a built-in subcommand, it will search the user's `PATH` for an executable named `fluivo-foo`. If it finds one, it will execute it, passing all subsequent arguments to it. In other words, if `fluvio-foo` exists and a user invokes `fluvio foo one two three -- four five`, then fluvio will execute `fluvio-foo one two three -- four five`