### PR TITLE
[Merged by Bors] - Re-enable latest helm chart release

### DIFF
--- a/.github/workflows/publish_latest_chart.yml
+++ b/.github/workflows/publish_latest_chart.yml
@@ -1,8 +1,8 @@
 name: Publish Latest Helm Chart
 
 on:
-#  push:
-#    branches: [master]
+  push:
+    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This should close #998.

- We originally disabled helm charts due to ambiguity in versions
- Since then, we have resolved the ambiguity by no longer using build metadata
- Now we can re-enable automatic helm chart publishing