### PR TITLE
increase SOCKET DELAY for linux unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       SCCACHE_CACHE_SIZE: 300M
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_IDLE_TIMEOUT: 0
+      FLV_SOCKET_WAIT: 600
     steps:
       - uses: actions/checkout@v2
       - name: Install sccache


### PR DESCRIPTION
to fix CI failure for running unit tests by increase SOCKET wait delay like cluster test