### PR TITLE
Topic delete reconcillation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Platform Version 0.7.3 - 2020-04-02
 * Added batching for producing records with `send_all` API
-
+# WASM based Smart Stream Filter MVP ([#901](https://github.com/infinyon/fluvio/pull/901)).
 ## Platform Version 0.7.2 - 2020-03-23
 * `fluvio update` updates plugins as well as CLI ([#865](https://github.com/infinyon/fluvio/issues/865)).
 * SPU controller uses SVC ingress annotation ([#888](https://github.com/infinyon/fluvio/pull/888)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Platform Version 0.7.3 - 2020-04-02
 * Added batching for producing records with `send_all` API
 # WASM based Smart Stream Filter MVP ([#901](https://github.com/infinyon/fluvio/pull/901)).
+* Fix topic not being deleted when SPU goes offline ([#914](https://github.com/infinyon/fluvio/pull/914))
+  
 ## Platform Version 0.7.2 - 2020-03-23
 * `fluvio update` updates plugins as well as CLI ([#865](https://github.com/infinyon/fluvio/issues/865)).
 * SPU controller uses SVC ingress annotation ([#888](https://github.com/infinyon/fluvio/pull/888)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## Unreleased
 
 ## Platform Version 0.7.3 - 2020-04-02
-* Added batching for producing records with `send_all` API
-# WASM based Smart Stream Filter MVP ([#901](https://github.com/infinyon/fluvio/pull/901)).
+* Added batching for producing records with `send_all` API.
+* WASM based Smart Stream Filter MVP ([#901](https://github.com/infinyon/fluvio/pull/901)).
 * Fix topic not being deleted when SPU goes offline ([#914](https://github.com/infinyon/fluvio/pull/914))
   
 ## Platform Version 0.7.2 - 2020-03-23

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]
-#lto = true
+lto = true
 #codegen-units = 1
 #incremental = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 # profile to make image sizer smaller
 # comment out for now
 [profile.release]
-lto = true
+#lto = true
 #codegen-units = 1
 #incremental = false
 

--- a/src/spu/src/controllers/leader_replica/replica_state.rs
+++ b/src/spu/src/controllers/leader_replica/replica_state.rs
@@ -21,7 +21,11 @@ use fluvio_storage::{FileReplica, StorageError, SlicePartitionResponse, ReplicaS
 use fluvio_types::{SpuId, event::offsets::OffsetChangeListener};
 use fluvio_types::event::offsets::OffsetPublisher;
 
-use crate::{config::SpuConfig, controllers::sc::SharedSinkMessageChannel, core::SharedSpuConfig};
+use crate::{
+    config::SpuConfig,
+    controllers::sc::SharedSinkMessageChannel,
+    core::{SharedSpuConfig, storage::clear_replica_storage},
+};
 use crate::core::storage::{create_replica_storage};
 use crate::controllers::follower_replica::{
     FileSyncRequest, PeerFileTopicResponse, PeerFilePartitionResponse,
@@ -374,6 +378,12 @@ impl LeaderReplicaState<FileReplica> {
             replica_ids,
             commands,
         ))
+    }
+
+    /// clear file replica if exists
+    pub async fn clear_file_replica(leader: &Replica, config: &SpuConfig) {
+        let storage_config = config.storage().new_config();
+        clear_replica_storage(leader.leader, &leader.id, &storage_config).await;
     }
 
     /// get start offset and hw

--- a/src/spu/src/core/storage/mod.rs
+++ b/src/spu/src/core/storage/mod.rs
@@ -19,3 +19,12 @@ pub(crate) async fn create_replica_storage(
     let config = default_config(local_spu, base_config);
     FileReplica::create(replica.topic.clone(), replica.partition as u32, 0, &config).await
 }
+
+pub async fn clear_replica_storage(
+    local_spu: SpuId,
+    replica: &ReplicaKey,
+    base_config: &ConfigOption,
+) {
+    let config = default_config(local_spu, base_config);
+    FileReplica::clear(replica, &config).await
+}


### PR DESCRIPTION
This fix issue where topic delete is not completed when SPU goes offline.

Steps to reproduce and test:

## Build and Set up Cluster

``` 
$ cargo build --bin fluvio
$ ./target/debug/fluvio start --local --develop
$ ./target/debug/fluvio topic create test
    topic "test" created
```

## Kill SPU in the local cluster
```
$ ps -ef | grep fluvioubuntu
   ubuntu   3733903       1  5 04:34 pts/0    00:00:00 /home/ubuntu/fluvio/target/debug/fluvio cluster run sc
  ubuntu   3733913       1  0 04:34 pts/0    00:00:00 /home/ubuntu/fluvio/target/debug/fluvio cluster run spu -i 5001 -p     0.0.0.0:9010 -v 0.0.0.0:9011 --log-base-dir /tmp/fluvio
   ubuntu   3733968 3622789  0 04:34 pts/2    00:00:00 grep --color=auto fluvio
$ kill -9 3733913
```

## Delete topic with SPU offline. 

This will hang, so you have to press ^c
```
$ flvd topic delete  test
^c
Error: 
   0: Fluvio client error
   1: Fluvio socket error
   2: time out in serial: 1002 request: 1
```

The topic `test` will be delete mode but not removed because of finalizer
```
$  kubectl get topic test -o yaml
apiVersion: fluvio.infinyon.com/v1
kind: Topic
metadata:
  creationTimestamp: "2021-04-02T04:36:24Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2021-04-02T04:36:50Z"
  finalizers:
  - foregroundDeletion
```

SPU logs
```
$ ls /tmp/fluvio/spu-logs-5001
 test-0
```

## Restarting SPU will complete delete

```
$ ./target/debug/fluvio cluster run spu -i 5001 -p 0.0.0.0:9010 -v 0.0.0.0:9011 --log-base-dir /tmp/fluvio starting spu server (id:5001)
SPU Version: 0.5.0 started successfully
```

Topics are gone:
```
$ ./target/debug/fluvio topic list
No topics found
```

And topic log directories are gone as well:
```
$ ls /tmp/fluvio/spu-logs-5001

```

