### PR TITLE
make  dataplane-protocol crate more modular

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ dependencies = [
  "event-listener",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-sc-schema",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1304,7 +1304,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1424,7 +1424,7 @@ version = "0.6.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-types",
  "log",
  "tracing",
@@ -1437,7 +1437,7 @@ dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1448,13 +1448,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes 1.0.1",
+ "cfg-if 1.0.0",
  "content_inspector",
  "crc32c",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-socket",
  "flv-util",
  "futures-util",
@@ -1554,6 +1555,17 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5748d15d4d86ec252304ab783b391dcff39dc237f16de84fab01158ef5670535"
+dependencies = [
+ "fluvio-protocol-api 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.4.1"
 dependencies = [
  "bytes 1.0.1",
  "fluvio-future",
@@ -1563,17 +1575,6 @@ dependencies = [
  "fluvio-protocol-derive 0.2.0",
  "flv-util",
  "log",
-]
-
-[[package]]
-name = "fluvio-protocol"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5748d15d4d86ec252304ab783b391dcff39dc237f16de84fab01158ef5670535"
-dependencies = [
- "fluvio-protocol-api 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1633,7 +1634,7 @@ dependencies = [
 name = "fluvio-protocol-derive"
 version = "0.2.0"
 dependencies = [
- "fluvio-protocol 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol 0.4.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1679,7 +1680,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -1711,7 +1712,7 @@ version = "0.7.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-types",
  "log",
  "serde",
@@ -1727,7 +1728,7 @@ dependencies = [
  "async-trait",
  "event-listener",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-socket",
  "futures-util",
  "log",
@@ -1750,7 +1751,7 @@ dependencies = [
  "chashmap",
  "event-listener",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "flv-util",
  "futures-util",
  "log",
@@ -1780,7 +1781,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-service",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1808,7 +1809,7 @@ version = "0.5.0"
 dependencies = [
  "bytes 1.0.1",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "log",
  "serde",
  "static_assertions",
@@ -1826,7 +1827,7 @@ dependencies = [
  "derive_builder",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.4.0",
+ "fluvio-protocol 0.4.1",
  "fluvio-socket",
  "fluvio-types",
  "flv-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3577,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["encoding", "api-bindings"]
 
 [features]
 default = ["file"]
-file = []
+file = ["fluvio-protocol/store"]
 
 [dependencies]
 log = "0.4.0"
@@ -24,7 +24,7 @@ once_cell = "1.5.2"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.2.0" }
-fluvio-protocol = { path = "../protocol", version = "0.4.0", features = ["derive", "api", "store"] }
+fluvio-protocol = { path = "../protocol", version = "0.4.0", features = ["derive", "api"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"
@@ -8,9 +8,13 @@ repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
 categories = ["encoding", "api-bindings"]
 
+[features]
+default = ["file"]
+file = []
 
 [dependencies]
 log = "0.4.0"
+cfg-if = "1.0.0"
 bytes = "1.0.0"
 futures-util = { version = "0.3.4" }
 content_inspector = "0.2.4"

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -11,12 +11,11 @@ use crate::derive::Encode;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;
-use crate::record::FileRecordSet;
 
 use super::FetchResponse;
 
 pub type DefaultFetchRequest = FetchRequest<RecordSet>;
-pub type FileFetchRequest = FetchRequest<FileRecordSet>;
+
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchRequest<R>
@@ -105,4 +104,13 @@ pub struct FetchPartition {
     /// The maximum bytes to fetch from this partition.  See KIP-74 for cases where this limit may
     /// not be honored.
     pub max_bytes: i32,
+}
+
+#[cfg(feature = "file")]
+pub use file::*;
+#[cfg(feature = "file")]
+mod file {
+    use super::*;
+    use crate::record::FileRecordSet;
+    pub type FileFetchRequest = FetchRequest<FileRecordSet>;
 }

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -16,7 +16,6 @@ use super::FetchResponse;
 
 pub type DefaultFetchRequest = FetchRequest<RecordSet>;
 
-
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchRequest<R>
 where

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -13,15 +13,12 @@ use crate::derive::Decode;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;
-use crate::record::FileRecordSet;
 use crate::ErrorCode;
 use crate::store::FileWrite;
 use crate::store::StoreValue;
 
 pub type DefaultFetchResponse = FetchResponse<RecordSet>;
-pub type FileFetchResponse = FetchResponse<FileRecordSet>;
-pub type FileTopicResponse = FetchableTopicResponse<FileRecordSet>;
-pub type FilePartitionResponse = FetchablePartitionResponse<FileRecordSet>;
+
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchResponse<R>
@@ -67,25 +64,7 @@ where
     }
 }
 
-impl FileWrite for FileFetchResponse {
-    fn file_encode(
-        &self,
-        src: &mut BytesMut,
-        data: &mut Vec<StoreValue>,
-        version: Version,
-    ) -> Result<(), IoError> {
-        trace!("file encoding FileFetchResponse");
-        trace!("encoding throttle_time_ms {}", self.throttle_time_ms);
-        self.throttle_time_ms.encode(src, version)?;
-        trace!("encoding error code {:#?}", self.error_code);
-        self.error_code.encode(src, version)?;
-        trace!("encoding session code {}", self.session_id);
-        self.session_id.encode(src, version)?;
-        trace!("encoding topics len: {}", self.topics.len());
-        self.topics.file_encode(src, data, version)?;
-        Ok(())
-    }
-}
+
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchableTopicResponse<R>
@@ -100,19 +79,7 @@ where
     pub data: PhantomData<R>,
 }
 
-impl FileWrite for FileTopicResponse {
-    fn file_encode(
-        &self,
-        src: &mut BytesMut,
-        data: &mut Vec<StoreValue>,
-        version: Version,
-    ) -> Result<(), IoError> {
-        trace!("file encoding fetch topic response");
-        self.name.encode(src, version)?;
-        self.partitions.file_encode(src, data, version)?;
-        Ok(())
-    }
-}
+
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchablePartitionResponse<R>
@@ -146,24 +113,6 @@ where
     pub records: R,
 }
 
-impl FileWrite for FilePartitionResponse {
-    fn file_encode(
-        &self,
-        src: &mut BytesMut,
-        data: &mut Vec<StoreValue>,
-        version: Version,
-    ) -> Result<(), IoError> {
-        trace!("file encoding fetch partition response");
-        self.partition_index.encode(src, version)?;
-        self.error_code.encode(src, version)?;
-        self.high_watermark.encode(src, version)?;
-        self.last_stable_offset.encode(src, version)?;
-        self.log_start_offset.encode(src, version)?;
-        self.aborted.encode(src, version)?;
-        self.records.file_encode(src, data, version)?;
-        Ok(())
-    }
-}
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct AbortedTransaction {
@@ -195,4 +144,73 @@ where
         }
         None
     }
+}
+
+
+#[cfg(feature = "file")]
+pub use file::*;
+
+
+#[cfg(feature = "file")]
+mod file {
+    use super::*;
+
+    use crate::record::FileRecordSet;
+    pub type FileFetchResponse = FetchResponse<FileRecordSet>;
+    pub type FileTopicResponse = FetchableTopicResponse<FileRecordSet>;
+    pub type FilePartitionResponse = FetchablePartitionResponse<FileRecordSet>;
+    
+    impl FileWrite for FilePartitionResponse {
+        fn file_encode(
+            &self,
+            src: &mut BytesMut,
+            data: &mut Vec<StoreValue>,
+            version: Version,
+        ) -> Result<(), IoError> {
+            trace!("file encoding fetch partition response");
+            self.partition_index.encode(src, version)?;
+            self.error_code.encode(src, version)?;
+            self.high_watermark.encode(src, version)?;
+            self.last_stable_offset.encode(src, version)?;
+            self.log_start_offset.encode(src, version)?;
+            self.aborted.encode(src, version)?;
+            self.records.file_encode(src, data, version)?;
+            Ok(())
+        }
+    }
+
+    impl FileWrite for FileFetchResponse {
+        fn file_encode(
+            &self,
+            src: &mut BytesMut,
+            data: &mut Vec<StoreValue>,
+            version: Version,
+        ) -> Result<(), IoError> {
+            trace!("file encoding FileFetchResponse");
+            trace!("encoding throttle_time_ms {}", self.throttle_time_ms);
+            self.throttle_time_ms.encode(src, version)?;
+            trace!("encoding error code {:#?}", self.error_code);
+            self.error_code.encode(src, version)?;
+            trace!("encoding session code {}", self.session_id);
+            self.session_id.encode(src, version)?;
+            trace!("encoding topics len: {}", self.topics.len());
+            self.topics.file_encode(src, data, version)?;
+            Ok(())
+        }
+    }
+
+    impl FileWrite for FileTopicResponse {
+        fn file_encode(
+            &self,
+            src: &mut BytesMut,
+            data: &mut Vec<StoreValue>,
+            version: Version,
+        ) -> Result<(), IoError> {
+            trace!("file encoding fetch topic response");
+            self.name.encode(src, version)?;
+            self.partitions.file_encode(src, data, version)?;
+            Ok(())
+        }
+    }
+    
 }

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -14,11 +14,8 @@ use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;
 use crate::ErrorCode;
-use crate::store::FileWrite;
-use crate::store::StoreValue;
 
 pub type DefaultFetchResponse = FetchResponse<RecordSet>;
-
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchResponse<R>
@@ -64,8 +61,6 @@ where
     }
 }
 
-
-
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchableTopicResponse<R>
 where
@@ -78,8 +73,6 @@ where
     pub partitions: Vec<FetchablePartitionResponse<R>>,
     pub data: PhantomData<R>,
 }
-
-
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct FetchablePartitionResponse<R>
@@ -113,7 +106,6 @@ where
     pub records: R,
 }
 
-
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct AbortedTransaction {
     /// The producer id associated with the aborted transaction.
@@ -146,20 +138,21 @@ where
     }
 }
 
