### PR TITLE
Prompt for Fluvio update only for new release versions

### DIFF
--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -42,9 +42,9 @@ impl InstallOpt {
 
         // After any "install" command, check if the CLI has an available update,
         // i.e. one that is not required, but present.
-        let update_available = check_update_available(&agent, false).await?;
-        if update_available {
-            prompt_available_update(&agent, false).await?;
+        let maybe_latest = check_update_available(&agent, false).await?;
+        if let Some(latest_version) = maybe_latest {
+            prompt_available_update(&latest_version);
         }
 
         Ok(())


### PR DESCRIPTION
When updating the install script to use latest RELEASE version (#812), I noticed this odd side effect, which was that I was immediately prompted to update to a new version of Fluvio. This happened because the installer gave me the latest RELEASE but the update-checker saw that there was a PRERELEASE that was more recent. This PR updates the update-checker to only compare against the latest RELEASE version.

```
❯ ./install.sh
fluvio: ⏳ Downloading Fluvio 0.6.1 for x86_64-apple-darwin...
fluvio: ⬇️ Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio
fluvio: ☁️ Installing Fluvio Cloud...
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.4...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.7.0-beta.1 of Fluvio
fluvio: 🎉 Install complete!
fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
fluvio:     You can run the following to set your PATH on shell startup:
fluvio:       For bash: echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.bashrc
fluvio:       For zsh : echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
fluvio:
fluvio:     To use Fluvio you'll need to restart your shell or run the following:
fluvio:       export PATH="${HOME}/.fluvio/bin:${PATH}"
```

