### PR TITLE
Make Bors ignore macos-latest jobs because of brew failing

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,8 +3,6 @@ status = [
     "Clippy (ubuntu-latest)",
     "Unit tests (ubuntu-latest)",
     "Doc tests (ubuntu-latest)",
-    "Unit tests (macos-latest)",
-    "Doc tests (macos-latest)",
     "Local cluster test (infinyon-ubuntu-bionic, stable)",
     "Kubernetes cluster test (infinyon-ubuntu-bionic, stable)",
 ]


### PR DESCRIPTION
This will allow us to `bors r+` on PRs even if these jobs are failing.

I'm introducing this because today, the macos runners seem to be unable to use brew correctly

<img width="879" alt="image" src="https://user-images.githubusercontent.com/4210949/114432863-22b75180-9b8f-11eb-8bcc-395381a99ae4.png">
