### PR TITLE
Updated Readme and cargo.toml to be more accurate for crates.io

### DIFF
--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.3.6"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
+categories = ["database"]
+keywords = ["streaming", "stream", "queue"]
 repository = "https://github.com/infinyon/fluvio"
 description = "The offical Fluvio driver for Rust"
 

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -1,6 +1,6 @@
-# flv-client
+# Fluvio Client
 
-Fluvio Rust Client
+The official Fluvio Rust Client. For usage see [fluvio.io](https://www.fluvio.io/).
 
 ## License
 


### PR DESCRIPTION
The stuff on https://crates.io/crates/fluvio says `flv-client` and doesn't have any keywords or categories. I chose the category slug of `database` because it seemed the least-not-wrong.

* [According to the cargo docs, each category should match one of the strings available](https://doc.rust-lang.org/cargo/reference/manifest.html#the-categories-field) at https://crates.io/category_slugs.