### PR TITLE
[Merged by Bors] - Mark cluster components as non-publish

### DIFF
--- a/src/extension-runner-local/Cargo.toml
+++ b/src/extension-runner-local/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Engine Runner"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
+publish = false
 
 [lib]
 name = "fluvio_runner_local"

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["fluvio.io"]
 description = "Fluvio Stream Controller"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
+publish = false
 
 [lib]
 name = "fluvio_sc"

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["fluvio.io"]
 description = "Fluvio Stream Processing Unit"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
+publish = false
 
 [lib]
 name = "fluvio_spu"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["fluvio.io"]
 description = "Storage for Fluvio platform"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
+publish = false
 
 [[bin]]
 name = "storage-cli"


### PR DESCRIPTION
Adds `publish = false` to the `Cargo.toml` of the following crates:

- fluvio-sc
- fluvio-spu
- fluvio-storage
- fluvio-runner-local