### PR TITLE
make k8 CI run more reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,8 @@ jobs:
         rust: [stable]
     env:
       FLUVIO_CMD:  true 
-      FLV_SOCKET_WAIT:  600 
+      FLV_SOCKET_WAIT:  600
+      FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 60 
     steps:
       - uses: actions/checkout@v2
       - run: helm version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 1
         run: |
-          make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
+          RUST_LOG=debug make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
       - run: minikube delete
       - name: Save logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
     env:
       FLUVIO_CMD:  true 
       FLV_SOCKET_WAIT:  600
-      FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 60 
+      FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 90 
     steps:
       - uses: actions/checkout@v2
       - run: helm version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 1
         run: |
-          RUST_LOG=debug make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
+          make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
       - run: minikube delete
       - name: Save logs
         if: failure()

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -925,7 +925,7 @@ impl ClusterInstaller {
     /// Wait until the platform version of the cluster matches the chart version here
     #[instrument(skip(self))]
     async fn wait_for_fluvio_version(&self, config: &FluvioConfig) -> Result<(), K8InstallError> {
-        const ATTEMPTS: u8 = 30;
+        const ATTEMPTS: u8 = 60;
         for attempt in 0..ATTEMPTS {
             let fluvio = match fluvio::Fluvio::connect_with_config(config).await {
                 Ok(fluvio) => fluvio,


### PR DESCRIPTION
increase FLV_CLUSTER_MAX_SC_NETWORK_LOOP, VERSION check count to higher to make it K8 run reliable