### PR TITLE
Make CLI help menu wording consistent

### DIFF
--- a/src/cli/src/profile/mod.rs
+++ b/src/cli/src/profile/mod.rs
@@ -46,7 +46,7 @@ pub enum ProfileCmd {
     #[structopt(name = "sync")]
     Sync(SyncCmd),
 
-    /// Display entire configuration
+    /// Display the entire Fluvio configuration
     #[structopt(name = "view")]
     View(ViewOpt),
 }

--- a/src/cli/src/profile/sync/mod.rs
+++ b/src/cli/src/profile/sync/mod.rs
@@ -14,9 +14,11 @@ use crate::profile::sync::k8::K8Opt;
     template = COMMAND_TEMPLATE,
 )]
 pub enum SyncCmd {
-    #[structopt(name = "k8", about = "sync profile from kubernetes cluster")]
+    /// Sync a profile from a Kubernetes cluster
+    #[structopt(name = "k8")]
     K8(K8Opt),
-    #[structopt(name = "local", about = "sync profile from local cluster")]
+    /// Sync a profile from a local cluster
+    #[structopt(name = "local")]
     Local(LocalOpt),
 }
 

--- a/src/cli/src/root_cli.rs
+++ b/src/cli/src/root_cli.rs
@@ -144,10 +144,12 @@ impl RootCmd {
     }
 }
 
-/// All top-level subcommands that require a Fluvio client
+// For some reason this doc string is the one that gets used for the top-level help menu.
+// Please don't change it unless you want to update the top-level help menu "about".
+/// Fluvio command-line interface
 #[derive(StructOpt, Debug)]
 pub enum FluvioCmd {
-    /// Reads messages from a topic/partition
+    /// Read messages from a topic/partition
     ///
     /// By default, this activates in "follow" mode, where
     /// the command will hang and continue to wait for new
@@ -157,7 +159,7 @@ pub enum FluvioCmd {
     #[structopt(name = "consume")]
     Consume(ConsumeLogOpt),
 
-    /// Writes messages to a topic/partition
+    /// Write messages to a topic/partition
     ///
     /// By default, this reads a single line from stdin to
     /// use as the message. If you run this with no file options,

--- a/src/cluster/src/extension/group/mod.rs
+++ b/src/cluster/src/extension/group/mod.rs
@@ -30,7 +30,7 @@ pub enum SpuGroupCmd {
     )]
     Delete(DeleteManagedSpuGroupOpt),
 
-    /// List all managed SPUs
+    /// List all SPU Groups
     #[structopt(
         name = "list",
         template = COMMAND_TEMPLATE,

--- a/src/cluster/src/extension/mod.rs
+++ b/src/cluster/src/extension/mod.rs
@@ -40,15 +40,15 @@ mod opt {
         #[structopt(name = "install")]
         Install(Box<InstallOpt>),
 
-        /// Uninstall a Fluvio cluster from the local machine or Minkube
+        /// Uninstall a Fluvio cluster from the local machine or Minikube
         #[structopt(name = "uninstall")]
         Uninstall(UninstallOpt),
 
-        /// Check that all requirements for installation are met
+        /// Check that all requirements for cluster installation are met
         #[structopt(name = "check")]
         Check(CheckOpt),
 
-        /// Prints information about various Fluvio releases
+        /// Print information about various Fluvio releases
         #[structopt(name = "releases")]
         Releases(ReleasesCmd),
 

--- a/src/cluster/src/extension/releases.rs
+++ b/src/cluster/src/extension/releases.rs
@@ -4,7 +4,7 @@ use crate::extension::Result;
 
 #[derive(Debug, StructOpt)]
 pub enum ReleasesCmd {
-    /// show list of versions
+    /// Show a list of Fluvio release versions
     #[structopt(name = "list")]
     List(ListOpt),
 }

--- a/src/cluster/src/extension/spu/mod.rs
+++ b/src/cluster/src/extension/spu/mod.rs
@@ -18,14 +18,14 @@ use unregister::UnregisterCustomSpuOpt;
 
 #[derive(Debug, StructOpt)]
 pub enum SpuCmd {
-    /// Registers a new custom SPU with the cluster
+    /// Register a new custom SPU with the cluster
     #[structopt(
         name = "register",
         template = COMMAND_TEMPLATE,
     )]
     Register(RegisterCustomSpuOpt),
 
-    /// Unregisters a custom SPU from the cluster
+    /// Unregister a custom SPU from the cluster
     #[structopt(
         name = "unregister",
         template = COMMAND_TEMPLATE,

--- a/src/extension-consumer/src/topic/mod.rs
+++ b/src/extension-consumer/src/topic/mod.rs
@@ -20,28 +20,28 @@ use crate::common::output::Terminal;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "topic", about = "Topic operations")]
 pub enum TopicCmd {
-    /// Creates a Topic with the given name
+    /// Create a Topic with the given name
     #[structopt(
         name = "create",
         template = COMMAND_TEMPLATE,
     )]
     Create(CreateTopicOpt),
 
-    /// Deletes a Topic with the given name
+    /// Delete a Topic with the given name
     #[structopt(
         name = "delete",
         template = COMMAND_TEMPLATE,
     )]
     Delete(DeleteTopicOpt),
 
-    /// Prints detailed information about a Topic
+    /// Print detailed information about a Topic
     #[structopt(
         name = "describe",
         template = COMMAND_TEMPLATE,
     )]
     Describe(DescribeTopicsOpt),
 
-    /// Lists all of the Topics in the cluster
+    /// List all of the Topics in the cluster
     #[structopt(
         name = "list",
         template = COMMAND_TEMPLATE,

--- a/src/extension-runner-local/src/run/mod.rs
+++ b/src/extension-runner-local/src/run/mod.rs
@@ -24,9 +24,11 @@ impl RunnerCmd {
 
 #[derive(Debug, StructOpt)]
 pub enum RunOpt {
-    #[structopt(about = "Run SPU server")]
+    /// Run a new Streaming Controller (SC)
+    #[structopt(name = "spu")]
     SPU(SpuOpt),
-    #[structopt(about = "Run streaming controller")]
+    /// Run a new Streaming Processing Unit (SPU)
+    #[structopt(name = "sc")]
     SC(ScOpt),
 }
 


### PR DESCRIPTION
These are some small wording changes on the structopt docstrings which change the way the help menu is rendered for the CLI. I changed it so that everything is using the imperative tone, e.g. "Read" rather than "Reads". This is also how the descriptions will be written for the CLI reference on the website.