### PR TITLE
disable mac local cluster test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
 
   mac_local_cluster_test:
     name: Local cluster test
+    if: ${{ false }}  # disable for now
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Local Mac cluster test is taking too long.  Disabling for now