### PR TITLE
Fix composite action when not in fluvio repo

### DIFF
--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -11,7 +11,7 @@ echo 'export PATH="$HOME/.fluvio/bin:$PATH"' >> $HOME/.bash_profile
 . $HOME/.bash_profile
 
 # Install Fluvio System Charts
-fluvio cluster start --setup --local
+fluvio cluster start --setup --local --sys
 
 # Run Fluvio Cluster Pre-Install Check
 


### PR DESCRIPTION
Yesterday in standup we discussed if there was any advantage to having the composite action in it's own repo and couldn't find a good one. This fixes fluvio cluster installer when you're not in the [root of the fluvio repo](https://github.com/infinyon/fluvio-client-node/pull/36/checks?check_run_id=1517989280).