### PR TITLE
Fix warning for fluvio profile delete

### DIFF
--- a/src/cli/src/profile/delete_profile.rs
+++ b/src/cli/src/profile/delete_profile.rs
@@ -24,7 +24,7 @@ impl DeleteProfileOpt {
                 } else {
                     println!("profile {} deleted", &profile_name);
                     if config_file.config().current_profile_name().is_none() {
-                        println!("warning: this removed your current profile, use 'config switch-profile to select a different one");
+                        println!("warning: this removed your current profile, use 'fluvio profile switch' to select a different one");
                     } else {
                         println!("profile deleted");
                     }


### PR DESCRIPTION
This fixes the wording of a warning on the `fluvio profile delete` command when deleting the current profile.

Previously, it said

> warning: this removed your current profile, use `config switch-profile to select a different one

which was missing a `'` and also referencing an outdated command. The fixed message is

> warning: this removed your current profile, use 'fluvio profile switch' to select a different one