### PR TITLE
[Merged by Bors] - Make publisher flow build fluvio and fluvio-run

### DIFF
--- a/makefiles/Base.toml
+++ b/makefiles/Base.toml
@@ -27,12 +27,16 @@ extend = "build-prod-musl"
 #
 
 [tasks.build-dev-mac.mac]
-command = "cargo"
-args = ["build", "--bin", "fluvio", "--target", "x86_64-apple-darwin"]
+script = """
+cargo build --bin fluvio --target=x86_64-apple-darwin
+cargo build --bin fluvio-run --target=x86_64-apple-darwin
+"""
 
 [tasks.build-prod-mac.mac]
-command = "cargo"
-args = ["build", "--bin", "fluvio", "--release", "--target", "x86_64-apple-darwin"]
+script ="""
+cargo build --bin fluvio --release --target=x86_64-apple-darwin
+cargo build --bin fluvio-run --release --target=x86_64-apple-darwin
+"""
 
 # Fail apple-darwin build on linux
 [tasks.build-dev-mac.linux]
@@ -47,22 +51,17 @@ script = "echo Cannot build for Mac from Linux && false"
 
 [tasks.build-dev-musl.linux]
 dependencies = ["setup-musl"]
-command = "cargo"
-args = [
-    "build",
-    "--bin", "fluvio",
-    "--target=x86_64-unknown-linux-musl",
-]
+script = """
+cargo build --bin fluvio --target=x86_64-unknown-linux-musl
+cargo build --bin fluvio-run --target=x86_64-unknown-linux-musl
+"""
 
 [tasks.build-prod-musl.linux]
 dependencies = ["setup-musl"]
-command = "cargo"
-args = [
-    "build",
-    "--release",
-    "--bin", "fluvio",
-    "--target=x86_64-unknown-linux-musl",
-]
+script = """
+cargo build --release --bin fluvio --target=x86_64-unknown-linux-musl
+cargo build --release --bin fluvio-run --target=x86_64-unknown-linux-musl
+"""
 
 [tasks.setup-musl.linux]
 script = '''


### PR DESCRIPTION
Prior to this, the publisher flow would only build `--bin fluvio`, now it will build `--bin fluvio-run` as well.