### PR TITLE
Cli error printout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "fluvio-extension-consumer",
  "fluvio-future",
  "fluvio-package-index",
+ "fluvio-sc-schema",
  "hex",
  "home",
  "http-types",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -54,6 +54,7 @@ fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 fluvio-extension-common = { version = "0.2.0", path = "../extension-common", features = ["target"]}
 fluvio-extension-consumer = { version = "0.3.0", path = "../extension-consumer" }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
+fluvio-sc-schema = { version = "0.6.0", path = "../sc-schema" }
 k8-types = { version = "0.1.0", features = ["core"]}
 
 [dev-dependencies]

--- a/src/cli/src/bin/main.rs
+++ b/src/cli/src/bin/main.rs
@@ -13,10 +13,8 @@ fn main() -> Result<()> {
 
     // If the CLI comes back with an error, attempt to handle it
     if let Err(e) = run_block_on(root.process()) {
-        match e.try_handle() {
-            Ok(exit_code) => std::process::exit(exit_code),
-            Err(unhandled) => return Err(unhandled.into_report()),
-        }
+        e.print()?;
+        std::process::exit(1);
     }
 
     Ok(())

--- a/src/cli/src/bin/main.rs
+++ b/src/cli/src/bin/main.rs
@@ -10,7 +10,14 @@ fn main() -> Result<()> {
         .install()?;
     print_help_hack()?;
     let root: Root = Root::from_args();
-    run_block_on(root.process()).map_err(CliError::into_report)?;
+    let result = run_block_on(root.process());
+
+    // If an error was handled gracefully, we still want to exit with the right code
+    if let Err(CliError::ExitWithCode(code)) = result {
+        std::process::exit(code);
+    }
+
+    result.map_err(CliError::into_report)?;
     Ok(())
 }
 

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -36,6 +36,8 @@ pub enum CliError {
     InvalidArg(String),
     #[error("Unknown error: {0}")]
     Other(String),
+    #[error("An error was handled and requires exit code {0}")]
+    ExitWithCode(i32),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -77,11 +77,11 @@ impl CliError {
                 match api {
                     ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
                         println!("Topic already exists");
-                        return Ok(1);
+                        Ok(1)
                     }
                     ApiError::Code(ErrorCode::TopicNotFound, _) => {
                         println!("Topic not found");
-                        return Ok(1);
+                        Ok(1)
                     }
                     _ => Err(self),
                 }

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -5,6 +5,8 @@ use fluvio_extension_common::output::OutputError;
 use fluvio_extension_consumer::ConsumerError;
 use fluvio_cluster::cli::ClusterCliError;
 use crate::common::target::TargetError;
+use fluvio_sc_schema::ApiError;
+use fluvio_sc_schema::errors::ErrorCode;
 
 pub type Result<T> = std::result::Result<T, CliError>;
 
@@ -36,8 +38,6 @@ pub enum CliError {
     InvalidArg(String),
     #[error("Unknown error: {0}")]
     Other(String),
-    #[error("An error was handled and requires exit code {0}")]
-    ExitWithCode(i32),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -63,6 +63,30 @@ impl CliError {
         match self {
             CliError::ClusterCliError(cluster) => cluster.into_report(),
             _ => Report::from(self),
+        }
+    }
+
+    /// Looks at the error value and attempts to gracefully handle reporting it
+    ///
+    /// Sometimes, specific errors require specific user-facing error messages.
+    /// Here is where we define those messages, as well as the exit code that the
+    /// program should return when exiting after those errors.
+    pub fn try_handle(self) -> std::result::Result<i32, CliError> {
+        match &self {
+            Self::ConsumerError(ConsumerError::ClientError(FluvioError::ApiError(api))) => {
+                match api {
+                    ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
+                        println!("Topic already exists");
+                        return Ok(1);
+                    }
+                    ApiError::Code(ErrorCode::TopicNotFound, _) => {
+                        println!("Topic not found");
+                        return Ok(1);
+                    }
+                    _ => Err(self),
+                }
+            }
+            _ => Err(self),
         }
     }
 }

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -71,17 +71,17 @@ impl CliError {
     /// Sometimes, specific errors require specific user-facing error messages.
     /// Here is where we define those messages, as well as the exit code that the
     /// program should return when exiting after those errors.
-    pub fn try_handle(self) -> std::result::Result<i32, CliError> {
+    pub fn print(self) -> Result<()> {
         match &self {
             Self::ConsumerError(ConsumerError::ClientError(FluvioError::ApiError(api))) => {
                 match api {
                     ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
                         println!("Topic already exists");
-                        Ok(1)
+                        Ok(())
                     }
                     ApiError::Code(ErrorCode::TopicNotFound, _) => {
                         println!("Topic not found");
-                        Ok(1)
+                        Ok(())
                     }
                     _ => Err(self),
                 }


### PR DESCRIPTION
Closes #580 

This adds graceful error handling to `fluvio topic create` (if a named topic already exists) and to `fluvio topic delete` (if the named topic does _not_ already exist).

Topic create used to look like this:

```
❯ cargo run --bin fluvio -- topic create foobar
Error:
   0: Consumer Error
   1: Fluvio client error
   2: Fluvio SC schema error
   3: Received error code: TopicAlreadyExists (Some("topic \'foobar\' already defined"))

```

Topic create now looks like:

```
❯ cargo run --bin fluvio -- topic create foobar
topic "foobar" created

❯ cargo run --bin fluvio -- topic create foobar
Topic already exists
```

Topic delete now looks like this:

```
❯ cargo run --bin fluvio -- topic delete foobar
Topic not found
```

One thing I added here is a new error variant: `CliError::ExitWithCode`. It is intended to signal that an error occurred _but was already handled_, and that after execution has bubbled all the way back up to main, it should exit with a particular error code. This is in order to avoid planting `std::process::exit(code)` throughout the codebase.