### PR TITLE
Update SerialFrame to take &self only

### DIFF
--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -61,7 +61,7 @@ impl TopicProducer {
             addr = spu_client.config().addr(),
             "Connected to replica leader:"
         );
-        send_record_raw(spu_client, &replica, Some(key), value).await
+        send_record_raw(&spu_client, &replica, Some(key), value).await
     }
 
     /// Sends an event to a specific partition within this producer's topic
@@ -93,13 +93,13 @@ impl TopicProducer {
 
         debug!("connect to replica leader at: {}", spu_client);
 
-        send_record_raw(spu_client, &replica, None, record).await
+        send_record_raw(&spu_client, &replica, None, record).await
     }
 }
 
 /// Sends record to a target server (Kf, SPU, or SC)
 async fn send_record_raw<F: SerialFrame>(
-    mut leader: F,
+    leader: &F,
     replica: &ReplicaKey,
     key: Option<&[u8]>,
     value: &[u8],


### PR DESCRIPTION
This is a little bit of upkeep in the client code. Prior to this, `SerialFrame`'s `send_receive` method took `&mut self`, but it was only necessary in one particular implementation of `SerialFrame`: VersionedSocket. In This PR, I changed `SerialFrame::send_receive` to take `&self`, and wrapped the `VersionedSocket` in a `Mutex` where the interior mutability was required.

This will make things nicer in some upcoming changes where we want to be able to do things like cache the socket connections for a Producer, which would be a headache and a half to do with the current API.