### PR TITLE
[Merged by Bors] - Fix Docker image publish flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,15 @@ jobs:
         timeout-minutes: 5
         run: |
           make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
+      - name: Publish image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+        run: |
+          docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
+          eval $(minikube -p minikube docker-env)
+          export VERSION="$(cat VERSION)"
+          export TAG="${VERSION}-${{ github.sha }}"
+          docker tag "infinyon/fluvio:${{ github.sha }}" "infinyon/fluvio:${TAG}"
+          docker push "infinyon/fluvio:${TAG}"
       - name: Clean minikube
         run: |
           minikube delete

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,30 +19,19 @@ env:
   FORCE_RELEASE: ${{ github.events.inputs.force }}
 
 jobs:
-  # Build a docker image using the latest `fluvio-run` build for linux-musl
+  # Re-tag the docker image for this commit as 'latest'
   docker:
     name: Publish Docker Image
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        rust: [stable]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Login GH CLI
-        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
-      - name: Download artifact
-        run: gh release download dev -R infinyon/fluvio -p "fluvio-run-x86_64-unknown-linux-musl"
-
       - name: Login to Docker Hub
         run: docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_PASSWORD }}
       - name: Publish latest development Fluvio Image
         run: |
           export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
           export TAG="${VERSION}-${{ github.sha }}"
-          k8-util/docker/build.sh "${TAG}" "./fluvio-run-x86_64-unknown-linux-musl"
+          docker pull "infinyon/fluvio:${TAG}"
           docker tag "infinyon/fluvio:${TAG}" "infinyon/fluvio:latest"
-          docker push "infinyon/fluvio:${TAG}"
           docker push "infinyon/fluvio:latest"
 
   # Publish the latest Helm chart, tagged with the version and the git commit.

--- a/k8-util/docker/build.sh
+++ b/k8-util/docker/build.sh
@@ -24,6 +24,7 @@ main() {
   fi
 
   cp "${FLUVIO_RUN}" "${tmp_dir}/fluvio-run"
+  chmod +x "${tmp_dir}/fluvio-run"
   cp "${PROGDIR}/fluvio.Dockerfile" "${tmp_dir}/Dockerfile"
 
   pushd "${tmp_dir}"


### PR DESCRIPTION
- Upon passing k8_cluster_test in CI, publish the docker image tagged with the current commit to Docker Hub
- Upon merge to master, re-tag the image as 'latest'
- Release flow will tag with release version