### PR TITLE
test CI not handling panic correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
 ]
 
 [[package]]
@@ -281,7 +281,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bc0bb03923141924d5b713a4acd7607c790f3fbc769abe63fe3f38bb268112"
+checksum = "8fb57305b07ffcc1a4d08808f1f2200647c8e3d91a4c83d2810ae20c997274e0"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "fluvio-helm"
 version = "0.1.0"
-source = "git+https://github.com/infinyon/fluvio-helm?branch=main#8c3af984f6a239747578b3ff3228ebc2829a696e"
+source = "git+https://github.com/infinyon/fluvio-helm?branch=main#6e15fd2c789c33ba8bae51a369a0983e177c2f78"
 dependencies = [
  "flv-util",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "serde",
  "serde_json",
  "tokio",
@@ -1544,7 +1544,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "waker-fn",
 ]
 
@@ -1786,7 +1786,7 @@ dependencies = [
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -2398,6 +2398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.16"
+version = "0.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
+checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
 dependencies = [
  "cc",
  "libc",
@@ -2655,14 +2661,14 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -3061,9 +3067,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443b4178719c5a851e1bde36ce12da21d74a0e60b4d982ec3385a933c812f0f6"
+checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3207,7 +3213,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio-macros",
 ]
 
@@ -3233,7 +3239,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -3254,13 +3260,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3386,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -28,7 +28,6 @@ fn main() {
     }));
 
     run_block_on(async move {
-        
         if option.setup() {
             let mut setup = Setup::new(option);
             setup.setup().await;
@@ -37,7 +36,7 @@ fn main() {
         }
 
         test_runner.run_test().await;
-        
-        assert_eq!(2,3);
+
+        assert_eq!(2, 3);
     });
 }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -36,7 +36,5 @@ fn main() {
         }
 
         test_runner.run_test().await;
-
-        assert_eq!(2, 3);
     });
 }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -21,7 +21,14 @@ fn main() {
 
     let test_runner = TestRunner::new(option.clone());
 
+    // catch panic in the spawn
+    std::panic::set_hook(Box::new(|panic_info| {
+        eprintln!("panic {}", panic_info);
+        std::process::exit(-1);
+    }));
+
     run_block_on(async move {
+        
         if option.setup() {
             let mut setup = Setup::new(option);
             setup.setup().await;
@@ -30,5 +37,7 @@ fn main() {
         }
 
         test_runner.run_test().await;
+        
+        assert_eq!(2,3);
     });
 }

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -116,6 +116,8 @@ pub async fn produce_message_with_api(offsets: Offsets, option: TestOption) {
             let message = generate_message(offset, &topic_name, &option);
             let len = message.len();
             info!("trying send: {}, iteration: {}", topic_name, i);
+            // create panic
+            assert_eq!(1, 2);
             producer
                 .send_record(message, 0)
                 .await

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -116,8 +116,6 @@ pub async fn produce_message_with_api(offsets: Offsets, option: TestOption) {
             let message = generate_message(offset, &topic_name, &option);
             let len = message.len();
             info!("trying send: {}, iteration: {}", topic_name, i);
-            // create panic
-            assert_eq!(1, 2);
             producer
                 .send_record(message, 0)
                 .await


### PR DESCRIPTION
Smoke test can hang if there is panic inside spawn.
This PR add panic handler in the main to ensure panic is handled correctly