### PR TITLE
[Merged by Bors] - Disable test that is flaky on CI

### DIFF
--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -515,7 +515,7 @@ mod test {
     use crate::services::create_public_server;
     use super::*;
 
-    #[test_async]
+    // #[test_async] Disable because flaky
     async fn test_stream_fetch() -> Result<(), ()> {
         let test_path = temp_dir().join("stream_test");
         ensure_clean_dir(&test_path);


### PR DESCRIPTION
Disables the unit test `test_stream_fetch`, since it fails on CI sporadically