### PR TITLE
Github actions for crates publishing

### DIFF
--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -1,0 +1,20 @@
+name: Publish Crates
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [stable]
+
+jobs:
+  publish_crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
I'm I read https://github.com/katyo/publish-crates correctly, I think this can actually work on every push of master without error and will work on all the projects in the workspace?

@sehz can you add a `CARGO_REGISTRY_TOKEN` to the settings with a token from crates.io?