### PR TITLE
Bump version of fluvio-auth to fix publishing of fluvio-sc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-auth"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "fluvio-controlplane-metadata",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-auth"
-version = "0.6.0"
+version = "0.5.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-auth"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
 
 # Fluvio dependencies
-fluvio-auth = { version = "0.4.0", path = "../auth" }
+fluvio-auth = { version = "0.5.0", path = "../auth" }
 fluvio-future = { version = "0.2.0", features = ["subscriber", "openssl_tls"] }
 fluvio-types = { version = "0.2.0", path = "../types", features = ["events"] }
 fluvio-sc-schema = { version = "0.7.0", path = "../sc-schema" }


### PR DESCRIPTION
Some of the changes from https://github.com/infinyon/fluvio/pull/856 need version bumps. If I read that PR right I think `fluvio-controlplane` may also need a version bump but I'm not sure.