### PR TITLE
Handle nonexistent extensions dir and extension signals.

### DIFF
--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -13,15 +13,20 @@ pub(crate) fn fluvio_extensions_dir() -> Result<PathBuf, CliError> {
     if let Ok(dir) = std::env::var("FLUVIO_DIR") {
         // Assume this is like `~/.fluvio
         let path = PathBuf::from(dir).join("extensions");
-        if path.exists() {
-            return Ok(path);
+        if !path.exists() {
+            std::fs::create_dir(&path)?;
         }
+        return Ok(path);
     }
 
     let home =
         home::home_dir().ok_or_else(|| IoError::new(ErrorKind::NotFound, "Homedir not found"))?;
-    let path = home.join(".fluvio/extensions/");
+    let path = home.join(".fluvio");
     if path.exists() {
+        let path = path.join("extensions/");
+        if !path.exists() {
+            std::fs::create_dir(&path)?;
+        }
         return Ok(path);
     }
     Err(IoError::new(ErrorKind::NotFound, "Fluvio extensions directory not found").into())

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -427,5 +427,15 @@ fn process_external_subcommand(mut args: Vec<String>) -> Result<()> {
         std::process::exit(code);
     }
 
+    #[cfg(unix)]
+    {
+        // https://doc.rust-lang.org/std/os/unix/process/trait.ExitStatusExt.html
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            println!("Extension killed via {} signal", signal);
+            std::process::exit(signal);
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Closes #532 also deals with the edge case where [`code`](https://doc.rust-lang.org/std/process/struct.ExitStatus.html#method.code) doesn't return a status code because it's been killed on a unix system (my version of fluvio-package segfaulted due to a `SIGSEGV`).