### PR TITLE
Protocol compatibility for Fluvio client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -47,7 +47,7 @@ tempdir = "0.3.7"
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
-fluvio = { version = "0.4.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.1", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 fluvio-extension-consumer = { version = "0.2.0", path = "../extension-consumer" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -190,7 +190,7 @@ fn check_platform_compatible(cluster_version: &Version) -> Result<(), FluvioErro
     let client_minimum_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
         .expect("MINIMUM_PLATFORM_VERSION must be semver");
 
-    if client_minimum_version < *cluster_version {
+    if *cluster_version < client_minimum_version {
         return Err(FluvioError::MinimumPlatformVersion {
             cluster_version: cluster_version.clone(),
             client_minimum_version,

--- a/src/client/src/client/cluster.rs
+++ b/src/client/src/client/cluster.rs
@@ -17,6 +17,7 @@ use crate::FluvioConfig;
 use crate::spu::SpuPool;
 
 use super::*;
+use semver::Version;
 
 /// An interface for interacting with Fluvio streaming
 pub struct Fluvio {
@@ -69,6 +70,7 @@ impl Fluvio {
         debug!("connected to cluster at: {}", inner_client.config().addr());
 
         let (socket, config, versions) = inner_client.split();
+        check_platform_compatible(versions.platform_version())?;
         let socket = AllMultiplexerSocket::shared(socket);
 
         let spu_pool = OnceCell::new();
@@ -179,4 +181,21 @@ impl Fluvio {
             self.versions.clone(),
         )
     }
+}
+
+/// The remote cluster is compatible with this client if its
+/// platform version is greater than this crate's
+/// `MINIMUM_PLATFORM_VERSION`.
+fn check_platform_compatible(cluster_version: &Version) -> Result<(), FluvioError> {
+    let client_minimum_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
+        .expect("MINIMUM_PLATFORM_VERSION must be semver");
+
+    if client_minimum_version < *cluster_version {
+        return Err(FluvioError::MinimumPlatformVersion {
+            cluster_version: cluster_version.clone(),
+            client_minimum_version,
+        });
+    }
+
+    Ok(())
 }

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -37,7 +37,7 @@ pub enum FluvioError {
     },
     #[error("Attempted to create negative offset: {0}")]
     NegativeOffset(i64),
-    #[error("Cluster (with platform version {cluster_version}) is older than the client minimum version {client_minimum_version}")]
+    #[error("Cluster (with platform version {cluster_version}) is older than the minimum required version {client_minimum_version}")]
     MinimumPlatformVersion {
         cluster_version: Version,
         client_minimum_version: Version,

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use fluvio_socket::FlvSocketError;
 use fluvio_sc_schema::ApiError;
 use crate::config::ConfigError;
+use semver::Version;
 
 /// Possible errors that may arise when using Fluvio
 #[derive(Error, Debug)]
@@ -36,6 +37,11 @@ pub enum FluvioError {
     },
     #[error("Attempted to create negative offset: {0}")]
     NegativeOffset(i64),
+    #[error("Cluster (with platform version {cluster_version}) is older than the client minimum version {client_minimum_version}")]
+    MinimumPlatformVersion {
+        cluster_version: Version,
+        client_minimum_version: Version,
+    },
     #[error("Unknown error: {0}")]
     Other(String),
 }

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;
 
 /// The minimum VERSION of the Fluvio Platform that this client is compatible with.
-const MINIMUM_PLATFORM_VERSION: &str = "0.6.2-alpha.1";
+const MINIMUM_PLATFORM_VERSION: &str = "0.7.0-alpha.1";
 
 /// Creates a producer that sends events to the named topic
 ///

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -101,6 +101,9 @@ pub use offset::Offset;
 pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;
 
+/// The minimum VERSION of the Fluvio Platform that this client is compatible with.
+const MINIMUM_PLATFORM_VERSION: &str = "0.6.0-alpha.2";
+
 /// Creates a producer that sends events to the named topic
 ///
 /// This is a shortcut function that uses the current profile

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::admin::FluvioAdmin;
 pub use crate::client::Fluvio;
 
 /// The minimum VERSION of the Fluvio Platform that this client is compatible with.
-const MINIMUM_PLATFORM_VERSION: &str = "0.6.0-alpha.2";
+const MINIMUM_PLATFORM_VERSION: &str = "0.6.2-alpha.1";
 
 /// Creates a producer that sends events to the named topic
 ///

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = "1.5"
 derive_builder = "0.9.0"
 
 # Fluvio dependencies
-fluvio = { version = "0.4.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.1", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.1.13" }
 fluvio-command = { path = "../command" }

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -30,7 +30,7 @@ hostname-validator = "1.0.0"
 
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io"] }
-fluvio = { version = "0.4.0", path = "../client", default-features = false }
+fluvio = { version = "0.4.1", path = "../client", default-features = false }
 fluvio-types = { version = "0.2.0" , path = "../types" }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { version = "0.5.0", path = "../controlplane-metadata", features = ["use_serde"] }


### PR DESCRIPTION
This change adds a `MINIMUM_PLATFORM_VERSION` constant to the client crate and causes it to check the platform version of the cluster it is communicating with. If the cluster's platform version is below the minimum, then the client will produce a new `FluvioError::MinimumPlatformVersion` error and refuse to connect.

I believe that we may want to have a bigger design discussion about this. I think it's possible that the solution here is rather brittle, since a future protocol change may change the offsets of data and the position of `platform_version` in the message may not be reliable, making this change useless. We probably want to think about creating a stable encoding of the _protocol_ version in such a way that is very future compatible and which can be checked by clients and servers alike.