### PR TITLE
Package id types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "http-types",
  "lazy_static",
@@ -2317,9 +2317,9 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c43eba5c640051fbde86a3377842386a94281df3ff0a5f0365c2075ed5c66f"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -3368,15 +3368,24 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -3388,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3602,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
 dependencies = [
  "tinyvec",
 ]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -69,7 +69,7 @@ fluvio-spu = { version = "0.2.0", path = "../spu", optional = true }
 fluvio-controlplane-metadata = { version = "0.2.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
 fluvio-cluster = { version = "0.3.0", path = "../cluster", default-features = false }
 fluvio-types = { path = "../types", version = "0.1.0" }
-fluvio-package-index = { version = "0.1.0", path = "../package-index" }
+fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.1.0", features = ["fixture"] }

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -1,5 +1,5 @@
 use structopt::StructOpt;
-use fluvio_index::{PackageId, HttpAgent};
+use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 
 use crate::CliError;
 use crate::install::{
@@ -11,7 +11,8 @@ use crate::install::update::{
 
 #[derive(StructOpt, Debug)]
 pub struct InstallOpt {
-    id: PackageId,
+    /// The ID of a package to install, e.g. "fluvio/fluvio-cloud".
+    package: PackageId<MaybeVersion>,
     /// Used for testing. Specifies alternate package location, e.g. "test/"
     #[structopt(hidden = true, long)]
     prefix: Option<String>,
@@ -48,22 +49,23 @@ impl InstallOpt {
         let target = fluvio_index::package_target()?;
 
         // If a version is given in the package ID, use it. Otherwise, use latest
-        let id = match self.id.version.as_ref() {
-            Some(_) => {
+        let id = match self.package.maybe_version() {
+            Some(version) => {
                 install_println(format!(
                     "⏳ Downloading package with provided version: {}...",
-                    &self.id
+                    &self.package
                 ));
-                self.id
+                let version = version.clone();
+                self.package.into_versioned(version)
             }
             None => {
-                let mut id = self.id;
+                let id = self.package;
                 install_println(format!(
                     "🎣 Fetching latest version for package: {}...",
                     &id
                 ));
                 let version = fetch_latest_version(agent, &id, target).await?;
-                id.version = Some(version);
+                let id = id.into_versioned(version);
                 install_println(format!(
                     "⏳ Downloading package with latest version: {}...",
                     &id

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 use tracing::{debug, instrument};
 
 use semver::Version;
-use fluvio_index::{PackageId, HttpAgent, WithoutVersion};
+use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 use crate::CliError;
 use crate::install::{
     fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println,
@@ -31,7 +31,7 @@ impl UpdateOpt {
 #[instrument(skip(agent))]
 async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<MaybeVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fluvio CLI updating self:");
 
     // Find the latest version of this package
@@ -80,7 +80,7 @@ pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> 
 )]
 pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<MaybeVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Checking for an available (not required) CLI update:");
 
     let request = agent.request_package(&id)?;
@@ -102,7 +102,7 @@ pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError>
 )]
 pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<MaybeVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 
@@ -122,7 +122,7 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
 )]
 pub async fn prompt_available_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<MaybeVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 use tracing::{debug, instrument};
 
 use semver::Version;
-use fluvio_index::{PackageId, HttpAgent};
+use fluvio_index::{PackageId, HttpAgent, WithoutVersion};
 use crate::CliError;
 use crate::install::{
     fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println,
@@ -31,13 +31,13 @@ impl UpdateOpt {
 #[instrument(skip(agent))]
 async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     let target = fluvio_index::package_target()?;
-    let mut id: PackageId = FLUVIO_PACKAGE_ID.parse::<PackageId>()?;
+    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fluvio CLI updating self:");
 
     // Find the latest version of this package
     install_println("🎣 Fetching latest version for fluvio/fluvio...");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
-    id.version = Some(latest_version);
+    let id = id.into_versioned(latest_version);
 
     // Download the package file from the package registry
     install_println(format!(
@@ -80,7 +80,7 @@ pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> 
 )]
 pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Checking for an available (not required) CLI update:");
 
     let request = agent.request_package(&id)?;
@@ -102,7 +102,7 @@ pub async fn check_update_available(agent: &HttpAgent) -> Result<bool, CliError>
 )]
 pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 
@@ -122,7 +122,7 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
 )]
 pub async fn prompt_available_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target = fluvio_index::package_target()?;
-    let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
+    let id: PackageId<WithoutVersion> = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, target).await?;
 

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Infinyon Contributors <team@infiyon.com>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/error.rs
+++ b/src/package-index/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("Failed to parse URL")]
     UrlParseError(#[from] url::ParseError),
     #[error("Invalid target {0}")]
-    InvalidPlatform(String),
+    InvalidTarget(String),
     #[error(transparent)]
     HttpError(#[from] HttpError),
     #[error("DANGER: Downloaded package checksum did not match")]

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -1,6 +1,7 @@
-use http_types::{Request, Response};
-use crate::{Result, FluvioIndex, Package, PackageId, Target, Error};
 use url::Url;
+use http_types::{Request, Response};
+use crate::package_id::WithVersion;
+use crate::{Result, FluvioIndex, Package, PackageId, Target};
 
 pub struct HttpAgent {
     base_url: url::Url,
@@ -35,7 +36,7 @@ impl HttpAgent {
         Ok(index)
     }
 
-    pub fn request_package(&self, id: &PackageId) -> Result<Request> {
+    pub fn request_package<T>(&self, id: &PackageId<T>) -> Result<Request> {
         let url = self
             .base_url
             .join(&format!("packages/{}/{}/meta.json", id.group, id.name))?;
@@ -47,26 +48,24 @@ impl HttpAgent {
         Ok(package)
     }
 
-    pub fn request_release_download(&self, id: &PackageId, target: Target) -> Result<Request> {
-        let version = id.version.as_ref().ok_or(Error::MissingVersion)?;
+    pub fn request_release_download(&self, id: &PackageId<WithVersion>, target: Target) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}",
             group = &id.group,
             name = &id.name,
-            version = version,
+            version = id.version(),
             target = target.as_str(),
         ))?;
 
         Ok(Request::get(url))
     }
 
-    pub fn request_release_checksum(&self, id: &PackageId, target: Target) -> Result<Request> {
-        let version = id.version.as_ref().ok_or(Error::MissingVersion)?;
+    pub fn request_release_checksum(&self, id: &PackageId<WithVersion>, target: Target) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}.sha256",
             group = &id.group,
             name = &id.name,
-            version = version,
+            version = id.version(),
             target = target.as_str(),
         ))?;
 

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -48,7 +48,11 @@ impl HttpAgent {
         Ok(package)
     }
 
-    pub fn request_release_download(&self, id: &PackageId<WithVersion>, target: Target) -> Result<Request> {
+    pub fn request_release_download(
+        &self,
+        id: &PackageId<WithVersion>,
+        target: Target,
+    ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}",
             group = &id.group,
@@ -60,7 +64,11 @@ impl HttpAgent {
         Ok(Request::get(url))
     }
 
-    pub fn request_release_checksum(&self, id: &PackageId<WithVersion>, target: Target) -> Result<Request> {
+    pub fn request_release_checksum(
+        &self,
+        id: &PackageId<WithVersion>,
+        target: Target,
+    ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}.sha256",
             group = &id.group,

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -19,14 +19,7 @@ mod package_id;
 pub use http::HttpAgent;
 pub use error::{Error, Result};
 pub use target::{Target, package_target};
-pub use package_id::{
-    PackageId,
-    GroupName,
-    PackageName,
-    Registry,
-    WithVersion,
-    MaybeVersion,
-};
+pub use package_id::{PackageId, GroupName, PackageName, Registry, WithVersion, MaybeVersion};
 
 pub const INDEX_HOST: &str = "https://packages.fluvio.io/";
 pub const INDEX_LOCATION: &str = "https://packages.fluvio.io/v1/";
@@ -209,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_serialize_package() {
-        let id = "fluvio/fluvio".parse().unwrap();
+        let id: PackageId<MaybeVersion> = "fluvio/fluvio".parse().unwrap();
         let package = Package::new_binary(&id, "Bob", "A package", "https://github.com");
         let stringified = serde_json::to_string(&package).unwrap();
         assert_eq!(

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -25,7 +25,6 @@ pub use package_id::{
     PackageName,
     Registry,
     WithVersion,
-    WithoutVersion,
     MaybeVersion,
 };
 
@@ -129,7 +128,7 @@ impl Package {
             .ok_or(Error::MissingTarget(target))
     }
 
-    fn package_id(&self) -> PackageId<WithoutVersion> {
+    fn package_id(&self) -> PackageId<MaybeVersion> {
         PackageId::new_unversioned(self.name.clone(), self.group.clone())
     }
 

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -19,7 +19,15 @@ mod package_id;
 pub use http::HttpAgent;
 pub use error::{Error, Result};
 pub use target::{Target, package_target};
-pub use package_id::{PackageId, GroupName, PackageName, Registry};
+pub use package_id::{
+    PackageId,
+    GroupName,
+    PackageName,
+    Registry,
+    WithVersion,
+    WithoutVersion,
+    MaybeVersion,
+};
 
 pub const INDEX_HOST: &str = "https://packages.fluvio.io/";
 pub const INDEX_LOCATION: &str = "https://packages.fluvio.io/v1/";
@@ -83,7 +91,7 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn new_binary<S1, S2, S3>(id: &PackageId, author: S1, desc: S2, repo: S3) -> Self
+    pub fn new_binary<S1, S2, S3, V>(id: &PackageId<V>, author: S1, desc: S2, repo: S3) -> Self
     where
         S1: Into<String>,
         S2: Into<String>,
@@ -121,8 +129,8 @@ impl Package {
             .ok_or(Error::MissingTarget(target))
     }
 
-    fn package_id(&self) -> PackageId {
-        PackageId::new(self.name.clone(), self.group.clone())
+    fn package_id(&self) -> PackageId<WithoutVersion> {
+        PackageId::new_unversioned(self.name.clone(), self.group.clone())
     }
 
     /// Adds a new release to this package. This will reject a release if a release by the same version exists.

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -467,8 +467,7 @@ mod tests {
         let package_id_string = package_id.to_string();
         assert_eq!(
             package_id_string,
-            "https://some.registry.somewhere/v11/\
-            infinyon.super.secret.division/\
+            "infinyon.super.secret.division/\
             project-x-secret-sauce:100.0.0-special-edition"
         );
 

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -10,7 +10,9 @@ pub struct Registry(url::Url);
 
 impl Registry {
     fn try_from_segments(segments: &[&str]) -> Option<Self> {
-        if segments.is_empty() { return None; }
+        if segments.is_empty() {
+            return None;
+        }
 
         let mut reconstructed: String = segments.join("/");
         if !reconstructed.ends_with('/') {
@@ -381,8 +383,8 @@ impl<'de> Deserialize<'de> for PackageId<WithVersion> {
 
 impl<'de> Deserialize<'de> for PackageId<MaybeVersion> {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let string = String::deserialize(deserializer)?;
         let package_id = match string.parse::<PackageId<MaybeVersion>>() {
@@ -439,7 +441,7 @@ mod tests {
         assert_eq!(package_id.registry(), &Registry::default());
         assert_eq!(package_id.group.as_str(), "fluvio.io");
         assert_eq!(package_id.name.as_str(), "fluvio");
-        assert_eq!(package_id.version, Some(Version::parse("0.6.0").unwrap()));
+        assert_eq!(package_id.version(), &Version::parse("0.6.0").unwrap());
     }
 
     #[test]
@@ -451,17 +453,16 @@ mod tests {
         assert_eq!(package_id.registry(), &registry_url.parse().unwrap());
         assert_eq!(package_id.group.as_str(), "fluvio.io");
         assert_eq!(package_id.name.as_str(), "fluvio");
-        assert_eq!(package_id.version, Some(Version::parse("0.6.0").unwrap()));
+        assert_eq!(package_id.version(), &Version::parse("0.6.0").unwrap());
     }
 
     #[test]
     fn test_package_id_idempotent() {
-        let package_id = PackageId {
-            registry: Some("https://some.registry.somewhere/v11/".parse().unwrap()),
-            group: "infinyon.super.secret.division".parse().unwrap(),
-            name: "project-x-secret-sauce".parse().unwrap(),
-            version: Some(Version::parse("100.0.0-special-edition").unwrap()),
-        };
+        let package_id = PackageId::new_versioned(
+            "project-x-secret-sauce".parse().unwrap(),
+            "infinyon.super.secret.division".parse().unwrap(),
+            Version::parse("100.0.0-special-edition").unwrap(),
+        );
 
         let package_id_string = package_id.to_string();
         assert_eq!(

--- a/src/package-index/src/target.rs
+++ b/src/package-index/src/target.rs
@@ -40,7 +40,7 @@ impl std::str::FromStr for Target {
             "x86_64-apple-darwin" => Self::X86_64AppleDarwin,
             "x86_64-unknown-linux-musl" => Self::X86_64UnknownLinuxMusl,
             "x86_64-unknown-linux-gnu" => Self::X86_64UnknownLinuxMusl,
-            invalid => return Err(Error::InvalidPlatform(invalid.to_string())),
+            invalid => return Err(Error::InvalidTarget(invalid.to_string())),
         };
         Ok(platform)
     }


### PR DESCRIPTION
The `PackageId` type from `fluvio-package-index` was somewhat finicky in that it always carried the package version as an `Option<Version>`, because it could be written in a string like either:

```
<group>/<name>:<version>
OR
<group>/<name>
```

This made some code surrounding PackageId somewhat unweildy because we always had to unwrap the option whenever we wanted to use the Version, even in a context where we knew that we had already checked that we had the version available.

---

This PR changes that type to have two different typed variants, `PackageId<WithVersion>` and `PackageId<MaybeVersion>`. The `PackageId<MaybeVersion>` behaves essentially the same way that the old `PackageId` did. However, the new `PackageId<WithVersion>` type guarantees that it will always have a Version embedded inside it, so when you have a `PackageId<WithVersion>`, you can just use the Version without needing to match or unwrap it.

Another advantage of having distinct types is that they have different `FromStr` implementations. For example, parsing a string into a `PackageId<WithVersion>` will add the requirement that the string must contain the `:<version>` suffix. On the other hand, parsing into `PackageId<MaybeVersion>` will allow a string with or without the `:<version>`.

```rust
let id_with_version: PackageId<WithVersion> = "fluvio/fluvio:1.0.0".parse()?;
let id_without_version: PackageId<MaybeVersion> = "fluvio/fluvio".parse()?;
let id_without_version: PackageId<MaybeVersion> = "fluvio/fluvio:1.0.0".parse()?;
```

You can upgrade a `PackageId<MaybeVersion>` into a `PackageId<WithVersion>` by providing a version to use.

```rust
let id: PackageId<MaybeVersion> = "fluvio/fluvio".parse()?;
let id_with_version: PackageId<WithVersion> = id.into_versioned(Version::parse("1.0.0").unwrap());
```