### PR TITLE
Update CI to publish each commit to master

### DIFF
--- a/.github/workflows/publish_latest_fluvio.yml
+++ b/.github/workflows/publish_latest_fluvio.yml
@@ -8,15 +8,10 @@ on:
       force:
         required: false
         description: 'Force push this release'
-
-env:
-  # Prod keys
-  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  # Test keys
-  AWS_ACCESS_KEY_ID: ${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}
+      test:
+        required: false
+        description: 'Whether to run a test release'
+        default: ''
 
 jobs:
   publish_fluvio_cli:
@@ -36,10 +31,20 @@ jobs:
       - name: install musl-tools
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo apt-get update && sudo apt-get install -y musl-tools build-essential
-      - name: Set env
+      - name: Set general env
         run: |
           echo "FORCE_RELEASE=${{ github.event.inputs.force }}"
           echo "FORCE_RELEASE=${{ github.event.inputs.force }}" >> $GITHUB_ENV
+      - name: Set test env
+        if: ${{ github.event.inputs.test != '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}"
+      - name: Set prod env
+        if: ${{ github.event.inputs.test == '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       - name: Build and publish using fluvio-packages
         run: cargo make -l verbose publish-fluvio-latest
 
@@ -51,5 +56,15 @@ jobs:
     needs: publish_fluvio_cli
     runs-on: ubuntu-latest
     steps:
+      - name: Set test env
+        if: ${{ github.event.inputs.test != '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}"
+      - name: Set prod env
+        if: ${{ github.event.inputs.test == '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       - name: Bump latest version of Fluvio CLI on fluvio-packages
         run: cargo make bump-fluvio-latest

--- a/.github/workflows/publish_latest_fluvio.yml
+++ b/.github/workflows/publish_latest_fluvio.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+#  push:
+#    branches: [master]
+  workflow_dispatch:
+    inputs:
+      force:
+        required: false
+        description: 'Force push this release'
+
+env:
+  # Prod keys
+  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  # Test keys
+  AWS_ACCESS_KEY_ID: ${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  publish_fluvio_cli:
+    name: Publish Fluvio CLI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [stable]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install cargo-make
+        uses: davidB/rust-cargo-make@v1
+        with:
+          version: '0.32.9'
+      - name: install musl-tools
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools build-essential
+      - name: Set env
+        run: |
+          echo "FORCE_RELEASE=${{ github.event.inputs.force }}"
+          echo "FORCE_RELEASE=${{ github.event.inputs.force }}" >> $GITHUB_ENV
+      - name: Build and publish using fluvio-packages
+        run: cargo make -l verbose publish-fluvio-latest
+
+  # Bump the latest version of the Fluvio CLI on the package registry
+  # This must be a distinct job than publish_fluvio_cli because this job requires
+  # that all targets are first published successfully before we can bump the version.
+  bump_fluvio_cli:
+    name: Bump Fluvio CLI version
+    needs: publish_fluvio_cli
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump latest version of Fluvio CLI on fluvio-packages
+        run: cargo make bump-fluvio-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,18 @@ on:
         description: 'Whether to update the install.sh script'
         required: false
 
+env:
+  # Prod keys
+  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  # Test keys
+  AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+
 jobs:
-  upload_fluvio_cli:
-    name: cli
+  publish_fluvio_cli:
+    name: Publish Fluvio CLI
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -47,16 +56,24 @@ jobs:
 
       - name: Build and publish using fluvio-packages
         run: cargo make -l verbose --profile production publish-fluvio
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Update fluvio install.sh
         if: ${{ startsWith(matrix.os, 'ubuntu') && github.event.inputs.update_script != '' }}
         run: cargo make -l verbose --profile production s3-upload-installer
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  # Bump the latest version of the Fluvio CLI on the package registry
+  # This must be a distinct job than publish_fluvio_cli because this job requires
+  # that all targets are first published successfully before we can bump the version.
+  bump_fluvio_cli:
+    name: Bump Fluvio CLI version
+    needs: publish_fluvio_cli
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump release version of Fluvio CLI using fluvio-packages
+        run: |
+          export FLUVIO_VERSION="$(cat VERSION)+$(git rev-parse HEAD)"
+          echo "Using Fluvio version ${FLUVIO_VERSION}"
+          cargo make bump-fluvio
 
 # TODO: Fix the pi build
 #  release_fluvio_pi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,6 @@ on:
         description: 'Whether to update the install.sh script'
         required: false
 
-env:
-  # Prod keys
-  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  # Test keys
-  AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-
 jobs:
   publish_fluvio_cli:
     name: Publish Fluvio CLI
@@ -54,6 +45,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_RELEASE }}
 
+      # Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      - name: Set test env
+        if: ${{ github.event.inputs.test != '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}"
+      - name: Set prod env
+        if: ${{ github.event.inputs.test == '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+
       - name: Build and publish using fluvio-packages
         run: cargo make -l verbose --profile production publish-fluvio
 
@@ -69,6 +72,18 @@ jobs:
     needs: publish_fluvio_cli
     runs-on: ubuntu-latest
     steps:
+      # Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+      - name: Set test env
+        if: ${{ github.event.inputs.test != '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.PACKAGE_TEST_AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.PACKAGE_TEST_AWS_SECRET_ACCESS_KEY }}"
+      - name: Set prod env
+        if: ${{ github.event.inputs.test == '' }}
+        run: |
+          echo "::set-env name=AWS_ACCESS_KEY_ID::${{ secrets.AWS_ACCESS_KEY_ID }}"
+          echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+
       - name: Bump release version of Fluvio CLI using fluvio-packages
         run: |
           export FLUVIO_VERSION="$(cat VERSION)+$(git rev-parse HEAD)"

--- a/makefiles/S3.toml
+++ b/makefiles/S3.toml
@@ -34,16 +34,32 @@ args = [
 [tasks.publish-fluvio]
 dependencies = [
     "build-release",
+    "install-fluvio-package",
+    "publish-fluvio-env",
 ]
-script = '''
-mkdir -p ~/.fluvio/extensions
-./target/${TARGET}/release/fluvio install fluvio/fluvio-package;
-./target/${TARGET}/release/fluvio package publish ./target/${TARGET}/release/fluvio --version=${FLUVIO_VERSION} ${FORCE_RELEASE};
-./target/${TARGET}/release/fluvio package bump latest;
-'''
+script = "${HOME}/.fluvio/bin/fluvio package --test publish --version=${FLUVIO_VERSION} ${FORCE_RELEASE} ./target/${TARGET}/release/fluvio"
 
-[tasks.publish-fluvio.linux]
+[tasks.publish-fluvio-env.linux]
 env = { TARGET = "x86_64-unknown-linux-musl" }
 
-[tasks.publish-fluvio.mac]
+[tasks.publish-fluvio-env.mac]
 env = { TARGET = "x86_64-apple-darwin" }
+
+[tasks.publish-fluvio-latest]
+extend = "publish-fluvio"
+env = { FLUVIO_VERSION = { script = ["""echo "$(cat VERSION)+$(git rev-parse HEAD)" """] } }
+
+[tasks.install-fluvio]
+script = "curl -fsS https://packages.fluvio.io/v1/install.sh | bash"
+
+[tasks.install-fluvio-package]
+dependencies = ["install-fluvio"]
+script = "${HOME}/.fluvio/bin/fluvio install --develop fluvio/fluvio-package"
+
+[tasks.bump-fluvio]
+dependencies = ["install-fluvio-package", "bump-fluvio-latest"]
+script = """${HOME}/.fluvio/bin/fluvio package --test bump dynamic ${FLUVIO_VERSION} """
+
+[tasks.bump-fluvio-latest]
+dependencies = ["install-fluvio-package"]
+script = """${HOME}/.fluvio/bin/fluvio package --test bump latest "$(cat VERSION)+$(git rev-parse HEAD)" """


### PR DESCRIPTION
This PR adds new `cargo make` tasks for publishing Fluvio to the `latest` release channel, as well as a brand new workflow file that will trigger these tasks, `publish_latest_fluvio`. Here's a breakdown of the new tasks:

- `cargo make publish-fluvio-latest` will publish the current release build of Fluvio to `latest`
  - FLUVIO_VESRION: `$(cat VERSION)+$(git rev-parse HEAD)`, e.g. `0.7.2-alpha.1+abcdef`
- `cargo make publish-fluvio` will publish the current release build of Fluvio to VERSION.
- `cargo make bump-fluvio-latest` will bump the `latest` version of Fluvio to the current VERSION+git hash
  - Only if Fluvio has been published on all targets for that VERSION, e.g. in prior steps of the CI job.
- `cargo make bump-fluvio` will use FLUVIO_VERSION to bump the appropriate tag
  - e.g. if FLUVIO_VERSION is `x.y.z` it will bump `stable`, but if it is `x.y.z-alpha.w+abcdef`, it will bump `latest`.
  - This will also always bump `latest`

I have done some limited testing locally, but in order to test this in earnest we will actually need to merge this PR, because that's the only way the new workflow will show up in Github.