### PR TITLE
Fluvio update

### DIFF
--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -60,6 +60,7 @@ async fn fetch_latest_version<T>(
     agent: &HttpAgent,
     id: &PackageId<T>,
     target: Target,
+    prerelease: bool,
 ) -> Result<Version, CliError> {
     let request = agent.request_package(id)?;
     debug!(
@@ -68,7 +69,7 @@ async fn fetch_latest_version<T>(
     );
     let response = crate::http::execute(request).await?;
     let package = agent.package_from_response(response).await?;
-    let latest_release = package.latest_release_for_target(target)?;
+    let latest_release = package.latest_release_for_target(target, prerelease)?;
     debug!(release = ?latest_release, "Latest release for package:");
     if !latest_release.target_exists(target) {
         return Err(fluvio_index::Error::MissingTarget(target).into());

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -38,7 +38,6 @@ impl InstallOpt {
             return Ok(());
         }
 
-        let prerelease = self.develop;
         self.install_plugin(&agent).await?;
 
         // After any "install" command, check if the CLI has an available update,

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -20,7 +20,7 @@ pub struct InstallOpt {
     ///
     /// If the package ID contains a version (e.g. `fluvio/fluvio:0.6.0`), this is ignored
     #[structopt(long)]
-    devel: bool,
+    develop: bool,
 }
 
 impl InstallOpt {
@@ -38,14 +38,14 @@ impl InstallOpt {
             return Ok(());
         }
 
-        let prerelease = self.devel;
+        let prerelease = self.develop;
         self.install_plugin(&agent).await?;
 
-        // After any 'install' command, check if the CLI has an available update,
+        // After any "install" command, check if the CLI has an available update,
         // i.e. one that is not required, but present.
-        let update_available = check_update_available(&agent, prerelease).await?;
+        let update_available = check_update_available(&agent, false).await?;
         if update_available {
-            prompt_available_update(&agent, prerelease).await?;
+            prompt_available_update(&agent, false).await?;
         }
 
         Ok(())
@@ -70,7 +70,7 @@ impl InstallOpt {
                     "🎣 Fetching latest version for package: {}...",
                     &id
                 ));
-                let version = fetch_latest_version(agent, &id, target, self.devel).await?;
+                let version = fetch_latest_version(agent, &id, target, self.develop).await?;
                 let id = id.into_versioned(version);
                 install_println(format!(
                     "⏳ Downloading package with latest version: {}...",

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -15,7 +15,7 @@ pub struct UpdateOpt {
     prefix: Option<String>,
     /// Update to the latest prerelease rather than the latest release
     #[structopt(long)]
-    devel: bool,
+    develop: bool,
 }
 
 impl UpdateOpt {
@@ -36,7 +36,7 @@ impl UpdateOpt {
 
         // Find the latest version of this package
         install_println("🎣 Fetching latest version for fluvio/fluvio...");
-        let latest_version = fetch_latest_version(agent, &id, target, self.devel).await?;
+        let latest_version = fetch_latest_version(agent, &id, target, self.develop).await?;
         let id = id.into_versioned(latest_version);
 
         // Download the package file from the package registry


### PR DESCRIPTION
Closes #704 

This adds a `--develop` flag to the `fluvio update` and `fluvio install` commands. When this flag is _not_ provided, these commands will look for the latest release version of the package. When `--develop` is provided, these commands will search for the latest pre-release versions. Note that this will change the default behavior of these commands, since right now they will always find the latest pre-release version. Another thing to note is that this means that the `curl | bash` install script will only ever be able to install release versions since we cannot pass command-line options to the curl'd script. I think this is the behavior we actually want, I just wanted to point it out.