### PR TITLE
[Merged by Bors] - Use file name for the external commands (fixes #889)

### DIFF
--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -185,7 +185,15 @@ impl HelpOpt {
         // Add external command definitions to our own clap::App definition
         let mut app: App = Root::clap();
         for i in &external_commands {
-            app = app.subcommand(SubCommand::with_name(&i.meta.title).about(&*i.meta.description));
+            if let Some(file_name) = i.path.file_name() {
+                app = app.subcommand(
+                    SubCommand::with_name(&*file_name.to_string_lossy())
+                        .about(&*i.meta.description),
+                );
+            } else {
+                app = app
+                    .subcommand(SubCommand::with_name(&*i.meta.title).about(&*i.meta.description));
+            }
         }
 
         // Use clap's help printer, loaded up with external subcommands

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -185,14 +185,20 @@ impl HelpOpt {
         // Add external command definitions to our own clap::App definition
         let mut app: App = Root::clap();
         for i in &external_commands {
-            if let Some(file_name) = i.path.file_name() {
-                app = app.subcommand(
-                    SubCommand::with_name(&*file_name.to_string_lossy())
+            match i.path.file_name() {
+                Some(file_name) => {
+                    app = app.subcommand(
+                        SubCommand::with_name(
+                            file_name.to_string_lossy().strip_prefix("fluvio-").unwrap(),
+                        )
                         .about(&*i.meta.description),
-                );
-            } else {
-                app = app
-                    .subcommand(SubCommand::with_name(&*i.meta.title).about(&*i.meta.description));
+                    );
+                }
+                None => {
+                    app = app.subcommand(
+                        SubCommand::with_name(&*i.meta.title).about(&*i.meta.description),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Ran into this issue myself, I thought I'd send a patch. Here is the new output now:

```shell 
$ cargo run

Fluvio command-line interface

fluvio-cli [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
        --tls                   Enable TLS
        --enable-client-cert    TLS: use client cert
    -h, --help                  Prints help information

OPTIONS:
    -c, --cluster <host:port>          Address of cluster
        --domain <domain>              Required if client cert is used
        --ca-cert <ca-cert>
            Path to TLS ca cert, required when client cert is enabled

        --client-cert <client-cert>    Path to TLS client certificate
        --client-key <client-key>      Path to TLS client private key
    -P, --profile <profile>

SUBCOMMANDS:
    consume         Read messages from a topic/partition
    produce         Write messages to a topic/partition
    topic           Manage and view Topics
    partition       Manage and view Partitions
    profile         Manage Profiles, which describe linked clusters
    cluster         Install or uninstall Fluvio clusters
    install         Install Fluvio plugins
    update          Update the Fluvio CLI
    version         Print Fluvio version information
    fluvio-cloud    Cloud Operations
    help            Prints this message or the help of the given
                    subcommand(s)
```