### PR TITLE
Bumped patch version to publish

### DIFF
--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "fluvio-service"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP service wrapper over fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-socket"


### PR DESCRIPTION
After staring at `cargo tree` for a while and removing all the path dependencies in the dependencies (to test out publishing), I finally figured out that `fluvio-service` in the repo has `fluvio-socket` with `0.6.0` but the [published version of `fluvio-service` uses `0.5.0` for `fluvio-socket](https://crates.io/crates/fluvio-service/0.4.0)` and this breaks a bunch of stuff. 