### PR TITLE
Index target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -1,5 +1,5 @@
 use structopt::StructOpt;
-use fluvio_index::{PackageId, Target, HttpAgent};
+use fluvio_index::{PackageId, HttpAgent};
 
 use crate::CliError;
 use crate::install::{
@@ -45,7 +45,7 @@ impl InstallOpt {
     }
 
     async fn install_plugin(self, agent: &HttpAgent) -> Result<String, CliError> {
-        let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
+        let target = fluvio_index::package_target()?;
 
         // If a version is given in the package ID, use it. Otherwise, use latest
         let id = match self.id.version.as_ref() {

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 use tracing::{debug, instrument};
 
 use semver::Version;
-use fluvio_index::{PackageId, HttpAgent, Target};
+use fluvio_index::{PackageId, HttpAgent};
 use crate::CliError;
 use crate::install::{
     fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println,
@@ -30,7 +30,7 @@ impl UpdateOpt {
 
 #[instrument(skip(agent))]
 async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
-    let target = fluvio_index::PACKAGE_TARGET.parse::<Target>()?;
+    let target = fluvio_index::package_target()?;
     let mut id: PackageId = FLUVIO_PACKAGE_ID.parse::<PackageId>()?;
     debug!(%target, %id, "Fluvio CLI updating self:");
 
@@ -79,7 +79,7 @@ pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> 
     fields(prefix = agent.base_url())
 )]
 pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError> {
-    let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
+    let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Checking for an available (not required) CLI update:");
 
@@ -101,7 +101,7 @@ pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError>
     fields(prefix = agent.base_url())
 )]
 pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
-    let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
+    let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
@@ -121,7 +121,7 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     fields(prefix = agent.base_url())
 )]
 pub async fn prompt_available_update(agent: &HttpAgent) -> Result<(), CliError> {
-    let target: Target = fluvio_index::PACKAGE_TARGET.parse()?;
+    let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Infinyon Contributors <team@infiyon.com>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/error.rs
+++ b/src/package-index/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     ReleaseAlreadyExists(semver::Version, Target),
     #[error("Failed to parse URL")]
     UrlParseError(#[from] url::ParseError),
-    #[error("Invalid platform {0}")]
+    #[error("Invalid target {0}")]
     InvalidPlatform(String),
     #[error(transparent)]
     HttpError(#[from] HttpError),

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -18,13 +18,12 @@ mod package_id;
 
 pub use http::HttpAgent;
 pub use error::{Error, Result};
-pub use target::Target;
+pub use target::{Target, package_target};
 pub use package_id::{PackageId, GroupName, PackageName, Registry};
 
 pub const INDEX_HOST: &str = "https://packages.fluvio.io/";
 pub const INDEX_LOCATION: &str = "https://packages.fluvio.io/v1/";
 pub const INDEX_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const PACKAGE_TARGET: &str = env!("PACKAGE_TARGET");
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexMetadata {

--- a/src/package-index/src/target.rs
+++ b/src/package-index/src/target.rs
@@ -2,6 +2,18 @@ use std::fmt;
 use serde::{Serialize, Deserialize};
 use crate::Error;
 
+const PACKAGE_TARGET: &str = env!("PACKAGE_TARGET");
+
+/// Detects the target triple of the current build and returns
+/// the name of a compatible build target on packages.fluvio.io.
+///
+/// Returns `Some(Target)` if there is a compatible target, or
+/// `None` if this target is unsupported or has no compatible target.
+pub fn package_target() -> Result<Target, Error> {
+    let target = PACKAGE_TARGET.parse()?;
+    Ok(target)
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum Target {
@@ -27,6 +39,7 @@ impl std::str::FromStr for Target {
         let platform = match s {
             "x86_64-apple-darwin" => Self::X86_64AppleDarwin,
             "x86_64-unknown-linux-musl" => Self::X86_64UnknownLinuxMusl,
+            "x86_64-unknown-linux-gnu" => Self::X86_64UnknownLinuxMusl,
             invalid => return Err(Error::InvalidPlatform(invalid.to_string())),
         };
         Ok(platform)


### PR DESCRIPTION
This causes `Target::from_str` to interpret `"x86_64-unknown-linux-gnu"` as `Target::X86_64UnknownLinuxMusl`, and replaces `fluvio_index::PACKAGE_TARGET` constant with `fluvio_index::package_target()` function to return a folded and structured version of the current build's target.