### PR TITLE
Fix leader controller with zero reconciliation loop timer

### DIFF
--- a/src/spu/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu/src/controllers/leader_replica/leader_controller.rs
@@ -90,7 +90,7 @@ impl ReplicaLeaderController<FileReplica> {
 
         leader_debug!(self, "starting");
         self.send_status_to_sc().await;
-       
+
         loop {
             self.sync_followers().await;
             leader_debug!(self, "waiting for next command");


### PR DESCRIPTION
SPU leader controller is supposed to have reconciliation loop timer with 60 seconds but due to logic bug, is only wait for first loop leading to log exhaustion