### PR TITLE
Implement flush on counted writes from #37

### DIFF
--- a/src/spu/src/config/spu_config.rs
+++ b/src/spu/src/config/spu_config.rs
@@ -29,6 +29,7 @@ use fluvio_types::defaults::FLV_LOG_BASE_DIR;
 use fluvio_types::defaults::FLV_LOG_SIZE;
 use fluvio_types::SpuId;
 use fluvio_storage::ConfigOption;
+use fluvio_storage::DEFAULT_FLUSH_WRITE_COUNT;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Replication {
@@ -50,6 +51,7 @@ pub struct Log {
     pub index_max_bytes: u32,
     pub index_max_interval_bytes: u32,
     pub segment_max_bytes: u32,
+    pub flush_write_count: u32,
 }
 
 impl Default for Log {
@@ -62,6 +64,7 @@ impl Default for Log {
             index_max_bytes: SPU_LOG_INDEX_MAX_BYTES,
             index_max_interval_bytes: SPU_LOG_INDEX_MAX_INTERVAL_BYTES,
             segment_max_bytes: SPU_LOG_SEGMENT_MAX_BYTES,
+            flush_write_count: DEFAULT_FLUSH_WRITE_COUNT,
         }
     }
 }
@@ -74,6 +77,7 @@ impl Log {
             self.index_max_bytes,
             self.index_max_interval_bytes,
             self.segment_max_bytes,
+            self.flush_write_count,
         )
     }
 }

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -10,6 +10,8 @@ use fluvio_types::defaults::SPU_LOG_SEGMENT_MAX_BYTES;
 
 use dataplane::Size;
 
+pub const DEFAULT_FLUSH_WRITE_COUNT: u32 = 1;
+
 // common option
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigOption {
@@ -21,6 +23,8 @@ pub struct ConfigOption {
     pub index_max_interval_bytes: Size,
     #[serde(default = "default_segment_max_bytes")]
     pub segment_max_bytes: Size,
+    #[serde(default = "default_flush_write_count")]
+    pub flush_write_count: Size,
 }
 
 impl fmt::Display for ConfigOption {
@@ -45,18 +49,24 @@ fn default_segment_max_bytes() -> Size {
     SPU_LOG_SEGMENT_MAX_BYTES
 }
 
+fn default_flush_write_count() -> Size {
+    DEFAULT_FLUSH_WRITE_COUNT
+}
+
 impl ConfigOption {
     pub fn new(
         base_dir: PathBuf,
         index_max_bytes: u32,
         index_max_interval_bytes: u32,
         segment_max_bytes: u32,
+        flush_write_count: u32,
     ) -> Self {
         ConfigOption {
             base_dir,
             index_max_bytes,
             index_max_interval_bytes,
             segment_max_bytes,
+            flush_write_count,
         }
     }
 
@@ -83,6 +93,7 @@ impl Default for ConfigOption {
             index_max_bytes: default_index_max_bytes(),
             index_max_interval_bytes: default_index_max_interval_bytes(),
             segment_max_bytes: default_segment_max_bytes(),
+            flush_write_count: default_flush_write_count(),
         }
     }
 }

--- a/src/storage/src/fixture.rs
+++ b/src/storage/src/fixture.rs
@@ -51,6 +51,7 @@ pub fn default_option(index_max_interval_bytes: Size) -> ConfigOption {
         index_max_interval_bytes,
         base_dir: temp_dir(),
         index_max_bytes: 1000,
+        ..Default::default()
     }
 }
 

--- a/src/storage/src/index.rs
+++ b/src/storage/src/index.rs
@@ -230,6 +230,7 @@ mod tests {
             base_dir: temp_dir(),
             index_max_bytes: 1000,
             index_max_interval_bytes: 0,
+            ..Default::default()
         }
     }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -17,6 +17,7 @@ mod validator;
 mod config;
 
 pub use crate::config::ConfigOption;
+pub use crate::config::DEFAULT_FLUSH_WRITE_COUNT;
 pub use crate::batch::DefaultFileBatchStream;
 pub use crate::batch_header::BatchHeaderPos;
 pub use crate::batch_header::BatchHeaderStream;

--- a/src/storage/src/range_map.rs
+++ b/src/storage/src/range_map.rs
@@ -154,6 +154,7 @@ mod tests {
             base_dir,
             index_max_bytes: 1000,
             index_max_interval_bytes: 0,
+            ..Default::default()
         }
     }
 

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -366,6 +366,7 @@ mod tests {
             base_dir,
             index_max_interval_bytes: 1000,
             index_max_bytes: 1000,
+            ..Default::default()
         }
     }
 
@@ -377,6 +378,7 @@ mod tests {
             base_dir,
             index_max_bytes: 1000,
             index_max_interval_bytes: 0,
+            ..Default::default()
         }
     }
 

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -401,6 +401,7 @@ mod tests {
             base_dir,
             index_max_interval_bytes,
             index_max_bytes: 1000,
+            ..Default::default()
         }
     }
 

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -35,6 +35,7 @@ fn default_option() -> ConfigOption {
         base_dir: temp_dir().join(TEST_REP_DIR),
         index_max_interval_bytes: 1000,
         index_max_bytes: 1000,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Implement an option of flush policy of flushing every n writes, default is still to flush every write, unit test coverage tests other cases. Issue #37 