### PR TITLE
[Merged by Bors] - fix: Fluvio development CLI should use development cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,10 @@ jobs:
           make RELEASE=release build_test
       - name: Setup installation pre-requisites
         run: |
-          ./target/release/fluvio cluster start --setup --local --develop
+          cargo run --release --bin fluvio -- cluster start --setup --local --develop
       - name: Print Fluvio version
         run: |
-          ./target/release/fluvio version
+          cargo run --release --bin fluvio -- version
       - name: Run smoke-test
         timeout-minutes: 1
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,6 @@ dependencies = [
  "color-eyre",
  "colored",
  "derive_builder",
- "directories-next",
  "fluvio",
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -47,12 +47,29 @@ $ cd fluvio
 $ cargo build
 ```
 
-Setup alias for development CLI.
-```
-$ alias flvd=./target/debug/fluvio
-``` 
+The next step is very important, as it will help you to prevent subtle development
+bugs. Fluvio is built in two separate pieces, `fluvio` (the CLI), and `fluvio-run`
+(the server). When testing changes to these components, you need to make sure to
+rebuild _both_ components before running. In other Rust projects, it is typical to
+just use `cargo run`:
 
-This avoid collision with released version of Fluvio.
+```
+$ cargo run -- my CLI args here
+```
+
+However, this will only rebuild `fluvio`, it will not also rebuild `fluvio-run`,
+which may make you think that the code changes you made did not have any effect.
+In order to automate the rebuilding of both of these components, we STRONGLY
+RECOMMEND adding the following alias to your `~/.bashrc` or `~/.zshrc` file:
+
+```
+alias flvd='cargo build --manifest-path="/Users/nick/infinyon/fluvio/Cargo.toml" --bin fluvio-run && \
+    cargo run --manifest-path="/Users/nick/infinyon/fluvio/Cargo.toml" --bin fluvio --'
+```
+
+Make sure to replace `/Users/nick/infinyon/fluvio` with the path where you cloned `fluvio`
+on your own system. Then, the `flvd` command (short for "fluvio develop") will recompile
+both `fluvio-run` and `fluvio`, then execute `fluvio` and pass the arguments to it.
 
 ## Download a published version of Fluvio
 
@@ -74,17 +91,15 @@ Install Fluvio `sys` chart from source.
 $ flvd cluster start --sys --develop
 ```
 
-
 # Running Fluvio with local cluster
 
-It is recommened to use `local` cluster for development.
+We highly recommend using the `flvd cluster start --local --develop` command for most development.
 
-In this case, we run `sc` and `spu` individually, allowing development testing.
-
+However, in the following cases, we run `sc` and `spu` individually, allowing individual testing.
 
 ## Starting SC
 
-The Streaming Controller (SC) is the controller for Fluvio cluster.
+The Streaming Controller (SC) is the controller for a Fluvio cluster.
 You only start a single SC for a single Fluvio cluster.
 
 To run the SC, you'll need to build and run the `fluvio-run` executable:
@@ -194,7 +209,7 @@ $ flvd cluster delete
 Run command below now to run install with image just built
 
 ```
-$ fluvio cluster start --develop
+$ flvd cluster start --develop
 ```
 
 Topic creation, product and consumer can now be tested as with `local` cluster.
@@ -202,14 +217,15 @@ Topic creation, product and consumer can now be tested as with `local` cluster.
 You can remove fluvio cluster by
 
 ```
-fluvio cluster delete
+$ flvd cluster delete
 ```
 
 Note that when you uninstall cluster, CLI will remove all related objects such as
-* Topics
-* Partitions
-* Tls Secrets
-* Storage
+
+- Topics
+- Partitions
+- Tls Secrets
+- Storage
 
 ## Running SC in locally
 
@@ -296,7 +312,7 @@ sh k8-util/minikube/reset-minikube.sh
 If you face issues while installing sys chart
 
 ```
-$ fluvio cluster start --sys
+$ flvd cluster start --sys
 "fluvio" has been added to your repositories
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
@@ -310,7 +326,7 @@ Rebuilding minikube cluster sometimes doesnt remove the storage class. Hence the
 
 ```
 kubectl delete storageclass fluvio-spu
- ```
+```
 
 #### Deleting partition
 
@@ -318,5 +334,3 @@ In certain cases, partition may not be deleted correctly.  In this case, you can
 ```
 kubectl patch partition  <partition_name> -p '{"metadata":{"finalizers":null}}' --type merge
 ```
-
-

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,15 @@ install_tools_mac:
 	brew install yq
 	brew install helm
 
+build_cli:
+	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin fluvio $(VERBOSE)
+
+build_cluster: install_test_target
+	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin fluvio-run $(VERBOSE)
+
 build_test: TEST_RELEASE_FLAG=$(if $(RELEASE),--release,)
 build_test: TEST_TARGET=$(if $(TARGET),--target $(TARGET),)
-build_test:	install_test_target
-	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin fluvio $(VERBOSE)
-	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin fluvio-run $(VERBOSE)
+build_test:	build_cluster
 	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin flv-test $(VERBOSE)
 
 install_test_target:
@@ -273,7 +277,6 @@ CLI_BINARY=fluvio
 BUILD_OUTPUT=/tmp
 
 release_github:	build-cli-darwin build-cli-linux create-gh-release upload-gh-darwin upload-gh-linux
-
 
 build-cli-darwin:
 	rustup target add $(TARGET_DARWIN)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build_cluster: install_test_target
 
 build_test: TEST_RELEASE_FLAG=$(if $(RELEASE),--release,)
 build_test: TEST_TARGET=$(if $(TARGET),--target $(TARGET),)
-build_test:	build_cluster
+build_test:	build_cluster build_cli
 	cargo build $(TEST_RELEASE_FLAG) $(TEST_TARGET) --bin flv-test $(VERBOSE)
 
 install_test_target:

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -232,9 +232,17 @@ impl CompletionCmd {
     }
 }
 
