### PR TITLE
add attributes feature async-std in echo example

### DIFF
--- a/examples/02-echo/Cargo.toml
+++ b/examples/02-echo/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 fluvio = { path = "../../src/client" }
 futures = "0.3.0"
-async-std = "1.6.4"
+async-std = { version = "1.8.0", features = ["attributes"] }


### PR DESCRIPTION
Pretty sure that this is due to rust-lang/cargo#8157. Basically, `cargo run` within the `examples/02-echo` directory vs running `cargo run --bin echo` outside said directory. 