### PR TITLE
lazy load spu pool in the client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
       #    make test-permission-user1-local
         run: |
-          FLV_CMD=true smoke-test
+          FLV_CMD=true make smoke-test
       - name: Upload logs on Linux
         if: startsWith(matrix.os,'ubuntu') && failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
       #    make test-permission-user1-local
         run: |
-          FLV_CMD=true make smoke-test
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
       - name: Upload logs on Linux
         if: startsWith(matrix.os,'ubuntu') && failure()
         uses: actions/upload-artifact@v2
@@ -216,7 +216,7 @@ jobs:
       #  run: | 
       #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
         run:  |
-          FLV_CMD=true make smoke-test-k8
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test-k8
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,11 @@ jobs:
       # - name: Setup tmate session
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
+      # run: |
+      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
+      #    make test-permission-user1-local
         run: |
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
-          make test-permission-user1-local
+          FLV_CMD=true smoke-test
       - name: Upload logs on Linux
         if: startsWith(matrix.os,'ubuntu') && failure()
         uses: actions/upload-artifact@v2
@@ -211,8 +213,10 @@ jobs:
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: smoke test k8 tls
-        run: | 
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+      #  run: | 
+      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+        run:  |
+          FLV_CMD=true make smoke-test-k8
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "fluvio-spu-schema",
  "fluvio-types",
  "futures-util",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror",

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,16 @@ build:
 #
 
 smoke-test:	test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local ${TEST_LOG}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local ${TEST_LOG} ${SKIP-CHECK}
 
 smoke-test-tls:	test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG} ${SKIP-CHECK}
 
 # test rbac with ROOT user
 smoke-test-tls-root:	test-clean-up
 	AUTH_POLICY=$(SC_AUTH_CONFIG)/policy.json X509_AUTH_SCOPES=$(SC_AUTH_CONFIG)/scopes.json  \
 	FLV_SPU_DELAY=$(SPU_DELAY) \
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG} ${SKIP-CHECK}
 
 # test rbac with user1 who doesn't have topic creation permission
 # assumes cluster is set
@@ -56,10 +56,10 @@ test-permission-user1-local:
 	
 
 smoke-test-k8:	test-clean-up minikube_image
-	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop ${TEST_LOG}
+	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop ${TEST_LOG} ${SKIP-CHECK}
 
 smoke-test-k8-tls:	test-clean-up minikube_image
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop ${TEST_LOG}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop ${TEST_LOG} ${SKIP-CHECK}
 
 smoke-test-k8-tls-root:	test-clean-up minikube_image
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
@@ -71,7 +71,7 @@ smoke-test-k8-tls-root:	test-clean-up minikube_image
 		--develop \
 		${TEST_LOG} \
 		--authorization-config-map authorization \
-		--skip-checks
+		${SKIP-CHECK}
 
 
 # test rbac

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DEFAULT_SPU=1
 DEFAULT_ITERATION=5
 SPU_DELAY=15
 SC_AUTH_CONFIG=./src/sc/test-data/auth_config
+SKIP_CHECK=--skip-checks
 
 
 # install all tools required
@@ -34,16 +35,16 @@ build:
 #
 
 smoke-test:	test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local ${TEST_LOG} ${SKIP-CHECK}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --local ${TEST_LOG}
 
 smoke-test-tls:	test-clean-up
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG} ${SKIP-CHECK}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG}
 
 # test rbac with ROOT user
 smoke-test-tls-root:	test-clean-up
 	AUTH_POLICY=$(SC_AUTH_CONFIG)/policy.json X509_AUTH_SCOPES=$(SC_AUTH_CONFIG)/scopes.json  \
 	FLV_SPU_DELAY=$(SPU_DELAY) \
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG} ${SKIP-CHECK}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --local ${TEST_LOG}
 
 # test rbac with user1 who doesn't have topic creation permission
 # assumes cluster is set
@@ -71,7 +72,7 @@ smoke-test-k8-tls-root:	test-clean-up minikube_image
 		--develop \
 		${TEST_LOG} \
 		--authorization-config-map authorization \
-		${SKIP-CHECK}
+		${SKIP_CHECK}
 
 
 # test rbac

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -33,9 +33,10 @@ event-listener = "2.5.1"
 async-mutex = "1.2.0"
 tokio = { version = "0.2.21", features = ["macros"] }
 thiserror = "1.0.20"
+once_cell = "1.5.2"
 
 # Fluvio dependencies
