### PR TITLE
Package index updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Infinyon Contributors <team@infiyon.com>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/target.rs
+++ b/src/package-index/src/target.rs
@@ -14,7 +14,7 @@ pub fn package_target() -> Result<Target, Error> {
     Ok(target)
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum Target {
     #[serde(rename = "x86_64-apple-darwin")]
@@ -24,6 +24,9 @@ pub enum Target {
 }
 
 impl Target {
+    pub const ALL_TARGETS: &'static [Target] =
+        &[Target::X86_64AppleDarwin, Target::X86_64UnknownLinuxMusl];
+
     pub fn as_str(&self) -> &str {
         match self {
             Self::X86_64AppleDarwin => "x86_64-apple-darwin",


### PR DESCRIPTION
This adds an associated constant `Target::ALL_TARGETS` which is a slice of all Target values. This is essentially used as an iterator over the variants of the Target enum, and is useful for cleaning up code in fluvio-packages.