### PR TITLE
Fix topic name validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,7 @@ dependencies = [
  "fluvio-types",
  "flv-util",
  "futures-lite",
+ "hostname-validator",
  "prettytable-rs",
  "serde",
  "serde_json",
@@ -1757,6 +1758,12 @@ name = "hostfile"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2733206bcc0550a15b450c64d8aa859f486d7281c4c0c36ef904b361960d658"
+
+[[package]]
+name = "hostname-validator"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b8bcb948d9f63a35f0527cde7ca4f4794e817451eaebd47a3c92ef6905c129"
 
 [[package]]
 name = "http"

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -24,7 +24,7 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 eyre = "0.6.1"
 which = "4.0.2"
-
+hostname-validator = "1.0.0"
 
 # Fluvio dependencies
 

--- a/src/extension-consumer/src/topic/create.rs
+++ b/src/extension-consumer/src/topic/create.rs
@@ -121,11 +121,10 @@ impl CreateTopicOpt {
             })
         };
 
-        let is_alphanumeric =
-            self.topic.is_ascii() && self.topic.chars().all(|c| c.is_alphanumeric());
-        if !is_alphanumeric {
+        let is_valid = hostname_validator::is_valid(&self.topic);
+        if !is_valid {
             return Err(ConsumerError::InvalidArg(
-                "Topic name must be alphanumeric".to_string(),
+                "Topic name must be a valid hostname".to_string(),
             ));
         }
 

--- a/src/extension-consumer/src/topic/create.rs
+++ b/src/extension-consumer/src/topic/create.rs
@@ -124,7 +124,7 @@ impl CreateTopicOpt {
         let is_valid = hostname_validator::is_valid(&self.topic);
         if !is_valid {
             return Err(ConsumerError::InvalidArg(
-                "Topic name must be a valid hostname".to_string(),
+                "Topic name must only contain alphanumeric characters, '-', or '.'".to_string(),
             ));
         }
 


### PR DESCRIPTION
This relaxes the constraint for creating topic names from alphanumeric-only to be valid for valid hostnames.