### PR TITLE
Fix tls test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
       # - name: Setup tmate session
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
+        #run: |
+        #  FLV_CMD=true  FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-tls-root
         run: |
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-tls-root
-        # run: |
-        #  FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test
       - name: Upload logs on Linux
         if: startsWith(matrix.os,'ubuntu') && failure()
         uses: actions/upload-artifact@v2
@@ -212,10 +212,10 @@ jobs:
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: smoke test k8 tls
-        run: | 
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-k8-tls-root
-      #  run:  |
-      #    FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test-k8
+      #  run: | 
+      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make RELEASE=true UNINSTALL=noclean smoke-test-k8-tls-root
+        run:  |
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-k8
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
       # - name: Setup tmate session
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
-      # run: |
-      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
         run: |
-          FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
+          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+        # run: |
+        #  FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
       - name: Upload logs on Linux
         if: startsWith(matrix.os,'ubuntu') && failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,10 @@ jobs:
           sudo apt install -y musl-tools
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: smoke test k8 tls
-      #  run: | 
-      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
-        run:  |
-          FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test-k8
+        run: | 
+          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+      #  run:  |
+      #    FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test-k8
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
           sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: smoke test k8 tls
         run: | 
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+          FLV_CMD=true  FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-k8-tls-root
       #  run:  |
       #    FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test-k8
       - name: Save logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
         run: |
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
+          FLV_CMD=true  FLV_SOCKET_WAIT=600 make UNINSTALL=noclean smoke-test-tls-root
         # run: |
         #  FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
       - name: Upload logs on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
         run: |
-          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
+          FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
         # run: |
         #  FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
       - name: Upload logs on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,7 @@ jobs:
       #  uses: mxschmitt/action-tmate@v3
       - name: smoke test tls
       # run: |
-      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-tls-root
-      #    make test-permission-user1-local
+      #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make smoke-test-k8-tls-root
         run: |
           FLV_CMD=true FLV_SOCKET_WAIT=600 make smoke-test
       - name: Upload logs on Linux

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ test-permission-user1-local:
 	
 
 smoke-test-k8:	test-clean-up minikube_image
-	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop ${TEST_LOG} ${SKIP-CHECK}
+	$(TEST_BIN)	--spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --develop ${TEST_LOG} ${SKIP_CHECK}
 
 smoke-test-k8-tls:	test-clean-up minikube_image
-	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop ${TEST_LOG} ${SKIP-CHECK}
+	$(TEST_BIN) --spu ${DEFAULT_SPU} --produce-iteration ${DEFAULT_ITERATION} --tls --develop ${TEST_LOG} ${SKIP_CHECK}
 
 smoke-test-k8-tls-policy:	test-clean-up minikube_image
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
@@ -88,11 +88,17 @@ test-rbac:
 	AUTH_POLICY=$(POLICY_FILE) X509_AUTH_SCOPES=$(SCOPE) make smoke-test-tls DEFAULT_LOG=fluvio=debug
 
 
-
 test-clean-up:
-	#$(FLUVIO_BIN) cluster uninstall
-	#$(FLUVIO_BIN) cluster uninstall --local
-	#kubectl delete configmap authorization --ignore-not-found
+ifeq ($(UNINSTALL),noclean)
+	echo "no clean"
+else
+	echo "clean up previous installation"
+	$(FLUVIO_BIN) cluster uninstall
+	$(FLUVIO_BIN) cluster uninstall --local
+	kubectl delete configmap authorization --ignore-not-found
+endif
+
+
 
 #
 #  Various Lint tools

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ test-rbac:
 
 
 test-clean-up:
-	$(FLUVIO_BIN) cluster uninstall
-	$(FLUVIO_BIN) cluster uninstall --local
-	kubectl delete configmap authorization --ignore-not-found
+	#$(FLUVIO_BIN) cluster uninstall
+	#$(FLUVIO_BIN) cluster uninstall --local
+	#kubectl delete configmap authorization --ignore-not-found
 
 #
 #  Various Lint tools

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ nightly_image:	fluvio_image
 
 # publish docker image to minikube environment
 minikube_image:	MINIKUBE_DOCKER_ENV=true
-minikube_image:	RELEASE=true
 minikube_image:	fluvio_image
 
 # build docker image for fluvio using release mode

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ nightly_image:	fluvio_image
 
 # publish docker image to minikube environment
 minikube_image:	MINIKUBE_DOCKER_ENV=true
+minikube_image:	RELEASE=true
 minikube_image:	fluvio_image
 
 # build docker image for fluvio using release mode


### PR DESCRIPTION
Fix smoke tests for running TLS with policy.  This was broken by changes to CLI refactoring.
Skip uninstalling in the CI
Add option to make release image for k8