### PR TITLE
Explicitly use latest Rust toolchain

### DIFF
--- a/.github/workflows/publish_latest_fluvio.yml
+++ b/.github/workflows/publish_latest_fluvio.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
         with:


### PR DESCRIPTION
Fixes #906 

I believe the reason the CI was failing is because an upstream crate started using const generics, and I'm not sure if we have explicitly declared using the latest stable toolchain.