### PR TITLE
Add cargo-make task for minikube-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 VERSION := $(shell cat VERSION)
 RUSTV=stable
-DOCKER_TAG=$(VERSION)
 GITHUB_TAG=v$(VERSION)
 GIT_COMMIT=$(shell git rev-parse HEAD)
 DOCKER_REGISTRY=infinyon
@@ -192,13 +191,11 @@ minikube_image:	fluvio_image
 
 # build docker image for fluvio using release mode
 # this will tag with current git tag
-fluvio_image: CARGO_PROFILE=$(if $(RELEASE),release,debug)
 fluvio_image: fluvio_bin_linux
 	echo "Building Fluvio musl image with version: $(VERSION)"
 	export CARGO_PROFILE=$(if $(RELEASE),release,debug); \
 	export MINIKUBE_DOCKER_ENV=$(MINIKUBE_DOCKER_ENV); \
-	export DOCKER_TAG=$(GIT_COMMIT); \
-	k8-util/docker/build.sh
+	k8-util/docker/build.sh "fluvio:$(GIT_COMMIT)" $(if $(RELEASE),release,debug)
 
 
 fluvio_bin_linux: RELEASE_FLAG=$(if $(RELEASE),--release,)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,6 @@
 extend = [
+    { path = "makefiles/Build.toml" },
+    { path = "makefiles/Docker.toml" },
     { path = "makefiles/Pi.toml" },
     { path = "makefiles/Github.toml" },
     { path = "makefiles/Helm.toml" },

--- a/k8-util/docker/build.sh
+++ b/k8-util/docker/build.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+# Params:
+# $1) the image tag to use, e.g. "fluvio:GIT_HASH"
+# $2) the build directory, "debug" or "release"
+
 if [ -n "$MINIKUBE_DOCKER_ENV" ]; then
   eval $(minikube -p minikube docker-env)
 fi
 
 tmp_dir=$(mktemp -d -t fluvio-docker-image-XXXXXX)
-cp target/x86_64-unknown-linux-musl/$CARGO_PROFILE/fluvio_runner_local_cli $tmp_dir/fluvio
+cp target/x86_64-unknown-linux-musl/$2/fluvio_runner_local_cli $tmp_dir/fluvio
 cp $(dirname $0)/fluvio.Dockerfile $tmp_dir/Dockerfile
 cd $tmp_dir
-docker build -t infinyon/fluvio:$DOCKER_TAG .
+docker build -t $1 .
 rm -rf $tmp_dir
+
+if [ -n "$MINIKUBE_DOCKER_ENV" ]; then
+  docker image tag $1 infinyon/$1
+fi

--- a/makefiles/Base.toml
+++ b/makefiles/Base.toml
@@ -1,8 +1,10 @@
 [env.development]
 CARGO_PROFILE = "dev"
+CARGO_BUILD_DIR = "debug"
 
 [env.production]
 CARGO_PROFILE = "release"
+CARGO_BUILD_DIR = "release"
 
 [tasks.set-image-tag]
 env = { IMAGE_TAG = "${CARGO_MAKE_GIT_HEAD_LAST_COMMIT_HASH}-${CARGO_PROFILE}" }

--- a/makefiles/Base.toml
+++ b/makefiles/Base.toml
@@ -7,7 +7,7 @@ CARGO_PROFILE = "release"
 CARGO_BUILD_DIR = "release"
 
 [tasks.set-image-tag]
-env = { IMAGE_TAG = "${CARGO_MAKE_GIT_HEAD_LAST_COMMIT_HASH}-${CARGO_PROFILE}" }
+env = { IMAGE_TAG = "${CARGO_MAKE_GIT_HEAD_LAST_COMMIT_HASH}" }
 
 [env]
 FLUVIO_VERSION = { script = ["cat VERSION"] }

--- a/makefiles/Build.toml
+++ b/makefiles/Build.toml
@@ -1,0 +1,24 @@
+extend = "Base.toml"
+
+[tasks.build-dev-musl]
+condition = { profiles = ["development"] }
+command = "cargo"
+args = ["build", "--target", "x86_64-unknown-linux-musl"]
+dependencies = ["set-musl-env", "rustup-add-target-musl"]
+
+[tasks.build-release-musl]
+condition = { profiles = ["production"] }
+command = "cargo"
+args = ["build", "--release", "--target", "x86_64-unknown-linux-musl"]
+dependencies = ["set-musl-env", "rustup-add-target-musl"]
+
+[tasks.rustup-add-target-musl]
+command = "rustup"
+args = ["target", "add", "x86_64-unknown-linux-musl"]
+
+[tasks.set-musl-env]
+condition = { platforms = ["mac"] }
+
+[tasks.set-musl-env.env]
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "x86_64-linux-musl-gcc"
+TARGET_CC = "x86_64-linux-musl-gcc"

--- a/makefiles/Docker.toml
+++ b/makefiles/Docker.toml
@@ -1,0 +1,14 @@
+extend = "Base.toml"
+
+[tasks.minikube-image]
+env = { MINIKUBE_DOCKER_ENV = "true" }
+run_task = "build-docker-image"
+
+[tasks.build-docker-image]
+dependencies = [
+    "build-dev-musl",
+    "build-release-musl",
+    "set-image-tag",
+]
+command = "k8-util/docker/build.sh"
+args = ["fluvio:${IMAGE_TAG}", "${CARGO_BUILD_DIR}"]


### PR DESCRIPTION
I've added some cargo-make tasks that mirror other ones that have worked well for us. I'm able to successfully build the musl images on Mac.

One thing I'm stuck on though is that `fluvio cluster start --develop` does not seem to be picking up on these new images, I'm getting `ErrImagePull` on the pods that come up. @nacardin is there anything extra that needs doing to these docker images for them to be seen?