### PR TITLE
Add fluvio-cloud install to bootstrapping script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -505,11 +505,16 @@ main() {
     # verify_checksum "${_url}" "${_temp_file}" || return 1
 
     # After verification, install the file and make it executable
-    say "✅ Downloaded Fluvio, installing..."
+    say "⬇️ Downloaded Fluvio, installing..."
     ensure mkdir -p "${FLUVIO_BIN}"
     local _install_file="${FLUVIO_BIN}/fluvio"
     ensure mv "${_temp_file}" "${_install_file}"
     ensure chmod +x "${_install_file}"
+
+    # Let fluvio know it is invoked from installer
+    say "☁️ Installing Fluvio Cloud..."
+    FLUVIO_BOOTSTRAP=true "${FLUVIO_BIN}/fluvio" install fluvio/fluvio-cloud
+
     say "🎉 Install complete!"
     remind_path
 

--- a/install.sh
+++ b/install.sh
@@ -510,6 +510,7 @@ main() {
     local _install_file="${FLUVIO_BIN}/fluvio"
     ensure mv "${_temp_file}" "${_install_file}"
     ensure chmod +x "${_install_file}"
+    say "✅ Successfully installed ~/.fluvio/bin/fluvio"
 
     # Let fluvio know it is invoked from installer
     say "☁️ Installing Fluvio Cloud..."

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -1,10 +1,10 @@
+use std::fs::File;
 use std::io::{ErrorKind, Error as IoError};
 use std::path::{Path, PathBuf};
-use tracing::debug;
+use tracing::{debug, instrument};
 use semver::Version;
 use fluvio_index::{HttpAgent, PackageId, Target};
 use crate::CliError;
-use std::fs::File;
 
 pub mod update;
 pub mod plugins;
@@ -16,6 +16,10 @@ fn fluvio_bin_dir() -> Result<PathBuf, CliError> {
 }
 
 /// Fetches the latest version of the package with the given ID
+#[instrument(
+    skip(agent, target, id),
+    fields(%target, %id)
+)]
 async fn fetch_latest_version(
     agent: &HttpAgent,
     id: &PackageId,
@@ -37,6 +41,10 @@ async fn fetch_latest_version(
 }
 
 /// Downloads and verifies a package file via it's versioned ID and target
+#[instrument(
+    skip(agent, id, target),
+    fields(%target, %id)
+)]
 async fn fetch_package_file(
     agent: &HttpAgent,
     id: &PackageId,

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -123,3 +123,11 @@ fn make_executable(file: &mut File) -> Result<(), IoError> {
 
 #[cfg(not(unix))]
 fn make_executable(_file: &mut File) {}
+
+pub fn install_println<S: AsRef<str>>(string: S) {
+    if std::env::var("FLUVIO_BOOTSTRAP").is_ok() {
+        println!("\x1B[1;34mfluvio:\x1B[0m {}", string.as_ref());
+    } else {
+        println!("{}", string.as_ref());
+    }
+}

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -9,11 +9,17 @@ use crate::install::update::{
 #[derive(StructOpt, Debug)]
 pub struct InstallOpt {
     id: PackageId,
+    /// Used for testing. Specifies alternate package location, e.g. "test/"
+    #[structopt(hidden = true, long)]
+    prefix: Option<String>,
 }
 
 impl InstallOpt {
     pub async fn process(self) -> Result<String, CliError> {
-        let agent = HttpAgent::default();
+        let agent = match &self.prefix {
+            Some(prefix) => HttpAgent::with_prefix(prefix)?,
+            None => HttpAgent::default(),
+        };
 
         // Before any "install" type command, check if the CLI needs updating.
         // This may be the case if the index schema has updated.

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -2,7 +2,9 @@ use structopt::StructOpt;
 use fluvio_index::{PackageId, Target, HttpAgent};
 
 use crate::CliError;
-use crate::install::{fetch_latest_version, fetch_package_file, fluvio_bin_dir, install_bin, install_println};
+use crate::install::{
+    fetch_latest_version, fetch_package_file, fluvio_bin_dir, install_bin, install_println,
+};
 use crate::install::update::{
     check_update_required, prompt_required_update, check_update_available, prompt_available_update,
 };
@@ -48,27 +50,39 @@ impl InstallOpt {
         // If a version is given in the package ID, use it. Otherwise, use latest
         let id = match self.id.version.as_ref() {
             Some(_) => {
-                install_println(format!("⏳ Downloading package with provided version: {}...", &self.id));
+                install_println(format!(
+                    "⏳ Downloading package with provided version: {}...",
+                    &self.id
+                ));
                 self.id
             }
             None => {
                 let mut id = self.id;
-                install_println(format!("🎣 Fetching latest version for package: {}...", &id));
+                install_println(format!(
+                    "🎣 Fetching latest version for package: {}...",
+                    &id
+                ));
                 let version = fetch_latest_version(agent, &id, target).await?;
                 id.version = Some(version);
-                install_println(format!("⏳ Downloading package with latest version: {}...", &id));
+                install_println(format!(
+                    "⏳ Downloading package with latest version: {}...",
+                    &id
+                ));
                 id
             }
         };
 
         // Download the package file from the package registry
         let package_file = fetch_package_file(agent, &id, target).await?;
-        install_println(format!("🔑 Downloaded and verified package file"));
+        install_println("🔑 Downloaded and verified package file");
 
         // Install the package to the ~/.fluvio/bin/ dir
         let fluvio_dir = fluvio_bin_dir()?;
         install_bin(&fluvio_dir, id.name.as_str(), &package_file)?;
-        install_println(format!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name));
+        install_println(format!(
+            "✅ Successfully installed ~/.fluvio/bin/{}",
+            &id.name
+        ));
 
         Ok("".to_string())
     }

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -1,7 +1,8 @@
 use structopt::StructOpt;
 use fluvio_index::{PackageId, Target, HttpAgent};
+
 use crate::CliError;
-use crate::install::{fetch_latest_version, fetch_package_file, fluvio_bin_dir, install_bin};
+use crate::install::{fetch_latest_version, fetch_package_file, fluvio_bin_dir, install_bin, install_println};
 use crate::install::update::{
     check_update_required, prompt_required_update, check_update_available, prompt_available_update,
 };
@@ -47,30 +48,27 @@ impl InstallOpt {
         // If a version is given in the package ID, use it. Otherwise, use latest
         let id = match self.id.version.as_ref() {
             Some(_) => {
-                println!(
-                    "⏳ Downloading package with provided version: {}...",
-                    &self.id
-                );
+                install_println(format!("⏳ Downloading package with provided version: {}...", &self.id));
                 self.id
             }
             None => {
                 let mut id = self.id;
-                println!("🎣 Fetching latest version for package: {}...", &id);
+                install_println(format!("🎣 Fetching latest version for package: {}...", &id));
                 let version = fetch_latest_version(agent, &id, target).await?;
                 id.version = Some(version);
-                println!("⏳ Downloading package with latest version: {}...", &id);
+                install_println(format!("⏳ Downloading package with latest version: {}...", &id));
                 id
             }
         };
 
         // Download the package file from the package registry
         let package_file = fetch_package_file(agent, &id, target).await?;
-        println!("🔑 Downloaded and verified package file");
+        install_println(format!("🔑 Downloaded and verified package file"));
 
         // Install the package to the ~/.fluvio/bin/ dir
         let fluvio_dir = fluvio_bin_dir()?;
         install_bin(&fluvio_dir, id.name.as_str(), &package_file)?;
-        println!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name);
+        install_println(format!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name));
 
         Ok("".to_string())
     }

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -1,26 +1,36 @@
 use structopt::StructOpt;
+use tracing::{debug, instrument};
 
-use crate::CliError;
-use fluvio_index::{PackageId, HttpAgent, Target};
-use crate::install::{fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir};
 use semver::Version;
+use fluvio_index::{PackageId, HttpAgent, Target};
+use crate::CliError;
+use crate::install::{fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir};
 
 const FLUVIO_PACKAGE_ID: &str = "fluvio/fluvio";
 
 #[derive(StructOpt, Debug)]
-pub struct UpdateOpt {}
+pub struct UpdateOpt {
+    /// Used for testing. Specifies alternate package location, e.g. "test/"
+    #[structopt(hidden = true, long)]
+    prefix: Option<String>,
+}
 
 impl UpdateOpt {
     pub async fn process(self) -> Result<String, CliError> {
-        let agent = HttpAgent::default();
+        let agent = match self.prefix {
+            Some(prefix) => HttpAgent::with_prefix(&prefix)?,
+            None => HttpAgent::default(),
+        };
         let output = update_self(&agent).await?;
         Ok(output)
     }
 }
 
+#[instrument(skip(agent))]
 async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     let target = fluvio_index::PACKAGE_TARGET.parse::<Target>()?;
     let mut id: PackageId = FLUVIO_PACKAGE_ID.parse::<PackageId>()?;
+    debug!(%target, %id, "Fluvio CLI updating self:");
 
     // Find the latest version of this package
     println!("🎣 Fetching latest version for fluvio/fluvio...");
@@ -43,7 +53,12 @@ async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
 /// Check whether the index requires a more recent version of the client.
 ///
 /// If this is the case, we need to prompt the user to perform an update.
+#[instrument(
+    skip(agent),
+    fields(prefix = agent.base_url())
+)]
 pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> {
+    debug!("Checking for a required CLI update");
     let request = agent.request_index()?;
     let response = crate::http::execute(request).await?;
     let index = agent.index_from_response(response).await?;
@@ -51,28 +66,36 @@ pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> 
 }
 
 /// Check whether there is any newer version of the Fluvio CLI available
