### PR TITLE
Fix release workflow with stable rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
           echo "FORCE_RELEASE=${{ github.event.inputs.force }}" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
         with:
@@ -82,6 +87,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-make
         uses: davidB/rust-cargo-make@v1
         with:


### PR DESCRIPTION
This is the same fix as the one we merged earlier this week, I just forgot to apply the same fix to all the workflows. I think this should be all we need in order for our workflows to always be using stable rust.