### PR TITLE
Add missing chart_version to SysConfig in check

### DIFF
--- a/src/cluster/src/cli/check.rs
+++ b/src/cluster/src/cli/check.rs
@@ -12,8 +12,7 @@ impl CheckOpt {
     pub async fn process(self, default_chart_version: &str) -> Result<(), ClusterCliError> {
         use colored::*;
         println!("{}", "Running pre-startup checks...".bold());
-        let sys_config: SysConfig = SysConfig::builder()
-            .chart_version(default_chart_version)
+        let sys_config: SysConfig = SysConfig::builder(default_chart_version)
             .build()
             .map_err(ClusterError::InstallSys)?;
         let mut progress = ClusterChecker::empty()

--- a/src/cluster/src/cli/check.rs
+++ b/src/cluster/src/cli/check.rs
@@ -9,10 +9,11 @@ use crate::check::SysChartCheck;
 pub struct CheckOpt {}
 
 impl CheckOpt {
-    pub async fn process(self) -> Result<(), ClusterCliError> {
+    pub async fn process(self, default_chart_version: &str) -> Result<(), ClusterCliError> {
         use colored::*;
         println!("{}", "Running pre-startup checks...".bold());
         let sys_config: SysConfig = SysConfig::builder()
+            .chart_version(default_chart_version)
             .build()
             .map_err(ClusterError::InstallSys)?;
         let mut progress = ClusterChecker::empty()

--- a/src/cluster/src/cli/mod.rs
+++ b/src/cluster/src/cli/mod.rs
@@ -87,7 +87,7 @@ impl ClusterCmd {
                 uninstall.process().await?;
             }
             Self::Check(check) => {
-                check.process().await?;
+                check.process(default_chart_version).await?;
             }
             Self::Releases(releases) => {
                 releases.process().await?;

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -26,7 +26,7 @@ pub async fn process_k8(
         .as_deref()
         .unwrap_or(default_chart_version);
 
-    let mut builder = ClusterConfig::builder();
+    let mut builder = ClusterConfig::builder(chart_version);
     builder
         .namespace(opt.k8_config.namespace)
         .group_name(opt.k8_config.group_name)
@@ -34,7 +34,6 @@ pub async fn process_k8(
         .save_profile(!opt.skip_profile_creation)
         .tls(client, server)
         .chart_values(opt.k8_config.chart_values)
-        .chart_version(chart_version)
         .render_checks(true)
         .upgrade(upgrade)
         .with_if(skip_sys, |b| b.install_sys(false))

--- a/src/cluster/src/cli/start/local.rs
+++ b/src/cluster/src/cli/start/local.rs
@@ -16,9 +16,8 @@ pub async fn process_local(
     opt: StartOpt,
     default_chart_version: &str,
 ) -> Result<(), ClusterCliError> {
-    let mut builder = LocalConfig::builder();
+    let mut builder = LocalConfig::builder(default_chart_version);
     builder
-        .chart_version(default_chart_version)
         .log_dir(opt.log_dir.to_string())
         .render_checks(true)
         .spu_replicas(opt.spu);

--- a/src/cluster/src/cli/start/sys.rs
+++ b/src/cluster/src/cli/start/sys.rs
@@ -24,9 +24,8 @@ fn install_sys_impl(
         .as_deref()
         .unwrap_or(default_chart_version);
 
-    let config = SysConfig::builder()
+    let config = SysConfig::builder(chart_version)
         .namespace(&opt.k8_config.namespace)
-        .chart_version(chart_version)
         .with(|builder| match &opt.k8_config.chart_location {
             // If a chart location is given, use it
             Some(chart_location) => builder.local_chart(chart_location),

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -11,9 +11,7 @@
 //! ```
 //! use fluvio_cluster::{ClusterInstaller, ClusterConfig, ClusterError};
 //! # async fn example() -> Result<(), ClusterError> {
-//! let config = ClusterConfig::builder()
-//!     .chart_version("0.7.0-alpha.1")
-//!     .build()?;
+//! let config = ClusterConfig::builder("0.7.0-alpha.1").build()?;
 //! let installer = ClusterInstaller::from_config(config)?;
 //! installer.install_fluvio().await?;
 //! # Ok(())


### PR DESCRIPTION
This should fix the remaining CI breakage. The problem was that `SysConfig` was being used in the `cli/check` module but had not been updated since `chart_version` was made into a required field, causing the "missing chart_version" error we were seeing before.

Do we want to force publish over `0.7.0-alpha.2` for this or bump to `0.7.0-alpha.3`?