### PR TITLE
helm: support arbitary annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,8 @@ dependencies = [
 [[package]]
 name = "fluvio-helm"
 version = "0.3.0"
-source = "git+https://github.com/sehz/fluvio-helm.git?branch=value_option#f37667bbde2b66b6d232e6b0c243e00636285a9b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939417933748f2aea4748d6f2fdf2d079f76221e38a3c65357bf3f53f5e28959"
 dependencies = [
  "flv-util",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,9 +1125,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-helm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd650605a0665ce3ca9cb26380f7a8e7cf40976cc24567039e49a9dfb3f151b2"
+version = "0.3.0"
+source = "git+https://github.com/sehz/fluvio-helm.git?branch=value_option#f37667bbde2b66b6d232e6b0c243e00636285a9b"
 dependencies = [
  "flv-util",
  "serde",
@@ -1545,24 +1544,24 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "31ebc390c6913de330e418add60e1a7e5af4cb5ec600d19111b339cafcdcc027"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "089bd0baf024d3216916546338fffe4fc8dfffdd901e33c278abb091e0d52111"
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "3868967e4e5ab86614e2176c99949eeef6cbcacaee737765f6ae693988273997"
 
 [[package]]
 name = "futures-lite"
@@ -1581,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "95778720c3ee3c179cd0d8fd5a0f9b40aa7d745c080f86a8f8bed33c4fd89758"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1593,24 +1592,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "d4e0f6be0ec0357772fd58fb751958dd600bd0b3edfd429e77793e4282831360"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "868090f28a925db6cb7462938c51d807546e298fb314088239f0e52fb4338b96"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "cad5e82786df758d407932aded1235e24d8e2eb438b6adafd37930c2462fb5d1"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -2511,9 +2510,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2561,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -3152,7 +3151,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.1",
+ "rand 0.8.2",
  "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ members = [
     "tests/runner",
 ]
 
+[patch.crates-io]
+fluvio-helm = { git = "https://github.com/sehz/fluvio-helm.git", branch = "value_option" }
+
+
 # profile to make image sizer smaller
 # comment out for now
 #[profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ members = [
     "tests/runner",
 ]
 
-[patch.crates-io]
-fluvio-helm = { git = "https://github.com/sehz/fluvio-helm.git", branch = "value_option" }
-
 
 # profile to make image sizer smaller
 # comment out for now

--- a/k8-util/helm/fluvio-app/Chart.yaml
+++ b/k8-util/helm/fluvio-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fluvio-app
 description: A Helm chart for Fluvio
 type: application
-version: 0.6.0
+version: 0.6.1

--- a/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app: fluvio-sc
 spec:
   serviceAccountName: {{ .Values.serviceAccount.name }}
+  securityContext: {{ .Values.podSecurityContext | toJson  }}
   containers:
     - name: fluvio-sc
       image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}
@@ -21,6 +22,7 @@ spec:
         - name: RUST_LOG
           value: {{ .Values.scLog }}
       command: ["/fluvio", "run", "sc"]
+      securityContext: {{ .Values.securityContext | toJson  }}
   {{ if .Values.tls }}
       args:
         - --tls

--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fluvio-sc-public
-  {{ if eq .Values.cloud.name "aws" }}
-  annotations:  {{ .Values.cloud.aws.serviceAnnotations | toJson | quote }}
+  {{ if eq .Values.cloud "aws" }}
+  annotations:  {{ .Values.aws.serviceAnnotations | toJson | quote }}
   {{ end }}
 spec:
   type: LoadBalancer

--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fluvio-sc-public
-  {{ if eq .Values.cloud "aws" }}
-  annotations:  {{ .Values.aws.serviceAnnotations | toJson | quote }}
-  {{ end }}
+  annotations:  {{ .Values.loadBalancer.serviceAnnotations | toJson  }}
 spec:
   type: LoadBalancer
   selector:

--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -2,13 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fluvio-sc-public
-  annotations:
-    {{ if eq .Values.cloud "aws" }}
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    {{ end }}
+  {{ if eq .Values.cloud.name "aws" }}
+  annotations:  {{ .Values.cloud.aws.serviceAnnotations | toJson | quote }}
+  {{ end }}
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
   selector:
     app: fluvio-sc
   ports:

--- a/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
+++ b/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
@@ -5,9 +5,6 @@ metadata:
 data:
   image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}
   resources: {{ .Values.spuResources | toJson | quote }}
-  {{ if eq .Values.cloud "aws" }}
-  lbServiceAnnotations: |+
-    {
-      "service.beta.kubernetes.io/aws-load-balancer-type": "nlb" 
-    }
-  {{ end }}
+  {{ if eq .Values.cloud.name "aws" }}
+  lbServiceAnnotations: {{ .Values.cloud.aws.serviceAnnotations | toJson | quote }}
+ {{ end }}

--- a/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
+++ b/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
@@ -5,6 +5,6 @@ metadata:
 data:
   image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}
   resources: {{ .Values.spuResources | toJson | quote }}
