### PR TITLE
[Merged by Bors] - Add permissions.contents: read to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/composite_action.yml
+++ b/.github/workflows/composite_action.yml
@@ -1,5 +1,8 @@
 name: Composite Action Test Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -1,4 +1,7 @@
-name: Hourly tests 
+name: Hourly tests
+
+permissions:
+  contents: read
 
 on:
   #schedule:

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -1,5 +1,8 @@
 name: Publish Crates
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish_latest_chart.yml
+++ b/.github/workflows/publish_latest_chart.yml
@@ -1,5 +1,8 @@
 name: Publish Latest Helm Chart
 
+permissions:
+  contents: read
+
 on:
 #  push:
 #    branches: [master]

--- a/.github/workflows/publish_latest_docker.yml
+++ b/.github/workflows/publish_latest_docker.yml
@@ -1,6 +1,9 @@
 name: Publish Latest Development Image
 
-on: 
+permissions:
+  contents: read
+
+on:
   push:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/publish_latest_fluvio.yml
+++ b/.github/workflows/publish_latest_fluvio.yml
@@ -1,5 +1,8 @@
 name: Publish latest Fluvio
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/publish_nightly_docker.yml
+++ b/.github/workflows/publish_nightly_docker.yml
@@ -1,6 +1,9 @@
 name: Publish Nightly Development Image
 
-on: 
+permissions:
+  contents: read
+
+on:
   schedule:
     - cron: '0 5 * * *' # run at 5AM UTC
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
 #  push:
 #    # Sequence of patterns matched against refs/tags


### PR DESCRIPTION
Based on a new [blog from GitHub], it is apparent that the default setup for `GITHUB_TOKEN` should not be considered secure. It seems that the default settings have the following problems:

- When using `actions/checkout`, the `GITHUB_TOKEN` becomes implicitly available to every subsequent action used in the workflow.
- Even if not using `actions/checkout`, any third-party action can ask for the `GITHUB_TOKEN` and freely receive it, with read/write permissions to your repository
- By setting `permissions.contents: read`, the `GITHUB_TOKEN` that is provided in the workflow is restricted from full read/write access on all resources to strictly read-only on the contents of the repository.

[Blog from GitHub]: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/