### PR TITLE
Fixed fluvio cluster delete when sys chart not installed

### DIFF
--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -153,6 +153,9 @@ pub enum UninstallError {
     /// An error occurred with the Fluvio client.
     #[error("Fluvio client error")]
     FluvioError(#[from] FluvioError),
+    /// Failed to execute a command
+    #[error(transparent)]
+    CommandError(#[from] CommandError),
     /// An error occurred with the Kubernetes config.
     #[error("Kubernetes config error")]
     K8ConfigError(#[from] K8ConfigError),

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -365,14 +365,11 @@ impl FlushPolicy {
 mod tests {
 
     // use std::time::{Duration, Instant};
-    use std::time::Duration;
     use std::env::temp_dir;
     use std::io::Cursor;
-
     use tracing::debug;
 
     use fluvio_future::test_async;
-    use fluvio_future::timer;
     use flv_util::fixture::ensure_clean_file;
     use dataplane::batch::DefaultBatch;
     use dataplane::core::{Decoder, Encoder};
@@ -381,12 +378,10 @@ mod tests {
 
     use super::MutFileRecords;
     use super::StorageError;
-
     use crate::config::ConfigOption;
 
     const TEST_FILE_NAME: &str = "00000000000000000100.log"; // for offset 100
     const TEST_FILE_NAMEC: &str = "00000000000000000200.log"; // for offset 200
-    const TEST_FILE_NAMEI: &str = "00000000000000000300.log"; // for offset 300
 
     #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
@@ -528,6 +523,10 @@ mod tests {
     #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
     async fn test_write_records_idle_delay() -> Result<(), StorageError> {
+        use std::time::Duration;
+        use fluvio_future::timer;
+        const TEST_FILE_NAMEI: &str = "00000000000000000300.log"; // for offset 300
+
         let test_file = temp_dir().join(TEST_FILE_NAMEI);
         ensure_clean_file(&test_file);
 


### PR DESCRIPTION
I finally figured out why `fluvio cluster delete` was behaving weird but only sometimes. If `fluvio-sys` was installed, `fluvio cluster delete` works just fine. BUT, if `fluvio-sys` was not installed, then we would get a Kubernetes 404 during the uninstall step because we were attempting to interact with CRD objects that weren't there.

This is a quick fix that skips certain uninstall steps if fluvio-sys is not installed.