-
 #[cfg(feature = "file")]
 pub use file::*;
-
 
 #[cfg(feature = "file")]
 mod file {
     use super::*;
 
     use crate::record::FileRecordSet;
+    use crate::store::FileWrite;
+    use crate::store::StoreValue;
+
     pub type FileFetchResponse = FetchResponse<FileRecordSet>;
     pub type FileTopicResponse = FetchableTopicResponse<FileRecordSet>;
     pub type FilePartitionResponse = FetchablePartitionResponse<FileRecordSet>;
-    
+
     impl FileWrite for FilePartitionResponse {
         fn file_encode(
             &self,
@@ -212,5 +205,4 @@ mod file {
             Ok(())
         }
     }
-    
 }

--- a/src/dataplane-protocol/src/lib.rs
+++ b/src/dataplane-protocol/src/lib.rs
@@ -16,5 +16,7 @@ pub use error_code::*;
 pub use fluvio_protocol as core;
 pub use fluvio_protocol::api;
 pub use fluvio_protocol::bytes;
-pub use fluvio_protocol::store;
 pub use fluvio_protocol::derive;
+
+#[cfg(feature = "file")]
+pub use fluvio_protocol::store;

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -14,16 +14,12 @@ use crate::derive::FluvioDefault;
 
 use crate::api::Request;
 use crate::record::RecordSet;
-use crate::store::FileWrite;
-use crate::store::StoreValue;
 
 use super::ProduceResponse;
 
 pub type DefaultProduceRequest = ProduceRequest<RecordSet>;
 pub type DefaultPartitionRequest = PartitionProduceData<RecordSet>;
 pub type DefaultTopicRequest = TopicProduceData<RecordSet>;
-
-
 
 #[derive(Encode, Decode, FluvioDefault, Debug)]
 pub struct ProduceRequest<R>
@@ -85,7 +81,6 @@ where
     pub records: R,
 }
 
-
 #[cfg(feature = "file")]
 pub use file::*;
 
@@ -93,6 +88,8 @@ pub use file::*;
 mod file {
 
     use crate::record::FileRecordSet;
+    use crate::store::FileWrite;
+    use crate::store::StoreValue;
 
     use super::*;
 

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -31,8 +31,6 @@ static MAX_STRING_DISPLAY: Lazy<usize> = Lazy::new(|| {
     var_value.parse().unwrap_or(16384)
 });
 
-
-
 /// slice that can works in Async Context
 pub trait AsyncBuffer {
     fn len(&self) -> usize;

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -31,7 +31,7 @@ static MAX_STRING_DISPLAY: Lazy<usize> = Lazy::new(|| {
     var_value.parse().unwrap_or(16384)
 });
 
-pub use file::*;
+
 
 /// slice that can works in Async Context
 pub trait AsyncBuffer {
@@ -605,6 +605,10 @@ mod test {
     }
 }
 
+#[cfg(feature = "file")]
+pub use file::*;
+
+#[cfg(feature = "file")]
 mod file {
 
     use std::fmt;

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"


### PR DESCRIPTION
In order to compile `dataplane-protocol` crate into WASM, we need to separate out I/O related code.