### PR TITLE
Add 'fluvio profile rename' to rename profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/cli/src/profile/mod.rs
+++ b/src/cli/src/profile/mod.rs
@@ -10,6 +10,7 @@ use structopt::StructOpt;
 mod sync;
 mod current;
 mod switch;
+mod rename;
 mod delete_profile;
 mod delete_cluster;
 mod view;
@@ -22,6 +23,7 @@ use crate::profile::delete_profile::DeleteProfileOpt;
 use crate::profile::switch::SwitchOpt;
 use crate::profile::sync::SyncCmd;
 use crate::profile::view::ViewOpt;
+use crate::profile::rename::RenameOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Available Commands")]
@@ -37,6 +39,10 @@ pub enum ProfileCmd {
     /// Delete the named cluster
     #[structopt(name = "delete-cluster")]
     DeleteCluster(DeleteClusterOpt),
+
+    /// Rename a profile
+    #[structopt(name = "rename")]
+    Rename(RenameOpt),
 
     /// Switch to the named profile
     #[structopt(name = "switch")]
@@ -54,22 +60,25 @@ pub enum ProfileCmd {
 impl ProfileCmd {
     pub async fn process<O: Terminal>(self, out: Arc<O>) -> Result<()> {
         match self {
-            ProfileCmd::View(view) => {
+            Self::View(view) => {
                 view.process(out).await?;
             }
-            ProfileCmd::DisplayCurrent(current) => {
+            Self::DisplayCurrent(current) => {
                 current.process().await?;
             }
-            ProfileCmd::Switch(switch) => {
+            Self::Rename(rename) => {
+                rename.process()?;
+            }
+            Self::Switch(switch) => {
                 switch.process(out).await?;
             }
-            ProfileCmd::DeleteProfile(delete_profile) => {
+            Self::DeleteProfile(delete_profile) => {
                 delete_profile.process(out).await?;
             }
-            ProfileCmd::DeleteCluster(delete_cluster) => {
+            Self::DeleteCluster(delete_cluster) => {
                 delete_cluster.process().await?;
             }
-            ProfileCmd::Sync(sync) => {
+            Self::Sync(sync) => {
                 sync.process().await?;
             }
         }

--- a/src/cli/src/profile/rename.rs
+++ b/src/cli/src/profile/rename.rs
@@ -1,0 +1,28 @@
+use structopt::StructOpt;
+use fluvio::config::ConfigFile;
+
+use crate::Result;
+
+#[derive(StructOpt, Debug)]
+pub struct RenameOpt {
+    /// The name of the profile to rename
+    pub from: String,
+    /// The new name to give the profile
+    pub to: String,
+}
+
+impl RenameOpt {
+    pub fn process(self) -> Result<()> {
+        let mut config_file = match ConfigFile::load(None) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("unable to find Fluvio config file");
+                return Err(e.into());
+            }
+        };
+
+        config_file.mut_config().rename_profile(&self.from, self.to);
+        config_file.save()?;
+        Ok(())
+    }
+}

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/config/config.rs
+++ b/src/client/src/config/config.rs
@@ -216,7 +216,8 @@ impl Config {
         self.add_profile(profile, to.clone());
 
         // If the renamed profile was current, we need to update the current name
-        let update_current = self.current_profile_name()
+        let update_current = self
+            .current_profile_name()
             .map(|it| it == from)
             .unwrap_or(false);
         if update_current {

--- a/src/client/src/config/config.rs
+++ b/src/client/src/config/config.rs
@@ -205,6 +205,27 @@ impl Config {
         }
     }
 
+    pub fn rename_profile(&mut self, from: &str, to: String) -> bool {
+        // Remove the profile from its old name, or return if it didn't exist
+        let profile = match self.profile.remove(from) {
+            Some(profile) => profile,
+            None => return false,
+        };
+
+        // Re-add the profile under its new name
+        self.add_profile(profile, to.clone());
+
+        // If the renamed profile was current, we need to update the current name
+        let update_current = self.current_profile_name()
+            .map(|it| it == from)
+            .unwrap_or(false);
+        if update_current {
+            self.current_profile = Some(to);
+        }
+
+        true
+    }
+
     /// delete profile
     pub fn delete_profile(&mut self, profile_name: &str) -> bool {
         if self.profile.remove(profile_name).is_some() {
@@ -426,6 +447,19 @@ pub mod test {
 
         let cluster = config.current_cluster().expect("cluster should exist");
         assert_eq!(cluster.addr, "127.0.0.1:9003");
+    }
+
+    #[test]
+    fn test_rename_profile() {
+        let mut conf_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
+            .expect("parse failed");
+
+        let config = conf_file.mut_config();
+        assert_eq!(config.current_profile_name(), Some("local"));
+        config.rename_profile("local", "remote".to_string());
+        assert_eq!(config.current_profile_name(), Some("remote"));
+        assert!(!config.profile.contains_key("local"));
+        assert!(config.profile.contains_key("remote"));
     }
 
     /// test TOML save generation


### PR DESCRIPTION
Closes #542 

Adds a new CLI command:

```
fluvio profile rename <from> <to>
```

which renames a profile called `from` to a new profile called `to`. If the old profile name was marked as the current profile, the "current profile" name will be updated to match the renamed profile, so this command will not change any other behavior.