### PR TITLE
Change error types back to tuples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-consumer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ctrlc",
  "eyre",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -18,7 +18,7 @@ fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-meta
 dataplane = { version = "0.3.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.1.12", features = ["net", "openssl_tls"] }
 fluvio-protocol = { path = "../protocol",  version = "0.3.0" }
-fluvio-socket = { path = "../socket", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.6.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 flv-tls-proxy = { version = "0.3.0" }
 futures-util = { version = "0.3.5" }

--- a/src/auth/src/error.rs
+++ b/src/auth/src/error.rs
@@ -5,16 +5,13 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum AuthError {
     #[error("IoError")]
-    IoError {
-        #[from]
-        source: IoError,
-    },
+    IoError(#[from] IoError),
 }
 
 impl Into<IoError> for AuthError {
     fn into(self) -> IoError {
         match self {
-            Self::IoError { source } => source,
+            Self::IoError(source) => source,
         }
     }
 }

--- a/src/auth/src/x509/authenticator.rs
+++ b/src/auth/src/x509/authenticator.rs
@@ -61,7 +61,7 @@ impl X509Authenticator {
                 .send(&request_message)
                 .await
                 .map_err(|err| match err {
-                    fluvio_socket::FlvSocketError::IoError { source } => source,
+                    fluvio_socket::FlvSocketError::IoError(source) => source,
                     fluvio_socket::FlvSocketError::SocketClosed => {
                         IoError::new(IoErrorKind::BrokenPipe, "connection closed")
                     }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -51,8 +51,8 @@ fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.5.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
-fluvio-extension-consumer = { version = "0.2.0", path = "../extension-consumer" }
 fluvio-extension-common = { version = "0.2.0", path = "../extension-common", features = ["target"]}
+fluvio-extension-consumer = { version = "0.3.0", path = "../extension-consumer" }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
 k8-types = { version = "0.1.0", features = ["core"]}
 

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -40,7 +40,7 @@ fluvio-future = { version = "0.1.15", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-sc-schema = { version = "0.6.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.4.0", path = "../spu-schema" }
-fluvio-socket = { path = "../socket", version = "0.5.0", features = ["tls"] }
+fluvio-socket = { path = "../socket", version = "0.6.0", features = ["tls"] }
 fluvio-protocol = { path = "../protocol", version = "0.3.0" }
 dataplane = { version = "0.3.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -16,25 +16,13 @@ pub enum FluvioError {
     #[error("Spu not found: {0}")]
     SPUNotFound(i32),
     #[error(transparent)]
-    IoError {
-        #[from]
-        source: IoError,
-    },
+    IoError(#[from] IoError),
     #[error("Fluvio socket error")]
-    FlvSocketError {
-        #[from]
-        source: FlvSocketError,
-    },
+    FlvSocketError(#[from] FlvSocketError),
     #[error("Fluvio SC schema error")]
-    ApiError {
-        #[from]
-        source: ApiError,
-    },
+    ApiError(#[from] ApiError),
     #[error("Fluvio config error")]
-    ConfigError {
-        #[from]
-        source: ConfigError,
-    },
+    ConfigError(#[from] ConfigError),
     #[error("Attempted to create negative offset: {0}")]
     NegativeOffset(i64),
     #[error("Cluster (with platform version {cluster_version}) is older than the minimum required version {client_minimum_version}")]

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -24,6 +24,6 @@ fluvio-protocol = { path = "../protocol", version = "0.3.0", features = ["derive
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { path = "../socket", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.6.0" }
 fluvio-future = { version = "0.1.0", features = ["fixture","fs"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }

--- a/src/extension-common/src/lib.rs
+++ b/src/extension-common/src/lib.rs
@@ -78,15 +78,9 @@ pub mod target {
     #[derive(thiserror::Error, Debug)]
     pub enum TargetError {
         #[error(transparent)]
-        IoError {
-            #[from]
-            source: IoError,
-        },
+        IoError(#[from] IoError),
         #[error("Fluvio client error")]
-        ClientError {
-            #[from]
-            source: FluvioError,
-        },
+        ClientError(#[from] FluvioError),
         #[error("Invalid argument: {0}")]
         InvalidArg(String),
         #[error("Unknown error: {0}")]

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-consumer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio consumer extension"

--- a/src/extension-consumer/src/error.rs
+++ b/src/extension-consumer/src/error.rs
@@ -9,27 +9,15 @@ pub type Result<T> = std::result::Result<T, ConsumerError>;
 #[derive(thiserror::Error, Debug)]
 pub enum ConsumerError {
     #[error(transparent)]
-    IoError {
-        #[from]
-        source: IoError,
-    },
+    IoError(#[from] IoError),
     #[error(transparent)]
-    OutputError {
-        #[from]
-        source: OutputError,
-    },
+    OutputError(#[from] OutputError),
     #[error("Fluvio client error")]
-    ClientError {
-        #[from]
-        source: FluvioError,
-    },
+    ClientError(#[from] FluvioError),
     #[error("Invalid argument: {0}")]
     InvalidArg(String),
     #[error("Error finding executable")]
-    WhichError {
-        #[from]
-        source: which::Error,
-    },
+    WhichError(#[from] which::Error),
     #[error("Unknown error: {0}")]
     Other(String),
 }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -53,7 +53,7 @@ k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.1.0", features = ["app"]}
 fluvio-protocol = { path = "../protocol", version = "0.3.0" }
 dataplane = { version = "0.3.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { path = "../socket", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.6.0" }
 fluvio-service = { path = "../service", version = "0.4.0" }
 flv-tls-proxy = { version = "0.3.0" }
 

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "0.2.21", features = ["macros"] }
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.1.0" }
-fluvio-socket = { version = "0.5.0", path = "../socket" }
+fluvio-socket = { version = "0.6.0", path = "../socket" }
 fluvio-protocol = { path = "../protocol", version = "0.3.0", features = ["derive", "api", "codec"] }
 
 

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/src/socket/src/error.rs
+++ b/src/socket/src/error.rs
@@ -5,16 +5,9 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum FlvSocketError {
     #[error(transparent)]
-    IoError {
-        #[from]
-        source: IoError,
-    },
+    IoError(#[from] IoError),
     #[error("Socket closed")]
     SocketClosed,
-
     #[error("Zero-copy IO error")]
-    SendFileError {
-        #[from]
-        source: SendFileError,
-    },
+    SendFileError(#[from] SendFileError),
 }

--- a/src/socket/src/stream.rs
+++ b/src/socket/src/stream.rs
@@ -85,7 +85,7 @@ where
                 }
                 Err(source) => {
                     error!("error receiving response: {:?}", source);
-                    Err(FlvSocketError::IoError { source })
+                    Err(FlvSocketError::IoError(source))
                 }
             }
         } else {

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -46,7 +46,7 @@ fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-meta
 fluvio-spu-schema = { version = "0.4.0", path = "../spu-schema" }
 fluvio-protocol = { path = "../protocol", version = "0.3.0" }
 dataplane = { version = "0.3.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { path = "../socket", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.6.0" }
 fluvio-service = { path = "../service", version = "0.4.0" }
 flv-tls-proxy = { version = "0.3.0" }
 flv-util = { version = "0.5.0" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -38,4 +38,4 @@ async-mutex = "1.4.0"
 [dev-dependencies]
 fluvio-future = { version = "0.1.8", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { path = "../socket", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.6.0" }


### PR DESCRIPTION
A little while ago I made the mistake of turning a bunch of error types into struct-variants. This makes it very difficult to pattern match on errors when we need to inspect them. I would like to change them back to being tuple-variants.

Updating the error enums is a breaking change, so I will open this PR now, and we can either merge it right away or we can wait until we are already ready to do a version bump on a few crates and we can include this in those changes.

The main motivation behind doing this is that it will make implementing things like https://github.com/infinyon/fluvio/issues/580 much easier