### PR TITLE
[Merged by Bors] - Add experimental benchmark support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "benfred-read-process-memory"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1113,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "echo"
@@ -1872,6 +1884,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "dyn-clone",
  "fluvio",
  "fluvio-cluster",
  "fluvio-command 0.2.1",
@@ -1907,6 +1920,7 @@ name = "flv-test"
 version = "1.0.1"
 dependencies = [
  "async-trait",
+ "bencher",
  "bytes",
  "fluvio",
  "fluvio-cluster",
@@ -1922,6 +1936,7 @@ dependencies = [
  "inventory",
  "log",
  "md-5",
+ "prettytable-rs",
  "rand 0.8.3",
  "serde",
  "serde_json",

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,8 +63,19 @@ Test runner can be a running in two ways:
 >
 > If you want the cluster to stick around, then you should start the cluster locally, and pass `--disable-install` and `--keep-cluster` flags.
 
-              
+## Benchmark testing
+(The feature is experimental.)
 
+* Tests must opt-in to be run in benchmark mode. To opt-in add `#[fluvio_test(benchmark = true)]` to test
+* To run a test in benchmark mode, run test with the `--benchmark` flag.
+
+An error message will appear when attempting to benchmark tests without `benchmark = true`.
+
+Benchmarks are performed with the [bencher](https://crates.io/crates/bencher) crate using the [auto_bench](https://docs.rs/bencher/0.1.5/bencher/struct.Bencher.html#method.auto_bench) method.
+
+The number of iterations are not user-controllable because it is the easiest way to use the crate to build a statistical summary.
+
+Total iterations run depend on the runtime of a single test. The longer the test, the fewer the runs.
 
 ---
 ## Smoke test

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,6 +69,12 @@ Test runner can be a running in two ways:
 * Tests must opt-in to be run in benchmark mode. To opt-in add `#[fluvio_test(benchmark = true)]` to test
 * To run a test in benchmark mode, run test with the `--benchmark` flag.
 
+```
+cargo run --release --bin flv-test -- producer_stress --develop --disable-install --benchmark -- --iteration 5 --producers 5
+```
+
+> The `--benchmark` flag is specified as an option of `flv-test` (Before the `--`.)
+
 An error message will appear when attempting to benchmark tests without `benchmark = true`.
 
 Benchmarks are performed with the [bencher](https://crates.io/crates/bencher) crate using the [auto_bench](https://docs.rs/bencher/0.1.5/bencher/struct.Bencher.html#method.auto_bench) method.

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -18,6 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 inventory = "0.1"
 tokio = { version = "1.4", features = ["macros"] }
+bencher = "0.1"
+prettytable-rs = "0.8"
 
 # Fluvio dependencies
 fluvio = { path = "../../src/client" }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use std::process::exit;
+use std::time::Duration;
 use structopt::StructOpt;
 use fluvio::Fluvio;
 use fluvio_test_util::test_meta::{BaseCli, TestCase, TestCli, TestOption, TestResult};
@@ -8,6 +10,8 @@ use fluvio_future::task::run_block_on;
 use std::panic::{self, AssertUnwindSafe};
 use fluvio_test_util::test_runner::FluvioTest;
 use fluvio_test_util::test_meta::TestTimer;
+use bencher::bench;
+use prettytable::{table, row, cell};
 
 // This is important for `inventory` crate
 #[allow(unused_imports)]
@@ -18,7 +22,7 @@ fn main() {
         let option = BaseCli::from_args();
         //println!("{:?}", option);
 
-        let test_name = option.test_name.clone();
+        let test_name = option.environment.test_name.clone();
 
         // Get test from inventory
         let test =
@@ -45,59 +49,101 @@ fn main() {
         // Deploy a cluster
         let fluvio_client = cluster_setup(&option.environment).await;
 
-        // Create a TestCase object with option.envronment and test_opt
-        let test_case = TestCase::new(option.environment.clone(), test_opt);
+        // Select test
+        let test = inventory::iter::<FluvioTest>
+            .into_iter()
+            .find(|t| t.name == test_name.as_str())
+            .expect("Test not found");
+
+        // Check on test requirements before running the test
+        if !FluvioTest::is_env_acceptable(
+            &(test.requirements)(),
+            &TestCase::new(option.environment.clone(), test_opt.clone()),
+        ) {
+            exit(-1);
+        }
 
         let panic_timer = TestTimer::start();
-
-        let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
-            let test = inventory::iter::<FluvioTest>
-                .into_iter()
-                .find(|t| t.name == test_name.as_str())
-                .expect("Test not found");
-
-            // Run the test
-            (test.test_fn)(fluvio_client.clone(), test_case)
-        }));
-
-        // Handle panics from user tests
         std::panic::set_hook(Box::new(move |_panic_info| {
-            let mut inside_timer = panic_timer.clone();
-            inside_timer.stop();
+            let mut panic_timer = panic_timer.clone();
+            panic_timer.stop();
 
             let test_result = TestResult {
                 success: false,
-                duration: inside_timer.duration(),
+                duration: panic_timer.duration(),
             };
             //run_block_on(async { cluster_cleanup(panic_options.clone()).await });
             eprintln!("Test panicked:\n");
             eprintln!("{}", test_result);
         }));
 
-        // Cluster cleanup
-        cluster_cleanup(option.environment).await;
+        if option.environment.benchmark {
+            run_benchmark(test, fluvio_client, option.environment.clone(), test_opt)
+        } else {
+            let test_result =
+                run_test(option.environment.clone(), test_opt, test, fluvio_client).await;
+            cluster_cleanup(option.environment).await;
 
-        match test_result {
-            // Pass/Fail results
-            Ok(results) => {
-                // We always return TestResults. This is awkward.
-                match results {
-                    Ok(r) => println!("{}", r),
-                    Err(r) => eprintln!("{}", r),
-                }
-            }
-            // Panic results
-            Err(fail_results) => {
-                let test_result = fail_results
-                    .downcast_ref::<TestResult>()
-                    .expect("Failed to convert error from panic")
-                    .to_owned();
-
-                eprintln!("{}", test_result);
-                std::process::exit(-1);
-            }
+            println!("{}", test_result)
         }
     });
+}
+
+async fn run_test(
+    environment: EnvironmentSetup,
+    test_opt: Box<dyn TestOption>,
+    test: &FluvioTest,
+    fluvio_client: Arc<Fluvio>,
+) -> TestResult {
+    let test_case = TestCase::new(environment, test_opt);
+    let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
+        (test.test_fn)(fluvio_client.clone(), test_case)
+    }))
+    .expect("Panic hook should have caught this");
+
+    test_result.expect("Test Result")
+}
+
+fn run_benchmark(
+    test_fn: &FluvioTest,
+    client: Arc<Fluvio>,
+    env: EnvironmentSetup,
+    opts: Box<dyn TestOption>,
+) {
+    println!("Starting benchmark test (Usual test output may be silenced)");
+
+    bench::run_once(move |b| {
+        let summary = b.auto_bench(move |inner_b| {
+            let test_case = TestCase::new(env.clone(), opts.clone());
+            inner_b.iter(|| (test_fn.test_fn)(client.clone(), test_case.clone()))
+        });
+
+        let elapsed_duration = format!("{:?}", Duration::from_nanos(b.ns_elapsed()));
+        let iter_duration = format!("{:?}", Duration::from_nanos(b.ns_per_iter()));
+
+        let table = table!(
+            [b->"Perf Test Summary", "Measurement"],
+            ["Total time elapsed", elapsed_duration],
+            ["Total time elapsed (ns)", b.ns_elapsed()],
+            ["Time per iteration", iter_duration],
+            ["Time per iteration (ns)", b.ns_per_iter()],
+            ["# of iteration", (b.ns_elapsed() / b.ns_per_iter())],
+            ["Sum (ns)", summary.sum],
+            ["Min (ns)", summary.min],
+            ["Max (ns)", summary.max],
+            ["Mean (ns)", summary.mean],
+            ["Median (ns)", summary.median],
+            ["Variance", summary.var],
+            ["Standard Deviation", summary.std_dev],
+            ["Standard Deviation (%)", summary.std_dev_pct],
+            ["Median Absolute Deviation", summary.median_abs_dev],
+            ["Median Absolute Deviation (%)", summary.median_abs_dev_pct],
+            ["Quartiles", format!("{:?}",summary.quartiles)],
+            ["Interquartile Range", summary.iqr]
+        );
+
+        println!("{}", table)
+    })
 }
 
 async fn cluster_cleanup(option: EnvironmentSetup) {
@@ -135,16 +181,11 @@ async fn cluster_setup(option: &EnvironmentSetup) -> Arc<Fluvio> {
 mod tests {
     // CLI Tests
 
-    // Extra vars
-    // No test name
-    // Invalid test name
-    // skip cluster delete then skip cluster start
-    // set topic name
-    // set # spu
-
     use structopt::StructOpt;
     use fluvio_test_util::test_meta::{BaseCli, TestCli};
+    use fluvio_test_util::test_meta::environment::EnvDetail;
     use flv_test::tests::smoke::SmokeTestOption;
+    use std::time::Duration;
 
     #[test]
     fn valid_test_name() {
@@ -172,7 +213,7 @@ mod tests {
 
         if let Some(TestCli::Args(cmd)) = args.test_cmd_args {
             // Structopt commands expect an arbitrary binary name before the test args
-            let mut subcommand = vec![args.test_name.clone()];
+            let mut subcommand = vec![args.environment.test_name.clone()];
             subcommand.extend(cmd);
 
             let smoke_test_case = SmokeTestOption::from_iter(subcommand);
@@ -206,6 +247,20 @@ mod tests {
         let args = BaseCli::from_iter(vec!["flv-test", "smoke", "--spu", "5"]);
 
         assert_eq!(args.environment.spu, 5);
+    }
+
+    #[test]
+    fn timeout() {
+        let args = BaseCli::from_iter(vec!["flv-test", "smoke", "--timeout", "9000"]);
+
+        assert_eq!(args.environment.timeout(), Duration::from_secs(9000));
+    }
+
+    #[test]
+    fn benchmark() {
+        let args = BaseCli::from_iter(vec!["flv-test", "smoke", "--benchmark"]);
+
+        assert!(args.environment.is_benchmark());
     }
 
     //// We validate that the behavior of cluster_setup and cluster_cleanup work as expected

--- a/tests/runner/src/tests/concurrent/mod.rs
+++ b/tests/runner/src/tests/concurrent/mod.rs
@@ -9,6 +9,7 @@ use structopt::StructOpt;
 use fluvio::Fluvio;
 use fluvio_future::task::spawn;
 use fluvio_integration_derive::fluvio_test;
+use fluvio_test_util::test_meta::derive_attr::TestRequirements;
 use fluvio_test_util::test_meta::environment::EnvironmentSetup;
 use fluvio_test_util::test_meta::{TestOption, TestCase, TestResult};
 

--- a/tests/runner/src/tests/producer_stress.rs
+++ b/tests/runner/src/tests/producer_stress.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 
 use fluvio::{Fluvio, TopicProducer};
 use fluvio_integration_derive::fluvio_test;
+use fluvio_test_util::test_meta::derive_attr::TestRequirements;
 use fluvio_test_util::test_meta::environment::EnvironmentSetup;
 use fluvio_test_util::test_meta::{TestOption, TestCase, TestResult};
 use fluvio_test_util::test_runner::FluvioTest;
@@ -51,19 +52,22 @@ async fn get_producer(client: Arc<Fluvio>, topic_name: String) -> TopicProducer 
         .expect("Couldn't get producer")
 }
 
-#[fluvio_test(name = "producer_stress", topic = "test")]
+#[fluvio_test(name = "producer_stress", topic = "test", benchmark = true)]
 pub async fn run(client: Arc<Fluvio>, mut test_case: TestCase) -> TestResult {
-    println!("\nStarting single-process producer stress");
     let test_case: ProducerStressTestCase = test_case.into();
 
-    println!(
-        "Producers              : {}",
-        test_case.option.producers.clone()
-    );
-    println!(
-        "# messages per producer: {}",
-        test_case.option.iteration.clone()
-    );
+    if !test_case.environment.is_benchmark() {
+        println!("\nStarting single-process producer stress");
+
+        println!(
+            "Producers              : {}",
+            test_case.option.producers.clone()
+        );
+        println!(
+            "# messages per producer: {}",
+            test_case.option.iteration.clone()
+        );
+    }
 
     let long_str = String::from("aaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccdddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffggggggggggggggggg");
     let topic_name = test_case.environment.topic_name;

--- a/tests/runner/src/tests/smoke/mod.rs
+++ b/tests/runner/src/tests/smoke/mod.rs
@@ -8,6 +8,7 @@ use structopt::StructOpt;
 
 use fluvio::Fluvio;
 use fluvio_integration_derive::fluvio_test;
+use fluvio_test_util::test_meta::derive_attr::TestRequirements;
 use fluvio_test_util::test_meta::environment::EnvironmentSetup;
 use fluvio_test_util::test_meta::{TestOption, TestCase, TestResult};
 

--- a/tests/runner/src/utils/Cargo.toml
+++ b/tests/runner/src/utils/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro2 = "1.0"
 inventory = "0.1"
 prettytable-rs = "0.8"
 once_cell = "1.7.2"
+dyn-clone = "1.0"
 
 fluvio = { path = "../../../../src/client" }
 fluvio-future = { version = "0.2.0", features = ["task", "timer", "subscriber", "fixture"] }

--- a/tests/runner/src/utils/test_meta/derive_attr.rs
+++ b/tests/runner/src/utils/test_meta/derive_attr.rs
@@ -2,14 +2,16 @@ use serde::{Serialize, Deserialize};
 use syn::{AttributeArgs, Error as SynError, Lit, Meta, NestedMeta, Path, Result as SynResult};
 use syn::spanned::Spanned;
 use crate::setup::environment::EnvironmentType;
+use std::time::Duration;
 
 #[derive(Debug)]
 pub enum TestRequirementAttribute {
     MinSpu(u16),
     Topic(String),
-    Timeout(u16),
+    Timeout(Duration),
     ClusterType(EnvironmentType),
     TestName(String),
+    Benchmark(bool),
 }
 
 impl TestRequirementAttribute {
@@ -21,6 +23,7 @@ impl TestRequirementAttribute {
                 "timeout" => Self::timeout(&name_value),
                 "cluster_type" => Self::cluster_type(&name_value),
                 "name" => Self::name(&name_value),
+                "benchmark" => Self::benchmark(&name_value),
                 _ => Err(SynError::new(name_value.span(), "Unsupported key")),
             },
             _ => Err(SynError::new(meta.span(), "Unsupported attribute:")),
@@ -35,6 +38,17 @@ impl TestRequirementAttribute {
             .collect();
 
         key.pop().expect("Key expected")
+    }
+
+    fn benchmark(name_value: &syn::MetaNameValue) -> Result<TestRequirementAttribute, SynError> {
+        if let Lit::Bool(b) = &name_value.lit {
+            Ok(Self::Benchmark(b.value()))
+        } else {
+            Err(SynError::new(
+                name_value.span(),
+                "Benchmark must be a LitBool",
+            ))
+        }
     }
 
     fn name(name_value: &syn::MetaNameValue) -> Result<TestRequirementAttribute, SynError> {
@@ -70,9 +84,8 @@ impl TestRequirementAttribute {
 
     fn timeout(name_value: &syn::MetaNameValue) -> Result<TestRequirementAttribute, SynError> {
         if let Lit::Int(timeout) = &name_value.lit {
-            Ok(Self::Timeout(
-                u16::from_str_radix(timeout.base10_digits(), 10).expect("Parse failed"),
-            ))
+            let parsed = u64::from_str_radix(timeout.base10_digits(), 10).expect("Parse failed");
+            Ok(Self::Timeout(Duration::from_secs(parsed)))
         } else {
             Err(SynError::new(name_value.span(), "Timeout must be LitInt"))
         }
@@ -102,9 +115,10 @@ impl TestRequirementAttribute {
 pub struct TestRequirements {
     pub min_spu: Option<u16>,
     pub topic: Option<String>,
-    pub timeout: Option<u16>,
+    pub timeout: Option<Duration>,
     pub cluster_type: Option<EnvironmentType>,
     pub test_name: Option<String>,
+    pub benchmark: Option<bool>,
 }
 
 impl TestRequirements {
@@ -140,6 +154,9 @@ impl TestRequirements {
                 }
                 TestRequirementAttribute::TestName(name) => {
                     test_requirements.test_name = Some(name)
+                }
+                TestRequirementAttribute::Benchmark(is_benchmark) => {
+                    test_requirements.benchmark = Some(is_benchmark)
                 }
             }
         }

--- a/tests/runner/src/utils/test_meta/mod.rs
+++ b/tests/runner/src/utils/test_meta/mod.rs
@@ -10,19 +10,20 @@ use structopt::clap::AppSettings;
 use prettytable::{table, row, cell};
 
 use environment::EnvironmentSetup;
-use crate::test_runner::FluvioTest;
 
-pub trait TestOption: Debug {
+use dyn_clone::DynClone;
+
+pub trait TestOption: Debug + DynClone {
     fn as_any(&self) -> &dyn Any;
 }
 
+dyn_clone::clone_trait_object!(TestOption);
+
+#[derive(Debug, Clone)]
 pub struct TestCase {
     pub environment: EnvironmentSetup,
     pub option: Box<dyn TestOption>,
 }
-
-unsafe impl Send for TestCase {}
-unsafe impl Sync for TestCase {}
 
 impl TestCase {
     pub fn new(environment: EnvironmentSetup, option: Box<dyn TestOption>) -> Self {
@@ -51,9 +52,6 @@ impl Default for TestCli {
     about = "Test fluvio platform",
     global_settings = &[AppSettings::ColoredHelp])]
 pub struct BaseCli {
-    #[structopt(possible_values=&FluvioTest::all_test_names())]
-    pub test_name: String,
-
     #[structopt(flatten)]
     pub environment: EnvironmentSetup,
 
@@ -88,7 +86,6 @@ impl TestTimer {
 pub struct TestResult {
     pub success: bool,
     pub duration: Duration,
-    // perf_results?
 }
 
 impl TestResult {


### PR DESCRIPTION
Built off of PR #895

* Add benchmarking support utilizing the [bencher](https://crates.io/crates/bencher) crate.
* Add new benchmark supported test `producer_stress`, a single-core producer
* Update README

Resolves #879
Resolves #883 
Resolves #951 
Closes #566 


## Example:
### Without benchmarking
```
$ cargo run --bin flv-test -- producer_stress -d -k -- --producers 3 --iteration 100
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/flv-test producer_stress -d -k -- --producers 3 --iteration 100`
Start running fluvio test runner
skipping cluster start
Creating the topic: test
topic "test" already exists

Starting single-process producer stress
Producers              : 3
# messages per producer: 100
skipping cluster delete

+--------------+--------------+
| Test Results |              |
+--------------+--------------+
| Pass?        | true         |
+--------------+--------------+
| Duration     | 289.408879ms |
+--------------+--------------+
```

### With benchmarking

```
$ cargo run --bin flv-test -- producer_stress -d -k --benchmark -- --producers 3 --iteration 100
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/flv-test producer_stress -d -k --benchmark -- --producers 3 --iteration 100`
Start running fluvio test runner
skipping cluster start
Starting benchmark test (Usual test output may be silenced)
+-------------------------------+------------------------------------------+
| Perf Test Summary             | Measurement                              |
+-------------------------------+------------------------------------------+
| Total time elapsed            | 1.402356271s                             |
+-------------------------------+------------------------------------------+
| Total time elapsed (ns)       | 1402356271                               |
+-------------------------------+------------------------------------------+
| Time per iteration            | 280.471254ms                             |
+-------------------------------+------------------------------------------+
| Time per iteration (ns)       | 280471254                                |
+-------------------------------+------------------------------------------+
| # of iteration                | 5                                        |
+-------------------------------+------------------------------------------+
| Sum (ns)                      | 14306013620.45                           |
+-------------------------------+------------------------------------------+
| Min (ns)                      | 281061233.6                              |
+-------------------------------+------------------------------------------+
| Max (ns)                      | 290169616.55                             |
+-------------------------------+------------------------------------------+
| Mean (ns)                     | 286120272.40900004                       |
+-------------------------------+------------------------------------------+
| Median (ns)                   | 286370877.5                              |
+-------------------------------+------------------------------------------+
| Variance                      | 7845839165779.815                        |
+-------------------------------+------------------------------------------+
| Standard Deviation            | 2801042.5140971737                       |
+-------------------------------+------------------------------------------+
| Standard Deviation (%)        | 0.978973803748226                        |
+-------------------------------+------------------------------------------+
| Median Absolute Deviation     | 2930262.531                              |
+-------------------------------+------------------------------------------+
| Median Absolute Deviation (%) | 1.023240406490007                        |
+-------------------------------+------------------------------------------+
| Quartiles                     | (284391694.25, 286370877.5, 288307360.5) |
+-------------------------------+------------------------------------------+
| Interquartile Range           | 3915666.25                               |
+-------------------------------+------------------------------------------+
```