### PR TITLE
Update Fluvio client README and front README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ built on three core principles:
 ## Release Status
 
 Fluvio is currently in **Alpha** and is not ready to be used in production.
-Do not rely on Fluvio with any data that you would care to lose.
 Our CLI and APIs are also in rapid development and may experience breaking
 changes at any time. We do our best to adhere to semantic versioning but
 until our R1 release we cannot guarantee it.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,57 @@
-<div>
-   <!-- CI status -->
-  <a href="https://github.com/infinyon/fluvio/actions">
-    <img src="https://github.com/infinyon/fluvio/workflows/CI/badge.svg"
-      alt="CI Status" />
-  </a>
-  <a href="https://crates.io/crates/fluvio">
-    <img src="https://img.shields.io/crates/v/fluvio?style=flat-square"
-    alt="Crates.io version" />
-  </a>
-   <!-- docs.rs docs -->
-  <a href="https://docs.rs/fluvio">
-    <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
-      alt="docs.rs docs" />
-  </a>
-
-  <a href="https://discordapp.com/invite/bBG2dTz">
-    <img src="https://img.shields.io/discord/695712741381636168.svg?logo=discord&style=flat-square"
-      alt="chat" />
-  </a>
-</div>
-
-
-
-<h1 align="center">Fluvio</h1>
 <div align="center">
- <strong>
-   Data streaming platform for connected Apps
- </strong>
+<h1>Fluvio</h1>
+<strong>Data streaming for real-time applications</strong>
+
+<br>
+<br>
+
+<div>
+<!-- CI status -->
+<a href="https://github.com/infinyon/fluvio/actions">
+<img src="https://github.com/infinyon/fluvio/workflows/CI/badge.svg" alt="CI Status" />
+</a>
+<a href="https://crates.io/crates/fluvio">
+<img src="https://img.shields.io/crates/v/fluvio?style=flat" alt="Crates.io version" />
+</a>
+<!-- docs.rs docs -->
+<a href="https://docs.rs/fluvio">
+<img src="https://docs.rs/fluvio/badge.svg" alt="Fluvio documentation" />
+</a>
+
+<a href="https://discordapp.com/invite/bBG2dTz">
+<img src="https://img.shields.io/discord/695712741381636168.svg?logo=discord&style=flat" alt="chat" />
+</a>
+</div>
 </div>
 
+Fluvio is a high-performance distributed streaming platform that's written
+in Rust, built to make it easy to develop real-time applications. Fluvio is
+built on three core principles:
 
+1) **Data is modeled as streams of events**, and streams should deliver data as fast as possible
+2) **Services should compose seamlessly** by using streams as their interface boundary
+3) **APIs and tools should be easy to use**, so that anybody can build real-time applications
 
-Fluvio is a high performance, low latency data streaming platform built for real-time Apps that can run on Mobile, Edge, Cloud, and your Data Center.
+## Quick Links
 
-Roll out your own log aggregation, DB replication, IOT middle layer, or an event driven infrastructure in a matter of minutes. Use our expressive Node or Rust APIs to create producers/consumers and start rapid experimentation with real-time data.
-
-The repository contains all the code necessary to run the Fluvio platform: Services, APIs, and the CLI.
-
-
+- [Getting Started with Fluvio](https://www.fluvio.io/docs/getting-started/)
+- [Rust API docs](https://docs.rs/fluvio)
+- [Node API docs](https://infinyon.github.io/fluvio-client-node/)
+- [Fluvio CLI docs](https://www.fluvio.io/docs/cli-reference/)
+- [Fluvio Architecture](https://www.fluvio.io/docs/architecture/)
 
 ## Release Status
-Fluvio is at Alpha and should be suitable for lab environment. APIs, Schema, CLI, and Services are continually evolving and subject to change before R1.
 
-
-## Documentation
-
-Please see doc at: https://www.fluvio.io
-
+Fluvio is currently in **Alpha** and is not ready to be used in production.
+Do not rely on Fluvio with any data that you would care to lose.
+Our CLI and APIs are also in rapid development and may experience breaking
+changes at any time. We do our best to adhere to semantic versioning but
+until our R1 release we cannot guarantee it.
 
 ## Contributing
 
-If you'd like to contribute to the project, please read our [Contributing guide](CONTRIBUTING.md).
+If you'd like to contribute to the project, please read our
+[Contributing guide](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,7 @@
 </div>
 
 Fluvio is a high-performance distributed streaming platform that's written
-in Rust, built to make it easy to develop real-time applications. Fluvio is
-built on three core principles:
-
-1) **Data is modeled as streams of events**, and streams should deliver data as fast as possible
-2) **Services should compose seamlessly** by using streams as their interface boundary
-3) **APIs and tools should be easy to use**, so that anybody can build real-time applications
+in Rust, built to make it easy to develop real-time applications.
 
 ## Quick Links
 

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -1,6 +1,27 @@
-# Fluvio Client
+# Fluvio
 
-The official Fluvio Rust Client. For usage see [fluvio.io](https://www.fluvio.io/).
+The official Fluvio Rust client.
+
+<a href="https://github.com/infinyon/fluvio">
+<img src="https://github.com/infinyon/fluvio/workflows/CI/badge.svg?branch=master" alt="Fluvio CI on Github" />
+</a>
+
+<a href="https://crates.io/crates/fluvio">
+<img src="https://img.shields.io/crates/v/fluvio" alt="Fluvio on Crates.io" />
+</a>
+
+<a href="https://docs.rs/fluvio">
+<img src="https://docs.rs/fluvio/badge.svg" alt="Fluvio documentation" />
+</a>
+
+<a href="https://discordapp.com/invite/bBG2dTz">
+<img src="https://img.shields.io/discord/695712741381636168.svg?logo=discord&style=flat" alt="Discord chat" />
+</a>
+
+[Fluvio] is a distributed streaming platform for building real-time applications,
+written from the ground up in Rust.
+
+[Fluvio]: https://www.fluvio.io/
 
 ## License
 


### PR DESCRIPTION
- Adds badges to `fluvio` README so that they appear on crates.io
- Centers badges on front README and makes badge styles consistent
- Update README wording to emphasize "real-time applications"
- Add quick links to send people to the website

[Rendered](https://github.com/infinyon/fluvio/blob/ff43abf9efa4e73d295df0d85106550fb0142453/README.md)