### PR TITLE
Show version for all subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ dependencies = [
  "eyre",
  "fluvio",
  "fluvio-cluster",
+ "fluvio-command 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
  "fluvio-extension-consumer",
@@ -1433,6 +1434,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-command"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b587d6cc4c0901a6766e133c64f727fc976c0a8bfa4518b22dfc7abed676b38"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "fluvio-controlplane"
 version = "0.6.0"
 dependencies = [
@@ -1479,12 +1491,13 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "fluvio",
  "futures-lite",
  "prettytable-rs",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1513,6 +1526,7 @@ dependencies = [
  "hostname-validator",
  "jsonpath",
  "prettytable-rs",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -47,8 +47,9 @@ k8-client = { version = "5.0.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.6.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
+fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
-fluvio-extension-common = { version = "0.2.0", path = "../extension-common", features = ["target"]}
+fluvio-extension-common = { version = "0.3.0", path = "../extension-common", features = ["target"]}
 fluvio-extension-consumer = { version = "0.3.0", path = "../extension-consumer" }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
 fluvio-sc-schema = { version = "0.6.0", path = "../sc-schema" }

--- a/src/cli/src/metadata.rs
+++ b/src/cli/src/metadata.rs
@@ -1,0 +1,64 @@
+use std::process::Command;
+use structopt::StructOpt;
+use fluvio_extension_common::FluvioExtensionMetadata;
+use fluvio_extension_consumer::topic::TopicCmd;
+use fluvio_extension_consumer::partition::PartitionCmd;
+use fluvio_extension_consumer::produce::ProduceLogOpt;
+use fluvio_extension_consumer::consume::ConsumeLogOpt;
+use fluvio_command::CommandExt;
+use crate::Result;
+
+#[derive(Debug, StructOpt)]
+pub struct MetadataOpt {}
+impl MetadataOpt {
+    pub fn process(self) -> Result<()> {
+        let metadata = Self::metadata()?;
+        if let Ok(out) = serde_json::to_string(&metadata) {
+            println!("{}", out);
+        }
+
+        Ok(())
+    }
+
+    fn metadata() -> Result<Vec<FluvioExtensionMetadata>> {
+        let mut metadata = vec![
+            TopicCmd::metadata(),
+            PartitionCmd::metadata(),
+            ProduceLogOpt::metadata(),
+            ConsumeLogOpt::metadata(),
+        ];
+
+        if let Ok(subcommand_meta) = subcommand_metadata() {
+            let extension_meta = subcommand_meta.into_iter().map(|it| it.meta);
+            metadata.extend(extension_meta);
+        }
+
+        Ok(metadata)
+    }
+}
+
+pub struct SubcommandMetadata {
+    pub filename: String,
+    pub meta: FluvioExtensionMetadata,
+}
+
+/// Collects the metadata of Fluvio extensions installed on the system
+pub fn subcommand_metadata() -> Result<Vec<SubcommandMetadata>> {
+    let mut metadata = Vec::new();
+
+    for (filename, path) in crate::install::get_extensions()? {
+        let result = Command::new(&path).arg("metadata").result();
+        let output = match result {
+            Ok(out) => out.stdout,
+            _ => continue,
+        };
+
+        let json_result = serde_json::from_slice::<FluvioExtensionMetadata>(&output);
+        if let Ok(meta) = json_result {
+            let subcommand = SubcommandMetadata { filename, meta };
+            metadata.push(subcommand);
+        }
+    }
+
+    Ok(metadata)
+}

--- a/src/cli/src/metadata.rs
+++ b/src/cli/src/metadata.rs
@@ -12,7 +12,7 @@ use crate::Result;
 pub struct MetadataOpt {}
 impl MetadataOpt {
     pub fn process(self) -> Result<()> {
-        let metadata = Self::metadata()?;
+        let metadata = Self::metadata();
         if let Ok(out) = serde_json::to_string(&metadata) {
             println!("{}", out);
         }
@@ -20,7 +20,7 @@ impl MetadataOpt {
         Ok(())
     }
 
-    fn metadata() -> Result<Vec<FluvioExtensionMetadata>> {
+    fn metadata() -> Vec<FluvioExtensionMetadata> {
         let mut metadata = vec![
             TopicCmd::metadata(),
             PartitionCmd::metadata(),
@@ -33,7 +33,7 @@ impl MetadataOpt {
             metadata.extend(extension_meta);
         }
 
-        Ok(metadata)
+        metadata
     }
 }
 

--- a/src/cli/src/version.rs
+++ b/src/cli/src/version.rs
@@ -1,0 +1,103 @@
+use sha2::{Digest, Sha256};
+use structopt::StructOpt;
+
+use fluvio::Fluvio;
+use fluvio::config::ConfigFile;
+use fluvio_extension_common::target::ClusterTarget;
+use crate::Result;
+use crate::metadata::subcommand_metadata;
+
+#[derive(Debug, StructOpt)]
+pub struct VersionOpt {}
+
+impl VersionOpt {
+    pub async fn process(self, target: ClusterTarget) -> Result<()> {
+        self.print("Fluvio CLI", crate::VERSION.trim());
+
+        if let Some(sha) = self.format_cli_sha() {
+            self.print("Fluvio CLI SHA256", &sha);
+        }
+        let platform = self.format_platform_version(target).await;
+        self.print("Fluvio Platform", &platform);
+        self.print("Git Commit", &env!("GIT_HASH"));
+        if let Some(os_info) = os_info() {
+            self.print("OS Details", &os_info);
+        }
+
+        if let Some(metadata) = self.format_subcommand_metadata() {
+            println!("=== Plugin Versions ===");
+            for (name, version) in metadata {
+                self.print_width(&name, &version, 30);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print(&self, name: &str, version: &str) {
+        self.print_width(name, version, 20);
+    }
+
+    fn print_width(&self, name: &str, version: &str, width: usize) {
+        println!("{:width$} : {}", name, version, width = width);
+    }
+
+    /// Read CLI and compute its sha256
+    fn format_cli_sha(&self) -> Option<String> {
+        let path = std::env::current_exe().ok()?;
+        let fluvio_bin = std::fs::read(path).ok()?;
+        let mut hasher = Sha256::new();
+        hasher.update(fluvio_bin);
+        let fluvio_bin_sha256 = hasher.finalize();
+        Some(format!("{:x}", &fluvio_bin_sha256))
+    }
+
+    async fn format_platform_version(&self, target: ClusterTarget) -> String {
+        // Attempt to connect to a Fluvio cluster to get platform version
+        // Even if we fail to connect, we should not fail the other printouts
+        let mut platform_version = String::from("Not available");
+        if let Ok(fluvio_config) = target.load() {
+            if let Ok(fluvio) = Fluvio::connect_with_config(&fluvio_config).await {
+                let version = fluvio.platform_version();
+                platform_version = version.to_string();
+            }
+        }
+
+        let profile_name = ConfigFile::load(None)
+            .ok()
+            .and_then(|it| {
+                it.config()
+                    .current_profile_name()
+                    .map(|name| name.to_string())
+            })
+            .map(|name| format!(" ({})", name))
+            .unwrap_or_else(|| "".to_string());
+        format!("{}{}", platform_version, profile_name)
+    }
+
+    fn format_subcommand_metadata(&self) -> Option<Vec<(String, String)>> {
+        let metadata = subcommand_metadata().ok()?;
+        let mut formats = Vec::new();
+        for sub_cmd in metadata {
+            let left = format!("{} ({})", sub_cmd.meta.title, sub_cmd.filename);
+            formats.push((left, sub_cmd.meta.version.to_string()));
+        }
+
+        Some(formats)
+    }
+}
+
+/// Fetch OS information
+fn os_info() -> Option<String> {
+    use sysinfo::SystemExt;
+    let sys = sysinfo::System::new_all();
+
+    let info = format!(
+        "{} {} (kernel {})",
+        sys.get_name()?,
+        sys.get_os_version()?,
+        sys.get_kernel_version()?,
+    );
+
+    Some(info)
+}

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -47,7 +47,7 @@ fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.1.13" }
 fluvio-command = { version = "0.2.0", path = "../command" }
 fluvio-runner-local = { version = "0.3.0", path = "../extension-runner-local", optional = true }
-fluvio-extension-common = { version = "0.2.0", path = "../extension-common", optional = true }
+fluvio-extension-common = { version = "0.3.0", path = "../extension-common", optional = true }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata", features = ["k8"] }
 flv-util = "0.5.2"
 k8-config = { version = "1.3.0" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"
@@ -26,5 +26,6 @@ serde_yaml = "0.8.8"
 async-trait = "0.1.21"
 futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
+semver = { version = "0.11.0", features = ["serde"] }
 
 fluvio = { version = "0.6.0", path = "../client",  optional = true }

--- a/src/extension-common/src/lib.rs
+++ b/src/extension-common/src/lib.rs
@@ -34,9 +34,10 @@ macro_rules! t_print_cli_err {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FluvioExtensionMetadata {
-    pub command: String,
+    #[serde(alias = "command")]
+    pub title: String,
     pub description: String,
-    pub version: String,
+    pub version: semver::Version,
 }
 
 pub struct PrintTerminal {}

--- a/src/extension-consumer/Cargo.toml
+++ b/src/extension-consumer/Cargo.toml
@@ -28,6 +28,7 @@ which = "4.0.2"
 hostname-validator = "1.0.0"
 content_inspector = "0.2.4"
 atty = "0.2.14"
+semver = "0.11.0"
 
 # Fluvio dependencies
 
@@ -35,6 +36,6 @@ flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.1.8", features = ["fs", "io"] }
 fluvio = { version = "0.6.0", path = "../client", default-features = false }
 fluvio-types = { version = "0.2.0" , path = "../types" }
-fluvio-extension-common = { version = "0.2.0", path = "../extension-common", features = ["target"] }
+fluvio-extension-common = { version = "0.3.0", path = "../extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { version = "0.6.0", path = "../controlplane-metadata", features = ["use_serde"] }
 fluvio-sc-schema = { version = "0.6.0", path = "../sc-schema", features = ["use_serde"] }

--- a/src/extension-consumer/src/consume/mod.rs
+++ b/src/extension-consumer/src/consume/mod.rs
@@ -91,9 +91,9 @@ impl ConsumeLogOpt {
 
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
-            command: "consume".into(),
+            title: "consume".into(),
             description: "Consume new data in a stream".into(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }
     }
 

--- a/src/extension-consumer/src/partition/mod.rs
+++ b/src/extension-consumer/src/partition/mod.rs
@@ -32,9 +32,9 @@ impl PartitionCmd {
     }
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
-            command: "partition".into(),
+            title: "partition".into(),
             description: "Partition Operations".into(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }
     }
 }

--- a/src/extension-consumer/src/produce/mod.rs
+++ b/src/extension-consumer/src/produce/mod.rs
@@ -149,9 +149,9 @@ impl ProduceLogOpt {
 
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
-            command: "produce".into(),
+            title: "produce".into(),
             description: "Produce new data in a stream".into(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }
     }
 }

--- a/src/extension-consumer/src/topic/mod.rs
+++ b/src/extension-consumer/src/topic/mod.rs
@@ -71,9 +71,9 @@ impl TopicCmd {
     }
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
-            command: "topic".into(),
+            title: "topic".into(),
             description: "Topic Operations".into(),
-            version: env!("CARGO_PKG_VERSION").into(),
+            version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }
     }
 }


### PR DESCRIPTION
Previously, there was no easy way to see the versions of all installed fluvio subcommands. Now, `fluvio version` will detect and print the versions:

```
$ fluvio version
Fluvio CLI           : 0.7.1-alpha.0
Fluvio CLI SHA256    : cef57bc33d2f730815c6b458bbae07d70775af0e8c0f1d3139e66584a6f2f20d
Fluvio Platform      : 0.7.1-alpha.0 (local)
Git Commit           : 0662bfa5eec00aa3c42ca6aeb63b1d04632a0235
OS Details           : Darwin 11.2.2 (kernel 20.3.0)
=== Plugin Versions ===
package (fluvio-package)       : 0.1.4
cloud (fluvio-cloud)           : 0.1.4
```

Let me know if anybody has different preferences as to how these get printed. I'm starting to think that there's so much information getting packed into `fluvio version` that we might want to start printing it in a structured format by default, maybe yaml. But that'd be a future issue.