-  {{ if eq .Values.cloud.name "aws" }}
-  lbServiceAnnotations: {{ .Values.cloud.aws.serviceAnnotations | toJson | quote }}
- {{ end }}
+  {{ if eq .Values.cloud "aws" }}
+  lbServiceAnnotations: {{ .Values.aws.serviceAnnotations | toJson | quote }}
+  {{ end }}

--- a/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
+++ b/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
@@ -5,6 +5,4 @@ metadata:
 data:
   image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}
   resources: {{ .Values.spuResources | toJson | quote }}
-  {{ if eq .Values.cloud "aws" }}
-  lbServiceAnnotations: {{ .Values.aws.serviceAnnotations | toJson | quote }}
-  {{ end }}
+  lbServiceAnnotations: {{ .Values.loadBalancer.serviceAnnotations | toJson | quote }}

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -2,11 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-cloud:
-  name: minikube
-  aws:
-    serviceAnnotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+cloud: minikube
+aws:
+  serviceAnnotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
 scLog: info
 tls: false
 imagePullSecrets: []

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -3,9 +3,8 @@
 # Declare variables to be passed into your templates.
 
 cloud: minikube
-aws:
-  serviceAnnotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+loadBalancer:
+  serviceAnnotations: {}
 scLog: info
 tls: false
 imagePullSecrets: []

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -2,7 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-cloud: minikube
+cloud:
+  name: minikube
+  aws:
+    serviceAnnotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
 scLog: info
 tls: false
 imagePullSecrets: []

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -48,7 +48,7 @@ k8-config = { version = "1.3.0" }
 k8-client = { version = "4.0.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.3.0", path = "../client", default-features = false }
-fluvio-cluster = { version = "0.5.0", path = "../cluster", default-features = false, features = ["cli", "platform"] }
+fluvio-cluster = { version = "0.6.0", path = "../cluster", default-features = false, features = ["cli", "platform"] }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 fluvio-extension-consumer = { version = "0.1.2", path = "../extension-consumer" }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", features = ["target"]}

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cluster"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = "1.5"
 
 # Fluvio dependencies
 fluvio = { version = "0.3.0", path = "../client", default-features = false }
