### PR TITLE
Remove optional in DefaultAsyncRecord.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Release Notes
 
+## Client 0.40
+* Added `bytes` and `bytes_ref` for `Record` and removing `try_into_bytes` ([#706](https://github.com/infinyon/fluvio/pull/706))
+
 ## Version 0.6.1 - 2020-1-16
 
 ## Bug Fixes
 * Restore Ok ([#675](https://github.com/infinyon/fluvio/pull/675))
-  
+
 ## Client
 * Expose Consumer Record ([#687](https://github.com/infinyon/fluvio/pull/687))
 
@@ -27,7 +30,7 @@
 ## Client
 * API Docs
 * Stream based Fetch
-  
+
 ## Platform
 * Cluster Installer with API and CLI support
 * Support for Installing in Minikube without workaround

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-attributes"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
  "syn",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "f07aa6688c702439a1be0307b6a94dffe1168569e45b9500c1372bc580740d59"
 
 [[package]]
 name = "byte-pool"
@@ -642,7 +642,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.7.3",
  "sha2",
- "time 0.2.24",
+ "time 0.2.25",
  "version_check",
 ]
 
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "bytes 0.5.6",
  "content_inspector",
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5378886be367e1bbaa5b9400e2ed09aaa768a854787d2e2abd5644dec4119d70"
+checksum = "6d06bb9a34769434a029c4c6424b5cf104e6372e619e9da1c49bf5c6ffbfe6b3"
 dependencies = [
  "bytes 0.5.6",
  "fluvio-future",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-api"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bb46225f77d4cfbad80803726d8375610db258212ae84873f70a9458c932df"
+checksum = "4997e09168ef29658b02986e570ac1c483536df2775da134c60c617ba53a7425"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-codec"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b24aefa4cd4fa185411fd093df2b0cb4114f07eb05fea1f5df15659ec62383a"
+checksum = "3aa87d4b153d262a270aa8dea9ef2f816f512ad4decf4c4048e1890ce9c9f26f"
 dependencies = [
  "bytes 0.5.6",
  "fluvio-protocol-core",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-core"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b87eb252268040aa1e9696dbb61fc5b7f61c013db73e8c96e69a5632ad2f6e2"
+checksum = "fba0d7122118bf5e2f9ec81f96976ba42bf0d2855745a8cd12d6bfd06fd9a436"
 dependencies = [
  "bytes 0.5.6",
  "log",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa0af14b0a687ffff20252d6bee29f1922f11e695425c0d283bc64187fcadfd"
+checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
 dependencies = [
  "log",
  "proc-macro2",
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-service"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4c21fc5bd3e566fd87bd30afeaf65f437c63ac8512ca39fdbe7f31c5f45619"
+checksum = "56cce23aae9bf1d5b40fee40a4a565a70eb3ce44dd86d6f5c457628175ad2c9f"
 dependencies = [
  "async-trait",
  "event-listener",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f2aeed860e54761b36c8c2a350d4db4c98bec8678a50eb17e90c81fbaee386"
+checksum = "80d530baae0b8673114a1200f0848c7936132b6a9083c6165cc86508023b2d3b"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -1835,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab8d0085fb82859c9adf050bd53992297ecdd03a665a230dfa50c8c964bf3d"
+checksum = "32613ebb139d1d430ef5783676f84abfa06fc5f2b4b5a25220cdeeff7e16ef5c"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1846,7 +1846,7 @@ dependencies = [
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.4",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -1940,9 +1940,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2828,18 +2828,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3089,9 +3089,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,11 +3164,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -3183,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
 dependencies = [
  "const_fn",
  "libc",
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3285,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -3512,9 +3512,9 @@ checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3522,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3537,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3549,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3559,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3572,15 +3572,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ inputs:
   minikube-version:
     description: "Use a specific minikube version"
     required: false
-    default: 'v1.13.1'
+    default: 'v1.17.0'
 runs:
   using: "composite"
   steps:

--- a/examples/01-consume/src/main.rs
+++ b/examples/01-consume/src/main.rs
@@ -47,10 +47,9 @@ async fn consume() -> Result<(), fluvio::FluvioError> {
     let mut stream = consumer.stream(fluvio::Offset::beginning()).await?;
 
     while let Some(Ok(record)) = stream.next().await {
-        if let Some(bytes) = record.try_into_bytes() {
-            let string = String::from_utf8_lossy(&bytes);
-            println!("{}", string);
-        }
+        let bytes = record.as_ref();
+        let string = String::from_utf8_lossy(&bytes);
+        println!("{}", string);
     }
     Ok(())
 }

--- a/examples/02-echo/src/main.rs
+++ b/examples/02-echo/src/main.rs
@@ -157,12 +157,11 @@ async fn consume() -> Result<(), FluvioError> {
     let mut stream = consumer.stream(Offset::beginning()).await?;
 
     while let Some(Ok(record)) = stream.next().await {
-        if let Some(bytes) = record.try_into_bytes() {
-            let string = String::from_utf8_lossy(&bytes);
-            println!("Got record: {}", string);
-            if string == "Done!" {
-                return Ok(());
-            }
+        let bytes = record.as_ref();
+        let string = String::from_utf8_lossy(&bytes);
+        println!("Got record: {}", string);
+        if string == "Done!" {
+            return Ok(());
         }
     }
 

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -15,10 +15,10 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.41"
 fluvio-controlplane-metadata = { version = "0.4.0", path = "../controlplane-metadata" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.1.12", features = ["net", "openssl_tls"] }
-fluvio-protocol = { version = "0.2.0" }
-fluvio-socket = { version = "0.4.0" }
+fluvio-protocol = { version = "0.3.0" }
+fluvio-socket = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 flv-tls-proxy = { version = "0.3.0" }
 futures-util = { version = "0.3.5" }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -47,7 +47,7 @@ tempdir = "0.3.7"
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
-fluvio = { version = "0.3.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.6.0", path = "../cluster", default-features = false, features = ["cli", "platform"] }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 fluvio-extension-consumer = { version = "0.1.2", path = "../extension-consumer" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -40,9 +40,9 @@ fluvio-future = { version = "0.1.15", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-sc-schema = { version = "0.4.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.2.0", path = "../spu-schema" }
-fluvio-socket = { version = "0.4.0", features = ["native_tls"] }
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-socket = { version = "0.5.0", features = ["native_tls"] }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 async-std = "1.6.4"

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use std::convert::TryFrom;
+use std::string::FromUtf8Error;
 
 use futures_util::stream::Stream;
 use tracing::debug;
@@ -410,8 +412,20 @@ impl Record {
         self.offset
     }
 
-    /// The actual bytes for this record.
-    pub fn try_into_bytes(self) -> Option<Vec<u8>> {
-        self.record.value.inner_value()
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(self.as_ref()).to_string()
+    }
+}
+
+impl AsRef<[u8]> for Record {
+    fn as_ref(&self) -> &[u8] {
+        self.record.value.as_ref()
+    }
+}
+
+impl TryFrom<Record> for String {
+    type Error = FromUtf8Error;
+    fn try_from(record: Record) -> Result<String, FromUtf8Error> {
+        String::from_utf8(record.as_ref().to_vec())
     }
 }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "0.2.21", features = ["macros"] }
 once_cell = "1.5"
 
 # Fluvio dependencies
-fluvio = { version = "0.3.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.0", path = "../client", default-features = false }
 fluvio-helm = "0.3.0"
 fluvio-future = { version = "0.1.13" }
 fluvio-runner-local = { version = "0.2.0", path = "../extension-runner-local", optional = true }

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -26,8 +26,8 @@ fluvio-future = { version = "0.1.0" }
 flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-stream-model = { path = "../stream-model", version = "0.4.0" }
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 
 [dev-dependencies]

--- a/src/controlplane-metadata/src/topic/spec.rs
+++ b/src/controlplane-metadata/src/topic/spec.rs
@@ -721,15 +721,21 @@ pub mod test {
         // test encode
         let result = topic_spec.encode(&mut dest, 0);
         assert!(result.is_ok());
-
         let expected_dest = [
-            0x00, // type
-            0x00, 0x00, 0x00, 0x01, // partition cnt
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x13, 0x89, 0x00, 0x00, 0x13,
+            0x8a,
+        ];
+
+        /*
+        let expected_dest = [
+            0, 2, 0, 0, 0, 0, 4, 0, 0,
+            0x00,
+            0x02, // partition cnt
             0x00, 0x00, 0x00, 0x00, // partition id
             0x00, 0x00, 0x00, 0x02, // replica cnt
             0x00, 0x00, 0x13, 0x89, // spu id: 5001
             0x00, 0x00, 0x13, 0x8a, // spu id: 5002
-        ];
+        ];*/
         assert_eq!(dest, expected_dest);
 
         // test encode

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -18,5 +18,5 @@ tracing = "0.1.19"
 # Fluvio dependencies
 fluvio-types = { path = "../types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.4.0" }
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"
@@ -20,10 +20,10 @@ once_cell = "1.5.2"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.1.0" }
-fluvio-protocol = { version = "0.2.0", features = ["derive", "api", "store"] }
+fluvio-protocol = { version = "0.3.0", features = ["derive", "api", "store"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { version = "0.4.0" }
+fluvio-socket = { version = "0.5.0" }
 fluvio-future = { version = "0.1.0", features = ["fixture","fs"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -243,8 +243,8 @@ mod test {
 
         let decoded_record = batch.records.get(0).unwrap();
         println!("record crc: {}", batch.header.crc);
-        assert_eq!(batch.header.crc, 1514417201);
-        let b = decoded_record.value.inner_value_ref().as_deref().unwrap();
+        assert_eq!(batch.header.crc, 1910360147);
+        let b = decoded_record.value.as_ref();
         assert_eq!(b, b"test");
 
         Ok(())

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -28,4 +28,4 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 
 
-fluvio = { version = "0.3.0", path = "../client",  optional = true }
+fluvio = { version = "0.4.0", path = "../client",  optional = true }

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -30,7 +30,7 @@ hostname-validator = "1.0.0"
 
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io"] }
-fluvio = { version = "0.3.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.0", path = "../client", default-features = false }
 fluvio-types = { version = "0.2.0" , path = "../types" }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { version = "0.4.0", path = "../controlplane-metadata", features = ["use_serde"] }

--- a/src/extension-consumer/src/consume/logs_output.rs
+++ b/src/extension-consumer/src/consume/logs_output.rs
@@ -92,15 +92,14 @@ pub fn partition_to_json_records(
     // convert all batches to json records
     for batch in &partition.records.batches {
         for record in &batch.records {
-            if let Some(batch_record) = record.get_value().inner_value_ref() {
-                match serde_json::from_slice(&batch_record) {
-                    Ok(value) => json_records.push(value),
-                    Err(_) => {
-                        if !suppress {
-                            json_records.push(serde_json::json!({
-                                "error": record.get_value().describe()
-                            }));
-                        }
+            let batch_record = record.get_value().as_ref();
+            match serde_json::from_slice(&batch_record) {
+                Ok(value) => json_records.push(value),
+                Err(_) => {
+                    if !suppress {
+                        json_records.push(serde_json::json!({
+                            "error": record.get_value().describe()
+                        }));
                     }
                 }
             }
@@ -141,14 +140,12 @@ pub fn print_text_records<O>(
 
         for batch in &r_partition.records.batches {
             for record in &batch.records {
-                if record.get_value().inner_value_ref().is_some() {
-                    if record.get_value().is_binary() {
-                        if !suppress {
-                            t_println!(out, "{}", record.get_value().describe());
-                        }
-                    } else {
-                        t_println!(out, "{}", record.get_value());
+                if record.get_value().is_binary() {
+                    if !suppress {
+                        t_println!(out, "{}", record.get_value().describe());
                     }
+                } else {
+                    t_println!(out, "{}", record.get_value());
                 }
             }
         }
@@ -183,11 +180,10 @@ pub fn print_binary_records<O>(
 
         for batch in &r_partition.records.batches {
             for record in &batch.records {
-                if let Some(batch_record) = record.get_value().inner_value_ref() {
-                    t_println!(out, "{}", hex_dump_separator());
-                    t_println!(out, "{}", bytes_to_hex_dump(&batch_record));
-                    printed = true;
-                }
+                let batch_record = record.get_value().as_ref();
+                t_println!(out, "{}", hex_dump_separator());
+                t_println!(out, "{}", bytes_to_hex_dump(&batch_record));
+                printed = true;
             }
         }
     }
@@ -216,18 +212,16 @@ pub fn print_dynamic_records<O>(
 
         for batch in &r_partition.records.batches {
             for record in &batch.records {
-                if let Some(batch_record) = record.get_value().inner_value_ref() {
-                    // TODO: this should be refactored
-                    if let Some(bytes) = record.get_value().inner_value_ref() {
-                        debug!("len: {}", bytes.len());
-                    }
-                    if record.get_value().is_binary() {
-                        t_println!(out, "{}", hex_dump_separator());
-                        t_println!(out, "{}", bytes_to_hex_dump(&batch_record));
-                        t_println!(out, "{}", hex_dump_separator());
-                    } else {
-                        t_println!(out, "{}", record.get_value());
-                    }
+                let batch_record = record.get_value().as_ref();
+                // TODO: this should be refactored
+                let bytes = record.get_value().as_ref();
+                debug!("len: {}", bytes.len());
+                if record.get_value().is_binary() {
+                    t_println!(out, "{}", hex_dump_separator());
+                    t_println!(out, "{}", bytes_to_hex_dump(&batch_record));
+                    t_println!(out, "{}", hex_dump_separator());
+                } else {
+                    t_println!(out, "{}", record.get_value());
                 }
             }
         }
@@ -254,10 +248,9 @@ pub fn print_raw_records<O>(
 
         for batch in &r_partition.records.batches {
             for record in &batch.records {
-                if let Some(value) = record.get_value().inner_value_ref() {
-                    let str_value = std::str::from_utf8(value).unwrap();
-                    t_println!(out, "{}", str_value);
-                }
+                let value = record.get_value().as_ref();
+                let str_value = std::str::from_utf8(value).unwrap();
+                t_println!(out, "{}", str_value);
             }
         }
     }

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -24,5 +24,5 @@ static_assertions = "1.1.0"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.4.0", default-features = false, path = "../controlplane-metadata" }
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -53,10 +53,10 @@ fluvio-stream-dispatcher = { version = "0.4.0", path = "../stream-dispatcher" }
 k8-client = { version = "5.0.0", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.1.0", features = ["app"]}
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.2", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { version = "0.4.2" }
-fluvio-service = { version = "0.3.0" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-socket = { version = "0.5.0" }
+fluvio-service = { version = "0.4.0" }
 flv-tls-proxy = { version = "0.3.0" }
 
 

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0.103", features = ['derive'] }
 static_assertions = "1.1.0"
 
 # Fluvio dependencies
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.2", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -44,10 +44,10 @@ fluvio-storage = { version = "0.2.0", path = "../storage" }
 fluvio-controlplane = { version = "0.4.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.4.0", path = "../controlplane-metadata" }
 fluvio-spu-schema = { version = "0.2.0", path = "../spu-schema" }
-fluvio-protocol = { version = "0.2.0" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { version = "0.4.3" }
-fluvio-service = { version = "0.3.0" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-socket = { version = "0.5.0" }
+fluvio-service = { version = "0.4.0" }
 flv-tls-proxy = { version = "0.3.0" }
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.12", features = ["subscriber", "openssl_tls"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -30,13 +30,12 @@ serde = { version = "1.0.103", features = ['derive'] }
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0" , path = "../types" }
 fluvio-future = { version = "0.1.8", features = ["fs","mmap"] }
-fluvio-protocol = { version = "0.2.1" }
-dataplane = { version = "0.1.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { version = "0.3.0" }
+dataplane = { version = "0.2.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 async-mutex = "1.4.0"
 
 
 [dev-dependencies]
 fluvio-future = { version = "0.1.8", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { version = "0.4.0" }
-
+fluvio-socket = { version = "0.5.0" }

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -414,9 +414,9 @@ mod tests {
         let mut records = batch.records;
         assert_eq!(records.len(), 2);
         let record1 = records.remove(0);
-        assert_eq!(record1.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record1.value.as_ref(), vec![10, 20]);
         let record2 = records.remove(0);
-        assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record2.value.as_ref(), vec![10, 20]);
 
         debug!("write 2");
         msg_sink.send(create_batch()).await?;
@@ -465,9 +465,9 @@ mod tests {
         let mut records = batch.records;
         assert_eq!(records.len(), 2);
         let record1 = records.remove(0);
-        assert_eq!(record1.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record1.value.as_ref(), vec![10, 20]);
         let record2 = records.remove(0);
-        assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record2.value.as_ref(), vec![10, 20]);
 
         // check flush counts don't increment yet
         let flush_count = msg_sink.flush_count();
@@ -540,9 +540,9 @@ mod tests {
         let mut records = batch.records;
         assert_eq!(records.len(), 2);
         let record1 = records.remove(0);
-        assert_eq!(record1.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record1.value.as_ref(), vec![10, 20]);
         let record2 = records.remove(0);
-        assert_eq!(record2.value.inner_value(), Some(vec![10, 20]));
+        assert_eq!(record2.value.as_ref(), vec![10, 20]);
 
         // check flush counts don't increment immediately
         let flush_count = msg_sink.flush_count();

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -453,7 +453,7 @@ mod tests {
             (active_segment.find_offset_position(20).await?).expect("offset exists");
         assert_eq!(offset_position.get_base_offset(), 20);
         assert_eq!(offset_position.get_pos(), 0); //
-        assert_eq!(offset_position.len(), 70 - 12);
+        assert_eq!(offset_position.len(), 55);
         assert!((active_segment.find_offset_position(30).await?).is_none());
         Ok(())
     }
@@ -492,7 +492,7 @@ mod tests {
             (active_segment.find_offset_position(20).await?).expect("offset exists");
         assert_eq!(offset_position.get_base_offset(), 20);
         assert_eq!(offset_position.get_pos(), 0); //
-        assert_eq!(offset_position.len(), 85);
+        assert_eq!(offset_position.len(), 82);
         assert!((active_segment.find_offset_position(30).await?).is_none());
 
         Ok(())
@@ -516,10 +516,10 @@ mod tests {
 
         assert_eq!(seg_sink.get_end_offset(), 46);
 
-        assert_eq!(seg_sink.get_log_pos(), 237); // each takes 79 bytes
+        assert_eq!(seg_sink.get_log_pos(), 228); // each takes 91 bytes
 
         let index = seg_sink.get_index();
-        assert_eq!(index[0].to_be(), (2, 79));
+        assert_eq!(index[0].to_be(), (2, 76));
 
         let bytes = read_bytes_from_file(&test_dir.join(TEST2_FILE_NAME))?;
         debug!("read {} bytes", bytes.len());
@@ -536,16 +536,16 @@ mod tests {
         let offset_pos1 = seg_sink.find_offset_position(40).await?.expect("pos");
         assert_eq!(offset_pos1.get_base_offset(), 40);
         assert_eq!(offset_pos1.get_pos(), 0);
-        assert_eq!(offset_pos1.len(), 67);
+        assert_eq!(offset_pos1.len(), 64);
         let offset_pos2 = seg_sink.find_offset_position(42).await?.expect("pos");
         assert_eq!(offset_pos2.get_base_offset(), 42);
-        assert_eq!(offset_pos2.get_pos(), 79);
-        assert_eq!(offset_pos2.len(), 67);
+        assert_eq!(offset_pos2.get_pos(), 76);
+        assert_eq!(offset_pos2.len(), 64);
 
         let offset_pos3 = seg_sink.find_offset_position(44).await?.expect("pos");
         assert_eq!(offset_pos3.get_base_offset(), 44);
-        assert_eq!(offset_pos3.get_pos(), 158);
-        assert_eq!(offset_pos3.len(), 67);
+        assert_eq!(offset_pos3.get_pos(), 152);
+        assert_eq!(offset_pos3.len(), 64);
 
         // test whether you can send batch with non zero base offset
         let mut next_batch = create_batch();

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -17,5 +17,5 @@ fluvio-future = { version = "0.1.0", features = ["task","timer","subscriber","fi
 fluvio = { path = "../../src/client" }
 fluvio-types = { version = "0.2.0", path = "../../src/types"  }
 fluvio-controlplane-metadata = { features = ["k8"], path = "../../src/controlplane-metadata" }
-dataplane = { version = "0.1.0", path = "../../src/dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.2.0", path = "../../src/dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-system-util = { version = "0.1.0", path = "../../src/utils" }

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -98,23 +98,22 @@ async fn validate_consume_message_api(offsets: Offsets, option: &TestOption) {
         let mut total_records: u16 = 0;
         while let Some(Ok(record)) = stream.next().await {
             let offset = record.offset();
-            if let Some(bytes) = record.try_into_bytes() {
-                info!(
-                    "* consumer iter: {}, received offset: {}, bytes: {}",
-                    total_records,
-                    offset,
-                    bytes.len()
-                );
-                validate_message(iteration, offset, &topic_name, option, &bytes);
-                info!(
-                    " total records: {}, validated offset: {}",
-                    total_records, offset
-                );
-                total_records += 1;
-                if total_records == iteration {
-                    println!("<<consume test done for: {} >>>>", topic_name);
-                    break;
-                }
+            let bytes = record.as_ref();
+            info!(
+                "* consumer iter: {}, received offset: {}, bytes: {}",
+                total_records,
+                offset,
+                bytes.len()
+            );
+            validate_message(iteration, offset, &topic_name, option, &bytes);
+            info!(
+                " total records: {}, validated offset: {}",
+                total_records, offset
+            );
+            total_records += 1;
+            if total_records == iteration {
+                println!("<<consume test done for: {} >>>>", topic_name);
+                break;
             }
         }
         println!("consume message validated!");


### PR DESCRIPTION
~This is dependent on https://github.com/infinyon/fluvio-protocol/pull/4 but I've written the refactor using a work around.~

Depends on https://github.com/infinyon/fluvio-protocol/pull/5

We should also probably rename `try_into_bytes` to `bytes`. 

Record updates:
* Added `AsRef` implementation `as_ref()` returns `&[u8]`
* `to_utf8_lossy` (returns a string)
* `to_bytes` takes ownership and returns a `Vec<u8>`
* `impl TryFrom<Record> for String`