### PR TITLE
Add CLI message when consumer stream closes

### DIFF
--- a/src/extension-consumer/src/consume/fetch_log_loop.rs
+++ b/src/extension-consumer/src/consume/fetch_log_loop.rs
@@ -111,6 +111,7 @@ where
         }
 
         debug!("fetch loop exited");
+        println!("Consumer stream has closed");
     }
 
     Ok(())


### PR DESCRIPTION
This solves half of #678 regarding the CLI consumer. If the stream is closed, the CLI will print a message saying so.

I am working on figuring out how to solve a similar problem on the producer side of things. It is slightly trickier with the producer because it seems like the producer (currently) does not keep an open connection that we can watch to see if it goes down. I will have to play with the setup to figure out the best way to do that.