### PR TITLE
Update fluvio dependency on dataplane-protocol

### DIFF
--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -44,7 +44,7 @@ fluvio-sc-schema = { version = "0.7.0", path = "../sc-schema", default-features 
 fluvio-spu-schema = { version = "0.5.0", path = "../spu-schema" }
 fluvio-socket = { path = "../socket", version = "0.7.0", features = ["tls"] }
 fluvio-protocol = { path = "../protocol", version = "0.4.0" }
-dataplane = { version = "0.4.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.4.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", default-features = false}


### PR DESCRIPTION
I went to publish `fluvio:0.6.1-alpha.1` this morning and it failed, making me realize I forgot to bump the dependency on `fluvio-dataplane-protocol` since I made changes there.

Also @sehz could you either publish `fluvio-dataplane-protocol:0.4.1` or invite me as an owner to the crate so I can do it?