### PR TITLE
Remove unfinished 'local cluster exists' check

### DIFF
--- a/src/cluster/src/check/mod.rs
+++ b/src/cluster/src/check/mod.rs
@@ -552,27 +552,6 @@ impl ClusterCheck for LoadBalancer {
     }
 }
 
-#[derive(Debug)]
-pub struct LocalClusterExists;
-
-#[async_trait]
-impl ClusterCheck for LocalClusterExists {
-    async fn perform_check(&self) -> CheckResult {
-        proclist::iterate_processes_info()
-            .filter_map(|it| it.ok())
-            .filter(|it| it.name.eq_ignore_ascii_case("fluvio"))
-            .inspect(|proc| println!("Found process: {:?}", proc))
-            .for_each(|proc| {
-                let pid = proc.pid as remoteprocess::Pid;
-                if let Ok(process) = remoteprocess::Process::new(pid) {
-                    println!("Process cmd: {:#?}", process.cmdline());
-                    println!("{:#?}", process.exe());
-                }
-            });
-        Ok(CheckStatus::pass("Testing fluvio process"))
-    }
-}
-
 /// Manages all cluster check operations
 ///
 /// A `ClusterChecker` can be configured with different sets of checks to run.
@@ -664,7 +643,6 @@ impl ClusterChecker {
             Box::new(HelmVersion),
             Box::new(K8Version),
             Box::new(LoadableConfig),
-            Box::new(LocalClusterExists),
         ];
         self.checks.extend(checks);
         self


### PR DESCRIPTION
This code was part of an experiment to locate existing SC and SPU processes on a local machine so we could detect if a cluster was already running. I had meant to remove it from a previous PR and forgot. The only harm it does is printing junk to stdout, it was not impacting CI beyond that.

As a note on the progress of this feature, I was having a difficult time figuring out a good cross-platform way of getting this done, and I'm still not 100% sure that this is the right way to approach this anyways. We can discuss alternate potential options later if this continues to be a problem.