### PR TITLE
Optimize musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           minikube status
       - name: Build Test
         run: |
-          make RELEASE=release build_test
+          make RELEASE=release  build_test
       - name: Setup installation pre-requisites
         run: |
           FLV_CMD=true ./target/release/fluvio cluster install --setup --local --develop
@@ -172,19 +172,23 @@ jobs:
         run: |
           minikube profile list
           minikube status
+      - name: Install musl-tools for Linux
+        run: |
+          sudo apt install -y musl-tools
+          sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: Build
         run: |
-          make RELEASE=release build_test
+          make RELEASE=release TARGET=x86_64-unknown-linux-musl build_test
       - name: Setup installation pre-requisites
         run: |
-          FLV_CMD=true ./target/release/fluvio cluster install --setup --develop
-          FLV_CMD=true ./target/release/fluvio cluster check --pre-install
+          FLV_CMD=true make RELEASE=true TARGET=x86_64-unknown-linux-musl  k8-setup
       - name: Make image
         run: make RELEASE=true minikube_image
-      - name: Run smoke-test-k8-tls-root
-        run:  |
-          FLV_CMD=true FLV_SOCKET_WAIT=600 make RELEASE=true UNINSTALL=noclean smoke-test-k8-tls-root
-      - run: minikube delete
+      - name: smoke test k8 tls
+        #  run: |
+        #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make RELEASE=true UNINSTALL=noclean smoke-test-k8-tls-root
+        run: |
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           minikube status
       - name: Build Test
         run: |
-          make RELEASE=release  build_test
+          make RELEASE=release build_test
       - name: Setup installation pre-requisites
         run: |
           FLV_CMD=true ./target/release/fluvio cluster install --setup --local --develop
@@ -172,10 +172,6 @@ jobs:
         run: |
           minikube profile list
           minikube status
-      - name: Install musl-tools for Linux
-        run: |
-          sudo apt install -y musl-tools
-          sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
       - name: Build
         run: |
           make RELEASE=release TARGET=x86_64-unknown-linux-musl build_test
@@ -184,11 +180,10 @@ jobs:
           FLV_CMD=true make RELEASE=true TARGET=x86_64-unknown-linux-musl  k8-setup
       - name: Make image
         run: make RELEASE=true minikube_image
-      - name: smoke test k8 tls
-        #  run: |
-        #    FLV_CMD=true  FLV_SOCKET_WAIT=600 make RELEASE=true UNINSTALL=noclean smoke-test-k8-tls-root
+      - name: Run smoke-test-k8-tls-root
         run: |
-          FLV_CMD=true FLV_SOCKET_WAIT=600 make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8
+          FLV_CMD=true FLV_SOCKET_WAIT=600 make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
+      - run: minikube delete
       - name: Save logs
         if: failure()
         run: kubectl logs flv-sc > /tmp/flv_sc.log


### PR DESCRIPTION
Use musl target for running k8 smoke test in CI.
This remove need to build 2 different targets