+#[instrument(
+    skip(agent),
+    fields(prefix = agent.base_url())
+)]
 pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError> {
     let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
-
-    let request = agent.request_index()?;
-    let response = crate::http::execute(request).await?;
-    let index = agent.index_from_response(response).await?;
-
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
-    let package = index.find_package(&id)?;
+    debug!(%target, %id, "Checking for an available (not required) CLI update:");
+
+    let request = agent.request_package(&id)?;
+    let response = crate::http::execute(request).await?;
+    let package = agent.package_from_response(response).await?;
+
     let release = package.latest_release_for_target(target)?;
     let latest_version = &release.version;
-
     let current_version =
         Version::parse(crate::VERSION).expect("Fluvio CLI 'VERSION' should be a valid semver");
 
     Ok(current_version < *latest_version)
 }
 
-/// Prompt the user about a more recent version of the Fluvio CLI
+/// Prompt the user about a new required version of the Fluvio CLI
+#[instrument(
+    skip(agent),
+    fields(prefix = agent.base_url())
+)]
 pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
+    debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 
     println!("⚠️ A major update to Fluvio has been detected!");
@@ -84,9 +107,15 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Prompt the user about a new available version of the Fluvio CLI
+#[instrument(
+    skip(agent),
+    fields(prefix = agent.base_url())
+)]
 pub async fn prompt_available_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