+/// Search for a Fluvio plugin in the following places:
+///
+/// - In the system PATH
+/// - In the directory where the `fluvio` executable is located
+/// - In the `~/.fluvio/extensions/` directory
 fn find_plugin(name: &str) -> Option<PathBuf> {
     let ext_dir = fluvio_extensions_dir().ok();
+    let self_exe = std::env::current_exe().ok();
+    let self_dir = self_exe.as_ref().and_then(|it| it.parent());
     which::which(name)
+        .or_else(|_| which::which_in(name, self_dir, "."))
         .or_else(|_| which::which_in(name, ext_dir, "."))
         .ok()
 }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -40,7 +40,6 @@ derive_builder = "0.9.0"
 proclist = "0.9.2"
 remoteprocess = "0.4.2"
 which = "4.1.0"
-directories-next = "2.0.0"
 
 # Fluvio dependencies
 fluvio = { version = "0.6.0", path = "../client", default-features = false }

--- a/src/cluster/src/start/local.rs
+++ b/src/cluster/src/start/local.rs
@@ -24,7 +24,6 @@ use crate::{
 use crate::check::{CheckResults, SysChartCheck};
 use crate::check::render::render_check_progress;
 use fluvio_command::CommandExt;
-use directories_next::UserDirs;
 
 const DEFAULT_LOG_DIR: &str = "/tmp";
 const DEFAULT_DATA_DIR: &str = "/tmp/fluvio";
@@ -34,12 +33,7 @@ const DEFAULT_TLS_POLICY: TlsPolicy = TlsPolicy::Disabled;
 const LOCAL_SC_ADDRESS: &str = "localhost:9003";
 const LOCAL_SC_PORT: u16 = 9003;
 
-static DEFAULT_RUNNER_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let ext_dir = UserDirs::new().map(|it| it.home_dir().join(".fluvio/bin"));
-    which::which("fluvio")
-        .or_else(|_| which::which_in("fluvio", ext_dir, "."))
-        .ok()
-});
+static DEFAULT_RUNNER_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| std::env::current_exe().ok());
 
 /// Describes how to install Fluvio locally
 #[derive(Builder, Debug)]


### PR DESCRIPTION
Closes #969.

- Causes CLI plugin system to search local directory for plugin executables
  - This allows `target/debug/fluvio` to naturally use `target/debug/fluvio-run`
- Updates `DEVELOPER.md` to recommend an improved `flvd` alias to keep `fluvio` and `fluvio-run` in sync