### PR TITLE
Make `fluvio update` update plugins as well as CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "fluvio",
+ "fluvio-package-index",
  "futures-lite",
  "prettytable-rs",
  "semver 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -48,7 +48,7 @@ fluvio-future = { version = "0.2.0", features = ["fs", "io", "subscriber"] }
 fluvio = { version = "0.6.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-command = { version = "0.2.0" }
-fluvio-package-index = { version = "0.2.0", path = "../package-index" }
+fluvio-package-index = { version = "0.3.0", path = "../package-index" }
 fluvio-extension-common = { version = "0.3.0", path = "../extension-common", features = ["target"]}
 fluvio-extension-consumer = { version = "0.3.0", path = "../extension-consumer" }
 fluvio-controlplane-metadata = { version = "0.7.0", path = "../controlplane-metadata", features = ["use_serde", "k8"] }

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -39,16 +39,17 @@ pub(crate) fn fluvio_extensions_dir() -> Result<PathBuf, CliError> {
     }
     Ok(path)
 }
-pub(crate) fn get_extensions() -> Result<Vec<(String, PathBuf)>, CliError> {
+
+pub(crate) fn get_extensions() -> Result<Vec<PathBuf>, CliError> {
     use std::fs;
-    let mut extensions: Vec<(String, PathBuf)> = Vec::new();
+    let mut extensions = Vec::new();
     let fluvio_dir = fluvio_extensions_dir()?;
     if let Ok(entries) = fs::read_dir(&fluvio_dir) {
         for entry in entries {
             if let Ok(entry) = entry {
-                let filename = entry.file_name().to_string_lossy().to_string();
-                if filename.starts_with("fluvio-") {
-                    extensions.push((filename, entry.path()));
+                let is_plugin = entry.file_name().to_string_lossy().starts_with("fluvio-");
+                if is_plugin {
+                    extensions.push(entry.path());
                 }
             }
         }

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn get_extensions() -> Result<Vec<PathBuf>, CliError> {
 /// Fetches the latest version of the package with the given ID
 #[instrument(
     skip(agent, target, id),
-    fields(%target, id = %id.display())
+    fields(%target, id = %id.shortname())
 )]
 async fn fetch_latest_version<T>(
     agent: &HttpAgent,

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn get_extensions() -> Result<Vec<PathBuf>, CliError> {
 /// Fetches the latest version of the package with the given ID
 #[instrument(
     skip(agent, target, id),
-    fields(%target, id = %id.shortname())
+    fields(%target, id = %id.pretty())
 )]
 async fn fetch_latest_version<T>(
     agent: &HttpAgent,

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -85,7 +85,7 @@ impl InstallOpt {
 
         // Install the package to the ~/.fluvio/bin/ dir
         let fluvio_dir = fluvio_extensions_dir()?;
-        let package_path = fluvio_dir.join(id.name.as_str());
+        let package_path = fluvio_dir.join(id.name().as_str());
         install_bin(&package_path, &package_file)?;
 
         Ok(())

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -46,7 +46,7 @@ impl UpdateOpt {
             // Collect updates from the given plugin IDs
             let ext_dir = fluvio_extensions_dir()?;
             for plugin in &self.plugins {
-                let path = ext_dir.join(plugin.name.as_str());
+                let path = ext_dir.join(plugin.name().as_str());
                 updates.push((plugin.clone(), path));
             }
         }
@@ -65,7 +65,7 @@ impl UpdateOpt {
             s = s
         );
         for (id, path) in &updates {
-            println!("   - {} ({})", id.name, path.display());
+            println!("   - {} ({})", id.name(), path.display());
         }
 
         for (id, path) in &updates {
@@ -119,7 +119,7 @@ impl UpdateOpt {
 
         println!(
             "⏳ Downloading plugin {} with version {}",
-            id.shortname(),
+            id.pretty(),
             version
         );
         let id = id.clone().into_versioned(version);

--- a/src/cli/src/version.rs
+++ b/src/cli/src/version.rs
@@ -78,9 +78,13 @@ impl VersionOpt {
     fn format_subcommand_metadata(&self) -> Option<Vec<(String, String)>> {
         let metadata = subcommand_metadata().ok()?;
         let mut formats = Vec::new();
-        for sub_cmd in metadata {
-            let left = format!("{} ({})", sub_cmd.meta.title, sub_cmd.filename);
-            formats.push((left, sub_cmd.meta.version.to_string()));
+        for cmd in metadata {
+            let filename = match cmd.path.file_name() {
+                Some(f) => f.to_string_lossy().to_string(),
+                None => continue,
+            };
+            let left = format!("{} ({})", cmd.meta.title, filename);
+            formats.push((left, cmd.meta.version.to_string()));
         }
 
         Some(formats)

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -29,3 +29,4 @@ thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
 fluvio = { version = "0.6.0", path = "../client",  optional = true }
+fluvio-package-index = { version = "0.2.2", path = "../package-index" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 [features]
 target = ["fluvio"]
 
-
 [dependencies]
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
@@ -29,4 +28,4 @@ thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
 fluvio = { version = "0.6.0", path = "../client",  optional = true }
-fluvio-package-index = { version = "0.2.2", path = "../package-index" }
+fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/src/extension-common/src/lib.rs
+++ b/src/extension-common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod tls;
 
 pub use common::*;
 pub use crate::output::Terminal;
+use fluvio_index::{PackageId, MaybeVersion};
 
 pub const COMMAND_TEMPLATE: &str = "{about}
 
@@ -32,11 +33,23 @@ macro_rules! t_print_cli_err {
     };
 }
 
+/// Metadata that plugins may provide to Fluvio at runtime.
+///
+/// This allows `fluvio` to include external plugins in the help
+/// menu, version printouts, and automatic updates.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FluvioExtensionMetadata {
+    /// The title is a human-readable pretty name
     #[serde(alias = "command")]
     pub title: String,
+    /// Identifies the plugin on the package index
+    ///
+    /// Example: `fluvio/fluvio-cloud`
+    #[serde(default)]
+    pub package: Option<PackageId<MaybeVersion>>,
+    /// A brief description of what this plugin does
     pub description: String,
+    /// The version of this plugin
     pub version: semver::Version,
 }
 

--- a/src/extension-consumer/src/consume/mod.rs
+++ b/src/extension-consumer/src/consume/mod.rs
@@ -92,6 +92,7 @@ impl ConsumeLogOpt {
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
             title: "consume".into(),
+            package: Some("fluvio/fluvio".parse().unwrap()),
             description: "Consume new data in a stream".into(),
             version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }

--- a/src/extension-consumer/src/partition/mod.rs
+++ b/src/extension-consumer/src/partition/mod.rs
@@ -30,9 +30,11 @@ impl PartitionCmd {
 
         Ok(())
     }
+
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
             title: "partition".into(),
+            package: Some("fluvio/fluvio".parse().unwrap()),
             description: "Partition Operations".into(),
             version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }

--- a/src/extension-consumer/src/produce/mod.rs
+++ b/src/extension-consumer/src/produce/mod.rs
@@ -150,6 +150,7 @@ impl ProduceLogOpt {
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
             title: "produce".into(),
+            package: Some("fluvio/fluvio".parse().unwrap()),
             description: "Produce new data in a stream".into(),
             version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }

--- a/src/extension-consumer/src/topic/mod.rs
+++ b/src/extension-consumer/src/topic/mod.rs
@@ -69,9 +69,11 @@ impl TopicCmd {
 
         Ok(())
     }
+
     pub fn metadata() -> FluvioExtensionMetadata {
         FluvioExtensionMetadata {
             title: "topic".into(),
+            package: Some("fluvio/fluvio".parse().unwrap()),
             description: "Topic Operations".into(),
             version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Infinyon Contributors <team@infiyon.com>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -37,9 +37,9 @@ impl HttpAgent {
     }
 
     pub fn request_package<T>(&self, id: &PackageId<T>) -> Result<Request> {
-        let url = self
-            .base_url
-            .join(&format!("packages/{}/{}/meta.json", id.group, id.name))?;
+        let url =
+            self.base_url
+                .join(&format!("packages/{}/{}/meta.json", id.group(), id.name()))?;
         Ok(Request::get(url))
     }
 
@@ -55,8 +55,8 @@ impl HttpAgent {
     ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}",
-            group = &id.group,
-            name = &id.name,
+            group = &id.group(),
+            name = &id.name(),
             version = id.version(),
             target = target.as_str(),
         ))?;
@@ -71,8 +71,8 @@ impl HttpAgent {
     ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}.sha256",
-            group = &id.group,
-            name = &id.name,
+            group = &id.group(),
+            name = &id.name(),
             version = id.version(),
             target = target.as_str(),
         ))?;

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -93,8 +93,8 @@ impl Package {
         let description = desc.into();
         let repository = repo.into();
         Package {
-            name: id.name.clone(),
-            group: id.group.clone(),
+            name: id.name().clone(),
+            group: id.group().clone(),
             kind: PackageKind::Binary,
             author: Some(author),
             description: Some(description),

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -206,14 +206,18 @@ impl<T> PackageId<T> {
     }
 
     /// A printable representation of this `PackageId`
-    pub fn display(&self) -> impl fmt::Display {
-        let registry = self.registry.as_ref().map(|it| it.0.as_str()).unwrap_or("");
-        format!(
-            "{registry}{group}/{name}",
-            registry = registry,
-            group = self.group.as_str(),
-            name = self.name.as_str(),
-        )
+    ///
+    /// This displays the most concise representation of this `PackageId` that is still unique.
+    /// For example, if the registry and group name are default values, this will display only
+    /// the package name. If the group name is non-standard, it will be printed. If the registry
+    /// is non-standard, both the registry and the group name will be printed.
+    pub fn shortname(&self) -> impl fmt::Display {
+        let prefix = match self.registry.as_ref() {
+            Some(reg) => format!("{reg}{group}/", reg = reg, group = self.group.as_str()),
+            None if self.group.as_str() == GroupName::DEFAULT => "".to_string(),
+            None => format!("{}/", self.group.as_str()),
+        };
+        format!("{}{}", prefix, self.name.as_str())
     }
 
     /// A unique representation of this package, excluding version.

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -318,8 +318,8 @@ impl std::str::FromStr for PackageId<WithVersion> {
 
         let maybe_group_segment = segments.pop();
         let group: Option<GroupName> = match maybe_group_segment {
+            None | Some("fluvio") => None,
             Some(group_string) => Some(group_string.parse()?),
-            None => None,
         };
 
         let registry = Registry::try_from_segments(&segments);
@@ -356,8 +356,8 @@ impl std::str::FromStr for PackageId<MaybeVersion> {
 
         let maybe_group_string = segments.pop();
         let group: Option<GroupName> = match maybe_group_string {
+            None | Some("fluvio") => None,
             Some(group_string) => Some(group_string.parse()?),
-            None => None,
         };
         let registry = Registry::try_from_segments(&segments);
 
@@ -581,6 +581,34 @@ mod tests {
             "fluvio/fluvio",
             format!("{}", package_id_maybe_without_version)
         );
+    }
+
+    #[test]
+    fn test_pretty_no_group() {
+        let package_id: PackageId = "fluvio:1.2.3".parse().unwrap();
+        let pretty = format!("{}", package_id.pretty());
+        assert_eq!(pretty, "fluvio");
+    }
+
+    #[test]
+    fn test_pretty_group() {
+        let package_id: PackageId = "fluvio/fluvio:1.2.3".parse().unwrap();
+        let pretty = format!("{}", package_id.pretty());
+        assert_eq!(pretty, "fluvio");
+    }
+
+    #[test]
+    fn test_pretty_maybe_id_no_group() {
+        let package_id: PackageId<MaybeVersion> = "fluvio".parse().unwrap();
+        let pretty = format!("{}", package_id.pretty());
+        assert_eq!(pretty, "fluvio");
+    }
+
+    #[test]
+    fn test_pretty_maybe_id_group() {
+        let package_id: PackageId<MaybeVersion> = "fluvio/fluvio".parse().unwrap();
+        let pretty = format!("{}", package_id.pretty());
+        assert_eq!(pretty, "fluvio");
     }
 
     #[test]


### PR DESCRIPTION
Closes #672 

This updates the `fluvio update` command to behave as follows:

- `fluvio update` with no parameters will update the CLI and any plugins that support being updated* to the latest stable version
- `fluvio update <pluginA> <pluginB>` will update any of the named plugins to the latest stable version
- `fluvio update` with a `--develop` flag with update the targets to the latest prerelease (rather than stable)

# *Plugin Update Mechanism

In order to be compatible with auto-updating, each plugin must now provide a new field of metadata called `package`, which identifies the plugin on packages.fluvio.io. For example, the `fluvio-cloud` plugin would provide a package field containing `fluvio/fluvio-cloud`. This is delivered via the already-existing metadata mechanism, where any plugin executed with a `metadata` argument is expected to return a `FluvioExtensionMetadata`, e.g.

```
$ fluvio-cloud metadata
{
  "title": "Fluvio Cloud CLI",
  "package": "fluvio/fluvio-cloud",
  "description": "A tool for interacting with Fluvio Cloud",
  "version": "0.1.4"
}
```

In the JSON above, the `package` field is new, and allows the plugin to tell the CLI where to search for its updates. Older plugins that do not provide the `package` field will not be auto-updated with `fluvio update` (with no arguments), but updates will still work fine if the plugin to update is named, e.g. `fluvio update fluvio-cloud`.

Example:

<img width="730" alt="image" src="https://user-images.githubusercontent.com/4210949/111198517-03300780-8596-11eb-94b9-0477ef973f89.png">
