### PR TITLE
implement limit for batch size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
         run: |
           make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
       - name: Clean minikube
-        run:
+        run: |
           minikube delete
           pkill -f "minikube tunnel"
       - name: Save logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,6 @@ jobs:
       FLUVIO_CMD:  true
       FLV_SOCKET_WAIT:  600
       FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 90
-      RUST_LOG: fluvio=debug
     steps:
       - uses: actions/checkout@v2
       - run: helm version
@@ -360,7 +359,7 @@ jobs:
         run: |
           minikube delete
           minikube start --driver=docker --kubernetes-version 1.19.6
-          sleep 30
+          nohup  minikube tunnel --alsologtostderr > /tmp/tunnel.out 2> /tmp/tunnel.out &
       - name: Test minikube
         run: |
           minikube profile list
@@ -377,7 +376,10 @@ jobs:
         timeout-minutes: 10
         run: |
           make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
-      - run: minikube delete
+      - name: Clean minikube
+        run:
+          minikube delete
+          pkill -f "minikube tunnel"
       - name: Save logs
         if: failure()
         run: kubectl logs fluvio-sc > /tmp/flv_sc.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "async-mutex",
  "async-trait",
  "bytes 0.5.6",
+ "derive_builder",
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-protocol",

--- a/src/dataplane-protocol/src/error_code.rs
+++ b/src/dataplane-protocol/src/error_code.rs
@@ -23,6 +23,7 @@ pub enum ErrorCode {
 
     OffsetOutOfRange = 1,
     NotLeaderForPartition = 6,
+    MessageTooLarge = 10,
     PermissionDenied = 13,
     StorageError = 56,
 

--- a/src/spu/src/config/spu_config.rs
+++ b/src/spu/src/config/spu_config.rs
@@ -28,7 +28,9 @@ use fluvio_types::defaults::SPU_MIN_IN_SYNC_REPLICAS;
 use fluvio_types::defaults::FLV_LOG_BASE_DIR;
 use fluvio_types::defaults::FLV_LOG_SIZE;
 use fluvio_types::SpuId;
-use fluvio_storage::config::{ConfigOption,DEFAULT_FLUSH_WRITE_COUNT,DEFAULT_FLUSH_IDLE_MSEC,DEFAULT_MAX_BATCH_SIZE};
+use fluvio_storage::config::{
+    ConfigOption, DEFAULT_FLUSH_WRITE_COUNT, DEFAULT_FLUSH_IDLE_MSEC, DEFAULT_MAX_BATCH_SIZE,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Replication {
@@ -52,7 +54,7 @@ pub struct Log {
     pub segment_max_bytes: u32,
     pub flush_write_count: u32,
     pub flush_idle_msec: u32,
-    pub max_batch_size: u32
+    pub max_batch_size: u32,
 }
 
 impl Default for Log {
@@ -67,7 +69,7 @@ impl Default for Log {
             segment_max_bytes: SPU_LOG_SEGMENT_MAX_BYTES,
             flush_write_count: DEFAULT_FLUSH_WRITE_COUNT,
             flush_idle_msec: DEFAULT_FLUSH_IDLE_MSEC,
-            max_batch_size: DEFAULT_MAX_BATCH_SIZE
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
         }
     }
 }
@@ -82,7 +84,7 @@ impl Log {
             self.segment_max_bytes,
             self.flush_write_count,
             self.flush_idle_msec,
-            self.max_batch_size
+            self.max_batch_size,
         )
     }
 }

--- a/src/spu/src/config/spu_config.rs
+++ b/src/spu/src/config/spu_config.rs
@@ -28,9 +28,7 @@ use fluvio_types::defaults::SPU_MIN_IN_SYNC_REPLICAS;
 use fluvio_types::defaults::FLV_LOG_BASE_DIR;
 use fluvio_types::defaults::FLV_LOG_SIZE;
 use fluvio_types::SpuId;
-use fluvio_storage::ConfigOption;
-use fluvio_storage::DEFAULT_FLUSH_WRITE_COUNT;
-use fluvio_storage::DEFAULT_FLUSH_IDLE_MSEC;
+use fluvio_storage::config::{ConfigOption,DEFAULT_FLUSH_WRITE_COUNT,DEFAULT_FLUSH_IDLE_MSEC,DEFAULT_MAX_BATCH_SIZE};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Replication {
@@ -54,6 +52,7 @@ pub struct Log {
     pub segment_max_bytes: u32,
     pub flush_write_count: u32,
     pub flush_idle_msec: u32,
+    pub max_batch_size: u32
 }
 
 impl Default for Log {
@@ -68,6 +67,7 @@ impl Default for Log {
             segment_max_bytes: SPU_LOG_SEGMENT_MAX_BYTES,
             flush_write_count: DEFAULT_FLUSH_WRITE_COUNT,
             flush_idle_msec: DEFAULT_FLUSH_IDLE_MSEC,
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE
         }
     }
 }
@@ -82,6 +82,7 @@ impl Log {
             self.segment_max_bytes,
             self.flush_write_count,
             self.flush_idle_msec,
+            self.max_batch_size
         )
     }
 }

--- a/src/spu/src/controllers/follower_replica/state.rs
+++ b/src/spu/src/controllers/follower_replica/state.rs
@@ -17,7 +17,7 @@ use chashmap::WriteGuard;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use dataplane::record::RecordSet;
 use fluvio_storage::FileReplica;
-use fluvio_storage::ConfigOption;
+use fluvio_storage::config::ConfigOption;
 use fluvio_storage::StorageError;
 use fluvio_storage::ReplicaStorage;
 use fluvio_types::SpuId;

--- a/src/spu/src/controllers/leader_replica/replica_state.rs
+++ b/src/spu/src/controllers/leader_replica/replica_state.rs
@@ -14,7 +14,7 @@ use dataplane::api::RequestMessage;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use fluvio_controlplane_metadata::partition::Replica;
 use fluvio_controlplane::LrsRequest;
-use fluvio_storage::{FileReplica, ConfigOption, StorageError};
+use fluvio_storage::{FileReplica, config::ConfigOption, StorageError};
 use fluvio_types::SpuId;
 use fluvio_storage::SlicePartitionResponse;
 use fluvio_storage::ReplicaStorage;

--- a/src/spu/src/core/storage/mod.rs
+++ b/src/spu/src/core/storage/mod.rs
@@ -1,4 +1,4 @@
-use fluvio_storage::ConfigOption;
+use fluvio_storage::config::ConfigOption;
 use fluvio_storage::FileReplica;
 use fluvio_storage::StorageError;
 use fluvio_controlplane_metadata::partition::ReplicaKey;

--- a/src/spu/src/services/public/produce_handler.rs
+++ b/src/spu/src/services/public/produce_handler.rs
@@ -1,5 +1,6 @@
 use std::io::Error;
 
+use fluvio_storage::StorageError;
 use tracing::warn;
 use tracing::trace;
 use tracing::error;
@@ -13,6 +14,7 @@ use dataplane::api::ResponseMessage;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use crate::core::DefaultSharedGlobalContext;
+use crate::InternalServerError;
 
 pub async fn handle_produce_request(
     request: RequestMessage<DefaultProduceRequest>,
@@ -60,7 +62,15 @@ pub async fn handle_produce_request(
                 }
                 Err(err) => {
                     error!("error: {:#?} writing to replica: {}", err, rep_id);
-                    partition_response.error_code = ErrorCode::StorageError;
+                    match err {
+                        InternalServerError::StorageError(storage_err) if matches!(storage_err,StorageError::BatchTooBig(_)) => {
+                            partition_response.error_code = ErrorCode::MessageTooLarge
+                        },
+                        _ =>  {
+                            partition_response.error_code = ErrorCode::StorageError;
+                        }
+                    }
+                    
                 }
             }
 

