### PR TITLE
Removed string helpers from consumer client

### DIFF
--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -1,6 +1,4 @@
 use std::sync::Arc;
-use std::convert::TryFrom;
-use std::string::FromUtf8Error;
 
 use futures_util::stream::Stream;
 use tracing::debug;
@@ -401,21 +399,10 @@ impl Record {
     pub fn offset(&self) -> i64 {
         self.offset
     }
-
-    pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(self.as_ref()).to_string()
-    }
 }
 
 impl AsRef<[u8]> for Record {
     fn as_ref(&self) -> &[u8] {
         self.record.value.as_ref()
-    }
-}
-
-impl TryFrom<Record> for String {
-    type Error = FromUtf8Error;
-    fn try_from(record: Record) -> Result<String, FromUtf8Error> {
-        String::from_utf8(record.as_ref().to_vec())
     }
 }


### PR DESCRIPTION
I added these string helpers in #706 because I want to be lazy. @nicholastmosher made some fair points about why they shouldn't be part of the fluvio client.

They're breaking changes so it should go out with the `0.5.0` client.

Also, this should be the last time we do some "quick fixes to the client UI", we should move to some design/review process.