### PR TITLE
Storage cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -523,6 +533,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -701,6 +714,99 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f782ffb172d8095cbb4c6464d85432c3bcfa8609b0bb1dc27cfd35bd90e052"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e0910022b490bd0a65d5baa1693b0475cdbeea1c26472343f2acea1f1f55b8"
+dependencies = [
+ "byteorder",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli",
+ "log",
+ "regalloc",
+ "serde",
+ "smallvec 1.6.1",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cafe95cb5ac659e113549b2794a2c8d3a14f36e1a98728a6e0ea7a773be2129"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1bd002e42cc094a131a8227d06d48df28ea3b9127e5e3bc3010e079858e9af"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55e9043403f0dec775f317280015150e78b2352fb947d2f37407fd4ce6311c7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0153680ebce89aac7cad90a5442bb136faacfc86ea62587a01b8e8e79f8249c9"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec 1.6.1",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d742cf2c28699eeea26b9a7f6a53b5976fb4a7ca4778e736c063ab57592dc0cb"
+dependencies = [
+ "cranelift-codegen",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e59effbaf9386ffa6742a737c159178f2085cf19634bcd8381caa87b48cd689"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools 0.10.0",
+ "log",
+ "serde",
+ "smallvec 1.6.1",
+ "thiserror",
+ "wasmparser 0.73.1",
+]
 
 [[package]]
 name = "crc32c"
@@ -947,13 +1053,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.5",
  "winapi 0.3.9",
 ]
 
@@ -974,7 +1090,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.5",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.0",
  "winapi 0.3.9",
 ]
 
@@ -1016,6 +1143,19 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "errno"
@@ -1100,6 +1240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "file-per-thread-logger"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+dependencies = [
+ "env_logger",
+ "log",
 ]
 
 [[package]]
@@ -1607,6 +1757,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-futures",
+ "wasmtime",
 ]
 
 [[package]]
@@ -1971,6 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 dependencies = [
  "fallible-iterator",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -2151,6 +2303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "hyper"
 version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2365,7 @@ checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2222,10 +2384,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2345,6 +2534,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "lexical-core"
@@ -2482,6 +2677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "more-asserts"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 dependencies = [
  "flate2",
- "wasmparser",
+ "wasmparser 0.57.0",
 ]
 
 [[package]]
@@ -2621,6 +2822,10 @@ name = "object"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+]
 
 [[package]]
 name = "once_cell"
