### PR TITLE
[Merged by Bors] - Add RecordKey API for sending records without keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/examples/00-produce/src/main.rs
+++ b/examples/00-produce/src/main.rs
@@ -35,7 +35,7 @@ async fn produce() -> Result<(), fluvio::FluvioError> {
     let producer = fluvio::producer("simple").await?;
 
     let value = "Hello, Fluvio!";
-    producer.send(RecordKey::Null, value).await?;
+    producer.send(RecordKey::NULL, value).await?;
     println!("{}", value);
 
     Ok(())

--- a/examples/00-produce/src/main.rs
+++ b/examples/00-produce/src/main.rs
@@ -22,6 +22,8 @@
 //! Hello, Fluvio!
 //! ```
 
+use fluvio::RecordKey;
+
 #[async_std::main]
 async fn main() {
     if let Err(e) = produce().await {
@@ -33,7 +35,7 @@ async fn produce() -> Result<(), fluvio::FluvioError> {
     let producer = fluvio::producer("simple").await?;
 
     let value = "Hello, Fluvio!";
-    producer.send_record(value, 0).await?;
+    producer.send(RecordKey::Null, value).await?;
     println!("{}", value);
 
     Ok(())

--- a/examples/01-produce-batch/src/main.rs
+++ b/examples/01-produce-batch/src/main.rs
@@ -32,7 +32,7 @@ async fn produce_batch() -> Result<(), fluvio::FluvioError> {
     let producer = fluvio::producer("batch").await?;
 
     let batch: Vec<_> = (0..10)
-        .map(|i| (Some(i.to_string()), format!("This is record {}", i)))
+        .map(|i| (i.to_string(), format!("This is record {}", i)))
         .collect();
 
     producer.send_all(batch).await?;

--- a/examples/03-echo/src/main.rs
+++ b/examples/03-echo/src/main.rs
@@ -89,7 +89,7 @@
 //! ```
 
 use std::time::Duration;
-use fluvio::{FluvioError, Offset};
+use fluvio::{FluvioError, Offset, RecordKey};
 use futures::future::join;
 use async_std::task::spawn;
 use async_std::future::timeout;
@@ -144,7 +144,7 @@ async fn produce() -> Result<(), FluvioError> {
             .send(format!("Key {}", i), format!("Value {}", i))
             .await?;
     }
-    producer.send_record("Done!", 0).await?;
+    producer.send(RecordKey::Null, "Done!").await?;
 
     Ok(())
 }

--- a/examples/03-echo/src/main.rs
+++ b/examples/03-echo/src/main.rs
@@ -144,7 +144,7 @@ async fn produce() -> Result<(), FluvioError> {
             .send(format!("Key {}", i), format!("Value {}", i))
             .await?;
     }
-    producer.send(RecordKey::Null, "Done!").await?;
+    producer.send(RecordKey::NULL, "Done!").await?;
 
     Ok(())
 }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -60,7 +60,7 @@ content_inspector = { version = "0.2.4", optional = true}
 # Fluvio dependencies
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
-fluvio = { version = "0.7.0", path = "../client", default-features = false }
+fluvio = { version = "0.8.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.7.0", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/src/cli/src/consumer/produce/mod.rs
+++ b/src/cli/src/consumer/produce/mod.rs
@@ -102,7 +102,7 @@ impl ProduceOpt {
         if self.kv_mode() {
             self.produce_key_value(producer, string).await?;
         } else {
-            producer.send(RecordKey::Null, string).await?;
+            producer.send(RecordKey::NULL, string).await?;
             if self.verbose {
                 println!("[null] {}", string);
             }

--- a/src/cli/src/consumer/produce/mod.rs
+++ b/src/cli/src/consumer/produce/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use tracing::debug;
 
-use fluvio::{Fluvio, TopicProducer};
+use fluvio::{Fluvio, TopicProducer, RecordKey};
 use fluvio_types::print_cli_ok;
 use crate::common::FluvioExtensionMetadata;
 use crate::consumer::error::ConsumerError;
@@ -102,7 +102,7 @@ impl ProduceOpt {
         if self.kv_mode() {
             self.produce_key_value(producer, string).await?;
         } else {
-            producer.send_record(string, 0).await?;
+            producer.send(RecordKey::Null, string).await?;
             if self.verbose {
                 println!("[null] {}", string);
             }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/fluvio.rs
+++ b/src/client/src/fluvio.rs
@@ -100,10 +100,10 @@ impl Fluvio {
     /// # Example
     ///
     /// ```no_run
-    /// # use fluvio::{Fluvio, FluvioError};
+    /// # use fluvio::{Fluvio, FluvioError, RecordKey};
     /// # async fn do_produce_to_topic(fluvio: &Fluvio) -> Result<(), FluvioError> {
     /// let producer = fluvio.topic_producer("my-topic").await?;
-    /// producer.send_record("Hello, Fluvio!", 0).await?;
+    /// producer.send(RecordKey::Null, "Hello, Fluvio!").await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/src/fluvio.rs
+++ b/src/client/src/fluvio.rs
@@ -103,7 +103,7 @@ impl Fluvio {
     /// # use fluvio::{Fluvio, FluvioError, RecordKey};
     /// # async fn do_produce_to_topic(fluvio: &Fluvio) -> Result<(), FluvioError> {
     /// let producer = fluvio.topic_producer("my-topic").await?;
-    /// producer.send(RecordKey::Null, "Hello, Fluvio!").await?;
+    /// producer.send(RecordKey::NULL, "Hello, Fluvio!").await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -44,7 +44,7 @@
 //! #     pub use futures_util::stream::StreamExt;
 //! # }
 //! use std::time::Duration;
-//! use fluvio::{Offset, FluvioError};
+//! use fluvio::{Offset, FluvioError, RecordKey};
 //! use futures::StreamExt;
 //!
 //! async_std::task::spawn(produce_records());
@@ -55,7 +55,7 @@
 //! async fn produce_records() -> Result<(), FluvioError> {
 //!     let producer = fluvio::producer("echo").await?;
 //!     for i in 0..10u8 {
-//!         producer.send_record(format!("Hello, Fluvio {}!", i), 0).await?;
+//!         producer.send(RecordKey::Null, format!("Hello, Fluvio {}!", i)).await?;
 //!         async_std::task::sleep(Duration::from_secs(1)).await;
 //!     }
 //!     Ok(())
@@ -95,7 +95,7 @@ pub mod config;
 
 pub use error::FluvioError;
 pub use config::FluvioConfig;
-pub use producer::TopicProducer;
+pub use producer::{TopicProducer, RecordKey};
 pub use consumer::{PartitionConsumer, ConsumerConfig};
 pub use offset::Offset;
 
@@ -118,10 +118,10 @@ const MINIMUM_PLATFORM_VERSION: &str = "0.8.0";
 /// a string:
 ///
 /// ```no_run
-/// # use fluvio::FluvioError;
+/// # use fluvio::{FluvioError, RecordKey};
 /// # async fn do_produce() -> Result<(), FluvioError> {
 /// let producer = fluvio::producer("my-topic").await?;
-/// producer.send_record("Hello, world!", 0).await?;
+/// producer.send(RecordKey::Null, "Hello, world!").await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -55,7 +55,7 @@
 //! async fn produce_records() -> Result<(), FluvioError> {
 //!     let producer = fluvio::producer("echo").await?;
 //!     for i in 0..10u8 {
-//!         producer.send(RecordKey::Null, format!("Hello, Fluvio {}!", i)).await?;
+//!         producer.send(RecordKey::NULL, format!("Hello, Fluvio {}!", i)).await?;
 //!         async_std::task::sleep(Duration::from_secs(1)).await;
 //!     }
 //!     Ok(())
@@ -121,7 +121,7 @@ const MINIMUM_PLATFORM_VERSION: &str = "0.8.0";
 /// # use fluvio::{FluvioError, RecordKey};
 /// # async fn do_produce() -> Result<(), FluvioError> {
 /// let producer = fluvio::producer("my-topic").await?;
-/// producer.send(RecordKey::Null, "Hello, world!").await?;
+/// producer.send(RecordKey::NULL, "Hello, world!").await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -42,7 +42,7 @@ remoteprocess = "0.4.2"
 which = "4.1.0"
 
 # Fluvio dependencies
-fluvio = { version = "0.7.0", path = "../client", default-features = false }
+fluvio = { version = "0.8.0", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.2.0" }
 fluvio-command = { version = "0.2.0", path = "../command" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
-fluvio = { version = "0.7.0", path = "../client",  optional = true }
+fluvio = { version = "0.8.0", path = "../client",  optional = true }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/tests/runner/src/tests/concurrent/producer.rs
+++ b/tests/runner/src/tests/concurrent/producer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::mpsc::Sender;
-use fluvio::Fluvio;
+use fluvio::{Fluvio, RecordKey};
 
 use super::ConcurrentTestCase;
 use super::util::*;
@@ -18,6 +18,6 @@ pub async fn producer(fluvio: Arc<Fluvio>, option: ConcurrentTestCase, digests: 
         let record = rand_record();
         let record_digest = hash_record(&record);
         digests.send(record_digest).unwrap();
-        producer.send_record(record, 0).await.unwrap();
+        producer.send(RecordKey::Null, record).await.unwrap();
     }
 }

--- a/tests/runner/src/tests/concurrent/producer.rs
+++ b/tests/runner/src/tests/concurrent/producer.rs
@@ -18,6 +18,6 @@ pub async fn producer(fluvio: Arc<Fluvio>, option: ConcurrentTestCase, digests: 
         let record = rand_record();
         let record_digest = hash_record(&record);
         digests.send(record_digest).unwrap();
-        producer.send(RecordKey::Null, record).await.unwrap();
+        producer.send(RecordKey::NULL, record).await.unwrap();
     }
 }

--- a/tests/runner/src/tests/producer_stress.rs
+++ b/tests/runner/src/tests/producer_stress.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::env;
 use structopt::StructOpt;
 
-use fluvio::{Fluvio, TopicProducer};
+use fluvio::{Fluvio, TopicProducer, RecordKey};
 use fluvio_integration_derive::fluvio_test;
 use fluvio_test_util::test_meta::derive_attr::TestRequirements;
 use fluvio_test_util::test_meta::environment::EnvironmentSetup;
@@ -86,17 +86,21 @@ pub async fn run(client: Arc<Fluvio>, mut test_case: TestCase) -> TestResult {
             // This is for CI stability. We need to not panic during CI, but keep errors visible
             if let Ok(is_ci) = env::var("CI") {
                 if is_ci == "true" {
-                    p.send_record(message.clone(), 0).await.unwrap_or_else(|_| {
-                        eprintln!(
-                            "[CI MODE] send record failed for iteration: {} message: {}",
-                            n, i
-                        );
-                    });
+                    p.send(RecordKey::Null, message.clone())
+                        .await
+                        .unwrap_or_else(|_| {
+                            eprintln!(
+                                "[CI MODE] send record failed for iteration: {} message: {}",
+                                n, i
+                            );
+                        });
                 }
             } else {
-                p.send_record(message.clone(), 0).await.unwrap_or_else(|_| {
-                    panic!("send record failed for iteration: {} message: {}", n, i)
-                });
+                p.send(RecordKey::Null, message.clone())
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!("send record failed for iteration: {} message: {}", n, i)
+                    });
             }
         }
     }

--- a/tests/runner/src/tests/producer_stress.rs
+++ b/tests/runner/src/tests/producer_stress.rs
@@ -86,7 +86,7 @@ pub async fn run(client: Arc<Fluvio>, mut test_case: TestCase) -> TestResult {
             // This is for CI stability. We need to not panic during CI, but keep errors visible
             if let Ok(is_ci) = env::var("CI") {
                 if is_ci == "true" {
-                    p.send(RecordKey::Null, message.clone())
+                    p.send(RecordKey::NULL, message.clone())
                         .await
                         .unwrap_or_else(|_| {
                             eprintln!(
@@ -96,7 +96,7 @@ pub async fn run(client: Arc<Fluvio>, mut test_case: TestCase) -> TestResult {
                         });
                 }
             } else {
-                p.send(RecordKey::Null, message.clone())
+                p.send(RecordKey::NULL, message.clone())
                     .await
                     .unwrap_or_else(|_| {
                         panic!("send record failed for iteration: {} message: {}", n, i)

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -132,7 +132,7 @@ pub async fn produce_message_with_api(
             let len = message.len();
             info!("trying send: {}, iteration: {}", topic_name, i);
             producer
-                .send(RecordKey::Null, message)
+                .send(RecordKey::NULL, message)
                 .await
                 .unwrap_or_else(|_| {
                     panic!("send record failed for replication: {} iteration: {}", r, i)

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -4,7 +4,7 @@ use log::info;
 
 use super::SmokeTestCase;
 use super::message::*;
-use fluvio::{Fluvio, TopicProducer};
+use fluvio::{Fluvio, TopicProducer, RecordKey};
 use fluvio_command::CommandExt;
 use std::sync::Arc;
 
@@ -131,9 +131,12 @@ pub async fn produce_message_with_api(
             let message = generate_message(offset, &test_case);
             let len = message.len();
             info!("trying send: {}, iteration: {}", topic_name, i);
-            producer.send_record(message, 0).await.unwrap_or_else(|_| {
-                panic!("send record failed for replication: {} iteration: {}", r, i)
-            });
+            producer
+                .send(RecordKey::Null, message)
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("send record failed for replication: {} iteration: {}", r, i)
+                });
 
             info!(
                 "completed send iter: {}, offset: {},len: {}",


### PR DESCRIPTION
Closes #977.

- Adds `RecordKey` API to `TopicProducer`
- Updates CLI and examples to use `send` with `RecordKey::Null`