### PR TITLE
make native-tls as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ install-clippy:
 
 check-clippy:	install-clippy
 	cargo +$(RUSTV) clippy --all-targets  -- -D warnings
-	cd src/client; cargo +$(RUSTV) clippy --all-targets  --features native_tls -- -D warnings
-	cd src/client; cargo +$(RUSTV) clippy --all-targets  --features rust_tls -- -D warnings
+	cd src/client; cargo +$(RUSTV) clippy --all-targets  -- -D warnings
+
 
 
 run-all-unit-test:

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -58,7 +58,7 @@ k8-config = { version = "1.3.0", features = ["context"] }
 k8-obj-core = { version = "1.1.0" }
 k8-obj-metadata = { version = "1.0.0" }
 k8-metadata-client = { version = "1.0.0" }
-fluvio = { version = "0.2.0", path = "../client", features = ["native_tls"] }
+fluvio = { version = "0.2.0", path = "../client" }
 fluvio-sc = { version = "0.2.0", path = "../sc", optional = true, features = ["k8"] }
 fluvio-sc-schema = { version = "0.1.0", path = "../sc-schema", features = ["use_serde"] }
 fluvio-spu = { version = "0.2.0", path = "../spu", optional = true }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -12,6 +12,7 @@ name = "fluvio"
 path = "src/lib.rs"
 
 [features]
+default = ["native_tls"]
 admin = ["fluvio-sc-schema/use_serde"]
 rust_tls = ["fluvio-future/tls","fluvio-socket/tls"]
 native_tls = ["fluvio-future/native2_tls","fluvio-socket/native_tls"]

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -7,16 +7,12 @@ use dataplane::core::Decoder;
 use fluvio_sc_schema::objects::{Metadata, AllCreatableSpec};
 use fluvio_sc_schema::AdminRequest;
 use fluvio_socket::FlvSocketError;
+use fluvio_socket::AllMultiplexerSocket;
 
 #[cfg(feature = "native_tls")]
 use fluvio_future::native_tls::AllDomainConnector;
-#[cfg(feature = "native_tls")]
-use fluvio_socket::AllMultiplexerSocket;
-
 #[cfg(feature = "rust_tls")]
 use fluvio_future::tls::AllDomainConnector;
-#[cfg(feature = "rust_tls")]
-use fluvio_socket::AllMultiplexerSocket;
 
 use crate::client::{ClientConfig, VersionedSerialSocket, SerialFrame};
 use crate::{FluvioError, FluvioConfig};

--- a/src/client/src/client/client.rs
+++ b/src/client/src/client/client.rs
@@ -10,14 +10,11 @@ use dataplane::api::RequestMessage;
 use dataplane::api::Request;
 use fluvio_spu_schema::server::versions::{ApiVersions, ApiVersionsRequest};
 use fluvio_socket::FlvSocketError;
-
-#[cfg(feature = "rust_tls")]
 use fluvio_socket::{AllFlvSocket, AllSerialSocket};
+
 #[cfg(feature = "rust_tls")]
 use fluvio_future::tls::AllDomainConnector;
 
-#[cfg(feature = "native_tls")]
-use fluvio_socket::{AllFlvSocket, AllSerialSocket};
 #[cfg(feature = "native_tls")]
 use fluvio_future::native_tls::AllDomainConnector;
 


### PR DESCRIPTION
Cherry pick from rbac branch which set `native_tls` as default feature for client. 
This avoid issue with use of AllFluvioSocket