### PR TITLE
Fix breaking change in config by adding serde alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/config/cluster.rs
+++ b/src/client/src/config/cluster.rs
@@ -14,6 +14,7 @@ pub struct FluvioConfig {
     /// The address to connect to the Fluvio cluster
     // TODO use a validated address type.
     // We don't want to have a "" address.
+    #[serde(alias = "addr")]
     pub endpoint: String,
     /// The TLS policy to use when connecting to the cluster
     // If no TLS field is present in config file,


### PR DESCRIPTION
Recently, the `FluvioConfig` field called `addr` was renamed to `endpoint`. This caused a backwards incompatible change because new clients could no longer communicate with an old version of Fluvio Cloud. This fixes this incompatibility by adding a serde "alias = addr" to the endpoint field. This means that serde will deserialize the field from either "endpoint" OR "addr", but it will always serialize it as "endpoint". We will need to bump the client crate prerelease version for this to be useful.