### PR TITLE
bump types version

### DIFF
--- a/src/types/Cargo.toml
+++ b/src/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "Fluvio common types and objects"


### PR DESCRIPTION
I think #769 should have bumped the patch version (or maybe even the minor) because this adds some new functionality that the client crate relies on.