### PR TITLE
Add profile name printout beside platform_version

### DIFF
--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -32,6 +32,7 @@ use common::COMMAND_TEMPLATE;
 use common::target::ClusterTarget;
 use common::output::Terminal;
 use common::PrintTerminal;
+use fluvio::config::ConfigFile;
 
 pub const VERSION: &str = include_str!("VERSION");
 static_assertions::const_assert!(!VERSION.is_empty());
@@ -263,7 +264,16 @@ impl VersionOpt {
             }
         }
 
-        println!("Fluvio Platform   : {}", platform_version);
+        let profile_name = ConfigFile::load(None)
+            .ok()
+            .and_then(|it| {
+                it.config()
+                    .current_profile_name()
+                    .map(|name| name.to_string())
+            })
+            .map(|name| format!(" ({})", name))
+            .unwrap_or_else(|| "".to_string());
+        println!("Fluvio Platform   : {}{}", platform_version, profile_name);
 
         println!("Git Commit        : {}", env!("GIT_HASH"));
         if let Some(os_info) = option_env!("UNAME") {


### PR DESCRIPTION
Closes #540 

The `fluvio version` command will now print the name of the profile that it used when asking the cluster for its platform version

```
$ fluvio version
Fluvio CLI      : 0.7.0-alpha.3
Fluvio Platform : 0.7.0-alpha.2 (minikube)
Git Commit      : 5bd790b4712c538f67311a0d56177f877915061e
OS Details      : Darwin 20.3.0 x86_64
Rustc Version   : 1.49.0 (e1884a8 2020-12-29)
```