--- a/src/spu/src/services/public/produce_handler.rs
+++ b/src/spu/src/services/public/produce_handler.rs
@@ -63,14 +63,15 @@ pub async fn handle_produce_request(
                 Err(err) => {
                     error!("error: {:#?} writing to replica: {}", err, rep_id);
                     match err {
-                        InternalServerError::StorageError(storage_err) if matches!(storage_err,StorageError::BatchTooBig(_)) => {
+                        InternalServerError::StorageError(storage_err)
+                            if matches!(storage_err, StorageError::BatchTooBig(_)) =>
+                        {
                             partition_response.error_code = ErrorCode::MessageTooLarge
-                        },
-                        _ =>  {
+                        }
+                        _ => {
                             partition_response.error_code = ErrorCode::StorageError;
                         }
                     }
-                    
                 }
             }
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -26,17 +26,18 @@ async-channel = "1.5.1"
 async-trait = "0.1.18"
 structopt = { version = "0.3.5", optional = true }
 serde = { version = "1.0.103", features = ['derive'] }
+async-mutex = "1.4.0"
+derive_builder = "0.9.0"
 
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0" , path = "../types" }
 fluvio-future = { version = "0.1.8", features = ["fs","mmap"] }
 fluvio-protocol = { path = "../protocol", version = "0.3.0" }
 dataplane = { version = "0.3.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-async-mutex = "1.4.0"
 
 
 [dev-dependencies]
-derive_builder = "0.9.0"
+
 fluvio-future = { version = "0.1.8", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-socket = { path = "../socket", version = "0.6.0" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -36,6 +36,7 @@ async-mutex = "1.4.0"
 
 
 [dev-dependencies]
+derive_builder = "0.9.0"
 fluvio-future = { version = "0.1.8", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-socket = { path = "../socket", version = "0.6.0" }

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -223,7 +223,7 @@ impl<R> FileBatchStream<R>
 where
     R: BatchRecords,
 {
-    pub(crate) async fn next(&mut self) -> Option<FileBatchPos<R>> {
+    pub async fn next(&mut self) -> Option<FileBatchPos<R>> {
         trace!("reading next from pos: {}", self.pos);
         match FileBatchPos::from(&mut self.file, self.pos).await {
             Ok(batch_res) => {

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -253,7 +253,7 @@ mod tests {
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_new_dir;
 
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use crate::StorageError;
     use crate::segment::MutableSegment;
     use crate::fixture::create_batch;

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -34,6 +34,7 @@ where
 
 impl<R> Unpin for FileBatchPos<R> where R: BatchRecords {}
 
+#[allow(clippy::len_without_is_empty)]
 impl<R> FileBatchPos<R>
 where
     R: BatchRecords,

--- a/src/storage/src/batch_header.rs
+++ b/src/storage/src/batch_header.rs
@@ -56,7 +56,7 @@ mod tests {
     use crate::fixture::create_batch;
     use crate::fixture::create_batch_with_producer;
     use crate::mut_records::MutFileRecords;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use crate::StorageError;
 
     use super::BatchHeaderStream;

--- a/src/storage/src/bin/cli.rs
+++ b/src/storage/src/bin/cli.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 use fluvio_future::task::run_block_on;
 use fluvio_future::fs::util as fs_util;
 
-use fluvio_storage::{ LogIndex,StorageError, OffsetPosition, BatchHeaderStream };
+use fluvio_storage::{ LogIndex,StorageError, OffsetPosition, batch_header::BatchHeaderStream };
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "storage", about = "Flavio Storage CLI")]

--- a/src/storage/src/bin/cli.rs
+++ b/src/storage/src/bin/cli.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 use fluvio_future::task::run_block_on;
 use fluvio_future::fs::util as fs_util;
 
-use fluvio_storage::{ LogIndex,StorageError, OffsetPosition, batch_header::BatchHeaderStream };
+use fluvio_storage::{LogIndex, StorageError, OffsetPosition, batch_header::BatchHeaderStream};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "storage", about = "Flavio Storage CLI")]
@@ -39,16 +39,13 @@ pub(crate) struct LogOpt {
 }
 
 async fn print_logs(path: PathBuf) -> Result<(), StorageError> {
-
-
     let file = fs_util::open(path).await?;
 
-    let mut header = BatchHeaderStream::new_with_pos(file,0).await?;
+    let mut header = BatchHeaderStream::new_with_pos(file, 0).await?;
 
     //  println!("base offset: {}",batch_stream.get_base_offset());
- 
+
     while let Some(batch_pos) = header.next().await {
-        
         println!(
             "batch offset: {}, pos: {}, len: {}, ",
             batch_pos.get_base_offset(),
@@ -56,7 +53,7 @@ async fn print_logs(path: PathBuf) -> Result<(), StorageError> {
             batch_pos.len(),
         );
     }
-    
+
     println!("done");
 
     Ok(())

--- a/src/storage/src/checkpoint.rs
+++ b/src/storage/src/checkpoint.rs
@@ -17,7 +17,7 @@ use fluvio_future::fs::File;
 use fluvio_future::fs::metadata;
 use fluvio_future::fs::util;
 
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 
 pub trait ReadToBuf: Sized {
     fn read_from<B>(buf: &mut B) -> Self
@@ -162,7 +162,7 @@ mod tests {
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_clean_file;
 
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use super::CheckPoint;
 
     #[test_async]

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -12,6 +12,7 @@ use dataplane::Size;
 
 pub const DEFAULT_FLUSH_WRITE_COUNT: u32 = 1;
 pub const DEFAULT_FLUSH_IDLE_MSEC: u32 = 0;
+pub const DEFAULT_MAX_BATCH_SIZE: u32 = 1048588;
 
 // common option
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -28,6 +29,8 @@ pub struct ConfigOption {
     pub flush_write_count: Size,
     #[serde(default = "default_flush_idle_msec")]
     pub flush_idle_msec: Size,
+    #[serde(default = "default_max_batch_size")]
+    pub max_batch_size: Size,
 }
 
 impl fmt::Display for ConfigOption {
@@ -40,34 +43,42 @@ fn default_base_dir() -> PathBuf {
     PathBuf::from(SPU_LOG_BASE_DIR)
 }
 
-fn default_index_max_bytes() -> Size {
+const fn default_index_max_bytes() -> Size {
     SPU_LOG_INDEX_MAX_BYTES
 }
 
-fn default_index_max_interval_bytes() -> Size {
+const fn default_index_max_interval_bytes() -> Size {
     SPU_LOG_INDEX_MAX_INTERVAL_BYTES
 }
 
-fn default_segment_max_bytes() -> Size {
+const fn default_segment_max_bytes() -> Size {
     SPU_LOG_SEGMENT_MAX_BYTES
 }
 
-fn default_flush_write_count() -> Size {
+const fn default_flush_write_count() -> Size {
     DEFAULT_FLUSH_WRITE_COUNT
 }
 
-fn default_flush_idle_msec() -> Size {
+const fn default_flush_idle_msec() -> Size {
     DEFAULT_FLUSH_IDLE_MSEC
 }
+
+const fn default_max_batch_size() -> Size {
+    DEFAULT_MAX_BATCH_SIZE
+}
+
+
 
 impl ConfigOption {
     pub fn new(
         base_dir: PathBuf,
-        index_max_bytes: u32,
-        index_max_interval_bytes: u32,
-        segment_max_bytes: u32,
-        flush_write_count: u32,
-        flush_idle_msec: u32,
+        index_max_bytes: Size,
+        index_max_interval_bytes: Size,
+        segment_max_bytes: Size,
+        flush_write_count: Size,
+        flush_idle_msec: Size,
+        max_batch_size: Size
+
     ) -> Self {
         ConfigOption {
             base_dir,
@@ -76,6 +87,7 @@ impl ConfigOption {
             segment_max_bytes,
             flush_write_count,
             flush_idle_msec,
+            max_batch_size
         }
     }
 
@@ -104,6 +116,7 @@ impl Default for ConfigOption {
             segment_max_bytes: default_segment_max_bytes(),
             flush_write_count: default_flush_write_count(),
             flush_idle_msec: default_flush_idle_msec(),
+            max_batch_size: default_max_batch_size()
         }
     }
 }

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -67,8 +67,6 @@ const fn default_max_batch_size() -> Size {
     DEFAULT_MAX_BATCH_SIZE
 }
 
-
-
 impl ConfigOption {
     pub fn new(
         base_dir: PathBuf,
@@ -77,8 +75,7 @@ impl ConfigOption {
         segment_max_bytes: Size,
         flush_write_count: Size,
         flush_idle_msec: Size,
-        max_batch_size: Size
-
+        max_batch_size: Size,
     ) -> Self {
         ConfigOption {
             base_dir,
@@ -87,7 +84,7 @@ impl ConfigOption {
             segment_max_bytes,
             flush_write_count,
             flush_idle_msec,
-            max_batch_size
+            max_batch_size,
         }
     }
 
@@ -116,7 +113,7 @@ impl Default for ConfigOption {
             segment_max_bytes: default_segment_max_bytes(),
             flush_write_count: default_flush_write_count(),
             flush_idle_msec: default_flush_idle_msec(),
-            max_batch_size: default_max_batch_size()
+            max_batch_size: default_max_batch_size(),
         }
     }
 }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -15,6 +15,7 @@ pub enum StorageError {
     OffsetError(OffsetError),
     LogValidationError(LogValidationError),
     SendFileError(SendFileError),
+    BatchTooBig(usize)
 }
 
 impl fmt::Display for StorageError {
@@ -25,6 +26,7 @@ impl fmt::Display for StorageError {
             Self::OffsetError(err) => write!(f, "{}", err),
             Self::LogValidationError(err) => write!(f, "{}", err),
             Self::SendFileError(err) => write!(f, "{}", err),
+            Self::BatchTooBig(max) => write!(f, "one of batch exceed maximum bytes: {}", max),
         }
     }
 }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -15,7 +15,7 @@ pub enum StorageError {
     OffsetError(OffsetError),
     LogValidationError(LogValidationError),
     SendFileError(SendFileError),
-    BatchTooBig(usize)
+    BatchTooBig(usize),
 }
 
 impl fmt::Display for StorageError {

--- a/src/storage/src/fixture.rs
+++ b/src/storage/src/fixture.rs
@@ -9,7 +9,7 @@ use dataplane::record::DefaultRecord;
 use dataplane::batch::DefaultBatch;
 use dataplane::Size;
 
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 
 pub fn create_batch() -> DefaultBatch {
     create_batch_with_producer(12, 2)

--- a/src/storage/src/fixture.rs
+++ b/src/storage/src/fixture.rs
@@ -15,16 +15,15 @@ use crate::config::ConfigOption;
 
 const DEFAULT_TEST_BYTE: u8 = 5;
 
-fn default_record_producer(_record_index: usize,producer: &BatchProducer) -> DefaultRecord {
+fn default_record_producer(_record_index: usize, producer: &BatchProducer) -> DefaultRecord {
     let mut record = DefaultRecord::default();
-    let bytes: Vec<u8> = vec![DEFAULT_TEST_BYTE;producer.per_record_bytes];
+    let bytes: Vec<u8> = vec![DEFAULT_TEST_BYTE; producer.per_record_bytes];
     record.value = bytes.into();
     record
 }
 
 #[derive(Builder)]
 pub struct BatchProducer {
-
     #[builder(setter(into), default = "0")]
     producer_id: i64,
     #[builder(setter(into), default = "1")]
@@ -34,17 +33,15 @@ pub struct BatchProducer {
     pub per_record_bytes: usize,
     /// generate record
     #[builder(setter, default = "Arc::new(default_record_producer)")]
-    pub record_generator: Arc<dyn Fn(usize,&BatchProducer) -> DefaultRecord>
+    pub record_generator: Arc<dyn Fn(usize, &BatchProducer) -> DefaultRecord>,
 }
 
 impl BatchProducer {
-
     pub fn builder() -> BatchProducerBuilder {
         BatchProducerBuilder::default()
     }
 
     fn generate_batch(&self) -> DefaultBatch {
-
         let mut batches = DefaultBatch::default();
         let header = batches.get_mut_header();
         header.magic = 2;
@@ -52,13 +49,13 @@ impl BatchProducer {
         header.producer_epoch = -1;
 
         for i in 0..self.records {
-            batches.add_record((self.record_generator)(i as usize,&self));
+            batches.add_record((self.record_generator)(i as usize, &self));
         }
 
         batches
     }
 
-    pub fn records(&self)  -> RecordSet {
+    pub fn records(&self) -> RecordSet {
         RecordSet::default().add(self.generate_batch())
     }
 }

--- a/src/storage/src/index.rs
+++ b/src/storage/src/index.rs
@@ -17,7 +17,7 @@ use dataplane::{Offset, Size};
 use crate::util::generate_file_name;
 use crate::util::log_path_get_offset;
 use crate::validator::LogValidationError;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::StorageError;
 
 /// size of the memory mapped isze
@@ -196,7 +196,7 @@ mod tests {
     use super::lookup_entry;
     use super::LogIndex;
     use crate::mut_index::MutLogIndex;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use super::OffsetPosition;
 
     #[allow(unused)]

--- a/src/storage/src/index.rs
+++ b/src/storage/src/index.rs
@@ -25,7 +25,7 @@ const INDEX_ENTRY_SIZE: Size = (size_of::<Size>() * 2) as Size;
 
 pub const EXTENSION: &str = "index";
 
-pub(crate) trait Index {
+pub trait Index {
     fn find_offset(&self, relative_offset: Size) -> Option<(Size, Size)>;
 
     fn len(&self) -> Size;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -1,5 +1,4 @@
-#[cfg(test)]
-mod fixture;
+pub mod fixture;
 
 pub mod batch;
 pub mod batch_header;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -11,7 +11,7 @@ mod mut_records;
 mod mut_index;
 mod range_map;
 mod replica;
-mod segment;
+pub mod segment;
 mod util;
 mod validator;
 mod config;
@@ -27,7 +27,7 @@ pub use crate::records::FileRecordsSlice;
 pub use crate::index::LogIndex;
 pub use crate::index::OffsetPosition;
 pub use crate::replica::FileReplica;
-pub(crate) use crate::segment::SegmentSlice;
+pub use crate::segment::SegmentSlice;
 
 use dataplane::{ErrorCode, Offset};
 use dataplane::fetch::FilePartitionResponse;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod fixture;
 
-mod batch;
-mod batch_header;
+pub mod batch;
+pub mod batch_header;
 mod checkpoint;
 mod error;
 mod records;
@@ -14,14 +14,8 @@ mod replica;
 pub mod segment;
 mod util;
 mod validator;
-mod config;
+pub mod config;
 
-pub use crate::config::ConfigOption;
-pub use crate::config::DEFAULT_FLUSH_WRITE_COUNT;
-pub use crate::config::DEFAULT_FLUSH_IDLE_MSEC;
-pub use crate::batch::DefaultFileBatchStream;
-pub use crate::batch_header::BatchHeaderPos;
-pub use crate::batch_header::BatchHeaderStream;
 pub use crate::error::StorageError;
 pub use crate::records::FileRecordsSlice;
 pub use crate::index::LogIndex;

--- a/src/storage/src/mut_index.rs
+++ b/src/storage/src/mut_index.rs
@@ -15,7 +15,7 @@ use fluvio_future::fs::mmap::MemoryMappedMutFile;
 use dataplane::{Offset, Size};
 
 use crate::util::generate_file_name;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::index::lookup_entry;
 use crate::index::Index;
 use crate::index::OffsetPosition;

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -26,7 +26,7 @@ use dataplane::core::Encoder;
 use crate::util::generate_file_name;
 use crate::validator::validate;
 use crate::validator::LogValidationError;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::StorageError;
 use crate::records::FileRecords;
 
@@ -377,7 +377,7 @@ mod tests {
     use super::StorageError;
     use crate::fixture::create_batch;
     use crate::fixture::read_bytes_from_file;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
 
     const TEST_FILE_NAME: &str = "00000000000000000100.log"; // for offset 100
     const TEST_FILE_NAMEC: &str = "00000000000000000200.log"; // for offset 200

--- a/src/storage/src/range_map.rs
+++ b/src/storage/src/range_map.rs
@@ -13,7 +13,7 @@ use dataplane::Offset;
 
 use crate::segment::ReadSegment;
 use crate::StorageError;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::util::log_path_get_offset;
 
 #[derive(Debug)]
@@ -131,7 +131,7 @@ mod tests {
     use crate::StorageError;
     use crate::segment::MutableSegment;
     use crate::segment::ReadSegment;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use crate::fixture::create_batch;
 
     const TEST_SEGMENT_DIR: &str = "segmentlist-test";

--- a/src/storage/src/records.rs
+++ b/src/storage/src/records.rs
@@ -17,9 +17,9 @@ use crate::validator::LogValidationError;
 use crate::ConfigOption;
 use crate::StorageError;
 
-pub(crate) const MESSAGE_LOG_EXTENSION: &str = "log";
+pub const MESSAGE_LOG_EXTENSION: &str = "log";
 
-pub(crate) trait FileRecords {
+pub trait FileRecords {
     fn get_base_offset(&self) -> Offset;
 
     // fn get_file(&self) -> &File;

--- a/src/storage/src/records.rs
+++ b/src/storage/src/records.rs
@@ -14,7 +14,7 @@ use dataplane::{Offset, Size};
 use crate::util::generate_file_name;
 use crate::validator::validate;
 use crate::validator::LogValidationError;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::StorageError;
 
 pub const MESSAGE_LOG_EXTENSION: &str = "log";

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -175,12 +175,11 @@ impl FileReplica {
         records: RecordSet,
         update_highwatermark: bool,
     ) -> Result<(), StorageError> {
-
         let max_batch_size = self.option.max_batch_size as usize;
         // check if any of the records's batch exceed max length
         for batch in &records.batches {
             if batch.write_size(0) > max_batch_size {
-                return Err(StorageError::BatchTooBig(max_batch_size))
+                return Err(StorageError::BatchTooBig(max_batch_size));
             }
         }
 

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -354,13 +354,11 @@ mod tests {
     use dataplane::record::RecordSet;
     use flv_util::fixture::ensure_clean_dir;
 
-    
     use crate::fixture::{BatchProducer, create_batch};
     use crate::fixture::read_bytes_from_file;
     use crate::config::ConfigOption;
     use crate::StorageError;
     use crate::ReplicaStorage;
-
 
     use super::FileReplica;
 
@@ -690,18 +688,23 @@ mod tests {
             .await
             .expect("test replica");
 
-        let small_batch = BatchProducer::builder()
-            .build().expect("batch")
-            .records();
-        assert!(small_batch.write_size(0) < 100);         // ensure we are writing less than 100 bytes
-        replica.send_records(small_batch,false).await.expect("writing records");
+        let small_batch = BatchProducer::builder().build().expect("batch").records();
+        assert!(small_batch.write_size(0) < 100); // ensure we are writing less than 100 bytes
+        replica
+            .send_records(small_batch, false)
+            .await
+            .expect("writing records");
 
         let larget_batch = BatchProducer::builder()
             .per_record_bytes(200)
-            .build().expect("batch")
+            .build()
+            .expect("batch")
             .records();
-        assert!(larget_batch.write_size(0) > 100);         // ensure we are writing more than 100
-        assert!(matches!(replica.send_records(larget_batch,false).await.unwrap_err(),StorageError::BatchTooBig(_)));
+        assert!(larget_batch.write_size(0) > 100); // ensure we are writing more than 100
+        assert!(matches!(
+            replica.send_records(larget_batch, false).await.unwrap_err(),
+            StorageError::BatchTooBig(_)
+        ));
 
         Ok(())
     }

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -25,10 +25,10 @@ use crate::index::OffsetPosition;
 use crate::validator::LogValidationError;
 use crate::util::OffsetError;
 
-pub(crate) type MutableSegment = Segment<MutLogIndex, MutFileRecords>;
-pub(crate) type ReadSegment = Segment<LogIndex, FileRecordsSlice>;
+pub type MutableSegment = Segment<MutLogIndex, MutFileRecords>;
+pub type ReadSegment = Segment<LogIndex, FileRecordsSlice>;
 
-pub(crate) enum SegmentSlice<'a> {
+pub enum SegmentSlice<'a> {
     MutableSegment(&'a MutableSegment),
     Segment(&'a ReadSegment),
 }
@@ -54,7 +54,7 @@ impl<'a> SegmentSlice<'a> {
 }
 
 /// Segment contains both message log and index
-pub(crate) struct Segment<I, L> {
+pub struct Segment<I, L> {
     option: ConfigOption,
     msg_log: L,
     index: I,

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -10,7 +10,7 @@ use dataplane::{Offset, Size};
 use fluvio_future::file_slice::AsyncFileSlice;
 use fluvio_future::fs::util as file_util;
 
-use crate::batch_header::{ BatchHeaderStream, BatchHeaderPos};
+use crate::batch_header::{BatchHeaderStream, BatchHeaderPos};
 use crate::mut_index::MutLogIndex;
 use crate::index::LogIndex;
 use crate::index::Index;

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -10,17 +10,16 @@ use dataplane::{Offset, Size};
 use fluvio_future::file_slice::AsyncFileSlice;
 use fluvio_future::fs::util as file_util;
 
-use crate::BatchHeaderStream;
+use crate::batch_header::{ BatchHeaderStream, BatchHeaderPos};
 use crate::mut_index::MutLogIndex;
 use crate::index::LogIndex;
 use crate::index::Index;
 use crate::records::FileRecords;
 use crate::mut_records::MutFileRecords;
 use crate::records::FileRecordsSlice;
-use crate::BatchHeaderPos;
-use crate::ConfigOption;
+use crate::config::ConfigOption;
 use crate::StorageError;
-use crate::DefaultFileBatchStream;
+use crate::batch::DefaultFileBatchStream;
 use crate::index::OffsetPosition;
 use crate::validator::LogValidationError;
 use crate::util::OffsetError;
@@ -390,7 +389,7 @@ mod tests {
     use crate::fixture::create_batch_with_producer;
     use crate::fixture::create_batch;
     use crate::fixture::read_bytes_from_file;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
     use crate::StorageError;
     use crate::index::OffsetPosition;
 

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -129,7 +129,7 @@ mod tests {
     use dataplane::Offset;
 
     use crate::mut_records::MutFileRecords;
-    use crate::ConfigOption;
+    use crate::config::ConfigOption;
 
     use super::validate;
     use crate::StorageError;

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -8,7 +8,7 @@ use tracing::trace;
 use dataplane::Offset;
 use fluvio_future::fs::util as file_util;
 
-use crate::BatchHeaderStream;
+use crate::batch_header::BatchHeaderStream;
 use crate::util::log_path_get_offset;
 use crate::util::OffsetError;
 

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -24,7 +24,7 @@ use fluvio_socket::FlvSocketError;
 use flv_util::fixture::ensure_clean_dir;
 use fluvio_storage::StorageError;
 use fluvio_storage::FileReplica;
-use fluvio_storage::ConfigOption;
+use fluvio_storage::config::ConfigOption;
 
 const TEST_REP_DIR: &str = "testreplica-fetch";
 const START_OFFSET: Offset = 0;

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -1,6 +1,6 @@
 // test fetch of replica
 
-use std::env::temp_dir;
+use std::{env::temp_dir, sync::Arc};
 use std::time::Duration;
 
 use tracing::debug;
@@ -10,12 +10,11 @@ use futures_lite::future::zip;
 use fluvio_future::test_async;
 use fluvio_future::timer::sleep;
 use fluvio_future::net::TcpListener;
-use dataplane::fetch::{
+use dataplane::{fetch::{
     FetchPartition, FetchableTopic, DefaultFetchRequest, FileFetchResponse, FileFetchRequest,
     FilePartitionResponse, FileTopicResponse,
-};
+}, record::RecordSet};
 use dataplane::api::RequestMessage;
-use dataplane::batch::DefaultBatch;
 use dataplane::record::DefaultRecord;
 use dataplane::Offset;
 
@@ -25,6 +24,7 @@ use flv_util::fixture::ensure_clean_dir;
 use fluvio_storage::StorageError;
 use fluvio_storage::FileReplica;
 use fluvio_storage::config::ConfigOption;
+use fluvio_storage::fixture::BatchProducer;
 
 const TEST_REP_DIR: &str = "testreplica-fetch";
 const START_OFFSET: Offset = 0;
@@ -39,21 +39,20 @@ fn default_option() -> ConfigOption {
     }
 }
 
+fn generate_record(record_index: usize,_producer: &BatchProducer) -> DefaultRecord {
+    let msg = format!("record {}", record_index);
+    let record: DefaultRecord = msg.into();
+    record
+}
+
 /// create sample batches with variable number of records
-fn create_batch(records: u16) -> DefaultBatch {
-    let mut batches = DefaultBatch::default();
-    let header = batches.get_mut_header();
-    header.magic = 2;
-    header.producer_id = 20;
-    header.producer_epoch = -1;
+fn create_records(records: u16) -> RecordSet {
 
-    for i in 0..records {
-        let msg = format!("record {}", i);
-        let record: DefaultRecord = msg.into();
-        batches.add_record(record);
-    }
-
-    batches
+    BatchProducer::builder()
+        .records(records)
+        .record_generator(Arc::new(generate_record))
+        .build().expect("batch")
+        .records()
 }
 
 // create new replica and add two batches
@@ -65,8 +64,8 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
     let mut replica = FileReplica::create("testsimple", 0, START_OFFSET, &option)
         .await
         .expect("test replica");
-    replica.send(create_batch(2)).await.expect("first batch");
-    replica.send(create_batch(2)).await.expect("second batch");
+    replica.send_records(create_records(2),false).await.expect("first batch");
+    replica.send_records(create_records(2),false).await.expect("second batch");
 
     Ok(replica)
 }

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -10,10 +10,13 @@ use futures_lite::future::zip;
 use fluvio_future::test_async;
 use fluvio_future::timer::sleep;
 use fluvio_future::net::TcpListener;
-use dataplane::{fetch::{
-    FetchPartition, FetchableTopic, DefaultFetchRequest, FileFetchResponse, FileFetchRequest,
-    FilePartitionResponse, FileTopicResponse,
-}, record::RecordSet};
+use dataplane::{
+    fetch::{
+        FetchPartition, FetchableTopic, DefaultFetchRequest, FileFetchResponse, FileFetchRequest,
+        FilePartitionResponse, FileTopicResponse,
+    },
+    record::RecordSet,
+};
 use dataplane::api::RequestMessage;
 use dataplane::record::DefaultRecord;
 use dataplane::Offset;
@@ -39,7 +42,7 @@ fn default_option() -> ConfigOption {
     }
 }
 
-fn generate_record(record_index: usize,_producer: &BatchProducer) -> DefaultRecord {
+fn generate_record(record_index: usize, _producer: &BatchProducer) -> DefaultRecord {
     let msg = format!("record {}", record_index);
     let record: DefaultRecord = msg.into();
     record
@@ -47,11 +50,11 @@ fn generate_record(record_index: usize,_producer: &BatchProducer) -> DefaultReco
 
 /// create sample batches with variable number of records
 fn create_records(records: u16) -> RecordSet {
-
     BatchProducer::builder()
         .records(records)
         .record_generator(Arc::new(generate_record))
-        .build().expect("batch")
+        .build()
+        .expect("batch")
         .records()
 }
 
@@ -64,8 +67,14 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
     let mut replica = FileReplica::create("testsimple", 0, START_OFFSET, &option)
         .await
         .expect("test replica");
-    replica.send_records(create_records(2),false).await.expect("first batch");
-    replica.send_records(create_records(2),false).await.expect("second batch");
+    replica
+        .send_records(create_records(2), false)
+        .await
+        .expect("first batch");
+    replica
+        .send_records(create_records(2), false)
+        .await
+        .expect("second batch");
 
     Ok(replica)
 }


### PR DESCRIPTION
Limit batch size to 1M as default.   SPU will now reject attempts to write the `RecordSet` if any of the batch size exceed limit.