### PR TITLE
Do not release install.sh by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,11 @@ on:
   workflow_dispatch:
     inputs:
       force:
+        required: false
         description: 'Force push this release'
+      update_script:
+        description: 'Whether to update the install.sh script'
+        required: false
 
 jobs:
   upload_fluvio_cli:
@@ -48,7 +52,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Update fluvio install.sh
-        if: startsWith(matrix.os, 'ubuntu')
+        if: ${{ startsWith(matrix.os, 'ubuntu') && github.event.inputs.update_script != '' }}
         run: cargo make -l verbose --profile production s3-upload-installer
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This is my best guess as to how to disable publishing install.sh. As always, this is hard to test without actually trying it out.

I used the `steps.if` key from the github workflow spec https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps