### PR TITLE
Implement flush policy to flush on a delay time after writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,8 @@ dependencies = [
 name = "fluvio-storage"
 version = "0.2.1"
 dependencies = [
+ "async-channel",
+ "async-mutex",
  "async-trait",
  "bytes 0.5.6",
  "fluvio-dataplane-protocol",

--- a/src/spu/src/config/spu_config.rs
+++ b/src/spu/src/config/spu_config.rs
@@ -30,6 +30,7 @@ use fluvio_types::defaults::FLV_LOG_SIZE;
 use fluvio_types::SpuId;
 use fluvio_storage::ConfigOption;
 use fluvio_storage::DEFAULT_FLUSH_WRITE_COUNT;
+use fluvio_storage::DEFAULT_FLUSH_IDLE_MSEC;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Replication {
@@ -52,6 +53,7 @@ pub struct Log {
     pub index_max_interval_bytes: u32,
     pub segment_max_bytes: u32,
     pub flush_write_count: u32,
+    pub flush_idle_msec: u32,
 }
 
 impl Default for Log {
@@ -65,6 +67,7 @@ impl Default for Log {
             index_max_interval_bytes: SPU_LOG_INDEX_MAX_INTERVAL_BYTES,
             segment_max_bytes: SPU_LOG_SEGMENT_MAX_BYTES,
             flush_write_count: DEFAULT_FLUSH_WRITE_COUNT,
+            flush_idle_msec: DEFAULT_FLUSH_IDLE_MSEC,
         }
     }
 }
@@ -78,6 +81,7 @@ impl Log {
             self.index_max_interval_bytes,
             self.segment_max_bytes,
             self.flush_write_count,
+            self.flush_idle_msec,
         )
     }
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -22,6 +22,7 @@ libc = "0.2.58"
 bytes = "0.5.3"
 futures-lite = "1.7.0"
 pin-utils = "0.1.0-alpha.4"
+async-channel = "1.5.1"
 async-trait = "0.1.18"
 structopt = { version = "0.3.5", optional = true }
 serde = { version = "1.0.103", features = ['derive'] }
@@ -31,6 +32,7 @@ fluvio-types = { version = "0.2.0" , path = "../types" }
 fluvio-future = { version = "0.1.8", features = ["fs","mmap"] }
 fluvio-protocol = { version = "0.2.1" }
 dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+async-mutex = "1.4.0"
 
 
 [dev-dependencies]

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -11,6 +11,7 @@ use fluvio_types::defaults::SPU_LOG_SEGMENT_MAX_BYTES;
 use dataplane::Size;
 
 pub const DEFAULT_FLUSH_WRITE_COUNT: u32 = 1;
+pub const DEFAULT_FLUSH_IDLE_MSEC: u32 = 0;
 
 // common option
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -25,6 +26,8 @@ pub struct ConfigOption {
     pub segment_max_bytes: Size,
     #[serde(default = "default_flush_write_count")]
     pub flush_write_count: Size,
+    #[serde(default = "default_flush_idle_msec")]
+    pub flush_idle_msec: Size,
 }
 
 impl fmt::Display for ConfigOption {
@@ -53,6 +56,10 @@ fn default_flush_write_count() -> Size {
     DEFAULT_FLUSH_WRITE_COUNT
 }
 
+fn default_flush_idle_msec() -> Size {
+    DEFAULT_FLUSH_IDLE_MSEC
+}
+
 impl ConfigOption {
     pub fn new(
         base_dir: PathBuf,
@@ -60,6 +67,7 @@ impl ConfigOption {
         index_max_interval_bytes: u32,
         segment_max_bytes: u32,
         flush_write_count: u32,
+        flush_idle_msec: u32,
     ) -> Self {
         ConfigOption {
             base_dir,
@@ -67,6 +75,7 @@ impl ConfigOption {
             index_max_interval_bytes,
             segment_max_bytes,
             flush_write_count,
+            flush_idle_msec,
         }
     }
 
@@ -94,6 +103,7 @@ impl Default for ConfigOption {
             index_max_interval_bytes: default_index_max_interval_bytes(),
             segment_max_bytes: default_segment_max_bytes(),
             flush_write_count: default_flush_write_count(),
+            flush_idle_msec: default_flush_idle_msec(),
         }
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -18,6 +18,7 @@ mod config;
 
 pub use crate::config::ConfigOption;
 pub use crate::config::DEFAULT_FLUSH_WRITE_COUNT;
+pub use crate::config::DEFAULT_FLUSH_IDLE_MSEC;
 pub use crate::batch::DefaultFileBatchStream;
 pub use crate::batch_header::BatchHeaderPos;
 pub use crate::batch_header::BatchHeaderStream;

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -1,12 +1,20 @@
 use std::io::Error as IoError;
 use std::path::PathBuf;
 use std::path::Path;
+use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use async_mutex::Mutex;
 
 use tracing::debug;
+use tracing::warn;
 use tracing::trace;
-use futures_lite::io::AsyncWriteExt;
 
-use fluvio_future::fs::File;
+use futures_lite::io::AsyncWriteExt;
+use async_channel::Sender;
+
+use fluvio_future::timer;
+// use fluvio_future::fs::File;
 use fluvio_future::file_slice::AsyncFileSlice;
 use fluvio_future::fs::BoundedFileSink;
 use fluvio_future::fs::BoundedFileOption;
@@ -24,32 +32,40 @@ use crate::records::FileRecords;
 
 pub const MESSAGE_LOG_EXTENSION: &str = "log";
 
-/// MutFileRecordsFlushPolicy describes and implements a flush policy
-pub enum MutFileRecordsFlushPolicy {
-    NoFlush,
-    EveryWrite,
-    CountWrites { n_writes: u32, write_tracking: u32 },
-}
+// Delay flush scheduling interrival time constant
+//   not something that a user should change
+// this is a delay put in because the scheduler switch
+// to the flush task is fast enough that it might beat
+// out waiting writes which should be preferred
+const DELAY_FLUSH_SIA_MSEC: u64 = 3;
 
 /// Can append new batch to file
 pub struct MutFileRecords {
     base_offset: Offset,
     item_last_offset_delta: Size,
-    f_sink: BoundedFileSink,
-    flush_policy: MutFileRecordsFlushPolicy,
+    f_sink: Arc<Mutex<BoundedFileSink>>,
+    f_slice_root: AsyncFileSlice,
+    cached_len: u64,
+    flush_policy: FlushPolicy,
     write_count: u64,
+    flush_count: Arc<AtomicU32>,
     path: PathBuf,
+    flush_time_tx: Option<Sender<Instant>>,
 }
 
 impl Unpin for MutFileRecords {}
 
-fn get_flush_policy_from_config(option: &ConfigOption) -> MutFileRecordsFlushPolicy {
-    if option.flush_write_count == 0 {
-        MutFileRecordsFlushPolicy::NoFlush
+fn get_flush_policy_from_config(option: &ConfigOption) -> FlushPolicy {
+    if option.flush_idle_msec > 0 {
+        FlushPolicy::IdleFlush {
+            delay_millis: option.flush_idle_msec,
+        }
+    } else if option.flush_write_count == 0 {
+        FlushPolicy::NoFlush
     } else if option.flush_write_count == 1 {
-        MutFileRecordsFlushPolicy::EveryWrite
+        FlushPolicy::EveryWrite
     } else {
-        MutFileRecordsFlushPolicy::CountWrites {
+        FlushPolicy::CountWrites {
             n_writes: option.flush_write_count,
             write_tracking: 0,
         }
@@ -67,13 +83,18 @@ impl MutFileRecords {
         let log_path = generate_file_name(&option.base_dir, base_offset, MESSAGE_LOG_EXTENSION);
         debug!("creating log at: {}", log_path.display());
         let f_sink = BoundedFileSink::open_append(&log_path, sink_option).await?;
+        let f_slice_root = f_sink.slice_from(0, 0)?;
         Ok(MutFileRecords {
             base_offset,
-            f_sink,
+            f_sink: Arc::new(Mutex::new(f_sink)),
+            f_slice_root,
+            cached_len: 0,
             flush_policy: get_flush_policy_from_config(option),
             write_count: 0,
+            flush_count: Arc::new(AtomicU32::new(0)),
             item_last_offset_delta: 0,
             path: log_path.to_owned(),
+            flush_time_tx: None,
         })
     }
 
@@ -87,15 +108,20 @@ impl MutFileRecords {
         let sink_option = BoundedFileOption {
             max_len: Some(option.segment_max_bytes as u64),
         };
-
         let f_sink = BoundedFileSink::open_append(&log_path, sink_option).await?;
+        let f_slice_root = f_sink.slice_from(0, 0)?;
+        let cached_len = f_sink.get_current_len();
         Ok(MutFileRecords {
             base_offset,
-            f_sink,
+            f_sink: Arc::new(Mutex::new(f_sink)),
+            f_slice_root,
+            cached_len,
             flush_policy: get_flush_policy_from_config(option),
             write_count: 0,
+            flush_count: Arc::new(AtomicU32::new(0)),
             item_last_offset_delta: 0,
             path: log_path.to_owned(),
+            flush_time_tx: None,
         })
     }
 
@@ -104,11 +130,18 @@ impl MutFileRecords {
     }
 
     pub async fn validate(&mut self) -> Result<Offset, LogValidationError> {
-        validate(self.f_sink.get_path()).await
+        let f_sink = self.f_sink.lock().await;
+        validate(f_sink.get_path()).await
     }
 
     pub fn get_pos(&self) -> Size {
-        self.f_sink.get_current_len() as Size
+        if self.cached_len > u32::MAX.into() {
+            warn!(
+                "mutRecord position truncation {} -> {}",
+                self.cached_len, self.cached_len as Size
+            );
+        }
+        self.cached_len as Size
     }
 
     pub fn get_item_last_offset_delta(&self) -> Size {
@@ -120,14 +153,30 @@ impl MutFileRecords {
         self.item_last_offset_delta = item.get_last_offset_delta();
         let mut buffer: Vec<u8> = vec![];
         item.encode(&mut buffer, 0)?;
+        let mf_sink = self.f_sink.clone();
+        let mut f_sink = mf_sink.lock().await;
 
-        if self.f_sink.can_be_appended(buffer.len() as u64) {
+        if f_sink.can_be_appended(buffer.len() as u64) {
             debug!("writing {} bytes at: {}", buffer.len(), self.path.display());
-            self.f_sink.write_all(&buffer).await?;
+
+            f_sink.write_all(&buffer).await?;
+            self.cached_len = f_sink.get_current_len();
+            drop(f_sink); // unlock because flush may reaqire the lock
             self.write_count = self.write_count.saturating_add(1);
-            if self.flush_policy.should_flush() {
-                self.f_sink.flush().await?;
+            match self.flush_policy.should_flush() {
+                FlushAction::NoFlush => {}
+
+                FlushAction::Now => {
+                    debug!("  flushing {:?}", self.flush_policy);
+                    self.flush().await?;
+                }
+
+                FlushAction::Delay(delay_millis) => {
+                    debug!("  delay flush start {:?}", self.flush_policy);
+                    self.delay_flush(delay_millis).await?;
+                }
             }
+
             Ok(())
         } else {
             Err(StorageError::NoRoom(item))
@@ -136,7 +185,92 @@ impl MutFileRecords {
 
     #[allow(unused)]
     pub async fn flush(&mut self) -> Result<(), IoError> {
-        self.f_sink.flush().await
+        self.flush_count.fetch_add(1, Ordering::Relaxed);
+        let mut f_sink = self.f_sink.lock().await;
+        debug!("flush: count {:?}", self.flush_count);
+        f_sink.flush().await
+    }
+
+    #[allow(unused)]
+    pub fn flush_count(&self) -> u32 {
+        self.flush_count.load(Ordering::Relaxed)
+    }
+
+    async fn delay_flush(&mut self, delay_millis: u32) -> Result<(), IoError> {
+        let delay_tgt = delay_millis as u64;
+        let mf_sink = self.f_sink.clone();
+
+        if self.flush_time_tx.is_none() {
+            // no task running so start one
+            let (tx, rx) = async_channel::bounded(100);
+            self.flush_time_tx = Some(tx);
+            let delay_tgt = Duration::from_millis(delay_tgt);
+            let flush_count = self.flush_count.clone();
+
+            fluvio_future::task::spawn(async move {
+                let mut delay_dur = delay_tgt;
+                let mut write_time = Instant::now();
+
+                // when the mut_record struct is dropped self.flush_time_tx
+                // will also be closed and dropped, causing this while loop
+                // to end then exit the task
+                while !rx.is_closed() {
+                    if let Ok(wt) = rx.recv().await {
+                        // always grab inital write time, but also
+                        // guarantee a wait on a write time for flush
+                        // for wait times after the first delay runs
+                        write_time = wt;
+                    }
+                    //  A short fixed wait was added here to give a little
+                    //  breathing space to accumulate clusters of writes which
+                    //  arrive closely but not fast enough for this task loop
+                    //  between the first and following check for write times
+                    //  It prevents extra flushes and the time is still accounted for
+                    //  in the delay_dur calculation.
+                    timer::after(Duration::from_millis(DELAY_FLUSH_SIA_MSEC)).await;
+
+                    // Clear out any accumulated write times but don't wait
+                    // Update to latest accumulated write time
+
+                    // could use a mutex for last write time instead?
+                    // could bundle write time with f_sink inside a stuct
+                    // held by the existing mutex, but that's more invasive
+                    while let Ok(wt) = rx.try_recv() {
+                        write_time = wt;
+                        debug!("update write time for delayed flush {:?}", write_time);
+                    }
+                    if write_time.elapsed() < delay_tgt {
+                        // calculate remaining delay time
+                        delay_dur = delay_tgt - write_time.elapsed();
+                    }
+                    debug!(
+                        "flush delay wait start delay:tgt {:?}:{:?}",
+                        delay_dur, delay_tgt
+                    );
+                    timer::after(delay_dur).await;
+
+                    debug!("delay flush: get lock");
+                    let mut f_sink = mf_sink.lock().await;
+                    if let Err(e) = f_sink.flush().await {
+                        warn!("flush error {}", e);
+                    } else {
+                        let fc = flush_count.fetch_add(1, Ordering::Relaxed);
+                        debug!(" - flushed: delay task flush cnt: {}", fc);
+                    }
+                }
+                debug!("delay_flush task exited");
+            });
+        }
+
+        // update running flush
+        if let Some(flush_tx) = &self.flush_time_tx {
+            if let Err(serr) = flush_tx.send(Instant::now()).await {
+                use std::io::{Error, ErrorKind};
+                warn!("Flush send error {}", serr);
+                return Err(Error::new(ErrorKind::Other, "flush send error"));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -145,34 +279,65 @@ impl FileRecords for MutFileRecords {
         self.base_offset
     }
 
-    fn get_file(&self) -> &File {
-        &self.f_sink.inner()
-    }
+    // the get_file method was never called, leaving it in makes
+    // the ownership management of the f_sink impossible to place in a mutex
+    // to manage access from send() writers and a async timed delay flush
+    // not sure how to resolve this
+
+    // fn get_file(&self) -> &File {
+    //
+    //     // &self.f_sink.inner()
+    //
+    //     block_on(async {
+    //         let am = self.f_sink.clone();
+    //         let f_sink = am.lock().await;
+    //         &f_sink.inner().clone()
+    //     })
+    // }
 
     fn get_path(&self) -> &Path {
         &self.path
     }
 
     fn as_file_slice(&self, start: Size) -> Result<AsyncFileSlice, IoError> {
-        self.f_sink
-            .slice_from(start as u64, self.f_sink.get_current_len() - start as u64)
+        let reslice = AsyncFileSlice::new(
+            self.f_slice_root.fd(),
+            start as u64,
+            self.cached_len - start as u64,
+        );
+        Ok(reslice)
     }
 
     fn as_file_slice_from_to(&self, start: Size, len: Size) -> Result<AsyncFileSlice, IoError> {
-        self.f_sink.slice_from(start as u64, len as u64)
+        let reslice = AsyncFileSlice::new(self.f_slice_root.fd(), start as u64, len as u64);
+        Ok(reslice)
     }
 }
 
-impl MutFileRecordsFlushPolicy {
-    /// Evaluates the flush policy and returns true
-    /// if the policy determines the need to flush
-    fn should_flush(&mut self) -> bool {
-        use MutFileRecordsFlushPolicy::*;
+/// MutFileRecordsFlushPolicy describes and implements a flush policy
+#[derive(Debug)]
+pub enum FlushPolicy {
+    NoFlush,
+    EveryWrite,
+    CountWrites { n_writes: u32, write_tracking: u32 },
+    IdleFlush { delay_millis: u32 },
+}
 
+enum FlushAction {
+    NoFlush,
+    Now,
+    Delay(u32),
+}
+
+impl FlushPolicy {
+    /// Evaluates the flush policy and returns a flush action
+    // to take
+    fn should_flush(&mut self) -> FlushAction {
+        use FlushPolicy::{NoFlush, EveryWrite, CountWrites, IdleFlush};
         match self {
-            NoFlush => false,
+            NoFlush => FlushAction::NoFlush,
 
-            EveryWrite => true,
+            EveryWrite => FlushAction::Now,
 
             CountWrites {
                 n_writes: n_max,
@@ -181,10 +346,12 @@ impl MutFileRecordsFlushPolicy {
                 *wcount += 1;
                 if *wcount >= *n_max {
                     *wcount = 0;
-                    return true;
+                    return FlushAction::Now;
                 }
-                false
+                FlushAction::NoFlush
             }
+
+            IdleFlush { delay_millis } => FlushAction::Delay(*delay_millis),
         }
     }
 }
@@ -192,12 +359,15 @@ impl MutFileRecordsFlushPolicy {
 #[cfg(test)]
 mod tests {
 
+    // use std::time::{Duration, Instant};
+    use std::time::Duration;
     use std::env::temp_dir;
     use std::io::Cursor;
 
     use tracing::debug;
 
     use fluvio_future::test_async;
+    use fluvio_future::timer;
     use dataplane::batch::DefaultBatch;
     use dataplane::core::Decoder;
     use dataplane::core::Encoder;
@@ -211,9 +381,12 @@ mod tests {
 
     const TEST_FILE_NAME: &str = "00000000000000000100.log"; // for offset 100
     const TEST_FILE_NAMEC: &str = "00000000000000000200.log"; // for offset 200
+    const TEST_FILE_NAMEI: &str = "00000000000000000300.log"; // for offset 300
 
     #[test_async]
     async fn test_write_records_every() -> Result<(), StorageError> {
+        debug!("test_write_records_every");
+
         let test_file = temp_dir().join(TEST_FILE_NAME);
         ensure_clean_file(&test_file);
 
@@ -224,14 +397,17 @@ mod tests {
         };
         let mut msg_sink = MutFileRecords::create(100, &options).await.expect("create");
 
+        debug!("{:?}", msg_sink.flush_policy);
+
         let batch = create_batch();
         let write_size = batch.write_size(0);
         debug!("write size: {}", write_size); // for now, this is 79 bytes
         msg_sink.send(create_batch()).await.expect("create");
 
+        debug!("read start");
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
-
+        debug!("read ok");
         let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records.len(), 2);
@@ -242,6 +418,7 @@ mod tests {
         let record2 = records.remove(0);
         assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
 
+        debug!("write 2");
         msg_sink.send(create_batch()).await?;
 
         let bytes = read_bytes_from_file(&test_file)?;
@@ -253,12 +430,8 @@ mod tests {
         Ok(())
     }
 
-    // This Test configures policy to flush after every NUM_WRITES and ensure
-    // the data is still durably retained on a postive test of triggering the
-    // flush. A negative test of the flush being held off was performed by
-    // inspection, and is not automated because of variable results. When a
-    // fs/storage system does committed internal writes is a race between the
-    // system and an application flushing above.
+    // This Test configures policy to flush after every NUM_WRITES
+    // and checks to see when the flush occurs relative to the write count
     #[test_async]
     async fn test_write_records_count() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAMEC);
@@ -296,13 +469,120 @@ mod tests {
         let record2 = records.remove(0);
         assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
 
-        for _ in 1..NUM_WRITES {
+        // check flush counts don't increment yet
+        let flush_count = msg_sink.flush_count();
+        msg_sink.send(create_batch()).await.expect("send");
+        for _ in 1..(NUM_WRITES - 2) {
             msg_sink.send(create_batch()).await.expect("send");
+            assert_eq!(flush_count, msg_sink.flush_count());
         }
+
+        // flush count should increment after final write
+        msg_sink.send(create_batch()).await.expect("send");
+        assert_eq!(flush_count + 1, msg_sink.flush_count());
 
         let bytes = read_bytes_from_file(&test_file).expect("read bytes final");
         let nbytes = write_size * NUM_WRITES as usize;
         assert_eq!(bytes.len(), nbytes, "should be {} bytes", nbytes);
+
+        let old_msg_sink = MutFileRecords::open(OFFSET, &options)
+            .await
+            .expect("check old sink");
+        assert_eq!(old_msg_sink.get_base_offset(), OFFSET);
+
+        Ok(())
+    }
+
+    // This test configures policy to flush after some write idle time
+    // and checks to see when the flush occurs relative to the write count
+
+    // Until the flush counts in the delay flush task are sent back to the
+    // main mut_records context, the test is verifid by inspection of the trace
+    // RUST_LOG=debug cargo test test_write_records_idle_delay
+
+    // The test still verifies that flushes on writes have occured within the
+    // expected timeframe
+    #[test_async]
+    async fn test_write_records_idle_delay() -> Result<(), StorageError> {
+        let test_file = temp_dir().join(TEST_FILE_NAMEI);
+        ensure_clean_file(&test_file);
+
+        const IDLE_FLUSH: u32 = 500;
+        const OFFSET: i64 = 300;
+
+        let options = ConfigOption {
+            base_dir: temp_dir(),
+            segment_max_bytes: 1000,
+            flush_write_count: 0,
+            flush_idle_msec: IDLE_FLUSH,
+            ..Default::default()
+        };
+        let mut msg_sink = MutFileRecords::create(OFFSET, &options)
+            .await
+            .expect("create");
+
+        let batch = create_batch();
+        let write_size = batch.write_size(0);
+        debug!("write size: {}", write_size); // for now, this is 79 bytes
+        msg_sink.send(create_batch()).await.expect("create");
+
+        debug!("direct flush");
+        msg_sink.flush().await.expect("create flush"); // ensure the file is created
+        debug!("direct done");
+
+        let bytes = read_bytes_from_file(&test_file).expect("read bytes");
+        assert_eq!(bytes.len(), write_size, "incorrect size for write");
+
+        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        assert_eq!(batch.get_header().magic, 2, "check magic");
+        assert_eq!(batch.records.len(), 2);
+        let mut records = batch.records;
+        assert_eq!(records.len(), 2);
+        let record1 = records.remove(0);
+        assert_eq!(record1.value.inner_value(), Some(vec![10, 20]));
+        let record2 = records.remove(0);
+        assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
+
+        // check flush counts don't increment immediately
+        let flush_count = msg_sink.flush_count();
+        // debug!("flush_count: {} {:?}", flush_count, Instant::now());
+        msg_sink.send(create_batch()).await.expect("send");
+        // debug!("flush_count: {}", flush_count);
+        assert_eq!(flush_count, msg_sink.flush_count());
+
+        debug!("check single write delayed flush: wait for flush");
+        let dur = Duration::from_millis((IDLE_FLUSH + 100).into());
+        timer::after(dur).await;
+        assert_eq!(flush_count + 1, msg_sink.flush_count());
+
+        // flush count needs some ownership rework to increment correctly
+        // assert_eq!(flush_count + 1, msg_sink.flush_count());
+        let bytes = read_bytes_from_file(&test_file).expect("read bytes final");
+        let nbytes = write_size * 2;
+        assert_eq!(bytes.len(), nbytes, "should be {} bytes", nbytes);
+
+        debug!("check multi write delayed flush: wait for flush");
+        let flush_count = msg_sink.flush_count();
+
+        msg_sink.send(create_batch()).await.expect("send");
+        assert_eq!(flush_count, msg_sink.flush_count());
+        msg_sink.send(create_batch()).await.expect("send");
+        assert_eq!(flush_count, msg_sink.flush_count());
+
+        let dur = Duration::from_millis((IDLE_FLUSH + 100).into());
+        timer::after(dur).await;
+        assert_eq!(flush_count + 1, msg_sink.flush_count());
+
+        let bytes = read_bytes_from_file(&test_file).expect("read bytes final");
+        let nbytes = write_size * 4;
+        assert_eq!(bytes.len(), nbytes, "should be {} bytes", nbytes);
+
+        // this drop and await is useful to verify the flush task exits the
+        // drop drops the mutrecords struct, and the await allows a scheduling
+        // switchover to the delay flush task to end itself
+        // TODO: find a way to use tracing lib to automatically verify this?
+        drop(msg_sink);
+        timer::after(dur).await;
 
         let old_msg_sink = MutFileRecords::open(OFFSET, &options)
             .await

--- a/src/storage/src/records.rs
+++ b/src/storage/src/records.rs
@@ -22,7 +22,7 @@ pub(crate) const MESSAGE_LOG_EXTENSION: &str = "log";
 pub(crate) trait FileRecords {
     fn get_base_offset(&self) -> Offset;
 
-    fn get_file(&self) -> &File;
+    // fn get_file(&self) -> &File;
 
     fn get_path(&self) -> &Path;
 
@@ -74,9 +74,9 @@ impl FileRecords for FileRecordsSlice {
         self.base_offset
     }
 
-    fn get_file(&self) -> &File {
-        &self.file
-    }
+    // fn get_file(&self) -> &File {
+    //     &self.file
+    // }
 
     fn get_path(&self) -> &Path {
         &self.path


### PR DESCRIPTION
https://github.com/infinyon/fluvio/issues/37

With a delay flush policy set, writes will cause a flush after the set delay
time.

Clusters of writes with an interarrival time below the delay will not incur
extra flushes, a final flush is scheduled after the latest write.

The delay flush task will exit after associated mut_records instance is
dropped

TOREVIEW: the get_file method was commented out for removal because the
ownership seemed convoluted to resolve (?) even with a sharing in place
for the f_sink file. the get_file method in the FileRecords trait never
seemed to be used in the codebase

This is a good way to inspect a couple of different cases:
RUST_LOG=debug cargo test test_write_records_idle_delay