@@ -2907,6 +3112,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abf49e5417290756acfd26501536358560c4a5cc4a0934d390939acb3e7083a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,6 +3305,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.2",
+ "redox_syscall 0.2.5",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "serde",
+ "smallvec 1.6.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3353,18 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach 0.3.2",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "remoteprocess"
@@ -3161,6 +3415,12 @@ name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3612,6 +3872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3910,15 @@ dependencies = [
  "byteorder",
  "dirs 1.0.5",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4105,6 +4380,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
+name = "wasmparser"
+version = "0.73.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8526ab131cbc49495a483c98954913ae7b83551adacab5e294cf77992e70ee7"
+
+[[package]]
+name = "wasmtime"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878f1f740127905dd8eddadfeaeea786f81856369eecc65e6c83ac909633cda"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "bincode",
+ "cfg-if 1.0.0",
+ "cpp_demangle",
+ "indexmap",
+ "libc",
+ "log",
+ "region",
+ "rustc-demangle",
+ "serde",
+ "smallvec 1.6.1",
+ "target-lexicon",
+ "wasmparser 0.73.1",
+ "wasmtime-cache",
+ "wasmtime-environ",
+ "wasmtime-jit",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "wat",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b28e400f6a4d5d8e0086b3a2999e03be217a807f3f376dbdac5136a81ec6f79"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "bincode",
+ "directories-next",
+ "errno 0.2.7",
+ "file-per-thread-logger",
+ "libc",
+ "log",
+ "serde",
+ "sha2",
+ "toml",
+ "winapi 0.3.9",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a13645a4b833dba480a18f048b8cebae06e70f9aa86313d779541cc1847ad"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-wasm",
+ "wasmparser 0.73.1",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-debug"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53b773abc89fed963d64969e38a08ed1cbc8fef43ac7383ad3f489e1a2b50ac"
+dependencies = [
+ "anyhow",
+ "gimli",
+ "more-asserts",
+ "object 0.23.0",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.73.1",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb053d9d3db2bbae51f87b11879386d472bf2b1dfdde8f413ae2ae0c8b9ddb"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-wasm",
+ "gimli",
+ "indexmap",
+ "log",
+ "more-asserts",
+ "serde",
+ "thiserror",
+ "wasmparser 0.73.1",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbf76a9b7da95c6099acf5610594f7e4eac462b163e75eb1fc333b6053c6e01"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "cfg-if 1.0.0",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli",
+ "log",
+ "more-asserts",
+ "object 0.23.0",
+ "rayon",
+ "region",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.73.1",
+ "wasmtime-cranelift",
+ "wasmtime-debug",
+ "wasmtime-environ",
+ "wasmtime-obj",
+ "wasmtime-profiling",
+ "wasmtime-runtime",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "wasmtime-obj"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4909472de9ea73609551d883a27ab7c2b04a1c7b90bb3d25cf1314ccaf7f3d4"
+dependencies = [
+ "anyhow",
+ "more-asserts",
+ "object 0.23.0",
+ "target-lexicon",
+ "wasmtime-debug",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-profiling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04a0119d0a30f8341d436b834da16a3cd23115045fb024f44b062d3abd29ae7"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "gimli",
+ "lazy_static",
+ "libc",
+ "object 0.23.0",
+ "scroll",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ",
+ "wasmtime-runtime",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac84560e3a8d378d76cc6c25cca5ad216a9ad85fc03ac06f91ecdf4bbbb62b8"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "log",
+ "memoffset",
+ "more-asserts",
+ "psm",
+ "region",
+ "thiserror",
+ "wasmtime-environ",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "wast"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de71ea922e46a60d0bde4b27ebf24ab7c4991006fd5de23ce9c58e129b3ab3c"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474403335b9a90b21120ab8131dd888f0a8d041c2d365ab960feddfe5a73c4b6"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,4 +4689,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zstd"
+version = "0.6.0+zstd.1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e44664feba7f2f1a9f300c1f6157f2d1bfc3c15c6f3cf4beabf3f5abe9c237"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "3.0.0+zstd.1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9447afcd795693ad59918c7bbffe42fdd6e467d708f3537e3dc14dc598c573f"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.19+zstd.1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools 0.9.0",
+ "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-runner-local"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fluvio-future",
  "fluvio-sc",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-channel",
  "async-io",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-storage"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/extension-runner-local/Cargo.toml
+++ b/src/extension-runner-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-runner-local"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Engine Runner"
@@ -26,4 +26,4 @@ thiserror = "1.0.20"
 # regardless of TLS, sc and spu always use openssl_tls for now because we need cert API
 fluvio-future = { version = "0.1.12", features = ["subscriber"] }
 fluvio-sc = { version = "0.5.0", path = "../sc" }
-fluvio-spu = { version = "0.4.0", path = "../spu" }
+fluvio-spu = { version = "0.5.0", path = "../spu" }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-spu"
 edition = "2018"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Processing Unit"
 repository = "https://github.com/infinyon/fluvio"
@@ -41,7 +41,7 @@ wasmtime = "0.23.0"
 
 # Fluvio dependencies
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
-fluvio-storage = { version = "0.3.0", path = "../storage" }
+fluvio-storage = { version = "0.4.0", path = "../storage" }
 fluvio-controlplane = { version = "0.6.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata" }
 fluvio-spu-schema = { version = "0.4.0", path = "../spu-schema" }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -37,6 +37,7 @@ async-rwlock = "1.1.0"
 async-mutex = "1.4.0"
 event-listener = "2.4.0"
 async-io = "1.3.1"
+wasmtime = "0.23.0"
 
 # Fluvio dependencies
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }

--- a/src/spu/src/controllers/follower_replica/state.rs
+++ b/src/spu/src/controllers/follower_replica/state.rs
@@ -183,7 +183,10 @@ impl FollowersState<FileReplica> {
                 let replica_key = ReplicaKey::new(topic.clone(), rep_id);
                 trace!("sync request for replica: {}", replica_key);
                 if let Some(mut replica) = self.get_mut_replica(&replica_key) {
-                    match replica.write_recordsets(&mut partition_request.records).await {
+                    match replica
+                        .write_recordsets(&mut partition_request.records)
+                        .await
+                    {
                         Ok(_) => {
                             trace!(
                                 "successfully written send to follower replica: {}",

--- a/src/spu/src/controllers/leader_replica/leaders_state.rs
+++ b/src/spu/src/controllers/leader_replica/leaders_state.rs
@@ -156,16 +156,15 @@ impl ReplicaLeadersState<FileReplica> {
         }
     }
 
-    /// write new record and notify the leader replica controller
-    /// TODO: may replica should be moved it's own map
-    pub async fn send_records(
+    /// write new record set and update shared offsets
+    pub async fn write_record_set(
         &self,
         rep_id: &ReplicaKey,
-        records: RecordSet,
+        records: &mut RecordSet,
         update_hw: bool,
     ) -> Result<bool, InternalServerError> {
         if let Some(mut leader_replica) = self.get_mut_replica(rep_id) {
-            leader_replica.send_records(records, update_hw).await?;
+            leader_replica.write_recordset(records, update_hw).await?;
             self.send_message(rep_id, LeaderReplicaControllerCommand::EndOffsetUpdated)
                 .await
                 .map_err(|err| err.into())

--- a/src/spu/src/controllers/leader_replica/replica_state.rs
+++ b/src/spu/src/controllers/leader_replica/replica_state.rs
@@ -378,9 +378,9 @@ impl LeaderReplicaState<FileReplica> {
         (self.hw(), self.leo())
     }
 
-    pub async fn send_records(
+    pub async fn write_recordset(
         &mut self,
-        records: RecordSet,
+        records: &mut RecordSet,
         update_highwatermark: bool,
     ) -> Result<(), StorageError> {
         trace!(
@@ -389,7 +389,7 @@ impl LeaderReplicaState<FileReplica> {
             self.replica_id
         );
         self.storage
-            .send_records(records, update_highwatermark)
+            .write_recordset(records, update_highwatermark)
             .await
     }
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "fluvio-storage"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["fluvio.io"]
 description = "Storage for Fluvio platform"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -279,7 +279,7 @@ mod tests {
         let mut active_segment = MutableSegment::create(300, &option).await?;
 
         active_segment
-            .send(create_batch())
+            .write_batch(&mut create_batch())
             .await
             .expect("writing batches");
 
@@ -304,9 +304,9 @@ mod tests {
 
         let mut active_segment = MutableSegment::create(300, &option).await?;
 
-        active_segment.send(create_batch()).await?;
+        active_segment.write_batch(&mut create_batch()).await?;
         active_segment
-            .send(create_batch_with_producer(25, 2))
+            .write_batch(&mut create_batch_with_producer(25, 2))
             .await?;
 
         let mut batch_stream = active_segment

--- a/src/storage/src/batch_header.rs
+++ b/src/storage/src/batch_header.rs
@@ -86,7 +86,7 @@ mod tests {
             .await
             .expect("create sink");
 
-        msg_sink.send(create_batch()).await.expect("send batch");
+        msg_sink.write_batch(&mut create_batch()).await.expect("send batch");
 
         let mut file = file_util::open(&test_file).await.expect("open test file");
 
@@ -117,8 +117,8 @@ mod tests {
 
         let mut msg_sink = MutFileRecords::create(201, &options).await?;
 
-        msg_sink.send(create_batch()).await?;
-        msg_sink.send(create_batch_with_producer(25, 2)).await?;
+        msg_sink.write_batch(&mut create_batch()).await?;
+        msg_sink.write_batch(&mut create_batch_with_producer(25, 2)).await?;
 
         let file = file_util::open(&test_file).await?;
 

--- a/src/storage/src/batch_header.rs
+++ b/src/storage/src/batch_header.rs
@@ -74,7 +74,7 @@ mod tests {
         }
     }
 
-    #[allow(unused)]
+    #[allow(unused, clippy::unnecessary_mut_passed)]
     //#[test_async]
     async fn test_decode_batch_header_simple() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAME);
@@ -86,7 +86,10 @@ mod tests {
             .await
             .expect("create sink");
 
-        msg_sink.write_batch(&mut create_batch()).await.expect("send batch");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send batch");
 
         let mut file = file_util::open(&test_file).await.expect("open test file");
 
@@ -107,7 +110,7 @@ mod tests {
     #[allow(unused)]
     const TEST_FILE_NAME2: &str = "00000000000000000201.log"; // for offset 200
 
-    #[allow(unused)]
+    #[allow(unused, clippy::unnecessary_mut_passed)]
     //#[test_async]
     async fn test_decode_batch_header_multiple() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAME2);
@@ -118,7 +121,9 @@ mod tests {
         let mut msg_sink = MutFileRecords::create(201, &options).await?;
 
         msg_sink.write_batch(&mut create_batch()).await?;
-        msg_sink.write_batch(&mut create_batch_with_producer(25, 2)).await?;
+        msg_sink
+            .write_batch(&mut create_batch_with_producer(25, 2))
+            .await?;
 
         let file = file_util::open(&test_file).await?;
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 use std::fmt;
 
-use dataplane::batch::DefaultBatch;
+
 use fluvio_future::fs::BoundedFileSinkError;
 use fluvio_future::zero_copy::SendFileError;
 
@@ -11,7 +11,6 @@ use crate::validator::LogValidationError;
 #[derive(Debug)]
 pub enum StorageError {
     IoError(IoError),
-    NoRoom(DefaultBatch),
     OffsetError(OffsetError),
     LogValidationError(LogValidationError),
     SendFileError(SendFileError),
@@ -22,7 +21,6 @@ impl fmt::Display for StorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::IoError(err) => write!(f, "{}", err),
-            Self::NoRoom(batch) => write!(f, "No room {:#?}", batch),
             Self::OffsetError(err) => write!(f, "{}", err),
             Self::LogValidationError(err) => write!(f, "{}", err),
             Self::SendFileError(err) => write!(f, "{}", err),

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -1,7 +1,6 @@
 use std::io::Error as IoError;
 use std::fmt;
 
-
 use fluvio_future::fs::BoundedFileSinkError;
 use fluvio_future::zero_copy::SendFileError;
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -26,8 +26,6 @@ use dataplane::{ErrorCode, Offset};
 use dataplane::fetch::FilePartitionResponse;
 use fluvio_future::file_slice::AsyncFileSlice;
 
-pub trait Captures<'a> {}
-impl<'a, T: ?Sized> Captures<'a> for T {}
 
 /// output from storage is represented as slice
 pub trait SlicePartitionResponse {

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -26,7 +26,6 @@ use dataplane::{ErrorCode, Offset};
 use dataplane::fetch::FilePartitionResponse;
 use fluvio_future::file_slice::AsyncFileSlice;
 
-
 /// output from storage is represented as slice
 pub trait SlicePartitionResponse {
     fn set_hw(&mut self, offset: i64);

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -149,7 +149,7 @@ impl MutFileRecords {
     }
 
     /// try to write batch
-    /// if there is enough room, return true, false otherwise 
+    /// if there is enough room, return true, false otherwise
     pub async fn write_batch(&mut self, item: &DefaultBatch) -> Result<bool, StorageError> {
         trace!("start sending using batch {:#?}", item.get_header());
         self.item_last_offset_delta = item.get_last_offset_delta();
@@ -385,6 +385,7 @@ mod tests {
     const TEST_FILE_NAMEC: &str = "00000000000000000200.log"; // for offset 200
     const TEST_FILE_NAMEI: &str = "00000000000000000300.log"; // for offset 300
 
+    #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
     async fn test_write_records_every() -> Result<(), StorageError> {
         debug!("test_write_records_every");
@@ -404,7 +405,10 @@ mod tests {
         let batch = create_batch();
         let write_size = batch.write_size(0);
         debug!("write size: {}", write_size); // for now, this is 79 bytes
-        msg_sink.write_batch(&mut create_batch()).await.expect("create");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("create");
 
         debug!("read start");
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
@@ -434,6 +438,7 @@ mod tests {
 
     // This Test configures policy to flush after every NUM_WRITES
     // and checks to see when the flush occurs relative to the write count
+    #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
     async fn test_write_records_count() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAMEC);
@@ -455,7 +460,10 @@ mod tests {
         let batch = create_batch();
         let write_size = batch.write_size(0);
         debug!("write size: {}", write_size); // for now, this is 79 bytes
-        msg_sink.write_batch(&mut create_batch()).await.expect("create");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("create");
         msg_sink.flush().await.expect("create flush"); // ensure the file is created
 
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
@@ -473,14 +481,23 @@ mod tests {
 
         // check flush counts don't increment yet
         let flush_count = msg_sink.flush_count();
-        msg_sink.write_batch(&mut create_batch()).await.expect("send");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         for _ in 1..(NUM_WRITES - 2) {
-            msg_sink.write_batch(&mut create_batch()).await.expect("send");
+            msg_sink
+                .write_batch(&mut create_batch())
+                .await
+                .expect("send");
             assert_eq!(flush_count, msg_sink.flush_count());
         }
 
         // flush count should increment after final write
-        msg_sink.write_batch(&mut create_batch()).await.expect("send");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         assert_eq!(flush_count + 1, msg_sink.flush_count());
 
         let bytes = read_bytes_from_file(&test_file).expect("read bytes final");
@@ -505,6 +522,7 @@ mod tests {
     // The test still verifies that flushes on writes have occured within the
     // expected timeframe
     #[cfg(not(target_os = "macos"))]
+    #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
     async fn test_write_records_idle_delay() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAMEI);
@@ -527,7 +545,10 @@ mod tests {
         let batch = create_batch();
         let write_size = batch.write_size(0);
         debug!("write size: {}", write_size); // for now, this is 79 bytes
-        msg_sink.write_batch(&mut create_batch()).await.expect("create");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("create");
 
         debug!("direct flush");
         msg_sink.flush().await.expect("create flush"); // ensure the file is created
@@ -549,7 +570,10 @@ mod tests {
         // check flush counts don't increment immediately
         let flush_count = msg_sink.flush_count();
         // debug!("flush_count: {} {:?}", flush_count, Instant::now());
-        msg_sink.write_batch(&mut create_batch()).await.expect("send");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         // debug!("flush_count: {}", flush_count);
         assert_eq!(flush_count, msg_sink.flush_count());
 
@@ -567,9 +591,15 @@ mod tests {
         debug!("check multi write delayed flush: wait for flush");
         let flush_count = msg_sink.flush_count();
 
-        msg_sink.write_batch(&mut create_batch()).await.expect("send");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         assert_eq!(flush_count, msg_sink.flush_count());
-        msg_sink.write_batch(&mut create_batch()).await.expect("send");
+        msg_sink
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         assert_eq!(flush_count, msg_sink.flush_count());
 
         let dur = Duration::from_millis((IDLE_FLUSH + 100).into());

--- a/src/storage/src/range_map.rs
+++ b/src/storage/src/range_map.rs
@@ -142,7 +142,7 @@ mod tests {
         _offsets: Offset,
     ) -> Result<ReadSegment, StorageError> {
         let mut mut_segment = MutableSegment::create(start, option).await?;
-        mut_segment.send(create_batch()).await?;
+        mut_segment.write_batch(&mut create_batch()).await?;
         //        mut_segment.set_end_offset(offsets);
         let segment = mut_segment.convert_to_segment().await?;
         Ok(segment)

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -314,7 +314,6 @@ impl FileReplica {
     async fn write_batch(&mut self, item: &mut DefaultBatch) -> Result<(), StorageError> {
         trace!("start_send");
         if !(self.active_segment.write_batch(item).await?) {
-           
             debug!("segment has no room, rolling over previous segment");
             self.active_segment.roll_over().await?;
             let last_offset = self.active_segment.get_end_offset();
@@ -400,7 +399,10 @@ mod tests {
         assert_eq!(replica.get_leo(), START_OFFSET);
         assert_eq!(replica.get_hw(), START_OFFSET);
 
-        replica.write_batch(&mut create_batch()).await.expect("send");
+        replica
+            .write_batch(&mut create_batch())
+            .await
+            .expect("send");
         assert_eq!(replica.get_leo(), START_OFFSET + 2); // 2 batches
         assert_eq!(replica.get_hw(), START_OFFSET); // hw should not change since we have not committed them
 
@@ -608,7 +610,10 @@ mod tests {
 
         let mut batch = create_batch();
         let batch_len = batch.write_size(0);
-        replica.write_batch(&mut batch).await.expect("writing records");
+        replica
+            .write_batch(&mut batch)
+            .await
+            .expect("writing records");
 
         let mut partition_response = FilePartitionResponse::default();
         replica
@@ -637,7 +642,10 @@ mod tests {
 
         // write 1 more batch
         let mut batch = create_batch();
-        replica.write_batch(&mut batch).await.expect("writing 2nd batch");
+        replica
+            .write_batch(&mut batch)
+            .await
+            .expect("writing 2nd batch");
         debug!(
             "2nd batch: replica end: {} high: {}",
             replica.get_leo(),
@@ -698,7 +706,10 @@ mod tests {
             .records();
         assert!(larget_batch.write_size(0) > 100); // ensure we are writing more than 100
         assert!(matches!(
-            replica.write_recordset(&mut larget_batch, false).await.unwrap_err(),
+            replica
+                .write_recordset(&mut larget_batch, false)
+                .await
+                .unwrap_err(),
             StorageError::BatchTooBig(_)
         ));
 

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -315,7 +315,6 @@ impl Segment<MutLogIndex, MutFileRecords> {
         SegmentSlice::new_mut_segment(self)
     }
 
-
     pub async fn write_batch(&mut self, item: &mut DefaultBatch) -> Result<bool, StorageError> {
         let current_offset = self.end_offset;
         let base_offset = self.base_offset;
@@ -340,7 +339,6 @@ impl Segment<MutLogIndex, MutFileRecords> {
         );
 
         if self.msg_log.write_batch(item).await? {
-            
             let batch_len = self.msg_log.get_pos();
 
             self.index
@@ -355,7 +353,6 @@ impl Segment<MutLogIndex, MutFileRecords> {
         } else {
             Ok(false)
         }
-        
     }
 
     #[allow(unused)]

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -189,9 +189,9 @@ mod tests {
 
         let mut msg_sink = MutFileRecords::create(SUCCESS_BASE_OFFSET, &options).await?;
 
-        msg_sink.send(create_batch(SUCCESS_BASE_OFFSET, 2)).await?;
+        msg_sink.write_batch(&mut create_batch(SUCCESS_BASE_OFFSET, 2)).await?;
         msg_sink
-            .send(create_batch(SUCCESS_BASE_OFFSET + 2, 3))
+            .write_batch(&mut create_batch(SUCCESS_BASE_OFFSET + 2, 3))
             .await?;
 
         let next_offset = validate(&test_file).await?;
@@ -215,8 +215,8 @@ mod tests {
 
         let mut msg_sink = MutFileRecords::create(401, &options).await?;
 
-        msg_sink.send(create_batch(401, 0)).await?;
-        msg_sink.send(create_batch(111, 1)).await?;
+        msg_sink.write_batch(&mut create_batch(401, 0)).await?;
+        msg_sink.write_batch(&mut create_batch(111, 1)).await?;
 
         //   assert!(validate(&test_file).await.is_err());
 
@@ -240,7 +240,7 @@ mod tests {
             .await
             .expect("record created");
         msg_sink
-            .send(create_batch(501, 2))
+            .write_batch(&mut create_batch(501, 2))
             .await
             .expect("create batch");
 

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -177,6 +177,7 @@ mod tests {
     const SUCCESS_BASE_OFFSET: Offset = 601;
 
     #[test_async]
+    #[allow(clippy::unnecessary_mut_passed)]
     async fn test_validate_success() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_SUCCESS_NAME);
         ensure_clean_file(&test_file);
@@ -189,7 +190,9 @@ mod tests {
 
         let mut msg_sink = MutFileRecords::create(SUCCESS_BASE_OFFSET, &options).await?;
 
-        msg_sink.write_batch(&mut create_batch(SUCCESS_BASE_OFFSET, 2)).await?;
+        msg_sink
+            .write_batch(&mut create_batch(SUCCESS_BASE_OFFSET, 2))
+            .await?;
         msg_sink
             .write_batch(&mut create_batch(SUCCESS_BASE_OFFSET + 2, 3))
             .await?;
@@ -203,6 +206,7 @@ mod tests {
     const TEST_FILE_NAME_FAIL: &str = "00000000000000000401.log"; // for offset 301
 
     #[test_async]
+    #[allow(clippy::unnecessary_mut_passed)]
     async fn test_validate_offset() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAME_FAIL);
         ensure_clean_file(&test_file);
@@ -225,6 +229,7 @@ mod tests {
 
     const TEST_FILE_NAME_FAIL2: &str = "00000000000000000501.log"; // for offset 301
 
+    #[allow(clippy::unnecessary_mut_passed)]
     #[test_async]
     async fn test_validate_invalid_contents() -> Result<(), StorageError> {
         let test_file = temp_dir().join(TEST_FILE_NAME_FAIL2);

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -68,11 +68,11 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
         .await
         .expect("test replica");
     replica
-        .send_records(create_records(2), false)
+        .write_recordset(&mut create_records(2), false)
         .await
         .expect("first batch");
     replica
-        .send_records(create_records(2), false)
+        .write_recordset(&mut create_records(2), false)
         .await
         .expect("second batch");
 


### PR DESCRIPTION
Remove unneeded code.
Send batches and records as mutable references instead of own
