### PR TITLE
Explicitly use latest Rust toolchain

### DIFF
--- a/.github/workflows/publish_latest_fluvio.yml
+++ b/.github/workflows/publish_latest_fluvio.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
         with:


### PR DESCRIPTION
Fixes #906 by explicitly setting the latest stable Rust toolchain. This fixes upstream dependencies on const generics