### PR TITLE
disable lto for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ members = [
 
 # profile to make image sizer smaller
 # comment out for now
-[profile.release]
-lto = true
+#[profile.release]
+#lto = true
 #codegen-units = 1
 #incremental = false
 

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -42,7 +42,7 @@ proclist = "0.9.2"
 remoteprocess = "0.4.2"
 
 # Fluvio dependencies
-fluvio = { version = "0.6.1-alpha.1", path = "../client", default-features = false }
+fluvio = { version = "0.6.0", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.2.0" }
 fluvio-command = { version = "0.2.0", path = "../command" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
-fluvio = { version = "0.6.1-alpha.1", path = "../client",  optional = true }
+fluvio = { version = "0.6.0", path = "../client",  optional = true }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }


### PR DESCRIPTION
To restore CI's build performance.
Revert back unnecessary dependency to pre-release crates due to workspace requirements