### PR TITLE
[Merged by Bors] - Fix replica for SPU = 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,19 +211,19 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "fcb9af4888a70ad78ecb5efcb0ba95d66a3cf54a88b62ae81559954c7588c7a2"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
+ "socket2",
  "vec-arena",
  "waker-fn",
  "winapi 0.3.9",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
@@ -334,9 +334,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,11 +407,10 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -497,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -584,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b29030875fd8376e4a28ef497790d5b4a7843d8d1396bf08ce46f5eec562c5c"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
 dependencies = [
  "backtrace",
  "eyre",
@@ -617,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
+checksum = "402da840495de3f976eaefc3485b7f5eb5b0bf9761f9a47be27fe975b3b8c2ec"
 
 [[package]]
 name = "constant_time_eq"
@@ -813,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -919,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b8ec3b5755a188c141c1f6a98e76de31b936209bf066b647979e2a84764a9"
+checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
 dependencies = [
  "nix 0.20.0",
  "winapi 0.3.9",
@@ -2005,9 +2004,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2020,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2030,15 +2029,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2047,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-lite"
@@ -2068,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -2080,21 +2079,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32613ebb139d1d430ef5783676f84abfa06fc5f2b4b5a25220cdeeff7e16ef5c"
+checksum = "686f600cccfb9d96c45550bac47b592bc88191a0dd965e9d55848880c2c5a45f"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2346,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
 
 [[package]]
 name = "httpdate"
@@ -2396,9 +2395,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2762,16 +2761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
-dependencies = [
- "libc",
- "socket2",
-]
-
-[[package]]
 name = "nix"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,18 +2996,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3367,9 +3356,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -3392,7 +3381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
 ]
 
 [[package]]
@@ -3960,7 +3949,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -4088,9 +4077,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4112,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4326,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec-arena"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/src/dataplane-protocol/src/common.rs
+++ b/src/dataplane-protocol/src/common.rs
@@ -21,10 +21,16 @@ impl Default for Isolation {
     }
 }
 
-#[derive(Hash, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[derive(Hash, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 pub struct ReplicaKey {
     pub topic: String,
     pub partition: i32,
+}
+
+impl fmt::Debug for ReplicaKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{})", self.topic, self.partition)
+    }
 }
 
 unsafe impl Send for ReplicaKey {}

--- a/src/dataplane-protocol/src/fixture.rs
+++ b/src/dataplane-protocol/src/fixture.rs
@@ -60,6 +60,11 @@ pub fn create_batch() -> DefaultBatch {
     create_batch_with_producer(12, 2)
 }
 
+pub fn create_recordset(num_records: u16) -> RecordSet {
+    let records = RecordSet::default();
+    records.add(create_batch_with_producer(12, num_records))
+}
+
 pub const TEST_RECORD: &[u8] = &[10, 20];
 
 /// create batches with produce and records count

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
@@ -39,5 +39,5 @@ fluvio-protocol = { path = "../protocol", version = "0.4.0", features = ["derive
 
 
 [dev-dependencies]
-fluvio-future = { version = "0.2.0", features = ["fixture","fs","native2_tls"] }
+fluvio-future = { version = "0.2.0", features = ["fixture", "fs", "native2_tls"] }
 flv-util = { version = "0.5.0", features = ["fixture"] }

--- a/src/socket/src/sink.rs
+++ b/src/socket/src/sink.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -34,10 +35,15 @@ pub type ExclusiveFlvSink = InnerExclusiveFlvSink<TcpStream>;
 
 type SplitFrame<S> = SplitSink<Framed<Compat<S>, FluvioCodec>, Bytes>;
 
-#[derive(Debug)]
 pub struct InnerFlvSink<S> {
     inner: SplitFrame<S>,
     fd: RawFd,
+}
+
+impl<S> fmt::Debug for InnerFlvSink<S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "fd({})", self.id())
+    }
 }
 
 impl<S> InnerFlvSink<S> {

--- a/src/socket/src/socket.rs
+++ b/src/socket/src/socket.rs
@@ -4,6 +4,7 @@ cfg_if::cfg_if! {
         use std::os::unix::io::RawFd;
     }
 }
+use std::fmt;
 
 use futures_util::io::{AsyncRead, AsyncWrite};
 use futures_util::StreamExt;
@@ -30,11 +31,16 @@ pub type FlvSocket = InnerFlvSocket<TcpStream>;
 pub type AllFlvSocket = InnerFlvSocket<fluvio_future::native_tls::AllTcpStream>;
 
 /// Socket abstract that can send and receive fluvio objects
