### PR TITLE
make CI more stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ DEFAULT_ITERATION=1
 DEFAULT_LOG=info
 AUTH_POLICY = ./src/sc/test-data/test-policy.json
 AUTH_SCOPE = ./src/sc/test-data/scopes.json
+SPU_DELAY=5
 
 # install all tools required
 install_tools_mac:
@@ -37,6 +38,7 @@ smoke-test-tls:	test-clean-up
 # test rbac with ROOT user
 smoke-test-tls-root:	test-clean-up
 	AUTH_POLICY=$(AUTH_POLICY) X509_AUTH_SCOPES=$(AUTH_SCOPE)  \
+	FLV_SPU_DELAY=$(SPU_DELAY) \
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local --rust-log ${DEFAULT_LOG}
 
 # test rbac with user1 who doesn't have topic creation permission
@@ -57,6 +59,7 @@ smoke-test-k8-tls:	test-clean-up minikube_image
 
 smoke-test-k8-tls-root:	test-clean-up minikube_image
 	AUTH_POLICY=$(AUTH_POLICY) X509_AUTH_SCOPES=$(AUTH_SCOPE)  \
+	FLV_SPU_DELAY=$(SPU_DELAY) \
 	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop --rust-log ${DEFAULT_LOG}
 
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEFAULT_ITERATION=1
 DEFAULT_LOG=info
 AUTH_POLICY = ./src/sc/test-data/test-policy.json
 AUTH_SCOPE = ./src/sc/test-data/scopes.json
-SPU_DELAY=5
+SPU_DELAY=10
 
 # install all tools required
 install_tools_mac:

--- a/Makefile
+++ b/Makefile
@@ -241,4 +241,3 @@ delete-gh-release:
 	--user ${GITHUB_USER} \
 	--repo ${GITHUB_REPO} \
 	--tag ${GITHUB_TAG}
-

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -195,8 +195,8 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
             println!("{} spus provisioned", spus.len());
             return Ok(());
         } else {
-            println!("{} out of spu: {} up, waiting 1 sec", live_spus, spu);
-            sleep(Duration::from_secs(1)).await;
+            println!("{} out of spu: {} up, waiting 5 sec", live_spus, spu);
+            sleep(Duration::from_secs(5)).await;
         }
     }
 

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -179,7 +179,8 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
     use fluvio_controlplane_metadata::spu::SpuSpec;
 
     println!("waiting for spu to be provisioned");
-
+    sleep(Duration::from_secs(5)).await;
+    
     let client = Fluvio::connect().await.expect("sc ");
     let mut admin = client.admin().await;
 

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -172,14 +172,21 @@ where
 /// check to ensure spu are all running
 async fn confirm_spu(spu: u16) -> Result<(), CliError> {
     use std::time::Duration;
+    use std::env;
 
     use fluvio_future::timer::sleep;
     use fluvio::Fluvio;
     use fluvio_cluster::ClusterError;
     use fluvio_controlplane_metadata::spu::SpuSpec;
 
-    println!("waiting for spu to be provisioned");
-    sleep(Duration::from_secs(5)).await;
+    let delay: u64 = env::var("FLV_SPU_DELAY")
+        .unwrap_or("1".to_string())
+        .parse()
+        .unwrap_or_else(|_| 1);
+
+    println!("waiting for spu to be provisioned for: {} seconds", delay);
+
+    sleep(Duration::from_secs(delay)).await;
 
     let client = Fluvio::connect().await.expect("sc ");
     let mut admin = client.admin().await;

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -180,7 +180,7 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
 
     println!("waiting for spu to be provisioned");
     sleep(Duration::from_secs(5)).await;
-    
+
     let client = Fluvio::connect().await.expect("sc ");
     let mut admin = client.admin().await;
 

--- a/src/cli/src/cluster/install/mod.rs
+++ b/src/cli/src/cluster/install/mod.rs
@@ -180,7 +180,7 @@ async fn confirm_spu(spu: u16) -> Result<(), CliError> {
     use fluvio_controlplane_metadata::spu::SpuSpec;
 
     let delay: u64 = env::var("FLV_SPU_DELAY")
-        .unwrap_or("1".to_string())
+        .unwrap_or_else(|_| "1".to_string())
         .parse()
         .unwrap_or_else(|_| 1);
 

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -84,6 +84,7 @@ impl TestRunner {
 
     /// main entry point
     pub async fn run_test(&self) {
+        use std::env;
         use crate::tests::create_test_driver;
 
         // at this point, cluster is up, we need to ensure clean shutdown of cluster
@@ -93,8 +94,15 @@ impl TestRunner {
         // we need to test what happens topic gets created before spu
         if self.option.init_topic() {
             self.setup_topic().await;
-
-            sleep(Duration::from_secs(10)).await;
+            let delay: u64 = env::var("FLV_SPU_DELAY")
+                .unwrap_or_else(|_| "1".to_string())
+                .parse()
+                .unwrap_or_else(|_| 1);
+            println!(
+                "waiting for topics to be provisioned for: {} seconds",
+                delay
+            );
+            sleep(Duration::from_secs(delay)).await;
         } else {
             println!("no topic initialized");
         }

--- a/tests/runner/src/test_runner.rs
+++ b/tests/runner/src/test_runner.rs
@@ -93,6 +93,8 @@ impl TestRunner {
         // we need to test what happens topic gets created before spu
         if self.option.init_topic() {
             self.setup_topic().await;
+
+            sleep(Duration::from_secs(10)).await;
         } else {
             println!("no topic initialized");
         }


### PR DESCRIPTION
Add more stabilities to CI by add wait time in couple of places which are configurable.
Cause of CI failure likely to be that CI VM are often throttle down due to oversubscribed host machine.