### PR TITLE
Fix self-update when /tmp is mounted on a different fs

### DIFF
--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -128,7 +128,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     std::fs::create_dir_all(&parent)?;
 
     // Write bin to temporary file
-    let tmp_dir = tempdir::TempDir::new_in(parent, "fluvio")?;
+    let tmp_dir = tempdir::TempDir::new_in(parent, "fluvio-tmp")?;
     let tmp_path = tmp_dir.path().join("fluvio");
     let mut tmp_file = File::create(&tmp_path)?;
     tmp_file.write_all(bytes.as_ref())?;

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -122,7 +122,8 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     let bin_path = bin_path.as_ref();
 
     // Create directories to bin_path if they do not exist
-    let parent = bin_path.parent()
+    let parent = bin_path
+        .parent()
         .ok_or_else(|| IoError::new(ErrorKind::NotFound, "parent directory not found"))?;
     std::fs::create_dir_all(&parent)?;
 

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -122,12 +122,12 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     let bin_path = bin_path.as_ref();
 
     // Create directories to bin_path if they do not exist
-    if let Some(parent) = bin_path.parent() {
-        std::fs::create_dir_all(&parent)?;
-    }
+    let parent = bin_path.parent()
+        .ok_or_else(|| IoError::new(ErrorKind::NotFound, "parent directory not found"))?;
+    std::fs::create_dir_all(&parent)?;
 
     // Write bin to temporary file
-    let tmp_dir = tempdir::TempDir::new("fluvio")?;
+    let tmp_dir = tempdir::TempDir::new_in(parent, "fluvio")?;
     let tmp_path = tmp_dir.path().join("fluvio");
     let mut tmp_file = File::create(&tmp_path)?;
     tmp_file.write_all(bytes.as_ref())?;
@@ -136,7 +136,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     make_executable(&mut tmp_file)?;
 
     // Rename (atomic move on unix) temp file to destination
-    std::fs::copy(&tmp_path, &bin_path)?;
+    std::fs::rename(&tmp_path, &bin_path)?;
 
     Ok(())
 }

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -136,7 +136,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     make_executable(&mut tmp_file)?;
 
     // Rename (atomic move on unix) temp file to destination
-    std::fs::rename(&tmp_path, &bin_path)?;
+    std::fs::copy(&tmp_path, &bin_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
`std::fs::rename` relies on the source and destination filesystems being the same. This falls apart if, say `/tmp` is mounted on a different partition. This change switches to use `std::fs::copy`, which works no matter the fs setup. Since our temp file is being created inside a `tempfile` (from tempfile crate), then the temp directory and contained files will be cleaned up no matter what.