### PR TITLE
Listing partitions on an empty system

### DIFF
--- a/src/cli/src/partition/list.rs
+++ b/src/cli/src/partition/list.rs
@@ -83,7 +83,7 @@ mod display {
         if !spus.is_empty() {
             out.render_list(&spus, output_type)?;
         } else {
-            t_println!(out, "no spu");
+            t_println!(out, "No partitions found");
         }
 
         Ok(())


### PR DESCRIPTION
Fixes #431 
Fixed output for `fluvio partition list`

Now the output is shown as:

```
$ fluvio partition list 
No partitions found
```