-fluvio-helm = "0.2.1"
+fluvio-helm = "0.3.0"
 fluvio-future = { version = "0.1.13" }
 fluvio-runner-local = { version = "0.2.0", path = "../extension-runner-local", optional = true }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", optional = true }

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -21,7 +21,8 @@ pub async fn install_core(opt: StartOpt) -> Result<(), ClusterCliError> {
         .with_group_name(opt.k8_config.group_name)
         .with_spu_replicas(opt.spu)
         .with_save_profile(!opt.skip_profile_creation)
-        .with_tls(client, server);
+        .with_tls(client, server)
+        .with_chart_values(opt.k8_config.chart_values);
 
     match opt.k8_config.image_version {
         // If an image tag is given, use it

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -1,4 +1,6 @@
 use std::{fmt, str::FromStr};
+use std::path::PathBuf;
+
 use structopt::StructOpt;
 
 mod local;
@@ -97,6 +99,10 @@ pub struct K8Install {
     /// k8
     #[structopt(long, default_value = "minikube")]
     pub cloud: String,
+
+    /// chart values
+    #[structopt(long,parse(from_os_str))]
+    pub chart_values: Vec<PathBuf>
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -101,8 +101,8 @@ pub struct K8Install {
     pub cloud: String,
 
     /// chart values
-    #[structopt(long,parse(from_os_str))]
-    pub chart_values: Vec<PathBuf>
+    #[structopt(long, parse(from_os_str))]
+    pub chart_values: Vec<PathBuf>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -921,11 +921,11 @@ impl ClusterInstaller {
                 self.helm_client.install(
                     InstallArg::new(
                         DEFAULT_CHART_SYS_REPO.to_owned(),
-                        DEFAULT_CHART_SYS_NAME.to_owned()
+                        DEFAULT_CHART_SYS_NAME.to_owned(),
                     )
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
-                    .develop()
+                    .develop(),
                 )?;
             }
             ChartLocation::Local(chart_home) => {
@@ -936,7 +936,7 @@ impl ClusterInstaller {
                     "Using local helm chart:"
                 );
                 self.helm_client.install(
-                    InstallArg::new(chart_string.to_string(),DEFAULT_CHART_SYS_NAME.to_owned())
+                    InstallArg::new(chart_string.to_string(), DEFAULT_CHART_SYS_NAME.to_owned())
                         .namespace(self.config.namespace.to_owned())
                         .develop()
                         .opts(install_settings),

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -99,7 +99,8 @@ pub struct ClusterInstallerBuilder {
     use_cluster_ip: bool,
     /// if set, disable spu liveness checking
     skip_spu_liveness_check: bool,
-    
+    /// chart values
+    chart_values: Vec<PathBuf>
 }
 
 impl ClusterInstallerBuilder {
@@ -555,6 +556,12 @@ impl ClusterInstallerBuilder {
         self.skip_spu_liveness_check = skip_checks;
         self
     }
+
+    /// set list of chart value path
+    pub fn with_chart_values(mut self, values: Vec<PathBuf>) -> Self {
+        self.chart_values = values;
+        self
+    }
 }
 
 /// Compute resource requirements for fluvio server components
@@ -726,6 +733,7 @@ impl ClusterInstaller {
             skip_checks: false,
             use_cluster_ip: false,
             skip_spu_liveness_check: false,
+            chart_values: vec![]
         }
     }
 
@@ -1064,6 +1072,7 @@ impl ClusterInstaller {
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
                     .develop()
+                    .values(self.config.chart_values.clone())
                     .version(self.config.chart_version.to_owned()),
                 )?;
             }
@@ -1083,6 +1092,7 @@ impl ClusterInstaller {
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
                     .develop()
+                    .values(self.config.chart_values.clone())
                     .version(self.config.chart_version.to_owned()),
                 )?;
             }

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -920,11 +920,12 @@ impl ClusterInstaller {
                 self.helm_client.repo_update()?;
                 self.helm_client.install(
                     InstallArg::new(
-                        DEFAULT_CHART_SYS_NAME.to_owned(),
                         DEFAULT_CHART_SYS_REPO.to_owned(),
+                        DEFAULT_CHART_SYS_NAME.to_owned()
                     )
                     .namespace(self.config.namespace.to_owned())
-                    .opts(install_settings),
+                    .opts(install_settings)
+                    .develop()
                 )?;
             }
             ChartLocation::Local(chart_home) => {
@@ -935,8 +936,9 @@ impl ClusterInstaller {
                     "Using local helm chart:"
                 );
                 self.helm_client.install(
-                    InstallArg::new(DEFAULT_CHART_SYS_NAME.to_owned(), chart_string.to_string())
+                    InstallArg::new(chart_string.to_string(),DEFAULT_CHART_SYS_NAME.to_owned())
                         .namespace(self.config.namespace.to_owned())
+                        .develop()
                         .opts(install_settings),
                 )?;
             }

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -100,7 +100,7 @@ pub struct ClusterInstallerBuilder {
     /// if set, disable spu liveness checking
     skip_spu_liveness_check: bool,
     /// chart values
-    chart_values: Vec<PathBuf>
+    chart_values: Vec<PathBuf>,
 }
 
 impl ClusterInstallerBuilder {
@@ -733,7 +733,7 @@ impl ClusterInstaller {
             skip_checks: false,
             use_cluster_ip: false,
             skip_spu_liveness_check: false,
-            chart_values: vec![]
+            chart_values: vec![],
         }
     }
 
@@ -1067,7 +1067,7 @@ impl ClusterInstaller {
                 self.helm_client.install(
                     InstallArg::new(
                         DEFAULT_CHART_APP_REPO.to_owned(),
-                        self.config.chart_name.to_owned()
+                        self.config.chart_name.to_owned(),
                     )
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
@@ -1087,7 +1087,7 @@ impl ClusterInstaller {
                 self.helm_client.install(
                     InstallArg::new(
                         DEFAULT_CHART_APP_REPO.to_owned(),
-                        chart_string.to_owned().to_string()
+                        chart_string.to_owned().to_string(),
                     )
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -935,8 +935,9 @@ impl ClusterInstaller {
                     chart_location = chart_string.as_ref(),
                     "Using local helm chart:"
                 );
+                println!("installing");
                 self.helm_client.install(
-                    InstallArg::new(chart_string.to_string(), DEFAULT_CHART_SYS_NAME.to_owned())
+                    InstallArg::new(DEFAULT_CHART_SYS_REPO.to_owned(), chart_string.to_string())
                         .namespace(self.config.namespace.to_owned())
                         .develop()
                         .opts(install_settings),

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -99,6 +99,7 @@ pub struct ClusterInstallerBuilder {
     use_cluster_ip: bool,
     /// if set, disable spu liveness checking
     skip_spu_liveness_check: bool,
+    
 }
 
 impl ClusterInstallerBuilder {
@@ -1057,11 +1058,12 @@ impl ClusterInstaller {
                 );
                 self.helm_client.install(
                     InstallArg::new(
-                        self.config.chart_name.to_owned(),
                         DEFAULT_CHART_APP_REPO.to_owned(),
+                        self.config.chart_name.to_owned()
                     )
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
+                    .develop()
                     .version(self.config.chart_version.to_owned()),
                 )?;
             }
@@ -1075,11 +1077,12 @@ impl ClusterInstaller {
                 );
                 self.helm_client.install(
                     InstallArg::new(
-                        chart_string.to_owned().to_string(),
                         DEFAULT_CHART_APP_REPO.to_owned(),
+                        chart_string.to_owned().to_string()
                     )
                     .namespace(self.config.namespace.to_owned())
                     .opts(install_settings)
+                    .develop()
                     .version(self.config.chart_version.to_owned()),
                 )?;
             }


### PR DESCRIPTION
* allow arbitrary helm values to when starting cluster.
* add `--chart-values` option to CLI
* add `annotations`,`securityContext`,`podSecurityContext` to helm chart values