### PR TITLE
Add helm-publish-sys to Makefile and release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,4 +99,5 @@ jobs:
         run: |
           make helm-install-plugin
           helm repo add fluvio https://gitops:${{ secrets.HELM_PASSWORD }}@charts.fluvio.io
+          make helm-publish-sys
           make helm-publish-app

--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,11 @@ helm-login:
 	helm repo remove fluvio
 	helm repo add fluvio https://gitops:$(HELM_PASSWORD)@charts.fluvio.io
 
+helm-publish-sys:
+	helm push k8-util/helm/fluvio-sys --version="$(VERSION)" --force fluvio
+
 helm-publish-app:
-	helm push k8-util/helm/fluvio-app  --version="$(VERSION)" --force fluvio
+	helm push k8-util/helm/fluvio-app --version="$(VERSION)" --force fluvio
 
 
 


### PR DESCRIPTION
We have been experiencing build breakages because the fluvio-cluster installer always assumes that for any version of `fluvio-app`, there will be an equivalent version of `fluvio-sys`, but our release.yml currently does not always push them together. This adds a make task and a CI step to always push fluvio-sys with fluvio-app at the same version number.