### PR TITLE
[Merged by Bors] - Add check for FLUVIO_VERSION in GH release task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,14 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]
     steps:
-      - name: Set Force Release env
-        run: |
-          echo "FORCE_RELEASE=${{ github.event.inputs.force }}"
-          echo "FORCE_RELEASE=${{ github.event.inputs.force }}" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Set dynamic env
+        run: |
+          echo "FORCE_RELEASE=${{ github.event.inputs.force }}" | tee $GITHUB_ENV
+          echo "FLUVIO_VERSION=$(cat VERSION)" | tee $GITHUB_ENV
+
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
@@ -51,9 +53,9 @@ jobs:
           sudo apt-get install -y musl-tools build-essential;
 
       - name: Build and upload release to github
-        run: cargo make -l verbose --profile production github-release-upload
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_RELEASE }}
+        run: cargo make -l verbose --profile production github-release-upload
 
       # Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       - name: Set test env

--- a/makefiles/Github.toml
+++ b/makefiles/Github.toml
@@ -22,6 +22,7 @@ github-release --help 2> /dev/null || {
 description = "Upload release binaries to Github"
 category = "Publish"
 dependencies = [
+    "github-release-ensure-env",
     "release-github-env",
     "install-github-release",
     "build-prod",
@@ -35,10 +36,20 @@ else
 fi
 '''
 
+[tasks.github-release-ensure-env]
+dependencies = ["github-release-check-env"]
+condition = { env_not_set = ["FLUVIO_VERSION_EXISTS"] }
+script = "echo \"ENV variables FLUVIO_VERSION and TARGET must be defined\" 1>&2; exit 1"
+
+[tasks.github-release-check-env]
+condition = { env_set = ["FLUVIO_VERSION", "TARGET"] }
+env = { FLUVIO_VERSION_EXISTS = true }
+
 [tasks.github-release-create-pre-release]
 description = "Create Pre-release on Github"
 category = "Publish"
 dependencies = [
+    "github-release-ensure-env",
     "install-github-release",
 ]
 script = '''
@@ -52,6 +63,9 @@ env = { TARGET = "x86_64-unknown-linux-musl" }
 env = { TARGET = "x86_64-apple-darwin" }
 
 [tasks.delete-github-release]
+dependencies = [
+    "github-release-ensure-env",
+]
 command = "github-release"
 args = [
     "delete",


### PR DESCRIPTION
Currently, the task `cargo make github-release-upload` uses `FLUVIO_VERSION` and `TARGET` without first checking that they exist. This has been leading to the problem where bad releases are pushed, e.g. a tag called `v` gets pushed because the version that should follow it is missing. This PR:

- Adds a check for FLUVIO_VERSION to the `github-release-upload` task
- Defines the `FLUVIO_VERSION` variable in the release workflow