### PR TITLE
fix regression in updates from SC to SPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,9 +827,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
 name = "echo"
@@ -1286,6 +1286,8 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88551bfb7e13fc90da5d297650fa52b1ddc17acc94b3a67fbc9b0a961b671139"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1644,10 +1646,11 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
+ "opaque-debug",
  "polyval",
 ]
 
@@ -1897,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
@@ -2257,9 +2260,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2286,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -2441,11 +2444,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fd92d8e0c06d08525d2e2643cc2b5c80c69ae8eb12c18272d501cd7079ccc0"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool 0.2.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2918,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2928,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
@@ -3073,9 +3077,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3118,18 +3122,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-rwlock",
  "event-listener",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes 0.5.6",
  "content_inspector",
@@ -1285,9 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed04dfe27097f986012b503abe86a03825e38fc3da97b6cdf4c9194aa850f07"
+version = "0.4.3"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ members = [
 #[profile.release]
 #debug = true
 
+[patch.crates-io]
+fluvio-socket = { path = '../fluvio-socket/crates/socket' }
+
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds
 [profile.dev.package.backtrace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ members = [
 #[profile.release]
 #debug = true
 
-[patch.crates-io]
-fluvio-socket = { path = '../fluvio-socket/crates/socket' }
 
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds

--- a/k8-util/minikube/reset-docker.sh
+++ b/k8-util/minikube/reset-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# restart docker if you have issue with installing helm chart on minikube running docker
+set -e
+sudo service restart docker

--- a/k8-util/minikube/reset-minikube.sh
+++ b/k8-util/minikube/reset-minikube.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# delete and re-install minikube ready for fluvio
+# this defaults to docker and assume you have have sudo access
+set -e
+ARG1=${1:-docker}
+minikube delete
+minikube start --driver $ARG1
+sudo nohup  minikube tunnel  > /tmp/tunnel.out 2> /tmp/tunnel.out &
+fluvio cluster start --sys

--- a/src/controlplane-metadata/src/partition/replica.rs
+++ b/src/controlplane-metadata/src/partition/replica.rs
@@ -45,8 +45,8 @@ where
     fn from(item: PartitionMetadata<C>) -> Self {
         let inner: MetadataStoreObject<PartitionSpec, C> = item;
         // consider either metadata ctx is deleted or status is deleted
-        let is_being_deleted = inner.status.is_being_deleted ||
-            inner.ctx().item().is_being_deleted();
+        let is_being_deleted =
+            inner.status.is_being_deleted || inner.ctx().item().is_being_deleted();
         Self {
             id: inner.key,
             leader: inner.spec.leader,

--- a/src/controlplane-metadata/src/partition/replica.rs
+++ b/src/controlplane-metadata/src/partition/replica.rs
@@ -44,7 +44,9 @@ where
 {
     fn from(item: PartitionMetadata<C>) -> Self {
         let inner: MetadataStoreObject<PartitionSpec, C> = item;
-        let is_being_deleted = inner.status.is_being_deleted;
+        // consider either metadata ctx is deleted or status is deleted
+        let is_being_deleted = inner.status.is_being_deleted ||
+            inner.ctx().item().is_being_deleted();
         Self {
             id: inner.key,
             leader: inner.spec.leader,

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -99,12 +99,18 @@ impl Debug for DefaultAsyncBuffer {
             Some(ref value) => {
                 // we assume content is text if it is not binary
                 if matches!(inspect(value), ContentType::BINARY) {
-                    write!(f,"values binary: ({} bytes)", self.len())
+                    write!(f, "values binary: ({} bytes)", self.len())
                 } else {
-                    writeln!(f,"value text: ({} bytes)", self.len())?;
-                    writeln!(f,"first 100: {}", String::from_utf8_lossy(&value[0..std::cmp::min(value.len(),MAX_STRING_DISPLAY)]))
+                    writeln!(f, "value text: ({} bytes)", self.len())?;
+                    writeln!(
+                        f,
+                        "first 100: {}",
+                        String::from_utf8_lossy(
+                            &value[0..std::cmp::min(value.len(), MAX_STRING_DISPLAY)]
+                        )
+                    )
                 }
-            },
+            }
             None => write!(f, "no values"),
         }
     }
@@ -115,10 +121,16 @@ impl Display for DefaultAsyncBuffer {
         match self.0 {
             Some(ref value) => {
                 if matches!(inspect(value), ContentType::BINARY) {
-                    write!(f,"binary: ({} bytes)", self.len())
+                    write!(f, "binary: ({} bytes)", self.len())
                 } else {
-                    writeln!(f,"text: ({} bytes)", self.len())?;
-                    writeln!(f,"first 100: {}", String::from_utf8_lossy(&value[0..std::cmp::min(value.len(),MAX_STRING_DISPLAY)]))
+                    writeln!(f, "text: ({} bytes)", self.len())?;
+                    writeln!(
+                        f,
+                        "first 100: {}",
+                        String::from_utf8_lossy(
+                            &value[0..std::cmp::min(value.len(), MAX_STRING_DISPLAY)]
+                        )
+                    )
                 }
             }
             None => write!(f, ""),

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -25,6 +25,9 @@ use crate::Offset;
 
 pub type DefaultRecord = Record<DefaultAsyncBuffer>;
 
+/// maxmimum number of records to display
+const MAX_STRING_DISPLAY: usize = 100;
+
 pub use file::*;
 
 /// slice that can works in Async Context
@@ -93,7 +96,15 @@ impl AsyncBuffer for DefaultAsyncBuffer {
 impl Debug for DefaultAsyncBuffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            Some(ref val) => write!(f, "{:?}", String::from_utf8_lossy(val)),
+            Some(ref value) => {
+                // we assume content is text if it is not binary
+                if matches!(inspect(value), ContentType::BINARY) {
+                    write!(f,"values binary: ({} bytes)", self.len())
+                } else {
+                    writeln!(f,"value text: ({} bytes)", self.len())?;
+                    writeln!(f,"first 100: {}", String::from_utf8_lossy(&value[0..std::cmp::min(value.len(),MAX_STRING_DISPLAY)]))
+                }
+            },
             None => write!(f, "no values"),
         }
     }
@@ -102,7 +113,14 @@ impl Debug for DefaultAsyncBuffer {
 impl Display for DefaultAsyncBuffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            Some(ref val) => write!(f, "{}", String::from_utf8_lossy(val)),
+            Some(ref value) => {
+                if matches!(inspect(value), ContentType::BINARY) {
+                    write!(f,"binary: ({} bytes)", self.len())
+                } else {
+                    writeln!(f,"text: ({} bytes)", self.len())?;
+                    writeln!(f,"first 100: {}", String::from_utf8_lossy(&value[0..std::cmp::min(value.len(),MAX_STRING_DISPLAY)]))
+                }
+            }
             None => write!(f, ""),
         }
     }

--- a/src/extension-consumer/src/produce/mod.rs
+++ b/src/extension-consumer/src/produce/mod.rs
@@ -174,7 +174,7 @@ mod produce {
                 print_cli_ok!()
             }
             Err(err) => {
-                print_cli_err!(format!("error processing record: {}", err));
+                print_cli_err!(format!("error processing record: {:#?}", err));
                 std::process::exit(-1);
             }
         }

--- a/src/sc/src/controllers/partitions/controller.rs
+++ b/src/sc/src/controllers/partitions/controller.rs
@@ -74,7 +74,7 @@ impl PartitionController {
             return;
         }
 
-        // we only care about delete timestamp changes which are in metadata only 
+        // we only care about delete timestamp changes which are in metadata only
         let changes = listener.sync_meta_changes().await;
         if changes.is_empty() {
             trace!("no partition metadata changes");
@@ -82,7 +82,10 @@ impl PartitionController {
         }
 
         let (updates, _) = changes.parts();
-        trace!(meta_changes=&*format!("{:#?}",updates),"metadata changes");
+        trace!(
+            meta_changes = &*format!("{:#?}", updates),
+            "metadata changes"
+        );
 
         let actions = self.reducer.process_partition_update(updates).await;
 

--- a/src/sc/src/controllers/partitions/controller.rs
+++ b/src/sc/src/controllers/partitions/controller.rs
@@ -74,14 +74,15 @@ impl PartitionController {
             return;
         }
 
-        trace!("sync partitions changes");
+        // we only care about delete timestamp changes which are in metadata only 
         let changes = listener.sync_meta_changes().await;
         if changes.is_empty() {
-            trace!("no partitions changes");
+            trace!("no partition metadata changes");
             return;
         }
 
         let (updates, _) = changes.parts();
+        trace!(meta_changes=&*format!("{:#?}",updates),"metadata changes");
 
         let actions = self.reducer.process_partition_update(updates).await;
 

--- a/src/sc/src/controllers/partitions/reducer.rs
+++ b/src/sc/src/controllers/partitions/reducer.rs
@@ -84,20 +84,21 @@ impl PartitionReducer {
         &self,
         updates: Vec<PartitionAdminMd>,
     ) -> Vec<PartitionWSAction> {
-        let mut actions = vec![];
 
-        for partition in updates.into_iter() {
-            // check if we are being deleted but our status is not set correctly
-            if partition.ctx().item().is_being_deleted() && !partition.status.is_being_deleted {
-                debug!("set partition: {} to delete", partition.key());
-                actions.push(PartitionWSAction::UpdateStatus((
-                    partition.key,
-                    partition.status.set_to_delete(),
-                )));
-            }
-        }
-
-        actions
+        // reconcile delete timestamp in the metadata with delete status
+        updates.into_iter()
+            .filter_map(|partition| {
+                if partition.ctx().item().is_being_deleted() && !partition.status.is_being_deleted {
+                    debug!("set partition: {} to delete", partition.key());
+                    Some(PartitionWSAction::UpdateStatus((
+                        partition.key,
+                        partition.status.set_to_delete(),
+                    )))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     ///

--- a/src/sc/src/controllers/partitions/reducer.rs
+++ b/src/sc/src/controllers/partitions/reducer.rs
@@ -84,9 +84,9 @@ impl PartitionReducer {
         &self,
         updates: Vec<PartitionAdminMd>,
     ) -> Vec<PartitionWSAction> {
-
         // reconcile delete timestamp in the metadata with delete status
-        updates.into_iter()
+        updates
+            .into_iter()
             .filter_map(|partition| {
                 if partition.ctx().item().is_being_deleted() && !partition.status.is_being_deleted {
                     debug!("set partition: {} to delete", partition.key());

--- a/src/sc/src/services/private_api/private_server.rs
+++ b/src/sc/src/services/private_api/private_server.rs
@@ -383,7 +383,7 @@ async fn send_replica_spec_changes(
     message.get_mut_header().set_client_id("sc");
 
     debug!(
-        "sending to spu: {}, all: {}, changes: {}",
+        "sending to spu: {}, replica updates all: {}, changes: {}",
         spu_id,
         message.request.all.len(),
         message.request.changes.len()

--- a/src/sc/src/services/private_api/private_server.rs
+++ b/src/sc/src/services/private_api/private_server.rs
@@ -262,9 +262,7 @@ async fn receive_replica_remove(ctx: &SharedContext, request: ReplicaRemovedRequ
             None
         }
     } else {
-        error!(
-            "replica doesn't exist"
-        );
+        error!("replica doesn't exist");
         None
     };
 

--- a/src/sc/src/services/public_api/watch.rs
+++ b/src/sc/src/services/public_api/watch.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 
 use tracing::{debug, trace};
 use tracing::error;
+use tracing::instrument;
 
 use futures_util::io::AsyncRead;
 use futures_util::io::AsyncWrite;
@@ -88,6 +89,13 @@ where
         spawn(controller.dispatch_loop());
     }
 
+    #[instrument(
+        skip(self),
+        fields(
+            spec = S::LABEL,
+            sink=self.response_sink.id()
+        )
+    )]
     async fn dispatch_loop(mut self) {
         use tokio::select;
 
@@ -103,7 +111,7 @@ where
             select! {
 
                 _ = self.end_event.listen() => {
-                    debug!("watch: {}, connection has been terminated, terminating",S::LABEL);
+                    debug!("connection has been terminated");
                     break;
                 },
 

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -46,7 +46,7 @@ fluvio-controlplane-metadata = { version = "0.3.0", path = "../controlplane-meta
 fluvio-spu-schema = { version = "0.2.0", path = "../spu-schema"  }
 fluvio-protocol = { version = "0.2.0" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { version = "0.4.2" }
+fluvio-socket = { version = "0.4.3" }
 fluvio-service = { version = "0.3.0" }
 flv-tls-proxy = { version = "0.3.0"}
 flv-util = { version = "0.5.0" }

--- a/src/spu/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu/src/controllers/leader_replica/leader_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tracing::debug;
+use tracing::{ debug,trace} ;
 use tracing::warn;
 use tracing::error;
 use async_channel::Receiver;
@@ -169,7 +169,7 @@ impl ReplicaLeaderController<FileReplica> {
 
     /// go thru each of follower and sync replicas
     async fn sync_followers(&self) {
-        debug!("sync followers");
+        trace!("sync followers, replica={}",self.id);
         if let Some(leader_replica) = self.leaders_state.get_replica(&self.id) {
             leader_replica
                 .sync_followers(&self.follower_sinks, self.max_bytes)

--- a/src/spu/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu/src/controllers/leader_replica/leader_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tracing::{ debug,trace} ;
+use tracing::{debug, trace};
 use tracing::warn;
 use tracing::error;
 use tracing::instrument;

--- a/src/spu/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu/src/controllers/leader_replica/leader_controller.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use tracing::{ debug,trace} ;
 use tracing::warn;
 use tracing::error;
+use tracing::instrument;
 use async_channel::Receiver;
 use futures_util::future::join3;
 use futures_util::future::join;
@@ -84,6 +85,11 @@ impl ReplicaLeaderController<FileReplica> {
         spawn(self.dispatch_loop());
     }
 
+    #[instrument(
+        skip(self),
+        fields(replica_id = %self.id),
+        name = "LeaderController",
+    )]
     async fn dispatch_loop(mut self) {
         use tokio::select;
 
@@ -104,20 +110,19 @@ impl ReplicaLeaderController<FileReplica> {
                     if let Some(command) = controller_req {
                         match command {
                             LeaderReplicaControllerCommand::EndOffsetUpdated => {
-                                leader_debug!(self,"leader replica end offset has updated, update the follower if need to be");
+                                debug!("leader replica end offset has updated, update the follower if need to be");
                                 join3(self.send_status_to_sc(),self.sync_followers(),self.update_offset_to_clients()).await;
                             },
 
                             LeaderReplicaControllerCommand::FollowerOffsetUpdate(offsets) => {
-                                leader_debug!(self,"Offset update from follower: {}", offsets);
                                 self.update_follower_offsets(offsets).await;
                             },
 
-                            LeaderReplicaControllerCommand::UpdateReplicaFromSc(replica) => {
-                                leader_debug!(self,"update replica from sc: {}",replica.id);
+                            LeaderReplicaControllerCommand::UpdateReplicaFromSc(_) => {
+                                debug!("update replica from sc");
                             },
                             LeaderReplicaControllerCommand::RemoveReplicaFromSc => {
-                                leader_debug!(self,"remove replica from sc: {}",self.id);
+                                debug!("RemoveReplica command, exiting");
                                 break;
                             }
                         }
@@ -131,7 +136,7 @@ impl ReplicaLeaderController<FileReplica> {
             }
         }
 
-        leader_debug!(self, "terminated");
+        debug!("terminated");
     }
 
     /// update the follower offsets
@@ -168,8 +173,8 @@ impl ReplicaLeaderController<FileReplica> {
     }
 
     /// go thru each of follower and sync replicas
+    #[instrument(skip(self))]
     async fn sync_followers(&self) {
-        trace!("sync followers, replica={}",self.id);
         if let Some(leader_replica) = self.leaders_state.get_replica(&self.id) {
             leader_replica
                 .sync_followers(&self.follower_sinks, self.max_bytes)
@@ -180,6 +185,7 @@ impl ReplicaLeaderController<FileReplica> {
     }
 
     /// send status back to sc
+    #[instrument(skip(self))]
     async fn send_status_to_sc(&self) {
         if let Some(leader_replica) = self.leaders_state.get_replica(&self.id) {
             leader_replica.send_status_to_sc(&self.sc_channel).await;

--- a/src/spu/src/controllers/leader_replica/leader_controller.rs
+++ b/src/spu/src/controllers/leader_replica/leader_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tracing::{debug, trace};
+use tracing::{debug};
 use tracing::warn;
 use tracing::error;
 use tracing::instrument;

--- a/src/spu/src/controllers/sc/dispatcher.rs
+++ b/src/spu/src/controllers/sc/dispatcher.rs
@@ -295,10 +295,7 @@ impl ScDispatcher<FileReplica> {
     ///
     /// Follower Update Handler sent by a peer Spu
     ///
-    #[instrument(
-        skip(self,sc_sink,req_msg),
-        name = "update_replica_request",
-    )]
+    #[instrument(skip(self, sc_sink, req_msg), name = "update_replica_request")]
     async fn handle_update_replica_request(
         &mut self,
         req_msg: RequestMessage<UpdateReplicaRequest>,
@@ -322,7 +319,7 @@ impl ScDispatcher<FileReplica> {
     ///
     /// Follower Update Handler sent by a peer Spu
     ///
-    #[instrument(skip(self,req_msg), name = "update_spu_request")]
+    #[instrument(skip(self, req_msg), name = "update_spu_request")]
     async fn handle_update_spu_request(
         &mut self,
         req_msg: RequestMessage<UpdateSpuRequest>,
@@ -352,13 +349,12 @@ impl ScDispatcher<FileReplica> {
         Ok(())
     }
 
-    #[instrument(skip(self,actions,sc_sink))]
+    #[instrument(skip(self, actions, sc_sink))]
     async fn apply_replica_actions(
         &self,
         actions: Actions<SpecChange<Replica>>,
         sc_sink: &mut FlvSink,
     ) -> Result<(), FlvSocketError> {
-        
         trace!( actions = ?actions,"replica actions");
 
         if actions.count() == 0 {
@@ -551,7 +547,6 @@ impl ScDispatcher<FileReplica> {
             false
         };
 
-        
         let confirm_request = ReplicaRemovedRequest::new(replica.id, confirm);
         debug!(
             sc_message = ?confirm_request,

--- a/src/spu/src/core/store.rs
+++ b/src/spu/src/core/store.rs
@@ -164,10 +164,9 @@ where
     }
 
     /// apply changes coming from sc which generates spec change actions
-    #[instrument(skip(self, changes), fields(spec = S::LABEL, change_count = changes.len()))]
+    #[instrument(level = "TRACE",skip(self, changes), fields(spec = S::LABEL, change_count = changes.len()))]
     pub fn apply_changes(&self, changes: Vec<Message<S>>) -> Actions<SpecChange<S>> {
         let (mut add_cnt, mut mod_cnt, mut del_cnt, mut skip_cnt) = (0, 0, 0, 0);
-        debug!("apply changes");
         // debug!(
         //     spec_label = S::LABEL,
         //     change_count = changes.len(),
@@ -204,13 +203,13 @@ where
             }
         }
 
-        debug!(
+        trace!(
             spec_label = S::LABEL,
             add_count = add_cnt,
             mod_count = mod_cnt,
             del_count = del_cnt,
             skip_count = skip_cnt,
-            "Apply spec changes",
+            "change count",
         );
 
         actions

--- a/src/storage/src/checkpoint.rs
+++ b/src/storage/src/checkpoint.rs
@@ -105,7 +105,7 @@ where
                     option: option.to_owned(),
                     file,
                     offset: initial_offset.clone(),
-                    path: checkpoint_path
+                    path: checkpoint_path,
                 };
                 checkpoint.write(initial_offset.clone()).await?;
                 Ok(checkpoint)
@@ -142,7 +142,7 @@ where
     }
 
     pub(crate) async fn write(&mut self, pos: T) -> Result<(), IoError> {
-        debug!("Update checkpoint: {} at: {}", pos,self.path.display());
+        debug!("Update checkpoint: {} at: {}", pos, self.path.display());
         self.file.seek(SeekFrom::Start(0)).await?;
         let mut contents = Vec::new();
         self.offset = pos;

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -94,13 +94,13 @@ impl MutFileRecords {
         self.item_last_offset_delta = item.get_last_offset_delta();
         let mut buffer: Vec<u8> = vec![];
         item.encode(&mut buffer, 0)?;
-       
+
         if self.f_sink.can_be_appended(buffer.len() as u64) {
-            debug!("writing {} bytes at: {}", buffer.len(),self.path.display());
+            debug!("writing {} bytes at: {}", buffer.len(), self.path.display());
             self.f_sink.write_all(&buffer).await?;
             // for now, we flush for every send
             self.f_sink.flush().await?;
-            debug!("flushed {}",self.path.display());
+            debug!("flushed {}", self.path.display());
             Ok(())
         } else {
             Err(StorageError::NoRoom(item))

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -94,11 +94,14 @@ impl MutFileRecords {
         self.item_last_offset_delta = item.get_last_offset_delta();
         let mut buffer: Vec<u8> = vec![];
         item.encode(&mut buffer, 0)?;
-        trace!("start sending finally {} bytes", buffer.len());
+       
         if self.f_sink.can_be_appended(buffer.len() as u64) {
+            debug!("writing {} bytes at: {}", buffer.len(),self.path.display());
             self.f_sink.write_all(&buffer).await?;
             // for now, we flush for every send
-            self.f_sink.flush().await.map_err(|err| err.into())
+            self.f_sink.flush().await?;
+            debug!("flushed {}",self.path.display());
+            Ok(())
         } else {
             Err(StorageError::NoRoom(item))
         }

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -33,7 +33,7 @@ static SC_RECONCILIATION_INTERVAL_SEC: Lazy<u64> = Lazy::new(|| {
     use std::env;
 
     let var_value = env::var("FLV_SC_RECONCILIATION_INTERVAL").unwrap_or_default();
-    let wait_time: u64 = var_value.parse().unwrap_or(60);
+    let wait_time: u64 = var_value.parse().unwrap_or(60*5);
     wait_time
 });
 
@@ -99,16 +99,14 @@ where
     async fn outer_loop(mut self) {
         info!("starting k8 dispatcher loop");
         loop {
-            debug!("starting inner loop");
-            self.inner_loop().await;
+            debug!("starting concilation loop");
+            self.reconcillation_loop().await;
         }
     }
 
     ///
     /// Main Event Loop
-    ///
-    #[instrument(skip(self))]
-    async fn inner_loop(&mut self) {
+    async fn reconcillation_loop(&mut self) {
         use tokio::select;
 
         info!("begin new reconcillation loop");

--- a/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -33,7 +33,7 @@ static SC_RECONCILIATION_INTERVAL_SEC: Lazy<u64> = Lazy::new(|| {
     use std::env;
 
     let var_value = env::var("FLV_SC_RECONCILIATION_INTERVAL").unwrap_or_default();
-    let wait_time: u64 = var_value.parse().unwrap_or(60*5);
+    let wait_time: u64 = var_value.parse().unwrap_or(60 * 5);
     wait_time
 });
 

--- a/src/stream-model/Cargo.toml
+++ b/src/stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2018"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/stream-model/src/store/dual_store.rs
+++ b/src/stream-model/src/store/dual_store.rs
@@ -532,7 +532,7 @@ mod listener {
 
             let current_epoch = self.event_publisher().current_change();
             if changes.epoch > current_epoch {
-                debug!(
+                trace!(
                     "latest epoch: {} > spec epoch: {}",
                     changes.epoch, current_epoch
                 );

--- a/src/stream-model/src/store/dual_store.rs
+++ b/src/stream-model/src/store/dual_store.rs
@@ -398,7 +398,6 @@ mod listener {
     use std::sync::Arc;
 
     use tracing::trace;
-    use tracing::debug;
 
     use crate::store::event::EventPublisher;
     use crate::store::{ChangeFlag, FULL_FILTER, SPEC_FILTER, STATUS_FILTER, META_FILTER};
@@ -534,7 +533,8 @@ mod listener {
             if changes.epoch > current_epoch {
                 trace!(
                     "latest epoch: {} > spec epoch: {}",
-                    changes.epoch, current_epoch
+                    changes.epoch,
+                    current_epoch
                 );
             }
             self.set_last_change(changes.epoch);

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -6,6 +6,7 @@ use std::num::ParseIntError;
 use std::fmt::Display;
 use std::fmt::Debug;
 use std::ops::Deref;
+use std::cmp::PartialEq;
 
 use tracing::error;
 
@@ -15,10 +16,22 @@ use crate::core::{Spec, MetadataItem, MetadataContext};
 
 pub type K8MetadataContext = MetadataContext<K8MetaItem>;
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone)]
 pub struct K8MetaItem {
     revision: u64,
     inner: ObjectMeta,
+}
+
+/// for sake of comparison, we only care about couple of fields in the metadata
+impl PartialEq for K8MetaItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.revision == other.revision && 
+            self.inner.uid == other.inner.uid &&
+            self.inner.labels == other.inner.labels &&
+            self.inner.owner_references == other.inner.owner_references &&
+            self.inner.annotations == other.inner.annotations &&
+            self.inner.finalizers == other.inner.finalizers
+    }
 }
 
 impl K8MetaItem {
@@ -32,9 +45,11 @@ impl K8MetaItem {
         }
     }
 
+    
     pub fn inner(&self) -> &ObjectMeta {
         &self.inner
     }
+    
 
     pub fn revision(&self) -> u64 {
         self.revision

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -25,12 +25,13 @@ pub struct K8MetaItem {
 /// for sake of comparison, we only care about couple of fields in the metadata
 impl PartialEq for K8MetaItem {
     fn eq(&self, other: &Self) -> bool {
-        self.revision == other.revision && 
-            self.inner.uid == other.inner.uid &&
-            self.inner.labels == other.inner.labels &&
-            self.inner.owner_references == other.inner.owner_references &&
-            self.inner.annotations == other.inner.annotations &&
-            self.inner.finalizers == other.inner.finalizers
+        self.inner.uid == other.inner.uid
+            && self.inner.labels == other.inner.labels
+            && self.inner.owner_references == other.inner.owner_references
+            && self.inner.annotations == other.inner.annotations
+            && self.inner.finalizers == other.inner.finalizers
+            && self.deletion_grace_period_seconds == other.inner.deletion_grace_period_seconds
+            && self.deletion_timestamp == other.deletion_timestamp
     }
 }
 
@@ -45,11 +46,9 @@ impl K8MetaItem {
         }
     }
 
-    
     pub fn inner(&self) -> &ObjectMeta {
         &self.inner
     }
-    
 
     pub fn revision(&self) -> u64 {
         self.revision

--- a/tests/produce-large.sh
+++ b/tests/produce-large.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+# generate large data size
+set -e
+fluvio topic create t1
+fluvio produce t1 -r $(ls /var/log/journal/**/*.journal)


### PR DESCRIPTION
With changes in topic delete, SC is sending out unnecessary replicate updates to SPU again.
This happens because SC's private services is listening to partition metadata changes in addition to spec changes. However, whenever status changes, metadata changes are triggered because it's revision id is changed as well.
In this PR, metadata changes are no longer trigger by changing K8's revision id.
In addition, SPU replica changes's delete status is computed from either deleted time stamp or delete status.  This insures that delete flag is only depends on metadata changes not Partition's delete status