-fluvio-future = { version = "0.1.10", default-features = false }
+fluvio-future = { version = "0.1.10", features = ["task"] }
 fluvio-types = { version = "0.1.0", path = "../types" }
 fluvio-sc-schema = { version = "0.2.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.1.0", path = "../spu-schema" }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures_util::stream::Stream;
 use tracing::debug;
 
@@ -46,11 +48,11 @@ use crate::spu::SpuPool;
 pub struct PartitionConsumer {
     topic: String,
     partition: i32,
-    pool: SpuPool,
+    pool: Arc<SpuPool>,
 }
 
 impl PartitionConsumer {
-    pub(crate) fn new(topic: String, partition: i32, pool: SpuPool) -> Self {
+    pub(crate) fn new(topic: String, partition: i32, pool: Arc<SpuPool>) -> Self {
         Self {
             topic,
             partition,

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -1,5 +1,6 @@
 use std::io::Error as IoError;
 use std::io::ErrorKind;
+use std::sync::Arc;
 
 use tracing::{debug, trace, instrument};
 use dataplane::ReplicaKey;
@@ -16,11 +17,11 @@ use crate::client::SerialFrame;
 /// each event should be delivered to.
 pub struct TopicProducer {
     topic: String,
-    pool: SpuPool,
+    pool: Arc<SpuPool>,
 }
 
 impl TopicProducer {
-    pub(crate) fn new(topic: String, pool: SpuPool) -> Self {
+    pub(crate) fn new(topic: String, pool: Arc<SpuPool>) -> Self {
         Self { topic, pool }
     }
 

--- a/src/client/src/spu/spu_pool.rs
+++ b/src/client/src/spu/spu_pool.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tracing::{ debug, trace};
+use tracing::{debug, trace};
 use async_mutex::Mutex;
-
 
 use dataplane::ReplicaKey;
 use dataplane::api::Request;
@@ -52,7 +51,6 @@ pub struct SpuPool {
     spu_clients: Arc<Mutex<HashMap<SpuId, SpuSocket>>>,
 }
 
-
 impl Drop for SpuPool {
     fn drop(&mut self) {
         trace!("dropping spu pool");
@@ -61,12 +59,13 @@ impl Drop for SpuPool {
 }
 
 impl SpuPool {
-
     /// start synchronize based on pool
-    pub async fn start(config: ClientConfig,sc_socket: &AllMultiplexerSocket) -> Result<Self,FlvSocketError> {
-        
+    pub async fn start(
+        config: ClientConfig,
+        sc_socket: &AllMultiplexerSocket,
+    ) -> Result<Self, FlvSocketError> {
         let metadata = MetadataStores::start(sc_socket).await?;
-        debug!("starting spu pool");    
+        debug!("starting spu pool");
         Ok(Self {
             metadata,
             config,

--- a/src/client/src/sync/store.rs
+++ b/src/client/src/sync/store.rs
@@ -20,7 +20,6 @@ pub struct MetadataStores {
 }
 
 impl MetadataStores {
-
     /// start synchronization
     pub async fn start(socket: &AllMultiplexerSocket) -> Result<Self, FlvSocketError> {
         let store = Self {
@@ -34,8 +33,6 @@ impl MetadataStores {
 
         Ok(store)
     }
-
-
 
     pub fn spus(&self) -> &StoreContext<SpuSpec> {
         &self.spus

--- a/src/client/src/sync/store.rs
+++ b/src/client/src/sync/store.rs
@@ -20,8 +20,9 @@ pub struct MetadataStores {
 }
 
 impl MetadataStores {
-    /// crete store and set up sync controllers
-    pub async fn new(socket: &AllMultiplexerSocket) -> Result<Self, FlvSocketError> {
+
+    /// start synchronization
+    pub async fn start(socket: &AllMultiplexerSocket) -> Result<Self, FlvSocketError> {
         let store = Self {
             shutdown: SimpleEvent::shared(),
             spus: StoreContext::new(),
@@ -33,6 +34,8 @@ impl MetadataStores {
 
         Ok(store)
     }
+
+
 
     pub fn spus(&self) -> &StoreContext<SpuSpec> {
         &self.spus


### PR DESCRIPTION
Currently, in the Fluvio Client, SPU Pool are automatically initialized when client is created even thought it may not needed until producer and consumer are created.  With this PR, pool are lazy initialized when producers or consumers requested it.

In addition, SPU pool are shared using Arc rather than directly which allows drop trait work correctly.
The skip checks are disabled for test