### PR TITLE
[Merged by Bors] - Add fine-grained token permissions. Add Bors finalizer job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,7 @@ jobs:
       matrix:
         artifact: [fluvio, fluvio-run]
         target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
-    permissions:
-      packages: write
+    permissions: write-all
     steps:
       - name: Login GH CLI
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     needs: [build, local_cluster_test, k8_cluster_test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Bump dev tag
@@ -201,6 +203,8 @@ jobs:
       matrix:
         artifact: [fluvio, fluvio-run]
         target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
+    permissions:
+      packages: write
     steps:
       - name: Login GH CLI
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
@@ -212,6 +216,17 @@ jobs:
         run: mv ${{ matrix.artifact }} ${{ matrix.artifact }}-${{ matrix.target }}
       - name: Publish artifact
         run: gh release upload -R infinyon/fluvio --clobber dev ./${{ matrix.artifact }}-${{ matrix.target }}
+
+  # Job that follows the success of all required jobs in this workflow.
+  # Used by Bors to detect that all required jobs have completed successfully
+  done:
+    name: Done
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Done
+        run: echo "Done!"
 
   local_cluster_test:
     name: Local cluster test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,6 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ${{ matrix.artifact }}-${{ matrix.target }}
-      - name: Rename artifact
-        run: mv ${{ matrix.artifact }} ${{ matrix.artifact }}-${{ matrix.target }}
       - name: Publish artifact
         run: gh release upload -R infinyon/fluvio --clobber dev ./${{ matrix.artifact }}-${{ matrix.target }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,9 @@ jobs:
         with:
           name: ${{ matrix.artifact }}-${{ matrix.target }}
       - name: Publish artifact
-        run: gh release upload -R infinyon/fluvio --clobber dev ./${{ matrix.artifact }}-${{ matrix.target }}
+        run: |
+          ls -la "${{ matrix.artifact }}-${{ matrix.target }}"
+          gh release upload -R infinyon/fluvio --clobber dev "./${{ matrix.artifact }}-${{ matrix.target }}/${{ matrix.artifact }}"
 
   # Job that follows the success of all required jobs in this workflow.
   # Used by Bors to detect that all required jobs have completed successfully

--- a/bors.toml
+++ b/bors.toml
@@ -7,6 +7,7 @@ status = [
     "Doc tests (macos-latest)",
     "Local cluster test (infinyon-ubuntu-bionic, stable)",
     "Kubernetes cluster test (infinyon-ubuntu-bionic, stable)",
+    "Done",
 ]
 use_squash_merge = true
 delete_merged_branches = true


### PR DESCRIPTION
This adds specific permissions to certain jobs that require write access to certain parts of the repo:

- Adds `permissions.contents: write` to the `bump_github_release` job
- Adds `permissions.packages: write` to the `github_release` job

Fingers crossed that this finally fixes the end-to-end CI flow