### PR TITLE
Add 'cancel previous runs' to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  cancel_previous_runs:
+    name: Cancel Previous Runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
   # check_helm_versions:
   #   runs-on: ubuntu-latest
   #   steps:


### PR DESCRIPTION
I don't know if there is specific reason we did not have this here before, but it makes CI faster when you can cancel the previous and queued jobs when you push to a branch. To make this work, we need to add a `GITHUB_TOKEN` secret