### PR TITLE
Add debug and reword error message for install

### DIFF
--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -63,8 +63,8 @@ pub enum K8InstallError {
     #[error("Failed to perform one or more pre-checks")]
     PrecheckErrored(CheckResults),
     /// Failed to update Fluvio cluster
-    #[error("Failed to to upgrade cluster to version {0}")]
-    FailedClusterUpgrade(String),
+    #[error("Expected to find cluster with platform version {0}")]
+    FailedPlatformVersion(String),
     /// Timed out when waiting for SC service.
     #[error("Timed out when waiting for SC service")]
     SCServiceTimeout,

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -939,8 +939,13 @@ impl ClusterInstaller {
                 // Success
                 break;
             }
+            debug!(
+                platform = %version,
+                chart_version = %self.config.chart_version,
+                "Existing platform version is different than chart version",
+            );
             if attempt >= ATTEMPTS - 1 {
-                return Err(K8InstallError::FailedClusterUpgrade(
+                return Err(K8InstallError::FailedPlatformVersion(
                     self.config.chart_version.to_string(),
                 ));
             }


### PR DESCRIPTION
Adds

```
            debug!(
                platform = %version,
                chart_version = %self.config.chart_version,
                "Existing platform version is different than chart version",
            );
```

and

```
    #[error("Expected to find cluster with platform version {0}")]
    FailedPlatformVersion(String),
```