### PR TITLE
Use exact version equality (with build metadata) for package-index releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-package-index"
-version = "0.3.0"
-authors = ["Infinyon Contributors <team@infiyon.com>"]
+version = "0.3.1"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"


### PR DESCRIPTION
This is required for the latest `fluvio-package` release, which is required for setting up publish-on-merge CI for fluvio.