### PR TITLE
Updates CommandExt to capture stdout and stderr in error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
  "colored",
  "derive_builder",
  "fluvio",
- "fluvio-command 0.1.0",
+ "fluvio-command 0.2.0",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
  "fluvio-future",
@@ -1087,6 +1087,8 @@ dependencies = [
 [[package]]
 name = "fluvio-command"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2dcf39df27ca6854ecf6adaf0e5cf83eafd668d27c1efc891ecc3a0b8a1f097"
 dependencies = [
  "once_cell",
  "thiserror",
@@ -1095,9 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-command"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dcf39df27ca6854ecf6adaf0e5cf83eafd668d27c1efc891ecc3a0b8a1f097"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "thiserror",
@@ -1225,7 +1225,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b6e3e6219becb39f3cc3a436ebbcdaf9a4cc1db70d310891e9b08a9f8baadf"
 dependencies = [
- "fluvio-command 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-command 0.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1555,7 +1555,7 @@ dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "fluvio",
- "fluvio-command 0.1.0",
+ "fluvio-command 0.2.0",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -43,7 +43,7 @@ derive_builder = "0.9.0"
 fluvio = { version = "0.4.1", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.1.13" }
-fluvio-command = { version = "0.1.0", path = "../command" }
+fluvio-command = { version = "0.2.0", path = "../command" }
 fluvio-runner-local = { version = "0.2.0", path = "../extension-runner-local", optional = true }
 fluvio-extension-common = { version = "0.1.0", path = "../extension-common", optional = true }
 fluvio-controlplane-metadata = { version = "0.5.0", path = "../controlplane-metadata", features = ["k8"] }

--- a/src/command/Cargo.toml
+++ b/src/command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-command"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio command utilities"

--- a/src/command/src/lib.rs
+++ b/src/command/src/lib.rs
@@ -151,10 +151,9 @@ mod tests {
             .arg("does-not-exist")
             .result()
             .unwrap_err();
-        assert!(format!("{}", error.source).starts_with(
-            "Child process completed with non-zero exit code 1
-  stdout: 
-  stderr: "
-        ));
+        let error_display = format!("{}", error.source);
+        assert!(error_display.starts_with("Child process completed with non-zero exit code"));
+        assert!(error_display.contains("stdout:"));
+        assert!(error_display.contains("stderr:"));
     }
 }

--- a/src/command/src/lib.rs
+++ b/src/command/src/lib.rs
@@ -151,12 +151,10 @@ mod tests {
             .arg("does-not-exist")
             .result()
             .unwrap_err();
-        assert_eq!(
-            format!("{}", error.source),
+        assert!(format!("{}", error.source).starts_with(
             "Child process completed with non-zero exit code 1
   stdout: 
-  stderr: ls: does-not-exist: No such file or directory
-"
-        );
+  stderr: "
+        ));
     }
 }


### PR DESCRIPTION
If `Command::new(...).result()?` fails with a nonzero exit code, the CommandError type will now capture the stdout and stderr values and render them in the Display of the error type. This will make it easier to debug problems that occur from exit codes of invoked commands.