### PR TITLE
Fix topic names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-consumer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ctrlc",
  "eyre",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -50,7 +50,7 @@ fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.3.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.5.0", path = "../cluster", default-features = false, features = ["cli", "platform"] }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
-fluvio-extension-consumer = { version = "0.1.0", path = "../extension-consumer" }
+fluvio-extension-consumer = { version = "0.1.1", path = "../extension-consumer" }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", features = ["target"]}
 fluvio-controlplane-metadata = { version = "0.3.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
 

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-consumer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio consumer extension"

--- a/src/extension-consumer/src/topic/create.rs
+++ b/src/extension-consumer/src/topic/create.rs
@@ -121,9 +121,12 @@ impl CreateTopicOpt {
             })
         };
 
-        let is_alphanumeric = self.topic.is_ascii() && self.topic.chars().all(|c| c.is_alphanumeric());
+        let is_alphanumeric =
+            self.topic.is_ascii() && self.topic.chars().all(|c| c.is_alphanumeric());
         if !is_alphanumeric {
-            return Err(ConsumerError::InvalidArg("Topic name must be alphanumeric".to_string()));
+            return Err(ConsumerError::InvalidArg(
+                "Topic name must be alphanumeric".to_string(),
+            ));
         }
 
         // return server separately from config

--- a/src/extension-consumer/src/topic/create.rs
+++ b/src/extension-consumer/src/topic/create.rs
@@ -13,7 +13,7 @@ use structopt::StructOpt;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
-use crate::Result;
+use crate::{Result, ConsumerError};
 
 // -----------------------------------
 // CLI Options
@@ -120,6 +120,11 @@ impl CreateTopicOpt {
                 ignore_rack_assignment: self.ignore_rack_assigment,
             })
         };
+
+        let is_alphanumeric = self.topic.is_ascii() && self.topic.chars().all(|c| c.is_alphanumeric());
+        if !is_alphanumeric {
+            return Err(ConsumerError::InvalidArg("Topic name must be alphanumeric".to_string()));
+        }
 
         // return server separately from config
         Ok((self.topic, topic))


### PR DESCRIPTION
This is a quick-and-dirty fix that closes #535 by simply rejecting `fluvio topic create` for non-alphanumeric topic names.

Now, upon using a non-alphanumeric name, you receive this error:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/4210949/104013681-c7388a80-517f-11eb-8f86-91ad7987340f.png">
