### PR TITLE
Use public consumer API for CLI consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
 name = "fluvio-extension-consumer"
 version = "0.3.0"
 dependencies = [
+ "content_inspector",
  "ctrlc",
  "eyre",
  "fluvio",

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -223,7 +223,7 @@ impl FluvioCmd {
 
         match self {
             Self::Consume(consume) => {
-                consume.process(out, &fluvio).await?;
+                consume.process(&fluvio).await?;
             }
             Self::Produce(produce) => {
                 produce.process(&fluvio).await?;

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0.20"
 eyre = "0.6.1"
 which = "4.0.2"
 hostname-validator = "1.0.0"
+content_inspector = "0.2.4"
 
 # Fluvio dependencies
 

--- a/src/extension-consumer/src/consume/mod.rs
+++ b/src/extension-consumer/src/consume/mod.rs
@@ -4,7 +4,6 @@
 //! CLI command for Consume operation
 //!
 
-use std::sync::Arc;
 use structopt::StructOpt;
 use structopt::clap::arg_enum;
 
@@ -13,7 +12,6 @@ mod logs_output;
 
 use fluvio::Fluvio;
 
-use crate::common::output::Terminal;
 use crate::consume::fetch_log_loop::fetch_log_loop;
 use crate::ConsumerError;
 use crate::common::FluvioExtensionMetadata;
@@ -61,15 +59,11 @@ pub struct ConsumeLogOpt {
 }
 
 impl ConsumeLogOpt {
-    pub async fn process<O: Terminal>(
-        self,
-        out: Arc<O>,
-        fluvio: &Fluvio,
-    ) -> Result<(), ConsumerError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<(), ConsumerError> {
         let consumer = fluvio
             .partition_consumer(&self.topic, self.partition)
             .await?;
-        fetch_log_loop(out, consumer, self).await?;
+        fetch_log_loop(consumer, self).await?;
         Ok(())
     }
 


### PR DESCRIPTION
This closes #397 

- Simplify CLI consumer
- Reduce dependency of CLI consumer on the internal details of API consumer
- Enhance API consumer with any required information