### PR TITLE
[Merged by Bors] - Add nodeSelector option for SC and SPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,14 +2564,13 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b594f3e94958cfcba4742e20f024dc4bdafb56af3e1aa3198fc80a14fe6656f"
+checksum = "bf4398c021446513c306633ae67ae6dfd7166e3d733f0ff19fe20c358446e71a"
 dependencies = [
  "serde",
  "serde_json",
  "serde_qs 0.8.3",
- "tracing",
 ]
 
 [[package]]
@@ -3899,9 +3898,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4655,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "35.0.1"
+version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5800e9f86a1eae935e38bea11e60fd253f6d514d153fb39b3e5535a7b37b56"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
 ]

--- a/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.scPod.nodeSelector | nindent 8 }}
       containers:
         - name: fluvio-sc
           image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}

--- a/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
+++ b/k8-util/helm/fluvio-app/templates/spu-k8-config.yaml
@@ -6,6 +6,6 @@ data:
   image: {{ .Values.image.registry }}/fluvio:{{ .Values.image.tag | default .Chart.Version }}
   resources: {{ .Values.spuPod.resources | toJson | quote }}
   podSecurityContext: {{ .Values.podSecurityContext | toJson | quote }}
+  nodeSelector: {{ .Values.spuPod.nodeSelector | toJson | quote }}
   lbServiceAnnotations: {{ .Values.loadBalancer.serviceAnnotations | toJson | quote }}
   service: {{ .Values.service | toJson | quote }}
-  sc: {{ .Values.sc | toJson | quote }}

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -26,12 +26,14 @@ scPod:
       memory: 512Mi
     limits:
       memory: 512Mi
+  nodeSelector: {}
 spuPod:
   resources:
     requests:
       memory: 256Mi
     limits:
       memory: 1Gi
+  nodeSelector: {}
 rbac:
   create: true
 serviceAccount:

--- a/src/sc/src/k8/controllers/mod.rs
+++ b/src/sc/src/k8/controllers/mod.rs
@@ -5,8 +5,6 @@ pub mod spu;
 pub use k8_operator::run_k8_operators;
 
 mod k8_operator {
-    use tracing::error;
-
     use k8_client::SharedK8Client;
 
     use crate::cli::TlsConfig;
@@ -14,7 +12,6 @@ mod k8_operator {
     use crate::stores::StoreContext;
     use crate::dispatcher::dispatcher::K8ClusterStateDispatcher;
     use crate::k8::objects::spu_service::SpuServiceSpec;
-    use crate::k8::objects::spu_k8_config::ScK8Config;
     use crate::k8::objects::statefulset::StatefulsetSpec;
     use crate::k8::objects::spg_service::SpgServiceSpec;
     use crate::k8::controllers::spg::SpgStatefulSetController;
@@ -59,19 +56,10 @@ mod k8_operator {
             tls,
         );
 
-        let disable_spu = match ScK8Config::load(&k8_client, &namespace).await {
-            Ok(config) => config.sc_config.disable_spu,
-            Err(err) => {
-                error!("error loading config: {:#?}", err);
-                false
-            }
-        };
-
         SpuController::start(
             global_ctx.spus().clone(),
             spu_service_ctx.clone(),
             global_ctx.spgs().clone(),
-            disable_spu,
         );
 
         SpuServiceController::start(

--- a/src/sc/src/k8/objects/spg_group.rs
+++ b/src/sc/src/k8/objects/spg_group.rs
@@ -247,6 +247,7 @@ mod k8_convert {
                 }],
                 volumes,
                 security_context: spu_k8_config.pod_security_context.clone(),
+                node_selector: Some(spu_k8_config.node_selector.clone()),
                 ..Default::default()
             },
         };

--- a/src/sc/src/k8/objects/spu_k8_config.rs
+++ b/src/sc/src/k8/objects/spu_k8_config.rs
@@ -46,12 +46,11 @@ impl ScK8Config {
                 None
             };
 
-        let node_selector =
-            if let Some(node_selector_string) = data.remove("nodeSelector") {
-                serde_json::from_str(&node_selector_string)?
-            } else {
-                HashMap::new()
-            };
+        let node_selector = if let Some(node_selector_string) = data.remove("nodeSelector") {
+            serde_json::from_str(&node_selector_string)?
+        } else {
+            HashMap::new()
+        };
 
         let lb_service_annotations =
             if let Some(lb_service_annotations) = data.remove("lbServiceAnnotations") {

--- a/src/sc/src/k8/objects/spu_k8_config.rs
+++ b/src/sc/src/k8/objects/spu_k8_config.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use tracing::debug;
-use serde::{Deserialize};
 
 use k8_client::{ClientError, SharedK8Client};
 use k8_metadata_client::MetadataClient;
@@ -12,20 +11,14 @@ use k8_types::core::service::ServiceSpec;
 
 const CONFIG_MAP_NAME: &str = "spu-k8";
 
-#[derive(Deserialize, Default, Debug)]
-pub struct ScConfig {
-    #[serde(rename = "disableSPU")]
-    pub disable_spu: bool,
-}
-
 #[derive(Debug)]
 pub struct ScK8Config {
     pub image: String,
     pub resources: Option<ResourceRequirements>,
     pub pod_security_context: Option<PodSecurityContext>,
+    pub node_selector: HashMap<String, String>,
     pub lb_service_annotations: HashMap<String, String>,
     pub service: Option<ServiceSpec>,
-    pub sc_config: ScConfig,
 }
 
 impl ScK8Config {
@@ -53,6 +46,13 @@ impl ScK8Config {
                 None
             };
 
+        let node_selector =
+            if let Some(node_selector_string) = data.remove("nodeSelector") {
+                serde_json::from_str(&node_selector_string)?
+            } else {
+                HashMap::new()
+            };
+
         let lb_service_annotations =
             if let Some(lb_service_annotations) = data.remove("lbServiceAnnotations") {
                 serde_json::from_str(&lb_service_annotations)?
@@ -66,19 +66,13 @@ impl ScK8Config {
             None
         };
 
-        let sc_config = if let Some(service_data) = data.remove("sc") {
-            serde_json::from_str(&service_data)?
-        } else {
-            ScConfig::default()
-        };
-
         Ok(Self {
             image,
             resources,
             pod_security_context,
+            node_selector,
             lb_service_annotations,
             service,
-            sc_config,
         })
     }
 


### PR DESCRIPTION
This lets the pods target K8 nodes by label so that SC and SPU can be deployed on specialized nodes.