### PR TITLE
Set fluvio-cluster back to 0.7.0 since it was not pushed to crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.7.1"
+version = "0.7.0"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cluster"
-version = "0.7.1"
+version = "0.7.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]


### PR DESCRIPTION
@sehz so we can publish to crates.io