### PR TITLE
[Merged by Bors] - Do GitHub prerelease at end of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Check rustfmt
         run: make check-fmt
 
-  tests:
+  build:
     name: ${{ matrix.task.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -164,19 +164,54 @@ jobs:
       - name: Stop sccache server
         run: sccache --stop-server || true
 
-      - name: Publish fluvio artifact
+      - name: Upload fluvio artifact
         if: ${{ matrix.task.publish }}
         uses: actions/upload-artifact@v2
         with:
-          name: fluvio-${{ matrix.target }}-${{ github.sha }}
+          name: fluvio-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/fluvio
 
-      - name: Publish fluvio-run artifact
+      - name: Upload fluvio-run artifact
         if: ${{ matrix.task.publish }}
         uses: actions/upload-artifact@v2
         with:
-          name: fluvio-run-${{ matrix.target }}-${{ github.sha }}
+          name: fluvio-run-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/fluvio-run
+
+  # When all required jobs pass, bump the `dev` GH prerelease to this commit
+  bump_github_release:
+    name: Bump dev tag
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    needs: [build, local_cluster_test, k8_cluster_test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump dev tag
+        run: |
+          git tag -f dev
+          git push -f origin dev
+
+  # Upload the build artifacts to the `dev` GH release, overwriting old artifacts
+  github_release:
+    name: Publish to GitHub Releases dev (${{ matrix.artifact }}-${{ matrix.target }})
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    needs: bump_github_release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        artifact: [fluvio, fluvio-run]
+        target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
+    steps:
+      - name: Login GH CLI
+        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+      - name: Download artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ matrix.artifact }}-${{ matrix.target }}
+      - name: Rename artifact
+        run: mv ${{ matrix.artifact }} ${{ matrix.artifact }}-${{ matrix.target }}
+      - name: Publish artifact
+        run: gh release upload -R infinyon/fluvio --clobber dev ./${{ matrix.artifact }}-${{ matrix.target }}
 
   local_cluster_test:
     name: Local cluster test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,36 +19,6 @@ env:
   FORCE_RELEASE: ${{ github.events.inputs.force }}
 
 jobs:
-  # Bump the `dev` tag to this commit in order to overwrite the `dev` GH prerelease
-  bump_github_release:
-    name: Bump dev tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Bump dev tag
-        run: |
-          git tag -f dev
-          git push -f origin dev
-
-  # Upload the build artifacts to the `dev` GH release, overwriting old artifacts
-  github_release:
-    name: Publish to GitHub Releases (${{ matrix.artifact }}-${{ matrix.target }})
-    needs: bump_github_release
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        artifact: [fluvio, fluvio-run]
-        target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
-    steps:
-      - name: Login GH CLI
-        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
-      - name: Download artifact
-        run: gh run download -R infinyon/fluvio -n "${{ matrix.artifact }}-${{ matrix.target }}-${{ github.sha }}"
-      - name: Rename artifact
-        run: mv ${{ matrix.artifact }} ${{ matrix.artifact }}-${{ matrix.target }}
-      - name: Publish artifact
-        run: gh release upload -R infinyon/fluvio --clobber dev ./${{ matrix.artifact }}-${{ matrix.target }}
-
   # Build a docker image using the latest `fluvio-run` build for linux-musl
   docker:
     name: Publish Docker Image
@@ -58,22 +28,21 @@ jobs:
         os: [ubuntu-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v2
       - name: Login GH CLI
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
       - name: Download artifact
-        run: gh run download -R infinyon/fluvio -n "fluvio-run-x86_64-unknown-linux-musl-${{ github.sha }}"
+        run: gh release download dev -R infinyon/fluvio -n "fluvio-run-x86_64-unknown-linux-musl"
 
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Publish latest development Fluvio Image
         run: |
-          export TAG="$(cat VERSION)-${{ github.sha }}"
+          export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
+          export TAG="${VERSION}-${{ github.sha }}"
           k8-util/docker/build.sh "${TAG}" "./fluvio-run"
           docker tag "infinyon/fluvio:${TAG}" "infinyon/fluvio:latest"
           docker push "infinyon/fluvio:${TAG}"
           docker push "infinyon/fluvio:latest"
-
 
   # Publish the latest Helm chart, tagged with the version and the git commit.
   # Example tag: 0.7.4-alpha.0-abcdef, where abcdef is the git commit.
@@ -90,13 +59,11 @@ jobs:
           HELM_VERSION: v3.3.4
           OS: ${{ matrix.os }}
       - name: Install Helm Push plugin
-        run: helm plugin install https://github.com/chartmuseum/helm-push.git
-      - name: Helm Add Repo
-        run: helm repo add chartmuseum https://gitops:${{ secrets.HELM_PASSWORD }}@charts.fluvio.io
-      - name: Push Sys Chart
-        run: helm push k8-util/helm/fluvio-sys --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
-      - name: Push App Chart
-        run: helm push k8-util/helm/fluvio-app --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push.git
+          helm repo add chartmuseum https://gitops:${{ secrets.HELM_PASSWORD }}@charts.fluvio.io
+          helm push k8-util/helm/fluvio-sys --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
+          helm push k8-util/helm/fluvio-app --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
 
   # Download the `fluvio` release artifact for each target and publish them to packages.fluvio.io
   fluvio:
@@ -106,13 +73,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
       - name: Login GH CLI
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
-      - name: Install cargo-make
-        uses: davidB/rust-cargo-make@v1
-        with:
-          version: '0.32.9'
       - name: Install fluvio-package
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
@@ -121,21 +83,22 @@ jobs:
       - name: Download fluvio x86_64-unknown-linux-musl
         run: |
           mkdir -p target/x86_64-unknown-linux-musl/release/
-          gh run download -R infinyon/fluvio \
-            -n "fluvio-x86_64-unknown-linux-musl-${{ github.sha }}" \
+          gh release download dev -R infinyon/fluvio \
+            -n "fluvio-x86_64-unknown-linux-musl" \
             -D target/x86_64-unknown-linux-musl/release/
 
       - name: Download fluvio x86_64-apple-darwin
         run: |
           mkdir -p target/x86_64-apple-darwin/release/
-          gh run download -R infinyon/fluvio \
-            -n "fluvio-x86_64-apple-darwin-${{ github.sha }}" \
+          gh release download dev -R infinyon/fluvio \
+            -n "fluvio-x86_64-apple-darwin" \
             -D target/x86_64-apple-darwin/release/
 
       - name: Publish to Fluvio Packages
         run: |
+          export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
           ${HOME}/.fluvio/bin/fluvio package publish \
-            --version="$(cat VERSION)+$(git rev-parse HEAD)" \
+            --version="${VERSION}+${{ github.sha }}" \
             target/x86_64-unknown-linux-musl/release/fluvio \
             target/x86_64-apple-darwin/release/fluvio
 
@@ -145,7 +108,7 @@ jobs:
   # If the 'latest' tag gets bumped, you can be sure the whole publish flow succeeded.
   bump_fluvio:
     name: Bump Fluvio CLI version
-    needs: [github_release, docker, helm, fluvio]
+    needs: [docker, helm, fluvio]
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,12 @@ jobs:
     needs: release_docker
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Install Helm
-        run: actions/ci-replace-helm.sh
         env:
           HELM_VERSION: v3.3.4
           OS: ubuntu-latest
+        run: actions/ci-replace-helm.sh
       - name: Publish helm charts
         run: |
           export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
@@ -56,15 +57,15 @@ jobs:
       - name: Download fluvio x86_64-unknown-linux-musl
         run: |
           mkdir -p target/x86_64-unknown-linux-musl/release/
-          gh run download -R infinyon/fluvio \
-            -n "fluvio-x86_64-unknown-linux-musl-${{ github.sha }}" \
+          gh release download dev -R infinyon/fluvio \
+            -n "fluvio-x86_64-unknown-linux-musl" \
             -D target/x86_64-unknown-linux-musl/release/
 
       - name: Download fluvio x86_64-apple-darwin
         run: |
           mkdir -p target/x86_64-apple-darwin/release/
-          gh run download -R infinyon/fluvio \
-            -n "fluvio-x86_64-apple-darwin-${{ github.sha }}" \
+          gh release download dev -R infinyon/fluvio \
+            -n "fluvio-x86_64-apple-darwin" \
             -D target/x86_64-apple-darwin/release/
 
       - name: Install fluvio-package
@@ -76,7 +77,7 @@ jobs:
         run: |
           export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
           ${HOME}/.fluvio/bin/fluvio package publish \
-            --force
+            --force \
             --version="${VERSION}" \
             target/x86_64-unknown-linux-musl/release/fluvio \
             target/x86_64-apple-darwin/release/fluvio
@@ -99,9 +100,9 @@ jobs:
           export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
           ${HOME}/.fluvio/bin/fluvio package bump dynamic "${VERSION}"
 
-      - name: Bump stable branch
-        if: false
-        run: |
-          git checkout stable
-          git rebase origin/master
-          git push origin stable
+      # Enable this when we are confident in the workflow
+#      - name: Bump stable branch
+#        run: |
+#          git checkout stable
+#          git rebase origin/master
+#          git push origin stable


### PR DESCRIPTION
This is a continuation of the overhaul of our releases workflow. I discovered that we had timing issues with using the `actions/upload-artifact` action because I was doing a hacky workaround instead of using the corresponding `actions/download-artifact` in the same workflow as is intended. This resulted in the "publish" step being unable to download the artifacts because they were unavailable via the API (using the `gh` CLI) when attempting to download those artifacts from the context of a different workflow.

To fix this, I have shuffled around a little bit of the release flow. Now, we publish to the GH `dev` prerelease at the end of the CI workflow, rather than at the beginning of the "publish" workflow. The end-to-end series of events now looks like this:

- Bors merges a PR to `upstream/staging`, kicking off the CI build
  - CI builds and tests the commit
  - As the last step in CI, we upload the release artifacts _to GitHub Releases, NOT just to github artifacts_
- When CI passes, Bors pushes the commit at staging to master
  - This kicks off the "publish" flow, which downloads the release artifacts from GH Releases (dev) and publishes them as "latest" releases to docker, helm, and packages.fluvio.io
- Then finally, we are able to run the release workflow, which will take the latest GH Releease from dev and publish them as a proper release.