### PR TITLE
fix metadata store updating logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-rwlock",
  "event-listener",

--- a/src/stream-model/Cargo.toml
+++ b/src/stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/stream-model/src/core.rs
+++ b/src/stream-model/src/core.rs
@@ -22,6 +22,11 @@ mod context {
         }
     }
 
+    pub trait MetadataRevExtension: MetadataItem {
+        // return next revision
+        fn next_rev(&self) -> Self;
+    }
+
     impl MetadataItem for u32 {
         type UId = u32;
 
@@ -92,6 +97,15 @@ mod context {
                 item: C::default(),
                 owner: Some(self.item.clone()),
             }
+        }
+    }
+
+    impl<C> MetadataContext<C>
+    where
+        C: MetadataRevExtension,
+    {
+        pub fn next_rev(&self) -> Self {
+            Self::new(self.item.next_rev(), None)
         }
     }
 

--- a/src/stream-model/src/epoch/dual_epoch_map.rs
+++ b/src/stream-model/src/epoch/dual_epoch_map.rs
@@ -14,7 +14,7 @@ use super::EpochChanges;
 
 pub trait DualDiff {
     /// check if another is different from myself
-    fn diff(&self, another: &Self) -> ChangeFlag;
+    fn diff(&self, new_value: &Self) -> ChangeFlag;
 }
 
 #[allow(clippy::clippy::redundant_closure)]
@@ -239,18 +239,20 @@ where
         // check each spec and status
         if let Some(existing_value) = self.values.get_mut(&key) {
             let diff = existing_value.diff(new_value.inner());
-            new_value.copy_epoch(existing_value);
-            if diff.spec {
-                new_value.set_spec_epoch(current_epoch);
-            }
-            if diff.status {
-                new_value.set_status_epoch(current_epoch);
-            }
-            if diff.meta {
-                new_value.set_meta_epoch(current_epoch);
-            }
+            if !diff.has_no_changes() {
+                new_value.copy_epoch(existing_value);
+                if diff.spec {
+                    new_value.set_spec_epoch(current_epoch);
+                }
+                if diff.status {
+                    new_value.set_status_epoch(current_epoch);
+                }
+                if diff.meta {
+                    new_value.set_meta_epoch(current_epoch);
+                }
 
-            *existing_value = new_value;
+                *existing_value = new_value;
+            }
             Some(diff)
         } else {
             // doesn't exist, so this is new

--- a/src/stream-model/src/lib.rs
+++ b/src/stream-model/src/lib.rs
@@ -8,7 +8,7 @@ pub use k8_types;
 #[cfg(test)]
 pub(crate) mod test_fixture {
 
-    use crate::core::{Spec, Status, MetadataItem, MetadataContext};
+    use crate::core::{Spec, Status, MetadataItem, MetadataContext, MetadataRevExtension};
     use crate::store::MetadataStoreObject;
     use crate::epoch::DualEpochMap;
 
@@ -50,7 +50,16 @@ pub(crate) mod test_fixture {
         }
 
         fn is_newer(&self, another: &Self) -> bool {
-            self.rev > another.rev
+            self.rev >= another.rev
+        }
+    }
+
+    impl MetadataRevExtension for TestMeta {
+        fn next_rev(&self) -> Self {
+            Self {
+                rev: self.rev + 1,
+                comment: self.comment.clone(),
+            }
         }
     }
 

--- a/src/stream-model/src/store/dual_store.rs
+++ b/src/stream-model/src/store/dual_store.rs
@@ -576,7 +576,8 @@ mod test {
 
         // sync all with spec changes only
 
-        let spec_changes = vec![DefaultTest::with_spec("t1", TestSpec { replica: 6 })];
+        let spec_changes =
+            vec![DefaultTest::with_spec("t1", TestSpec { replica: 6 }).with_context(2)];
         let sync2 = test_store.sync_all(spec_changes.clone()).await;
         assert_eq!(test_store.epoch().await, 2);
         assert_eq!(sync2.add, 0);

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -94,7 +94,7 @@ impl MetadataItem for K8MetaItem {
 
     #[inline]
     fn is_newer(&self, another: &Self) -> bool {
-        self.revision > another.revision
+        self.revision >= another.revision
     }
 
     fn is_being_deleted(&self) -> bool {

--- a/src/stream-model/src/store/metadata.rs
+++ b/src/stream-model/src/store/metadata.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::core::{Spec, MetadataContext, MetadataItem};
+use crate::core::{Spec, MetadataContext, MetadataItem, MetadataRevExtension};
 use crate::store::{LocalStore};
 
 pub type DefaultMetadataObject<S> = MetadataStoreObject<S, u32>;
@@ -163,6 +163,18 @@ where
                 meta: self.ctx.item() != new_value.ctx.item(),
             }
         }
+    }
+}
+
+impl<S, C> MetadataStoreObject<S, C>
+where
+    S: Spec,
+    C: MetadataRevExtension,
+{
+    // create clone of my self with next rev, useful for testing and other
+    #[allow(unused)]
+    pub fn next_rev(&self) -> Self {
+        self.clone().with_context(self.ctx.next_rev())
     }
 }
 

--- a/src/stream-model/src/store/metadata.rs
+++ b/src/stream-model/src/store/metadata.rs
@@ -153,14 +153,14 @@ where
     C: MetadataItem + PartialEq,
 {
     /// compute difference, in our case we take account of version as well
-    fn diff(&self, another: &Self) -> ChangeFlag {
-        if self.is_newer(another) {
+    fn diff(&self, new_value: &Self) -> ChangeFlag {
+        if self.is_newer(new_value) {
             ChangeFlag::no_change()
         } else {
             ChangeFlag {
-                spec: self.spec != another.spec,
-                status: self.status != another.status,
-                meta: self.ctx.item() != another.ctx.item(),
+                spec: self.spec != new_value.spec,
+                status: self.status != new_value.status,
+                meta: self.ctx.item() != new_value.ctx.item(),
             }
         }
     }


### PR DESCRIPTION
Fixed bug where stale data was allowed to write to cache event thought their rev was outdated.
This could happens when there are rapid state changes and cache didn't caught up.
This makes store to be idempotent