### PR TITLE
Added initial changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,14 @@
+name: Chargelog CI
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  changelog_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Changelog CI
+        uses: saadmk11/changelog-ci@master


### PR DESCRIPTION
Closes #677.

Two constraints of this is:
* We have to do releases via PR on origin rather than a fork. https://github.com/saadmk11/changelog-ci/issues/41 is a topic of discussion
* Releases must be done via a PR titled `Release ${VERSION}` where `VERSION` fits semver.

This will append a comment with all the PR's since the previous version. See https://github.com/saadmk11/changelog-ci/pull/36 as an example.