### PR TITLE
Fluvio self update using rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "sha2",
  "static_assertions",
  "structopt",
+ "tempdir",
  "thiserror",
  "tracing",
  "tracing-futures",
@@ -3084,6 +3085,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -38,6 +38,7 @@ hex = "0.4.2"
 home = "0.5.3"
 serde_json = "1.0"
 static_assertions = "1.1.0"
+tempdir = "0.3.7"
 
 # Fluvio dependencies
 

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -122,10 +122,7 @@ fn verify_checksum<B: AsRef<[u8]>>(buffer: B, checksum: &str) -> bool {
     &*buffer_checksum == checksum
 }
 
-pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(
-    bin_path: P,
-    bytes: B,
-) -> Result<(), CliError> {
+pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Result<(), CliError> {
     use std::io::Write as _;
 
     let bin_path = bin_path.as_ref();

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -25,12 +25,6 @@ fn fluvio_base_dir() -> Result<PathBuf, CliError> {
     Err(IoError::new(ErrorKind::NotFound, "Fluvio base directory not found").into())
 }
 
-pub(crate) fn fluvio_bin_dir() -> Result<PathBuf, CliError> {
-    let base_dir = fluvio_base_dir()?;
-    let path = base_dir.join("bin");
-    Ok(path)
-}
-
 pub(crate) fn fluvio_extensions_dir() -> Result<PathBuf, CliError> {
     let base_dir = fluvio_base_dir()?;
     let path = base_dir.join("extensions");

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -123,15 +123,17 @@ fn verify_checksum<B: AsRef<[u8]>>(buffer: B, checksum: &str) -> bool {
 }
 
 pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(
-    bin_dir: P,
-    name: &str,
+    bin_path: P,
     bytes: B,
 ) -> Result<(), CliError> {
     use std::io::Write as _;
 
-    // Create bin_dir if it does not exist
-    let bin_dir = bin_dir.as_ref();
-    std::fs::create_dir_all(&bin_dir)?;
+    let bin_path = bin_path.as_ref();
+
+    // Create directories to bin_path if they do not exist
+    if let Some(parent) = bin_path.parent() {
+        std::fs::create_dir_all(&parent)?;
+    }
 
     // Write bin to temporary file
     let tmp_dir = tempdir::TempDir::new("fluvio")?;
@@ -143,8 +145,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(
     make_executable(&mut tmp_file)?;
 
     // Rename (atomic move on unix) temp file to destination
-    let install_path = bin_dir.join(name);
-    std::fs::rename(&tmp_path, &install_path)?;
+    std::fs::rename(&tmp_path, &bin_path)?;
 
     Ok(())
 }

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -80,7 +80,8 @@ impl InstallOpt {
 
         // Install the package to the ~/.fluvio/bin/ dir
         let fluvio_dir = fluvio_extensions_dir()?;
-        install_bin(&fluvio_dir, id.name.as_str(), &package_file)?;
+        let package_path = fluvio_dir.join(id.name.as_str());
+        install_bin(&package_path, &package_file)?;
 
         Ok("".to_string())
     }

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -4,9 +4,7 @@ use tracing::{debug, instrument};
 use semver::Version;
 use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 use crate::CliError;
-use crate::install::{
-    fetch_latest_version, fetch_package_file, install_bin, install_println,
-};
+use crate::install::{fetch_latest_version, fetch_package_file, install_bin, install_println};
 
 const FLUVIO_PACKAGE_ID: &str = "fluvio/fluvio";
 

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -5,7 +5,7 @@ use semver::Version;
 use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 use crate::CliError;
 use crate::install::{
-    fetch_latest_version, fetch_package_file, install_bin, fluvio_bin_dir, install_println,
+    fetch_latest_version, fetch_package_file, install_bin, install_println,
 };
 
 const FLUVIO_PACKAGE_ID: &str = "fluvio/fluvio";
@@ -47,12 +47,12 @@ async fn update_self(agent: &HttpAgent) -> Result<String, CliError> {
     let package_file = fetch_package_file(agent, &id, target).await?;
     install_println("🔑 Downloaded and verified package file");
 
-    // Install the package to the ~/.fluvio/bin/ dir
-    let fluvio_dir = fluvio_bin_dir()?;
-    install_bin(&fluvio_dir, "fluvio", &package_file)?;
+    // Install the update over the current executable
+    let fluvio_path = std::env::current_exe()?;
+    install_bin(&fluvio_path, &package_file)?;
     install_println(format!(
-        "✅ Successfully installed ~/.fluvio/bin/{}",
-        &id.name
+        "✅ Successfully updated {}",
+        &fluvio_path.display(),
     ));
 
     Ok("".to_string())


### PR DESCRIPTION
Closes #617.

The error was caused by the fact that I was directly opening the executable's current file and trying to write to it. This fix causes the updater to write the update to a new temporary file, then `rename` that file to the path of the original executable. The original executable remains available on disk for as long as the executing process needs it, but the path becomes inhabited by the newly updated executable immediately. On unix this is actually an atomic operation, so at no point is there an inconsistent state (e.g. if some process tried to execute `fluvio` while we were halfway through writing it before).

This PR is rebased on top of #603 so that I could test the musl build on a docker ubuntu image. We can either merge #603 first or merge this one to supersede it.