### PR TITLE
Prevent 'fluvio profile view' from error with missing config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-h1",
  "color-eyre",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI"

--- a/src/cli/src/profile/view.rs
+++ b/src/cli/src/profile/view.rs
@@ -21,7 +21,7 @@ impl ViewOpt {
             Err(_) => {
                 eprintln!("Unable to find Fluvio config");
                 eprintln!("Try using 'fluvio cloud login' or 'fluvio cluster start'");
-                return Ok(())
+                return Ok(());
             }
         };
         format_config_file(out, config_file.config(), self.output.format)?;

--- a/src/cli/src/profile/view.rs
+++ b/src/cli/src/profile/view.rs
@@ -16,7 +16,14 @@ pub struct ViewOpt {
 
 impl ViewOpt {
     pub async fn process<O: Terminal>(self, out: Arc<O>) -> Result<()> {
-        let config_file = ConfigFile::load(None)?;
+        let config_file = match ConfigFile::load(None) {
+            Ok(config) => config,
+            Err(_) => {
+                eprintln!("Unable to find Fluvio config");
+                eprintln!("Try using 'fluvio cloud login' or 'fluvio cluster start'");
+                return Ok(())
+            }
+        };
         format_config_file(out, config_file.config(), self.output.format)?;
         Ok(())
     }


### PR DESCRIPTION
Closes #639 

```
❯ cargo run --bin fluvio -- profile view
    PROFILE   CLUSTER   ADDRESS          TLS
 *  minikube  minikube  10.97.5.40:9003  Disabled

❯ rm -rf ~/.fluvio
```

Then, what happened Before:

```
❯ cargo run --bin fluvio -- profile view
Error:
   0: Fluvio client error
   1: Fluvio config error
   2: No such file or directory (os error 2)
```

What happens After:

```
❯ cargo run --bin fluvio -- profile view
Unable to find Fluvio config
Try using 'fluvio cloud login' or 'fluvio cluster start'
```