### PR TITLE
Move composite action to new workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       SCCACHE_CACHE_SIZE: 300M
       SCCACHE_DIR: /Users/runner/Library/Caches/Mozilla.sccache
       FLUVIO_CMD: true
-      FLV_SOCKET_WAIT:  600 
+      FLV_SOCKET_WAIT:  600
 
     steps:
       - uses: actions/checkout@v2
@@ -343,7 +343,7 @@ jobs:
         os: [infinyon-ubuntu-bionic]
         rust: [stable]
     env:
-      FLUVIO_CMD:  true 
+      FLUVIO_CMD:  true
       FLV_SOCKET_WAIT:  600
       FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 90
       RUST_LOG: fluvio=debug
@@ -388,26 +388,3 @@ jobs:
         with:
           name: fluvio-k8-logs
           path: /tmp/flv_sc.log
-
-  composite_action_test:
-    name: Composite Action Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust: [stable]
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./
-        name: Install Fluvio Local Cluster
-      - name: Fluvio command test
-        run: |
-          fluvio version
-          fluvio topic list
-          fluvio topic create "foobar"
-          sleep 3
-          echo foo | fluvio produce "foobar"
-          fluvio consume foobar -o 0 -d
-          # Delete the topic afterword but this looks to not work right now.
-          # fluvio topic delete "foobar"

--- a/.github/workflows/composite_action.yml
+++ b/.github/workflows/composite_action.yml
@@ -1,0 +1,36 @@
+name: Composite Action Test Workflow
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  composite_action_test:
+    name: Composite Action Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [stable]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: Install Fluvio Local Cluster
+      - name: Fluvio command test
+        continue-on-error: true
+        run: |
+          fluvio version
+          fluvio topic list
+          fluvio topic create "foobar"
+          sleep 3
+          echo foo | fluvio produce "foobar"
+          fluvio consume foobar -o 0 -d
+          # Delete the topic afterword but this looks to not work right now.
+          # fluvio topic delete "foobar"


### PR DESCRIPTION
Closes #563.

Based on the comments in https://github.com/actions/toolkit/issues/399, it seems that there's currently no way to remove the red X from the builds using the continue-on-error flag. So, this seems to be the best way to do it.