+    debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 
     println!();

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -4,7 +4,9 @@ use tracing::{debug, instrument};
 use semver::Version;
 use fluvio_index::{PackageId, HttpAgent, Target};
 use crate::CliError;
-use crate::install::{fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println};
+use crate::install::{
+    fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println,
+};
 
 const FLUVIO_PACKAGE_ID: &str = "fluvio/fluvio";
 
@@ -33,19 +35,25 @@ async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     debug!(%target, %id, "Fluvio CLI updating self:");
 
     // Find the latest version of this package
-    install_println(format!("🎣 Fetching latest version for fluvio/fluvio..."));
+    install_println("🎣 Fetching latest version for fluvio/fluvio...");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
     id.version = Some(latest_version);
 
     // Download the package file from the package registry
-    install_println(format!("⏳ Downloading Fluvio CLI with latest version: {}...", &id));
+    install_println(format!(
+        "⏳ Downloading Fluvio CLI with latest version: {}...",
+        &id
+    ));
     let package_file = fetch_package_file(agent, &id, target).await?;
-    install_println(format!("🔑 Downloaded and verified package file"));
+    install_println("🔑 Downloaded and verified package file");
 
     // Install the package to the ~/.fluvio/bin/ dir
     let fluvio_dir = fluvio_bin_dir()?;
     install_bin(&fluvio_dir, "fluvio", &package_file)?;
-    install_println(format!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name));
+    install_println(format!(
+        "✅ Successfully installed ~/.fluvio/bin/{}",
+        &id.name
+    ));
 
     Ok("".to_string())
 }

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -4,7 +4,7 @@ use tracing::{debug, instrument};
 use semver::Version;
 use fluvio_index::{PackageId, HttpAgent, Target};
 use crate::CliError;
-use crate::install::{fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir};
+use crate::install::{fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println};
 
 const FLUVIO_PACKAGE_ID: &str = "fluvio/fluvio";
 
@@ -33,19 +33,19 @@ async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     debug!(%target, %id, "Fluvio CLI updating self:");
 
     // Find the latest version of this package
-    println!("🎣 Fetching latest version for fluvio/fluvio...");
+    install_println(format!("🎣 Fetching latest version for fluvio/fluvio..."));
     let latest_version = fetch_latest_version(agent, &id, target).await?;
     id.version = Some(latest_version);
 
     // Download the package file from the package registry
