### PR TITLE
Fix tests. Push develop mode into fluvio-cluster

### DIFF
--- a/src/sc/build.rs
+++ b/src/sc/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     // Copy VERSION file. Do not fail e.g. when built via `cargo publish`
+    println!("cargo:rerun-if-changed=../../VERSION");
     let _ = std::fs::copy("../../VERSION", "./src/VERSION");
 }

--- a/tests/runner/src/environment/k8.rs
+++ b/tests/runner/src/environment/k8.rs
@@ -24,6 +24,9 @@ impl EnvironmentDriver for K8EnvironmentDriver {
 
     async fn start_cluster(&self) {
         let mut builder = ClusterConfig::builder(crate::VERSION);
+        if self.option.develop_mode() {
+            builder.development().expect("should test in develop mode");
+        }
         builder
             .spu_replicas(self.option.spu)
             .skip_checks(self.option.skip_checks())


### PR DESCRIPTION
Closes #790.

This fixes an error that would occur when updating the `VERSION` file. There were actually two problems in play:

- The new test runner was not applying development options
- The build.rs script for fluvio-sc was not rebuilding the SC with the updated VERSION.

Both of these problems are fixed in this PR. The first one is fixed by adding a `.development()` method to the fluvio-cluster builder so that development options will be consistent in the various places it is used.