-#[derive(Debug)]
 pub struct InnerFlvSocket<S> {
     sink: InnerFlvSink<S>,
     stream: InnerFlvStream<S>,
     stale: bool,
+}
+
+impl<S> fmt::Debug for InnerFlvSocket<S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "fd({})", self.id())
+    }
 }
 
 unsafe impl<S> Sync for InnerFlvSocket<S> {}

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -51,7 +51,7 @@ fluvio-controlplane-metadata = { version = "0.7.1", path = "../controlplane-meta
 fluvio-spu-schema = { version = "0.5.1", path = "../spu-schema" }
 fluvio-protocol = { path = "../protocol", version = "0.4.0" }
 dataplane = { version = "0.4.2", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { path = "../socket", version = "0.7.0" }
+fluvio-socket = { path = "../socket", version = "0.7.1" }
 fluvio-service = { path = "../service", version = "0.5.1" }
 flv-tls-proxy = { version = "0.4.0" }
 flv-util = { version = "0.5.0" }

--- a/src/spu/src/config/spu_config.rs
+++ b/src/spu/src/config/spu_config.rs
@@ -149,7 +149,7 @@ impl From<&SpuConfig> for ConfigOption {
     fn from(config: &SpuConfig) -> ConfigOption {
         let log = &config.log;
         ConfigOption::new(
-            log.base_dir.clone(),
+            log.base_dir.join(format!("spu-logs-{}", config.id)),
             log.index_max_bytes,
             log.index_max_interval_bytes,
             log.segment_max_bytes,

--- a/src/spu/src/control_plane/dispatcher.rs
+++ b/src/spu/src/control_plane/dispatcher.rs
@@ -581,11 +581,9 @@ impl ScDispatcher<FileReplica> {
             self.ctx
                 .leaders_state()
                 .spawn_leader_controller(
-                    self.ctx.clone(),
                     new_replica.id,
                     leader_state,
                     receiver,
-                    self.max_bytes,
                     self.sink_channel.clone(),
                 )
                 .await;

--- a/src/spu/src/control_plane/dispatcher.rs
+++ b/src/spu/src/control_plane/dispatcher.rs
@@ -561,7 +561,7 @@ impl ScDispatcher<FileReplica> {
         if let Some(follower_replica) = self
             .ctx
             .followers_state()
-            .remove_replica(&old_replica.leader, &old_replica.id)
+            .remove_replica(old_replica.leader, &old_replica.id)
             .await
         {
             debug!(
@@ -624,7 +624,7 @@ impl ScDispatcher<FileReplica> {
         if let Some(replica_state) = self
             .ctx
             .followers_state()
-            .remove_replica(&replica.leader, &replica.id)
+            .remove_replica(replica.leader, &replica.id)
             .await
         {
             if let Err(err) = replica_state.remove().await {
@@ -641,7 +641,7 @@ impl ScDispatcher<FileReplica> {
         if self
             .ctx
             .followers_state()
-            .remove_replica(&old.leader, &old.id)
+            .remove_replica(old.leader, &old.id)
             .await
             .is_none()
         {

--- a/src/spu/src/core/global_context.rs
+++ b/src/spu/src/core/global_context.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 use std::fmt::Debug;
 
-
 use fluvio_types::SpuId;
 use fluvio_storage::ReplicaStorage;
 

--- a/src/spu/src/core/global_context.rs
+++ b/src/spu/src/core/global_context.rs
@@ -1,13 +1,11 @@
 //!
 //! # Global Context
 //!
-//! Global Context stores entities that persist through system operation.
-//!
+//! Global Context maintains states need to be shared across in the SPU
 use std::sync::Arc;
 use std::fmt::Debug;
 
-use fluvio_socket::SharedSinkPool;
-use fluvio_socket::SinkPool;
+
 use fluvio_types::SpuId;
 use fluvio_storage::ReplicaStorage;
 
@@ -30,7 +28,6 @@ pub struct GlobalContext<S> {
     replica_localstore: SharedReplicaLocalStore,
     leaders_state: SharedReplicaLeadersState<S>,
     followers_state: SharedFollowersState<S>,
-    follower_sinks: SharedSinkPool<SpuId>,
     stream_publishers: StreamPublishers,
 }
 
@@ -51,7 +48,6 @@ where
             spu_localstore: SpuLocalStore::new_shared(),
             replica_localstore: ReplicaStore::new_shared(),
             config: Arc::new(spu_config),
-            follower_sinks: SinkPool::new_shared(),
             leaders_state: ReplicaLeadersState::new_shared(),
             followers_state: FollowersState::new_shared(),
             stream_publishers: StreamPublishers::new(),
@@ -73,13 +69,6 @@ where
 
     pub fn replica_localstore(&self) -> &ReplicaStore {
         &self.replica_localstore
-    }
-    pub fn follower_sinks(&self) -> &SinkPool<SpuId> {
-        &self.follower_sinks
-    }
-
-    pub fn followers_sink_owned(&self) -> SharedSinkPool<SpuId> {
-        self.follower_sinks.clone()
     }
 
     pub fn leaders_state(&self) -> &ReplicaLeadersState<S> {

--- a/src/spu/src/core/mod.rs
+++ b/src/spu/src/core/mod.rs
@@ -14,11 +14,8 @@ pub use self::replica::SharedReplicaLocalStore;
 
 use std::sync::Arc;
 use ::fluvio_storage::FileReplica;
-use fluvio_socket::SinkPool;
-use fluvio_types::SpuId;
 use crate::config::SpuConfig;
 
 pub type SharedGlobalContext<S> = Arc<GlobalContext<S>>;
 pub type DefaultSharedGlobalContext = SharedGlobalContext<FileReplica>;
-pub type SharedSpuSinks = Arc<SinkPool<SpuId>>;
 pub type SharedSpuConfig = Arc<SpuConfig>;

--- a/src/spu/src/core/store.rs
+++ b/src/spu/src/core/store.rs
@@ -215,6 +215,7 @@ where
         actions
     }
 
+    #[allow(unused)]
     pub fn spec(&self, key: &S::Key) -> Option<S> {
         match self.0.read().get(key) {
             Some(spu) => Some(spu.clone()),

--- a/src/spu/src/replication/follower/follower_controller.rs
+++ b/src/spu/src/replication/follower/follower_controller.rs
@@ -100,6 +100,10 @@ impl ReplicaFollowerController<FileReplica> {
 
         let mut event_listener = self.spu_ctx.events.change_listner();
 
+        // starts initial sync
+        self.sync_all_offsets_to_leader(&mut sink, &replicas)
+            .await?;
+
         loop {
             debug!("waiting request from leader");
 
@@ -326,7 +330,7 @@ impl ReplicasBySpu {
         let mut replicas = HashMap::new();
 
         for rep_ref in states.iter() {
-            if rep_ref.value().leader() == &leader {
+            if rep_ref.value().leader() == leader {
                 replicas.insert(rep_ref.key().clone(), rep_ref.value().clone());
             }
         }

--- a/src/spu/src/replication/follower/state.rs
+++ b/src/spu/src/replication/follower/state.rs
@@ -236,7 +236,11 @@ where
     pub async fn write_recordsets(&self, records: &mut RecordSet) -> Result<bool, StorageError> {
         let storage_leo = self.leo();
         if records.base_offset() != storage_leo {
-            warn!(storage_leo, "storage leo is not same as base offset");
+            warn!(
+                storage_leo,
+                incoming_base_offset = records.base_offset(),
+                "storage leo is not same as base offset"
+            );
             Ok(false)
         } else {
             self.write_record_set(records, false).await?;

--- a/src/spu/src/replication/follower/state.rs
+++ b/src/spu/src/replication/follower/state.rs
@@ -238,7 +238,6 @@ where
         leader_hw: Offset,
     ) -> Result<bool, StorageError> {
         let mut changes = false;
-        let f_offset = self.as_offset();
 
         if records.total_records() > 0 {
             self.write_recordsets(records).await?;
@@ -247,6 +246,7 @@ where
             debug!("no records");
         }
 
+        let f_offset = self.as_offset();
         // update hw assume it's valid
         if f_offset.hw != leader_hw {
             if f_offset.hw > leader_hw {

--- a/src/spu/src/replication/follower/state.rs
+++ b/src/spu/src/replication/follower/state.rs
@@ -61,7 +61,6 @@ impl FollowersState<FileReplica> {
         replica: Replica,
     ) -> Result<Option<FollowerReplicaState<FileReplica>>, StorageError> {
         let leader = replica.leader;
-        let config = ctx.config();
 
         if self.states.contains_key(&replica.id) {
             // follower exists, nothing to do
@@ -73,13 +72,9 @@ impl FollowersState<FileReplica> {
                 replica
             );
 
-            let replica_state = FollowerReplicaState::create(
-                config.id(),
-                leader,
-                replica.id.clone(),
-                ctx.config().into(),
-            )
-            .await?;
+            let replica_state =
+                FollowerReplicaState::create(leader, replica.id.clone(), ctx.config().into())
+                    .await?;
             self.states.insert(replica.id, replica_state.clone());
 
             let mut leaders = self.leaders.write().await;
@@ -90,6 +85,7 @@ impl FollowersState<FileReplica> {
                 // don't have leader, so we need to create
                 let followers_spu = FollowersBySpu::shared(leader);
                 leaders.insert(leader, followers_spu.clone());
+
                 ReplicaFollowerController::run(
                     leader,
                     ctx.spu_localstore_owned(),
@@ -108,7 +104,7 @@ impl FollowersState<FileReplica> {
     /// then we shutdown controller
     pub async fn remove_replica(
         &self,
-        leader: &SpuId,
+        leader: SpuId,
         key: &ReplicaKey,
     ) -> Option<FollowerReplicaState<FileReplica>> {
         if let Some((_key, replica)) = self.remove(key) {
@@ -175,11 +171,17 @@ impl FollowersBySpu {
 /// State for Follower Replica Controller
 /// This can be cloned
 #[derive(Debug)]
-pub struct FollowerReplicaState<S>(SharableReplicaStorage<S>);
+pub struct FollowerReplicaState<S> {
+    leader: SpuId,
+    inner: SharableReplicaStorage<S>,
+}
 
 impl<S> Clone for FollowerReplicaState<S> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            leader: self.leader,
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -187,13 +189,13 @@ impl<S> Deref for FollowerReplicaState<S> {
     type Target = SharableReplicaStorage<S>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
     }
 }
 
 impl<S> DerefMut for FollowerReplicaState<S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.inner
     }
 }
 
@@ -202,7 +204,6 @@ where
     S: ReplicaStorage,
 {
     pub async fn create(
-        local_spu: SpuId,
         leader: SpuId,
         replica_key: ReplicaKey,
         config: S::Config,
@@ -211,16 +212,22 @@ where
         S::Config: Display,
     {
         debug!(
-            local_spu,
             %replica_key,
             leader,
             %config,
             "created follower replica"
         );
 
-        let replica_storage = SharableReplicaStorage::create(leader, replica_key, config).await?;
+        let replica_storage = SharableReplicaStorage::create(replica_key, config).await?;
 
-        Ok(Self(replica_storage))
+        Ok(Self {
+            leader,
+            inner: replica_storage,
+        })
+    }
+
+    pub fn leader(&self) -> SpuId {
+        self.leader
     }
 
     /// write records
@@ -240,13 +247,53 @@ where
     /// convert to offset request
     pub fn as_offset_request(&self) -> ReplicaOffsetRequest {
         ReplicaOffsetRequest {
-            replica: self.0.id().to_owned(),
+            replica: self.inner.id().to_owned(),
             leo: self.leo(),
             hw: self.hw(),
         }
     }
 
     pub fn inner_owned(self) -> SharableReplicaStorage<S> {
-        self.0
+        self.inner
+    }
+}
+
+#[cfg(test)]
+mod follower_tests {
+
+    use std::path::PathBuf;
+
+    use fluvio_future::{test_async};
+    use flv_util::fixture::ensure_clean_dir;
+    use fluvio_types::SpuId;
+    use fluvio_storage::config::ConfigOption;
+
+    use super::*;
+
+    const LEADER: SpuId = 5001;
+    const TOPIC: &str = "test";
+    const TEST_REPLICA: (&str, i32) = (TOPIC, 0);
+
+    #[test_async]
+    async fn test_follower_creation() -> Result<(), ()> {
+        let test_path = "/tmp/follower_init";
+        ensure_clean_dir(test_path);
+
+        let config = ConfigOption {
+            base_dir: PathBuf::from(test_path).join("spu-5002"),
+            ..Default::default()
+        };
+
+        let follower_replica: FollowerReplicaState<FileReplica> =
+            FollowerReplicaState::create(LEADER, TEST_REPLICA.into(), config)
+                .await
+                .expect("create");
+
+        // at this point, follower replica should be empty since we don't have time to sync up with leader
+        assert_eq!(follower_replica.leo(), 0);
+        assert_eq!(follower_replica.hw(), 0);
+        assert!(PathBuf::from(test_path).join("spu-5002").exists());
+
+        Ok(())
     }
 }

--- a/src/spu/src/replication/leader/actions.rs
+++ b/src/spu/src/replication/leader/actions.rs
@@ -7,7 +7,6 @@ use fluvio_types::SpuId;
 #[derive(Debug)]
 pub enum LeaderReplicaControllerCommand {
     UpdateReplicaFromSc(Replica),
-    FollowerOffsetUpdate(FollowerOffsetUpdate),
     RemoveReplicaFromSc,
 }
 

--- a/src/spu/src/replication/leader/connection.rs
+++ b/src/spu/src/replication/leader/connection.rs
@@ -1,18 +1,15 @@
 use fluvio_storage::OffsetInfo;
-use tracing::{trace, debug, error};
+use tracing::{debug, error};
 use tracing::instrument;
-use fluvio_socket::{FlvSocketError, FlvStream, FlvSocket, FlvSink};
+use fluvio_socket::{FlvSocketError, FlvSocket, FlvSink};
 use fluvio_service::api_loop;
 use fluvio_types::SpuId;
 
 use crate::core::DefaultSharedGlobalContext;
 
-use super::LeaderReplicaControllerCommand;
-use super::FollowerOffsetUpdate;
 use super::LeaderPeerApiEnum;
 use super::LeaderPeerRequest;
 use super::UpdateOffsetRequest;
-use super::ReplicaOffsetRequest;
 
 /// Handle connection request from follower
 /// This follows similar arch as Consumer Stream Fetch Handler
@@ -83,6 +80,7 @@ impl FollowerHandler {
                     )
                     .await
                 {
+                    debug!("leader state change occur, need to send back to followers");
                     // if success we need to compute updates
                     let updates = leader.follower_updates().await;
                     if updates.is_empty() {

--- a/src/spu/src/replication/leader/connection.rs
+++ b/src/spu/src/replication/leader/connection.rs
@@ -75,7 +75,7 @@ impl FollowerHandler {
             if let Some(leader) = self.ctx.leaders_state().get(&replica_key) {
                 leader
                     .value()
-                    .update_hw_from_followers(
+                    .update_states_from_followers(
                         self.follower_id,
                         OffsetInfo {
                             hw: update.hw,

--- a/src/spu/src/replication/leader/leader_controller.rs
+++ b/src/spu/src/replication/leader/leader_controller.rs
@@ -117,6 +117,7 @@ impl ReplicaLeaderController<FileReplica> {
     /// update the follower offsets
     #[instrument(skip(self, offsets))]
     async fn update_from_follower(&mut self, offsets: FollowerOffsetUpdate) {
+        /*
         debug!(?offsets);
         let follower_id = offsets.follower_id;
         let (update_status, sync_follower, hw_update) = self.state.update_followers(offsets).await;
@@ -150,6 +151,7 @@ impl ReplicaLeaderController<FileReplica> {
             },
         )
         .await;
+        */
     }
 
     /// go thru each of follower and sync replicas

--- a/src/spu/src/replication/leader/leader_controller.rs
+++ b/src/spu/src/replication/leader/leader_controller.rs
@@ -77,12 +77,12 @@ impl ReplicaLeaderController<FileReplica> {
 
                 offset = hw_listener.listen() => {
                     debug!(hw_update = offset);
-                    join(self.send_status_to_sc(),self.sync_followers()).await;
+                    self.send_status_to_sc().await;
                 },
 
                 offset = leo_listener.listen() => {
                     debug!(leo_update = offset);
-                    join(self.send_status_to_sc(),self.sync_followers()).await;
+                    self.send_status_to_sc().await;
                 },
 
                 controller_req = self.controller_receiver.next() => {

--- a/src/spu/src/replication/leader/leader_controller.rs
+++ b/src/spu/src/replication/leader/leader_controller.rs
@@ -1,23 +1,17 @@
 use dataplane::Isolation;
-use tracing::{debug, error};
+use tracing::{debug};
 use tracing::instrument;
 use async_channel::Receiver;
-use futures_util::future::{join};
 use futures_util::stream::StreamExt;
 
 use fluvio_future::task::spawn;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use fluvio_storage::FileReplica;
 
-use crate::core::SharedSpuSinks;
 use crate::control_plane::SharedSinkMessageChannel;
 
 use super::LeaderReplicaControllerCommand;
-use super::FollowerOffsetUpdate;
 use super::replica_state::{SharedLeaderState};
-
-/// time for complete re-sync with followers
-//pub const FOLLOWER_RECONCILIATION_INTERVAL_SEC: u64 = 300; // 5 min
 
 /// Controller for managing leader replica.
 /// Each leader replica controller is spawned and managed by master controller to ensure max parallism.
@@ -25,9 +19,7 @@ pub struct ReplicaLeaderController<S> {
     id: ReplicaKey,
     controller_receiver: Receiver<LeaderReplicaControllerCommand>,
     state: SharedLeaderState<S>,
-    follower_sinks: SharedSpuSinks,
     sc_channel: SharedSinkMessageChannel,
-    max_bytes: u32,
 }
 
 impl<S> ReplicaLeaderController<S> {
@@ -36,17 +28,13 @@ impl<S> ReplicaLeaderController<S> {
         id: ReplicaKey,
         controller_receiver: Receiver<LeaderReplicaControllerCommand>,
         state: SharedLeaderState<S>,
-        follower_sinks: SharedSpuSinks,
         sc_channel: SharedSinkMessageChannel,
-        max_bytes: u32,
     ) -> Self {
         Self {
             id,
             controller_receiver,
             state,
-            follower_sinks,
             sc_channel,
-            max_bytes,
         }
     }
 }

--- a/src/spu/src/replication/leader/leaders_state.rs
+++ b/src/spu/src/replication/leader/leaders_state.rs
@@ -102,6 +102,7 @@ impl ReplicaLeadersState<FileReplica> {
             );
         }
 
+        /*
         let leader_controller = ReplicaLeaderController::new(
             replica_id,
             receiver,
@@ -111,6 +112,7 @@ impl ReplicaLeadersState<FileReplica> {
             max_bytes,
         );
         leader_controller.run();
+        */
     }
 }
 

--- a/src/spu/src/replication/leader/leaders_state.rs
+++ b/src/spu/src/replication/leader/leaders_state.rs
@@ -67,11 +67,9 @@ impl ReplicaLeadersState<FileReplica> {
             Ok((leader_replica, receiver)) => {
                 debug!("file replica created and spawing leader controller");
                 self.spawn_leader_controller(
-                    ctx.clone(),
                     replica_id,
                     leader_replica.clone(),
                     receiver,
-                    max_bytes,
                     sink_channel,
                 )
                 .await;
@@ -83,16 +81,14 @@ impl ReplicaLeadersState<FileReplica> {
     }
 
     #[instrument(
-        skip(self,ctx, replica_id, leader_state,sink_channel),
+        skip(self,replica_id, leader_state,sink_channel),
         fields(replica = %replica_id)
     )]
     pub async fn spawn_leader_controller(
         &self,
-        ctx: SharedGlobalContext<FileReplica>,
         replica_id: ReplicaKey,
         leader_state: LeaderReplicaState<FileReplica>,
         receiver: Receiver<LeaderReplicaControllerCommand>,
-        max_bytes: u32,
         sink_channel: SharedSinkMessageChannel,
     ) {
         if let Some(old_replica) = self.insert(replica_id.clone(), leader_state.clone()) {
@@ -102,17 +98,9 @@ impl ReplicaLeadersState<FileReplica> {
             );
         }
 
-        /*
-        let leader_controller = ReplicaLeaderController::new(
-            replica_id,
-            receiver,
-            leader_state,
-            ctx.followers_sink_owned(),
-            sink_channel,
-            max_bytes,
-        );
+        let leader_controller =
+            ReplicaLeaderController::new(replica_id, receiver, leader_state, sink_channel);
         leader_controller.run();
-        */
     }
 }
 

--- a/src/spu/src/replication/leader/mod.rs
+++ b/src/spu/src/replication/leader/mod.rs
@@ -10,7 +10,7 @@ mod actions;
 pub use self::leader_controller::ReplicaLeaderController;
 pub use self::leaders_state::{ReplicaLeadersState, SharedReplicaLeadersState};
 pub use self::replica_state::{SharedFileLeaderState, SharedLeaderState, LeaderReplicaState};
-pub use self::connection::LeaderConnection;
+pub use self::connection::FollowerHandler;
 pub use self::api_key::LeaderPeerApiEnum;
 pub use self::peer_api::LeaderPeerRequest;
 pub use self::update_offsets::UpdateOffsetRequest;

--- a/src/spu/src/replication/leader/replica_state.rs
+++ b/src/spu/src/replication/leader/replica_state.rs
@@ -169,7 +169,7 @@ where
         // follower must be always behind leader
 
         if follower_pos.newer(&leader_pos) {
-            warn!("follower pos must not be newer",);
+            warn!(?follower_pos, ?leader_pos, "follower pos must not be newer");
             return false;
         }
 

--- a/src/spu/src/replication/leader/replica_state.rs
+++ b/src/spu/src/replication/leader/replica_state.rs
@@ -371,10 +371,11 @@ where
                 )
                 .await;
             debug!(
-                offset.hw,
-                offset.leo,
+                follower_id,
+                hw = offset.hw,
+                leo = offset.leo,
                 len = partition_response.records.len(),
-                "read records"
+                "sending records"
             );
             // ensure leo and hw are set correctly. storage might have update last stable offset
             partition_response.leo = offset.leo;

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -53,7 +53,7 @@ mod replica_test {
             ]
         }
 
-        let test_path = temp_dir().join("replication_test");
+        let test_path = temp_dir().join("init_replication_test");
         ensure_clean_dir(&test_path);
 
         let replica = Replica::new((TOPIC, 0), LEADER, vec![FOLLOWER]);
@@ -148,7 +148,7 @@ mod replica_test {
             ]
         }
 
-        let test_path = "/tmp/replication_test";
+        let test_path = "/tmp/new_replication_test";
         ensure_clean_dir(test_path);
 
         let replica = Replica::new((TOPIC, 0), LEADER, vec![FOLLOWER]);

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -114,7 +114,7 @@ mod replica_test {
             .get(&replica.id)
             .expect("follower");
 
-        // at this point, follower replica should be empty since we don't have time to sync up with leader
+        // at this point, follower replica should be empty since we didn't have time to sync up with leader
         assert_eq!(follower_replica.leo(), 0);
         assert_eq!(follower_replica.hw(), 0);
 

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -18,7 +18,7 @@ mod replica_test {
     use fluvio_controlplane_metadata::partition::{Replica};
     use fluvio_controlplane_metadata::spu::{SpuSpec};
     use dataplane::record::RecordSet;
-    use dataplane::fixture::{create_batch};
+    use dataplane::fixture::{create_recordset};
 
     use crate::core::GlobalContext;
     use crate::config::SpuConfig;
@@ -84,9 +84,8 @@ mod replica_test {
             .expect("leader");
 
         // write records
-        let mut records = RecordSet::default().add(create_batch());
         leader_replica
-            .write_record_set(&mut records)
+            .write_record_set(&mut create_recordset(2))
             .await
             .expect("write");
 

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -42,8 +42,6 @@ mod replica_test {
         ]
     }
 
-    
-    
     /// Test 2 replica
     /// Replicating with existing records
     ///    
@@ -125,7 +123,6 @@ mod replica_test {
         Ok(())
     }
 
-
     /// Test 2 replica
     /// Replicating new records
     ///    
@@ -155,8 +152,6 @@ mod replica_test {
             )
             .await
             .expect("leader");
-
-        
 
         let spu_server = create_internal_server(leader_addr(), leader_gctx.clone()).run();
 

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -122,10 +122,11 @@ mod replica_test {
 
         debug!("done waiting. checking result");
 
+        /*
         assert_eq!(follower_replica.leo(), 2);
         assert_eq!(follower_replica.hw(), 2);
         assert_eq!(leader_replica.hw(), 0); // leader should have update it's hw since follower has replicated it
-
+        */
         spu_server.notify();
 
         Ok(())

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -122,9 +122,9 @@ mod replica_test {
 
         debug!("done waiting. checking result");
 
-        /*
         assert_eq!(follower_replica.leo(), 2);
         assert_eq!(follower_replica.hw(), 2);
+        /*
         assert_eq!(leader_replica.hw(), 0); // leader should have update it's hw since follower has replicated it
         */
         spu_server.notify();

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -42,19 +42,11 @@ mod replica_test {
         ]
     }
 
-    /// Scenario: Follower sync with Leader
+    
+    
+    /// Test 2 replica
+    /// Replicating with existing records
     ///    
-    /// Pre-condition:
-    ///     Writes to batches Leader
-    ///     LEO is updated but now HW because replication didn't happen yet
-    ///
-    /// Actions:   
-    ///     Starts Leader Controller
-    ///     Starts Follower Controller
-    ///
-    /// Expectation:
-    ///     Follower replica contains same batch
-    //      both HW is replicated across leader and follower
     #[test_async]
     async fn test_initial_replication() -> Result<(), ()> {
         let test_path = temp_dir().join("replication_test");
@@ -115,6 +107,90 @@ mod replica_test {
         // at this point, follower replica should be empty since we didn't have time to sync up with leader
         assert_eq!(follower_replica.leo(), 0);
         assert_eq!(follower_replica.hw(), 0);
+
+        // wait until follower sync up with leader
+        sleep(Duration::from_millis(1000)).await;
+
+        debug!("done waiting. checking result");
+
+        // all records has been fully replicated
+        assert_eq!(follower_replica.leo(), 2);
+
+        // hw has been replicated
+        assert_eq!(follower_replica.hw(), 2);
+        assert_eq!(leader_replica.hw(), 2);
+
+        spu_server.notify();
+
+        Ok(())
+    }
+
+
+    /// Test 2 replica
+    /// Replicating new records
+    ///    
+    #[test_async]
+    async fn test_replication2_new_records() -> Result<(), ()> {
+        let test_path = "/tmp/replication_test";
+        ensure_clean_dir(test_path);
+
+        let replica = Replica::new((TOPIC, 0), LEADER, vec![FOLLOWER]);
+
+        let mut leader_config = SpuConfig::default();
+        leader_config.log.base_dir = PathBuf::from(test_path);
+        leader_config.replication.min_in_sync_replicas = 2;
+        leader_config.id = LEADER;
+
+        leader_config.private_endpoint = leader_addr();
+        let leader_gctx = GlobalContext::new_shared_context(leader_config);
+        leader_gctx.spu_localstore().sync_all(spu_specs());
+
+        let leader_replica = leader_gctx
+            .leaders_state()
+            .add_leader_replica(
+                leader_gctx.clone(),
+                replica.clone(),
+                MAX_BYTES,
+                ScSinkMessageChannel::shared(),
+            )
+            .await
+            .expect("leader");
+
+        
+
+        let spu_server = create_internal_server(leader_addr(), leader_gctx.clone()).run();
+
+        // sleep little bit until we spin up follower
+        sleep(Duration::from_millis(100)).await;
+
+        let mut follower_config = SpuConfig::default();
+        follower_config.log.base_dir = PathBuf::from(test_path);
+        follower_config.id = FOLLOWER;
+        let follower_gctx = GlobalContext::new_shared_context(follower_config);
+        follower_gctx.spu_localstore().sync_all(spu_specs());
+        follower_gctx
+            .followers_state_owned()
+            .add_replica(follower_gctx.clone(), replica.clone())
+            .await
+            .expect("create");
+
+        let follower_replica = follower_gctx
+            .followers_state()
+            .get(&replica.id)
+            .expect("follower");
+
+        // at this point, follower replica should be empty since we didn't have time to sync up with leader
+        assert_eq!(follower_replica.leo(), 0);
+        assert_eq!(follower_replica.hw(), 0);
+
+        // write records
+        leader_replica
+            .write_record_set(&mut create_recordset(2))
+            .await
+            .expect("write");
+
+        assert_eq!(leader_replica.leo(), 2);
+        assert_eq!(leader_replica.hw(), 0);
 
         // wait until follower sync up with leader
         sleep(Duration::from_millis(1000)).await;

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -26,27 +26,31 @@ mod replica_test {
 
     const LEADER: SpuId = 5001;
     const FOLLOWER: SpuId = 5002;
-    const LEADER_PORT: u16 = 13000;
-    const FOLLOWER_PORT: u16 = 13001;
+
     const TOPIC: &str = "test";
     const HOST: &str = "127.0.0.1";
-    fn leader_addr() -> String {
-        format!("{}:{}", HOST, LEADER_PORT)
-    }
 
     const MAX_BYTES: u32 = 100000;
-    fn spu_specs() -> Vec<SpuSpec> {
-        vec![
-            SpuSpec::new_private_addr(LEADER, LEADER_PORT, HOST.to_owned()),
-            SpuSpec::new_private_addr(FOLLOWER, FOLLOWER_PORT, HOST.to_owned()),
-        ]
-    }
 
     /// Test 2 replica
     /// Replicating with existing records
     ///    
     #[test_async]
     async fn test_initial_replication() -> Result<(), ()> {
+        const LEADER_PORT: u16 = 13000;
+        const FOLLOWER_PORT: u16 = 13001;
+
+        fn leader_addr() -> String {
+            format!("{}:{}", HOST, LEADER_PORT)
+        }
+
+        fn spu_specs() -> Vec<SpuSpec> {
+            vec![
+                SpuSpec::new_private_addr(LEADER, LEADER_PORT, HOST.to_owned()),
+                SpuSpec::new_private_addr(FOLLOWER, FOLLOWER_PORT, HOST.to_owned()),
+            ]
+        }
+
         let test_path = temp_dir().join("replication_test");
         ensure_clean_dir(&test_path);
 
@@ -128,6 +132,20 @@ mod replica_test {
     ///    
     #[test_async]
     async fn test_replication2_new_records() -> Result<(), ()> {
+        const LEADER_PORT: u16 = 13010;
+        const FOLLOWER_PORT: u16 = 13011;
+
+        fn leader_addr() -> String {
+            format!("{}:{}", HOST, LEADER_PORT)
+        }
+
+        fn spu_specs() -> Vec<SpuSpec> {
+            vec![
+                SpuSpec::new_private_addr(LEADER, LEADER_PORT, HOST.to_owned()),
+                SpuSpec::new_private_addr(FOLLOWER, FOLLOWER_PORT, HOST.to_owned()),
+            ]
+        }
+
         let test_path = "/tmp/replication_test";
         ensure_clean_dir(test_path);
 

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -2,10 +2,12 @@ pub(crate) mod follower;
 pub(crate) mod leader;
 
 #[cfg(test)]
+#[cfg(target_os = "linux")]
 mod replica_test {
 
     use std::path::PathBuf;
     use std::time::Duration;
+    use std::env::temp_dir;
 
     use fluvio_future::{test_async};
     use fluvio_future::timer::sleep;
@@ -42,13 +44,13 @@ mod replica_test {
     /// test a single leader and follower
     #[test_async]
     async fn test_initial_replication() -> Result<(), ()> {
-        let test_path = "/tmp/replication_test";
-        ensure_clean_dir(test_path);
+        let test_path = temp_dir().join("replication_test");
+        ensure_clean_dir(&test_path);
 
         let replica = Replica::new((TOPIC, 0), LEADER, vec![FOLLOWER]);
 
         let mut leader_config = SpuConfig::default();
-        leader_config.log.base_dir = PathBuf::from(test_path);
+        leader_config.log.base_dir = test_path.clone();
         leader_config.id = LEADER;
         leader_config.private_endpoint = leader_addr();
         let leader_gctx = GlobalContext::new_shared_context(leader_config);

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -121,11 +121,13 @@ mod replica_test {
 
         debug!("done waiting. checking result");
 
+        // all records has been fully replicated
         assert_eq!(follower_replica.leo(), 2);
+
+        // hw has been replicated
         assert_eq!(follower_replica.hw(), 2);
-        /*
-        assert_eq!(leader_replica.hw(), 0); // leader should have update it's hw since follower has replicated it
-        */
+        assert_eq!(leader_replica.hw(), 2);
+
         spu_server.notify();
 
         Ok(())

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -31,6 +31,8 @@ mod replica_test {
     const HOST: &str = "127.0.0.1";
 
     const MAX_BYTES: u32 = 100000;
+    const MAX_WAIT_REPLICATION: u64 = 5000;
+    const MAX_WAIT_LEADER: u64 = 1000;
 
     /// Test 2 replica
     /// Replicating with existing records
@@ -87,8 +89,8 @@ mod replica_test {
 
         let spu_server = create_internal_server(leader_addr(), leader_gctx.clone()).run();
 
-        // sleep little bit until we spin up follower
-        sleep(Duration::from_millis(100)).await;
+        // give leader controller time to startup
+        sleep(Duration::from_millis(MAX_WAIT_LEADER)).await;
 
         let mut follower_config = SpuConfig::default();
         follower_config.log.base_dir = test_path;
@@ -111,7 +113,7 @@ mod replica_test {
         assert_eq!(follower_replica.hw(), 0);
 
         // wait until follower sync up with leader
-        sleep(Duration::from_millis(1000)).await;
+        sleep(Duration::from_millis(MAX_WAIT_REPLICATION)).await;
 
         debug!("done waiting. checking result");
 
@@ -173,8 +175,8 @@ mod replica_test {
 
         let spu_server = create_internal_server(leader_addr(), leader_gctx.clone()).run();
 
-        // sleep little bit until we spin up follower
-        sleep(Duration::from_millis(100)).await;
+        // give leader controller time to startup
+        sleep(Duration::from_millis(MAX_WAIT_LEADER)).await;
 
         let mut follower_config = SpuConfig::default();
         follower_config.log.base_dir = PathBuf::from(test_path);
@@ -206,7 +208,7 @@ mod replica_test {
         assert_eq!(leader_replica.hw(), 0);
 
         // wait until follower sync up with leader
-        sleep(Duration::from_millis(1000)).await;
+        sleep(Duration::from_millis(MAX_WAIT_REPLICATION)).await;
 
         debug!("done waiting. checking result");
 

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -17,7 +17,6 @@ mod replica_test {
     use fluvio_types::SpuId;
     use fluvio_controlplane_metadata::partition::{Replica};
     use fluvio_controlplane_metadata::spu::{SpuSpec};
-    use dataplane::record::RecordSet;
     use dataplane::fixture::{create_recordset};
 
     use crate::core::GlobalContext;

--- a/src/spu/src/services/internal/fetch_stream.rs
+++ b/src/spu/src/services/internal/fetch_stream.rs
@@ -5,7 +5,7 @@ use fluvio_socket::FlvSocket;
 use fluvio_socket::FlvSocketError;
 
 use crate::core::DefaultSharedGlobalContext;
-use crate::replication::leader::LeaderConnection;
+use crate::replication::leader::FollowerHandler;
 use super::FetchStreamRequest;
 use super::FetchStreamResponse;
 
@@ -28,7 +28,7 @@ pub(crate) async fn handle_fetch_stream_request(
         .send_response(&res_msg, req_msg.header.api_version())
         .await?;
 
-    LeaderConnection::handle(ctx, follower_id, socket).await?;
+    FollowerHandler::start(ctx, follower_id, socket).await?;
 
     Ok(()) as Result<(), FlvSocketError>
 }

--- a/src/spu/src/services/internal/service_impl.rs
+++ b/src/spu/src/services/internal/service_impl.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tracing::{debug, error};
 
-use fluvio_service::api_loop;
-use fluvio_service::FlvService;
-use fluvio_socket::FlvSocket;
-use fluvio_socket::FlvSocketError;
+use fluvio_service::{api_loop, FlvService};
+use fluvio_socket::{FlvSocket, FlvSocketError};
 use fluvio_future::net::TcpStream;
 
 use super::SpuPeerRequest;
@@ -43,12 +42,15 @@ impl FlvService<TcpStream> for InternalService {
 
                 drop(api_stream);
                 let orig_socket: FlvSocket  = (sink,stream).into();
-                handle_fetch_stream_request(request, context, orig_socket).await?;
+                if let Err(err) = handle_fetch_stream_request(request, context, orig_socket).await {
+                    error!("fetch stream request: {:#?}",err);
+                }
                 break;
 
             }
         );
 
+        debug!("finishing SPU peer loop");
         Ok(())
     }
 }

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -491,7 +491,7 @@ mod test {
     use std::{
         path::{Path, PathBuf},
         time::Duration,
-        env::temp_dir
+        env::temp_dir,
     };
 
     use fluvio_controlplane_metadata::partition::Replica;

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -498,11 +498,13 @@ pub mod publishers {
 }
 
 #[cfg(test)]
+#[cfg(target_os = "linux")]
 mod test {
 
     use std::{
         path::{Path, PathBuf},
         time::Duration,
+        env::temp_dir
     };
 
     use fluvio_controlplane_metadata::partition::Replica;
@@ -528,12 +530,12 @@ mod test {
 
     #[test_async]
     async fn test_stream_fetch() -> Result<(), ()> {
-        let test_path = "/tmp/stream_test";
-        ensure_clean_dir(test_path);
+        let test_path = temp_dir().join("stream_test");
+        ensure_clean_dir(&test_path);
 
         let addr = "127.0.0.1:12000";
         let mut spu_config = SpuConfig::default();
-        spu_config.log.base_dir = PathBuf::from(test_path);
+        spu_config.log.base_dir = test_path;
         let ctx = GlobalContext::new_shared_context(spu_config);
 
         let server_end_event = create_public_server(addr.to_owned(), ctx.clone()).run();
@@ -695,12 +697,12 @@ mod test {
 
     #[test_async]
     async fn test_stream_filter_fetch() -> Result<(), ()> {
-        let test_path = "/tmp/filter_stream_fetch";
-        ensure_clean_dir(test_path);
+        let test_path = temp_dir().join("filter_stream_fetch");
+        ensure_clean_dir(&test_path);
 
         let addr = "127.0.0.1:12001";
         let mut spu_config = SpuConfig::default();
-        spu_config.log.base_dir = PathBuf::from(test_path);
+        spu_config.log.base_dir = test_path;
         let ctx = GlobalContext::new_shared_context(spu_config);
 
         let server_end_event = create_public_server(addr.to_owned(), ctx.clone()).run();
@@ -850,12 +852,12 @@ mod test {
     /// test filter with max bytes
     #[test_async]
     async fn test_stream_filter_max() -> Result<(), ()> {
-        let test_path = "/tmp/filter_stream_max";
-        ensure_clean_dir(test_path);
+        let test_path = temp_dir().join("filter_stream_max");
+        ensure_clean_dir(&test_path);
 
         let addr = "127.0.0.1:12002";
         let mut spu_config = SpuConfig::default();
-        spu_config.log.base_dir = PathBuf::from(test_path);
+        spu_config.log.base_dir = test_path;
         let ctx = GlobalContext::new_shared_context(spu_config);
 
         let server_end_event = create_public_server(addr.to_owned(), ctx.clone()).run();

--- a/src/spu/src/smart_stream/filter.rs
+++ b/src/spu/src/smart_stream/filter.rs
@@ -440,6 +440,7 @@ impl Iterator for FileBatchIterator {
 #[cfg(test)]
 mod test {
     use std::{fs::File, io::Write};
+    use std::env::temp_dir;
     use std::os::unix::io::AsRawFd;
 
     use fluvio_storage::config::DEFAULT_MAX_BATCH_SIZE;
@@ -448,12 +449,13 @@ mod test {
 
     #[test]
     fn test_file() {
-        let mut file = File::create("/tmp/pread.txt").expect("create");
+        let path = temp_dir().join("pread.txt");
+        let mut file = File::create(&path).expect("create");
         file.write_all(b"Hello, world!").expect("write");
         file.sync_all().expect("flush");
         drop(file);
 
-        let read_only = File::open("/tmp/pread.txt").expect("open");
+        let read_only = File::open(path).expect("open");
         let fd = read_only.as_raw_fd();
         let mut buf = vec![0; DEFAULT_MAX_BATCH_SIZE as usize];
         // let mut buf = BytesMut::with_capacity(64);

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -110,7 +110,12 @@ where
 
     pub async fn update_hw(&self, hw: Offset) -> Result<bool, StorageError> {
         let mut writer = self.write().await;
-        writer.update_high_watermark(hw).await
+        if writer.update_high_watermark(hw).await? {
+            self.hw.update(hw);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     pub async fn write_record_set(

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -65,6 +65,13 @@ where
         self.hw.current_value()
     }
 
+    pub fn as_offset(&self) -> OffsetInfo {
+        OffsetInfo {
+            hw: self.hw(),
+            leo: self.leo(),
+        }
+    }
+
     /// listen to offset based on isolation
     pub fn offset_listener(&self, isolation: &Isolation) -> OffsetChangeListener {
         match isolation {

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -9,7 +9,7 @@ use fluvio_controlplane_metadata::partition::{ReplicaKey};
 use dataplane::{Isolation, record::RecordSet};
 use dataplane::core::Encoder;
 use dataplane::{Offset};
-use fluvio_storage::{ReplicaStorage, SlicePartitionResponse, StorageError};
+use fluvio_storage::{ReplicaStorage, SlicePartitionResponse, StorageError, OffsetInfo};
 use fluvio_types::{event::offsets::OffsetChangeListener};
 use fluvio_types::event::offsets::OffsetPublisher;
 
@@ -90,14 +90,14 @@ where
     }
 
     /// read records into partition response
-    /// return hw and leo
+    /// return leo and hw
     pub async fn read_records<P>(
         &self,
         offset: Offset,
         max_len: u32,
         isolation: Isolation,
         partition_response: &mut P,
-    ) -> (Offset, Offset)
+    ) -> OffsetInfo
     where
         P: SlicePartitionResponse + Send,
     {

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -74,12 +74,12 @@ where
     }
 
     /// readable ref to storage
-    async fn read(&self) -> RwLockReadGuard<'_, S> {
+    pub async fn read(&self) -> RwLockReadGuard<'_, S> {
         self.inner.read().await
     }
 
     /// writable ref to storage
-    async fn write(&self) -> RwLockWriteGuard<'_, S> {
+    pub async fn write(&self) -> RwLockWriteGuard<'_, S> {
         self.inner.write().await
     }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -30,7 +30,6 @@ mod inner {
     use dataplane::fetch::FilePartitionResponse;
     use dataplane::record::RecordSet;
     use fluvio_future::file_slice::AsyncFileSlice;
-    use fluvio_types::SpuId;
 
     use crate::StorageError;
 
@@ -79,11 +78,7 @@ mod inner {
 
         /// create new storage area,
         /// if there exists replica state, this should restore state
-        async fn create(
-            replica: &ReplicaKey,
-            spu: SpuId,
-            config: Self::Config,
-        ) -> Result<Self, StorageError>;
+        async fn create(replica: &ReplicaKey, config: Self::Config) -> Result<Self, StorageError>;
 
         /// high water mark offset (records that has been replicated)
         fn get_hw(&self) -> Offset;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -65,7 +65,8 @@ mod inner {
 
         /// check if offset contains value
         pub fn is_valid(&self) -> bool {
-            self.hw != -1 && self.leo != -1
+            self.hw != -1 && self.leo != -1 &&
+                self.leo >= self.hw
         }
 
         /// update hw, leo
@@ -179,5 +180,62 @@ mod inner {
 
         /// permanently remove
         async fn remove(&self) -> Result<(), StorageError>;
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_offset_validation() {
+            assert!(!OffsetInfo::default().is_valid());
+
+            assert!(!OffsetInfo {
+                hw: 2,
+                leo: 1
+            }.is_valid());
+
+            assert!(OffsetInfo {
+                hw: 2,
+                leo: 3
+            }.is_valid());
+        }
+
+
+        #[test]
+        fn test_offset_newer() {
+           
+
+            assert!(!OffsetInfo {
+                hw: 1,
+                leo: 2
+            }.newer(&OffsetInfo {
+                hw: 2,
+                leo: 2
+            }));
+
+            assert!(OffsetInfo {
+                hw: 2,
+                leo: 10
+            }.newer(&OffsetInfo {
+                hw: 0,
+                leo: 0
+            }));
+        }
+
+        #[test]
+        fn test_offset_update() {
+           
+
+            assert!(!OffsetInfo {
+                hw: 1,
+                leo: 2
+            }.update(&OffsetInfo {
+                hw: 0,
+                leo: 0
+            }));
+
+           
+        }
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -65,8 +65,7 @@ mod inner {
 
         /// check if offset contains value
         pub fn is_valid(&self) -> bool {
-            self.hw != -1 && self.leo != -1 &&
-                self.leo >= self.hw
+            self.hw != -1 && self.leo != -1 && self.leo >= self.hw
         }
 
         /// update hw, leo
@@ -190,60 +189,23 @@ mod inner {
         fn test_offset_validation() {
             assert!(!OffsetInfo::default().is_valid());
 
-            assert!(!OffsetInfo {
-                hw: 2,
-                leo: 1
-            }.is_valid());
+            assert!(!OffsetInfo { hw: 2, leo: 1 }.is_valid());
 
-            assert!(OffsetInfo {
-                hw: 2,
-                leo: 3
-            }.is_valid());
+            assert!(OffsetInfo { hw: 2, leo: 3 }.is_valid());
         }
-
 
         #[test]
         fn test_offset_newer() {
-           
+            assert!(!OffsetInfo { hw: 1, leo: 2 }.newer(&OffsetInfo { hw: 2, leo: 2 }));
 
-            assert!(!OffsetInfo {
-                hw: 1,
-                leo: 2
-            }.newer(&OffsetInfo {
-                hw: 2,
-                leo: 2
-            }));
-
-            assert!(OffsetInfo {
-                hw: 2,
-                leo: 10
-            }.newer(&OffsetInfo {
-                hw: 0,
-                leo: 0
-            }));
+            assert!(OffsetInfo { hw: 2, leo: 10 }.newer(&OffsetInfo { hw: 0, leo: 0 }));
         }
 
         #[test]
         fn test_offset_update() {
-           
+            assert!(!OffsetInfo { hw: 1, leo: 2 }.update(&OffsetInfo { hw: 0, leo: 0 }));
 
-            assert!(!OffsetInfo {
-                hw: 1,
-                leo: 2
-            }.update(&OffsetInfo {
-                hw: 0,
-                leo: 0
-            }));
-
-            assert!(OffsetInfo {
-                hw: 1,
-                leo: 2
-            }.update(&OffsetInfo {
-                hw: 1,
-                leo: 3
-            }));
-
-           
+            assert!(OffsetInfo { hw: 1, leo: 2 }.update(&OffsetInfo { hw: 1, leo: 3 }));
         }
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -235,6 +235,14 @@ mod inner {
                 leo: 0
             }));
 
+            assert!(OffsetInfo {
+                hw: 1,
+                leo: 2
+            }.update(&OffsetInfo {
+                hw: 1,
+                leo: 3
+            }));
+
            
         }
     }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -31,6 +31,21 @@ mod inner {
     use dataplane::record::RecordSet;
     use fluvio_future::file_slice::AsyncFileSlice;
 
+    pub struct OffsetInfo {
+        pub hw: Offset,
+        pub leo: Offset,
+    }
+
+    impl OffsetInfo {
+        /// get isolation offset
+        pub fn isolation(&self, isolation: &Isolation) -> Offset {
+            match isolation {
+                Isolation::ReadCommitted => self.hw,
+                Isolation::ReadUncommitted => self.leo,
+            }
+        }
+    }
+
     use crate::StorageError;
 
     /// output from storage is represented as slice
@@ -96,7 +111,7 @@ mod inner {
             max_len: u32,
             isolation: Isolation,
             partition_response: &mut P,
-        ) -> (Offset, Offset)
+        ) -> OffsetInfo
         where
             P: SlicePartitionResponse + Send;
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -63,9 +63,11 @@ mod inner {
             }
         }
 
-        /// check if offset contains value
+        /// check if offset contains valid value
+        ///  invalid if either hw or leo is -1
+        ///  or if hw > leo
         pub fn is_valid(&self) -> bool {
-            self.hw != -1 && self.leo != -1 && self.leo >= self.hw
+            !(self.hw == -1 || self.leo == -1) && self.leo >= self.hw
         }
 
         /// update hw, leo
@@ -192,6 +194,12 @@ mod inner {
             assert!(!OffsetInfo { hw: 2, leo: 1 }.is_valid());
 
             assert!(OffsetInfo { hw: 2, leo: 3 }.is_valid());
+
+            assert!(OffsetInfo { hw: 0, leo: 0 }.is_valid());
+
+            assert!(OffsetInfo { hw: 4, leo: 4 }.is_valid());
+
+            assert!(!OffsetInfo { hw: -1, leo: 3 }.is_valid());
         }
 
         #[test]

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -193,7 +193,7 @@ impl FileReplica {
         let commit_checkpoint: CheckPoint<Offset> =
             CheckPoint::create(&rep_option, "replication.chk", last_base_offset).await?;
 
-        Ok(FileReplica {
+        Ok(Self {
             option: rep_option,
             last_base_offset,
             partition,

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -1,7 +1,6 @@
 use std::mem;
 
 use fluvio_protocol::Encoder;
-use fluvio_types::SpuId;
 use tracing::{debug, trace, error, warn};
 use async_trait::async_trait;
 
@@ -34,23 +33,12 @@ pub struct FileReplica {
 
 impl Unpin for FileReplica {}
 
-fn default_config(spu_id: SpuId, config: &ConfigOption) -> ConfigOption {
-    let base_dir = config.base_dir.join(format!("spu-logs-{}", spu_id));
-    let new_config = config.clone();
-    new_config.base_dir(base_dir)
-}
-
 #[async_trait]
 impl ReplicaStorage for FileReplica {
     type Config = ConfigOption;
 
-    async fn create(
-        replica: &ReplicaKey,
-        spu: SpuId,
-        base_config: Self::Config,
-    ) -> Result<Self, StorageError> {
-        let config = default_config(spu, &base_config);
-        Self::create(replica.topic.clone(), replica.partition as u32, 0, &config).await
+    async fn create(replica: &ReplicaKey, config: Self::Config) -> Result<Self, StorageError> {
+        Self::create(replica.topic.clone(), replica.partition as u32, 0, config).await
     }
 
     fn get_hw(&self) -> Offset {
@@ -168,7 +156,7 @@ impl FileReplica {
         topic: S,
         partition: Size,
         base_offset: Offset,
-        option: &ConfigOption,
+        option: ConfigOption,
     ) -> Result<FileReplica, StorageError>
     where
         S: AsRef<str> + Send + 'static,
@@ -442,7 +430,7 @@ mod tests {
     #[test_async]
     async fn test_replica_simple() -> Result<(), StorageError> {
         let option = base_option("test_simple");
-        let mut replica = FileReplica::create("test", 0, START_OFFSET, &option)
+        let mut replica = FileReplica::create("test", 0, START_OFFSET, option.clone())
             .await
             .expect("test replica");
 
@@ -491,7 +479,7 @@ mod tests {
     async fn test_uncommitted_fetch() -> Result<(), StorageError> {
         let option = base_option(TEST_UNCOMMIT_DIR);
 
-        let mut replica = FileReplica::create("test", 0, 0, &option)
+        let mut replica = FileReplica::create("test", 0, 0, option)
             .await
             .expect("test replica");
 
@@ -558,7 +546,7 @@ mod tests {
     async fn test_replica_end_offset() -> Result<(), StorageError> {
         let option = base_option(TEST_OFFSET_DIR);
 
-        let mut rep_sink = FileReplica::create("test", 0, START_OFFSET, &option)
+        let mut rep_sink = FileReplica::create("test", 0, START_OFFSET, option.clone())
             .await
             .expect("test replica");
         rep_sink.write_batch(&mut create_batch()).await?;
@@ -566,7 +554,7 @@ mod tests {
         drop(rep_sink);
 
         // open replica
-        let replica2 = FileReplica::create("test", 0, START_OFFSET, &option)
+        let replica2 = FileReplica::create("test", 0, START_OFFSET, option)
             .await
             .expect("test replica");
         assert_eq!(replica2.get_leo(), START_OFFSET + 4);
@@ -582,7 +570,7 @@ mod tests {
     async fn test_rep_log_roll_over() -> Result<(), StorageError> {
         let option = rollover_option(TEST_REPLICA_DIR);
 
-        let mut replica = FileReplica::create("test", 1, START_OFFSET, &option)
+        let mut replica = FileReplica::create("test", 1, START_OFFSET, option.clone())
             .await
             .expect("create rep");
 
@@ -626,7 +614,7 @@ mod tests {
     #[test_async]
     async fn test_replica_commit() -> Result<(), StorageError> {
         let option = base_option(TEST_COMMIT_DIR);
-        let mut replica = FileReplica::create("test", 0, 0, &option)
+        let mut replica = FileReplica::create("test", 0, 0, option.clone())
             .await
             .expect("test replica");
 
@@ -640,7 +628,7 @@ mod tests {
         drop(replica);
 
         // restore replica
-        let replica = FileReplica::create("test", 0, 0, &option)
+        let replica = FileReplica::create("test", 0, 0, option)
             .await
             .expect("test replica");
         assert_eq!(replica.get_hw(), 2);
@@ -655,7 +643,7 @@ mod tests {
     async fn test_committed_fetch() -> Result<(), StorageError> {
         let option = base_option(TEST_COMMIT_FETCH_DIR);
 
-        let mut replica = FileReplica::create("test", 0, 0, &option)
+        let mut replica = FileReplica::create("test", 0, 0, option)
             .await
             .expect("test replica");
 
@@ -734,7 +722,7 @@ mod tests {
         let mut option = base_option("test_delete");
         option.max_batch_size = 50; // enforce 50 length
 
-        let replica = FileReplica::create("testr", 0, START_OFFSET, &option)
+        let replica = FileReplica::create("testr", 0, START_OFFSET, option.clone())
             .await
             .expect("test replica");
 
@@ -755,7 +743,7 @@ mod tests {
         option.max_batch_size = 100;
         option.update_hw = false;
 
-        let mut replica = FileReplica::create("test", 0, START_OFFSET, &option)
+        let mut replica = FileReplica::create("test", 0, START_OFFSET, option)
             .await
             .expect("test replica");
 

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -67,7 +67,7 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
 
     ensure_clean_dir(&option.base_dir);
 
-    let mut replica = FileReplica::create(TOPIC_NAME, 0, START_OFFSET, &option)
+    let mut replica = FileReplica::create(TOPIC_NAME, 0, START_OFFSET, option)
         .await
         .expect("test replica");
     replica


### PR DESCRIPTION
More changes as part of #922.  Full replication is still work-in-progress.

SPU updates:
* Remove SinkPool.
* LeaderController is no longer involved with Follower sync.  This is done by LeaderConnection directly
* Lots of clean up with Leader and Follower Replica with unit tests
* Add Replication integration test
* Verify replication works with 2 SPU

Update Dependencies 

TODO:
* Follower States are not send back to SC
* Need to update follower updates when SPU > 2

