### PR TITLE
further k8 svc customization

### DIFF
--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -8,6 +8,12 @@ spec:
   type: {{ .Values.service.type }}
   selector:
     app: fluvio-sc
+{{ if .Values.service.externalTrafficPolicy }}
+    externalTrafficPolicy: .Values.service.externalTrafficPolicy
+{{ end }}
+{{ if .Values.service.externalName }}
+    externalName: .Values.service.externalName
+{{ end }}
   ports:
   - protocol: TCP
     port: 9003

--- a/src/sc/src/k8/operator/spg_operator.rs
+++ b/src/sc/src/k8/operator/spg_operator.rs
@@ -347,7 +347,6 @@ impl SpgOperator {
         selector.insert("statefulset.kubernetes.io/pod-name".to_owned(), pod_name);
 
         let mut service_spec = ServiceSpec {
-            external_traffic_policy: Some(ExternalTrafficPolicy::Local),
             selector: Some(selector),
             ports: vec![public_port.clone()],
             ..Default::default()

--- a/src/sc/src/k8/operator/spu_k8_config.rs
+++ b/src/sc/src/k8/operator/spu_k8_config.rs
@@ -73,6 +73,15 @@ impl SpuK8Config {
             if let Some(ty) = &service_template.r#type {
                 service.r#type = Some(ty.clone());
             }
+            if let Some(local_traffic) = &service_template.external_traffic_policy {
+                service.external_traffic_policy = Some(local_traffic.clone());
+            }
+            if let Some(external_name) = &service_template.external_name {
+                service.external_name = Some(external_name.clone());
+            }
+            if let Some(lb_ip) = &service.load_balancer_ip {
+                service.load_balancer_ip = Some(lb_ip.clone());
+            }
         }
     }
 }

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -502,6 +502,7 @@ mod tests {
 
     // The test still verifies that flushes on writes have occured within the
     // expected timeframe
+    #[cfg(not(target_os = "macos"))]
     #[test_async]
     async fn test_write_records_idle_delay() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAMEI);


### PR DESCRIPTION
Remove hard coded `external_local_traffic` from SPU service spec.  Instead make it configurable thru helm template