-    println!("⏳ Downloading Fluvio CLI with latest version: {}...", &id);
+    install_println(format!("⏳ Downloading Fluvio CLI with latest version: {}...", &id));
     let package_file = fetch_package_file(agent, &id, target).await?;
-    println!("🔑 Downloaded and verified package file");
+    install_println(format!("🔑 Downloaded and verified package file"));
 
     // Install the package to the ~/.fluvio/bin/ dir
     let fluvio_dir = fluvio_bin_dir()?;
     install_bin(&fluvio_dir, "fluvio", &package_file)?;
-    println!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name);
+    install_println(format!("✅ Successfully installed ~/.fluvio/bin/{}", &id.name));
 
     Ok("".to_string())
 }

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -1,5 +1,6 @@
 use http_types::{Request, Response};
 use crate::{Result, FluvioIndex, Package, PackageId, Target, Error};
+use url::Url;
 
 pub struct HttpAgent {
     base_url: url::Url,
@@ -14,6 +15,16 @@ impl Default for HttpAgent {
 }
 
 impl HttpAgent {
+    pub fn with_prefix(prefix: &str) -> Result<Self> {
+        Ok(Self {
+            base_url: Url::parse(crate::INDEX_HOST).unwrap().join(prefix)?,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
     pub fn request_index(&self) -> Result<Request> {
         let url = self.base_url.join("index.json")?;
         Ok(Request::get(url))

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -22,6 +22,7 @@ pub use error::{Error, Result};
 pub use target::Target;
 pub use package_id::{PackageId, GroupName, PackageName, Registry};
 
+pub const INDEX_HOST: &str = "https://packages.fluvio.io/";
 pub const INDEX_LOCATION: &str = "https://packages.fluvio.io/v1/";
 pub const INDEX_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const PACKAGE_TARGET: &str = env!("PACKAGE_TARGET");
@@ -64,13 +65,13 @@ pub struct FluvioIndex {
 }
 
 impl FluvioIndex {
-    pub fn find_package(&self, id: &PackageId) -> Result<&Package> {
+    fn find_package(&self, id: &PackageId) -> Result<&Package> {
         let group = self.group(&id.group)?;
         let package = group.package(&id.name)?;
         Ok(package)
     }
 
-    pub fn find_release(&self, id: &PackageId) -> Result<&Release> {
+    fn find_release(&self, id: &PackageId) -> Result<&Release> {
         let version = id.version.as_ref().ok_or(Error::MissingVersion)?;
         let group = self.group(&id.group)?;
         let package = group.package(&id.name)?;
@@ -78,7 +79,7 @@ impl FluvioIndex {
         Ok(release)
     }
 
-    pub fn add_package(&mut self, package: Package) -> Result<()> {
+    fn add_package(&mut self, package: Package) -> Result<()> {
         let group = self
             .groups
             .entry(package.group.clone())
@@ -87,7 +88,7 @@ impl FluvioIndex {
         Ok(())
     }
 
-    pub fn add_release(
+    fn add_release(
         &mut self,
         id: &PackageId,
         version: semver::Version,


### PR DESCRIPTION
This makes the bootstrapping script automatically install the fluvio-cloud plugin by invoking `fluvio install` after installing the Fluvio CLI. This PR also introduces changes that make the install subcommand "bootstrap aware", and format its output printing style to match the bootstrap script's. Specifically, if it detects a `FLUVIO_BOOTSTRAP` environment variable is set, it will prepend `fluvio: ` to each line of output. The full install flow now looks like this:

```
fluvio: ⏳ Downloading Fluvio 0.6.0-alpha.4 for x86_64-apple-darwin...
fluvio: ⬇️ Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio
fluvio: ☁ Installing Fluvio Cloud...
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.0...
fluvio: 🔑 Downloaded and verified package file
fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio-cloud
fluvio: 🎉 Install complete!
fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
fluvio:     You can run the following to set your PATH on shell startup:
fluvio:       For bash: echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.bashrc
fluvio:       For zsh : echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
fluvio:
fluvio:     To use Fluvio you'll need to restart your shell or run the following:
fluvio:       export PATH="${HOME}/.fluvio/bin:${PATH}"
```

Once this PR is accepted, here's the flow of events to get everything set up and published and working:

1) Publish the new version of the Fluvio CLI
2) Upload the new `install.sh` to the package registry
3) Update the `latest` file in the package registry to point to the newest CLI version