### PR TITLE
Fix doc tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
  "event-listener",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-sc-schema",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1314,7 +1314,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1441,7 +1441,7 @@ version = "0.6.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-types",
  "log",
  "tracing",
@@ -1454,7 +1454,7 @@ dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1471,7 +1471,7 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-socket",
  "flv-util",
  "futures-util",
@@ -1600,7 +1600,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.9",
  "serde_json",
- "syn 1.0.63",
+ "syn 1.0.64",
  "trybuild",
 ]
 
@@ -1624,10 +1624,31 @@ version = "0.4.0"
 dependencies = [
  "bytes 1.0.1",
  "fluvio-future 0.2.0",
- "fluvio-protocol-api",
+ "fluvio-protocol-api 0.3.0",
  "fluvio-protocol-codec",
- "fluvio-protocol-core",
- "fluvio-protocol-derive",
+ "fluvio-protocol-core 0.3.0",
+ "fluvio-protocol-derive 0.2.0",
+ "flv-util",
+ "log",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5748d15d4d86ec252304ab783b391dcff39dc237f16de84fab01158ef5670535"
+dependencies = [
+ "fluvio-protocol-api 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fluvio-protocol-api"
+version = "0.3.0"
+dependencies = [
+ "fluvio-protocol-core 0.3.0",
+ "fluvio-protocol-derive 0.2.0",
  "flv-util",
  "log",
 ]
@@ -1635,9 +1656,11 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-api"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae66072f907fffff49299438a9afe0379aa4718587f408eb5d98545445ff0c6c"
 dependencies = [
- "fluvio-protocol-core",
- "fluvio-protocol-derive",
+ "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flv-util",
  "log",
 ]
@@ -1648,7 +1671,7 @@ version = "0.3.0"
 dependencies = [
  "bytes 1.0.1",
  "fluvio-future 0.2.0",
- "fluvio-protocol-core",
+ "fluvio-protocol-core 0.3.0",
  "flv-util",
  "futures",
  "log",
@@ -1664,8 +1687,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-protocol-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c950608da27edf870cdebb301e64a09c8de3bda11c9b374ffa892e80bab2024a"
+dependencies = [
+ "bytes 1.0.1",
+ "log",
+]
+
+[[package]]
 name = "fluvio-protocol-derive"
 version = "0.2.0"
+dependencies = [
+ "fluvio-protocol 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "fluvio-protocol-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
 dependencies = [
  "log",
  "proc-macro2",
@@ -1700,7 +1746,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -1732,7 +1778,7 @@ version = "0.7.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-types",
  "log",
  "serde",
@@ -1748,7 +1794,7 @@ dependencies = [
  "async-trait",
  "event-listener",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-socket",
  "futures-util",
  "log",
@@ -1771,7 +1817,7 @@ dependencies = [
  "chashmap",
  "event-listener",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "flv-util",
  "futures-util",
  "log",
@@ -1800,7 +1846,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-service",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1828,7 +1874,7 @@ version = "0.5.0"
 dependencies = [
  "bytes 1.0.1",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "log",
  "serde",
  "static_assertions",
@@ -1846,7 +1892,7 @@ dependencies = [
  "derive_builder",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.2.0",
- "fluvio-protocol",
+ "fluvio-protocol 0.4.0",
  "fluvio-socket",
  "fluvio-types",
  "flv-util",
@@ -1934,7 +1980,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "syn 1.0.63",
+ "syn 1.0.64",
  "tokio 0.2.25",
 ]
 
@@ -1971,7 +2017,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "syn 1.0.63",
+ "syn 1.0.64",
  "tokio 0.2.25",
 ]
 

--- a/src/command/src/lib.rs
+++ b/src/command/src/lib.rs
@@ -87,14 +87,14 @@ pub trait CommandExt {
     /// // On success, we get the stdout and stderr output
     /// let output: Output = Command::new("true").result().unwrap();
     ///
-    /// let error = Command::new("ls")
-    ///     .arg("does-not-exist")
+    /// let error = Command::new("bash")
+    ///     .args(&["-c", r#"echo "this command failed with this stderr" 1>&2 && false"#])
     ///     .result()
     ///     .unwrap_err();
     /// if let CommandErrorKind::ExitError(1i32, output) = error.source {
     ///     assert_eq!(
     ///         String::from_utf8_lossy(&output.stderr).to_string(),
-    ///         "ls: does-not-exist: No such file or directory\n",
+    ///         "this command failed with this stderr\n",
     ///     );
     /// } else {
     ///     panic!("should fail with stderr output");

--- a/src/protocol/fluvio-protocol-derive/Cargo.toml
+++ b/src/protocol/fluvio-protocol-derive/Cargo.toml
@@ -20,3 +20,6 @@ log = "0.4.8"
 [dependencies.syn]
 version = "1.0.0"
 features = ["full"]
+
+[dev-dependencies]
+fluvio-protocol = { version = "0.4.0", features = ["derive", "api"] }

--- a/src/protocol/fluvio-protocol-derive/src/lib.rs
+++ b/src/protocol/fluvio-protocol-derive/src/lib.rs
@@ -21,10 +21,11 @@ use syn::parse_macro_input;
 /// # Examples
 ///
 /// ```
+/// use std::io::Cursor;
 /// use fluvio_protocol::Decoder;
 /// use fluvio_protocol::derive::Decode;
 ///
-/// #[derive(Decode)]
+/// #[derive(Default, Decode)]
 /// pub struct SimpleRecord {
 ///     val: u8
 /// }
@@ -34,8 +35,7 @@ use syn::parse_macro_input;
 /// ];
 ///
 /// let record = SimpleRecord::decode_from(&mut Cursor::new(&data),0).expect("decode");
-/// assert_eq!(record.val,4);
-///
+/// assert_eq!(record.val, 4);
 /// ```
 ///
 ///
@@ -45,6 +45,8 @@ use syn::parse_macro_input;
 /// So this works
 ///
 /// ```
+/// # use fluvio_protocol::derive::Decode;
+/// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
 /// #[derive(Decode)]
 /// pub enum ThreeChoice {
 ///     First = 1,
@@ -54,7 +56,10 @@ use syn::parse_macro_input;
 /// ```
 ///
 /// Also, enum without integer literal works as well
+///
 /// ```
+/// # use fluvio_protocol::derive::Decode;
+/// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
 /// #[derive(Decode)]
 /// pub enum ThreeChoice {
 ///     First,
@@ -97,23 +102,17 @@ pub fn fluvio_decode(tokens: TokenStream) -> TokenStream {
 ///     val: u8
 /// }
 ///
-/// let data = vec![];
+/// let mut data = vec![];
 ///
-/// let record = SimpleRecord { val: 4};
-/// recprd.encode(&mut data,0);
+/// let record = SimpleRecord { val: 4 };
+/// record.encode(&mut data,0);
 ///     
 /// assert_eq!(data[0],4);
-///
 /// ```
 ///
-///
-/// Encode applys to either Struct of Enum.  
-///
+/// Encode applies to either Struct of Enum.  
 ///
 /// Encode respects version attributes.  See Decode derive.
-///
-///
-///
 #[proc_macro_derive(Encode, attributes(varint, fluvio))]
 pub fn fluvio_encode(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input![tokens as ast::DeriveItem];
@@ -139,21 +138,19 @@ pub fn fluvio_api(tokens: TokenStream) -> TokenStream {
 /// use fluvio_protocol::derive::Decode;
 /// use fluvio_protocol::derive::Encode;
 /// use fluvio_protocol::api::Request;
-/// use fluvio_protocol::derive::RequestApi;
+/// use fluvio_protocol::derive::RequestApi as Request;
 ///
 /// #[fluvio(default,api_min_version = 5, api_max_version = 6, api_key = 10, response = "SimpleResponse")]
-/// #[derive(Request,Encode,Decode,Default)]
+/// #[derive(Debug, Default, Encode, Decode, Request)]
 /// pub struct SimpleRequest {
 ///     val: u8
 /// }
 ///
-///
-/// #[derive(Encode,Decode,Default)]
+/// #[derive(Debug, Default, Encode, Decode)]
 /// #[fluvio(default)]
-/// pub struct TestResponse {
+/// pub struct SimpleResponse {
 ///     pub value: i8,
 /// }
-///
 /// ```
 ///
 /// RequestApi derives respects following attributes in `fluvio`
@@ -173,19 +170,20 @@ pub fn fluvio_request(tokens: TokenStream) -> TokenStream {
 
 /// Custom derive for generating default structure
 ///
-///
 /// Example:
 ///
 /// ```
+/// use fluvio_protocol::derive::FluvioDefault;
+///
 /// #[derive(FluvioDefault)]
 /// #[fluvio(default)]
 /// pub struct SimpleRecord {
-///     #[fluvio(default = "-1" )]
+///     #[fluvio(default = "12")]
 ///     val: u8
 /// }
 ///
-/// let record = SimpleRecord::default;
-/// assert_eq!(record.val,-1);
+/// let record = SimpleRecord::default();
+/// assert_eq!(record.val, 12);
 /// ```
 ///
 /// `default` assignment can be any Rust expression.


### PR DESCRIPTION
Closes #873 

- Fixes the `fluvio-protocol-derive` doc tests, including adding `fluvio-protocol` to dev-dependencies
- Fixed the `fluvio-command` doc tests. This one was tricky/interesting. I had written a doc test to demonstrate that the error returned by `Command::result` would carry the stderr output that the command returned. As a test case, I used `ls some-file-that-doesn't-exist`, but apparently there is a difference in the behavior of `ls` on different platforms. On Mac, it gives an exit code of 1, and on Linux it appeared not to. I wrote a new example of a failing command with stderr output.