### PR TITLE
Enabling minikube tunnel in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
         run: |
           minikube profile list
           minikube status
+      - name: Run minikube tunnel
+        run: |
+          minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
+          sleep 10
+          echo "tunnel status"
+          cat /tmp/tunnel.out    
       - name: Build
         run: |
           cargo build


### PR DESCRIPTION
Now that we are skipping checks in CI, I am re-enabling minikube tunnel.