### PR TITLE
Made fluvio-cluster an optional dependency

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -46,7 +46,7 @@ k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
 fluvio-future = { version = "0.2.0", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.6.0", path = "../client", default-features = false }
-fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
+fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"], optional = true}
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.2.0", path = "../package-index" }
 fluvio-extension-common = { version = "0.3.0", path = "../extension-common", features = ["target"]}

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -3,6 +3,7 @@ use std::io::Error as IoError;
 use fluvio::FluvioError;
 use fluvio_extension_common::output::OutputError;
 use fluvio_extension_consumer::ConsumerError;
+#[cfg(feature = "fluvio-cluster")]
 use fluvio_cluster::cli::ClusterCliError;
 use crate::common::target::TargetError;
 use fluvio_sc_schema::ApiError;
@@ -16,6 +17,8 @@ pub enum CliError {
     IoError(#[from] IoError),
     #[error(transparent)]
     OutputError(#[from] OutputError),
+
+    #[cfg(feature = "fluvio-cluster")]
     #[error("Fluvio cluster error")]
     ClusterCliError(#[from] ClusterCliError),
     #[error("Target Error")]
@@ -61,6 +64,7 @@ impl CliError {
         use color_eyre::Report;
 
         match self {
+            #[cfg(feature = "fluvio-cluster")]
             CliError::ClusterCliError(cluster) => cluster.into_report(),
             _ => Report::from(self),
         }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -23,6 +23,7 @@ use version::VersionOpt;
 pub use error::{Result, CliError};
 
 use fluvio::Fluvio;
+#[cfg(feature = "fluvio-cluster")]
 use fluvio_cluster::cli::ClusterCmd;
 use fluvio_extension_consumer::consume::ConsumeLogOpt;
 use fluvio_extension_consumer::produce::ProduceLogOpt;
@@ -86,6 +87,7 @@ enum RootCmd {
     #[structopt(name = "profile")]
     Profile(ProfileCmd),
 
+    #[cfg(feature = "fluvio-cluster")]
     /// Install or uninstall Fluvio clusters
     ///
     /// If you are not using Fluvio Cloud, you may wish to install your own Fluvio
@@ -142,6 +144,7 @@ impl RootCmd {
             Self::Profile(profile) => {
                 profile.process(out).await?;
             }
+            #[cfg(feature = "fluvio-cluster")]
             Self::Cluster(cluster) => {
                 cluster.process(out, crate::VERSION, root.target).await?;
             }


### PR DESCRIPTION
Not sure how I feel about this, was good practice to re-learn cargo features (I've been getting rusty on it).

Probably need to update release CI to include `fluvio-cluster` as a parameter.