### PR TITLE
Fix Display impl for PackageId<MaybeVersion>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Infinyon Contributors <team@infiyon.com>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -482,15 +482,23 @@ mod tests {
             "fluvio".parse().unwrap(),
             Version::parse("1.2.3-alpha").unwrap(),
         );
-        assert_eq!("fluvio/fluvio:1.2.3-alpha", format!("{}", package_id_with_version));
-
-        let package_id_maybe_with_version: PackageId<MaybeVersion> = "fluvio/fluvio:3.4.5-beta".parse().unwrap();
-        assert_eq!("fluvio/fluvio:3.4.5-beta", format!("{}", package_id_maybe_with_version));
-
-        let package_id_maybe_without_version = PackageId::new_unversioned(
-            "fluvio".parse().unwrap(),
-            "fluvio".parse().unwrap(),
+        assert_eq!(
+            "fluvio/fluvio:1.2.3-alpha",
+            format!("{}", package_id_with_version)
         );
-        assert_eq!("fluvio/fluvio", format!("{}", package_id_maybe_without_version));
+
+        let package_id_maybe_with_version: PackageId<MaybeVersion> =
+            "fluvio/fluvio:3.4.5-beta".parse().unwrap();
+        assert_eq!(
+            "fluvio/fluvio:3.4.5-beta",
+            format!("{}", package_id_maybe_with_version)
+        );
+
+        let package_id_maybe_without_version =
+            PackageId::new_unversioned("fluvio".parse().unwrap(), "fluvio".parse().unwrap());
+        assert_eq!(
+            "fluvio/fluvio",
+            format!("{}", package_id_maybe_without_version)
+        );
     }
 }

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -352,7 +352,7 @@ impl fmt::Display for PackageId<MaybeVersion> {
             .unwrap_or_else(|| "".to_string());
         write!(
             f,
-            "{registry}{group}/{name}:{version}",
+            "{registry}{group}/{name}{version}",
             registry = registry,
             group = self.group.as_str(),
             name = self.name.as_str(),
@@ -473,5 +473,24 @@ mod tests {
 
         let parsed_package_id: PackageId<WithVersion> = package_id_string.parse().unwrap();
         assert_eq!(package_id, parsed_package_id);
+    }
+
+    #[test]
+    fn test_package_id_display() {
+        let package_id_with_version = PackageId::new_versioned(
+            "fluvio".parse().unwrap(),
+            "fluvio".parse().unwrap(),
+            Version::parse("1.2.3-alpha").unwrap(),
+        );
+        assert_eq!("fluvio/fluvio:1.2.3-alpha", format!("{}", package_id_with_version));
+
+        let package_id_maybe_with_version: PackageId<MaybeVersion> = "fluvio/fluvio:3.4.5-beta".parse().unwrap();
+        assert_eq!("fluvio/fluvio:3.4.5-beta", format!("{}", package_id_maybe_with_version));
+
+        let package_id_maybe_without_version = PackageId::new_unversioned(
+            "fluvio".parse().unwrap(),
+            "fluvio".parse().unwrap(),
+        );
+        assert_eq!("fluvio/fluvio", format!("{}", package_id_maybe_without_version));
     }
 }


### PR DESCRIPTION
This fixes an itty bitty bug that I found having to do with the `fluvio install` command.

When running something like `fluvio install fluvio/fluvio-cloud`, I get this output:

```
🎣 Fetching latest version for package: fluvio/fluvio-cloud:...
⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.0...
🔑 Downloaded and verified package file
```

This is _almost_ what we want, except there is a trailing `:` after the `fluvio/fluvio-cloud` on the first line of output

<img width="101" alt="image" src="https://user-images.githubusercontent.com/4210949/103239828-b3d62580-491c-11eb-8e2e-4d652a7e64a9.png">

This is because the `Display` impl of `PackageId<MaybeVersion>` was _just barely_ wrong. So I fixed it and added a test to make sure it prints as expected. Now we have:

```
🎣 Fetching latest version for package: fluvio/fluvio-cloud...
⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.0...
🔑 Downloaded and verified package file
```