### PR TITLE
Fixed help for fluvio subcommands

### DIFF
--- a/src/cli/src/bin/main.rs
+++ b/src/cli/src/bin/main.rs
@@ -8,12 +8,22 @@ fn main() -> Result<()> {
     color_eyre::config::HookBuilder::blank()
         .display_env_section(false)
         .install()?;
-    let args = std::env::args();
+    print_help_hack()?;
+    let root: Root = Root::from_args();
+    run_block_on(root.process()).map_err(CliError::into_report)?;
+    Ok(())
+}
+
+fn print_help_hack() -> Result<()> {
+    let mut args = std::env::args();
     if args.len() < 2 {
         HelpOpt {}.process()?;
-    } else {
-        let root: Root = Root::from_args();
-        run_block_on(root.process()).map_err(CliError::into_report)?;
+        std::process::exit(1);
+    } else if let Some(first_arg) = args.nth(1) {
+        if vec!["-h", "--help", "help"].contains(&&first_arg.as_str()) {
+            HelpOpt {}.process()?;
+            std::process::exit(1);
+        }
     }
     Ok(())
 }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -67,7 +67,6 @@ struct RootOpt {
     AppSettings::VersionlessSubcommands,
     AppSettings::DeriveDisplayOrder,
     AppSettings::DisableVersion,
-    AppSettings::DisableHelpFlags,
     ]
 )]
 enum RootCmd {
@@ -125,13 +124,6 @@ enum RootCmd {
     )]
     Metadata(MetadataOpt),
 
-    /// Give help message
-    #[structopt(
-        name = "help",
-        aliases = &["-h", "--help"],
-    )]
-    Help(HelpOpt),
-
     #[structopt(external_subcommand)]
     External(Vec<String>),
 }
@@ -161,9 +153,6 @@ impl RootCmd {
             }
             Self::Completions(completion) => {
                 completion.process()?;
-            }
-            Self::Help(help) => {
-                help.process()?;
             }
             Self::Metadata(metadata) => {
                 metadata.process()?;


### PR DESCRIPTION
Fixes help for subcommands and sub-options (this might not be the right word) such as `fluvio profile help`