### PR TITLE
Disable flaky tests

### DIFF
--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -240,7 +240,7 @@ mod replica_test {
     /// Test 2 replica
     /// Replicating new records
     ///    
-    #[test_async]
+    // #[test_async] Disable test because flaky
     async fn test_replication2_new_records() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .in_sync_replica(2 as u16)

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -515,7 +515,7 @@ mod test {
     use crate::services::create_public_server;
     use super::*;
 
-    #[test_async]
+    // #[test_async] Disable because flaky
     async fn test_stream_fetch() -> Result<(), ()> {
         let test_path = temp_dir().join("stream_test");
         ensure_clean_dir(&test_path);


### PR DESCRIPTION
Disables unit tests that are known to be flaky in CI.

- src/spu/src/replication/mod.rs:test_replication2_new_records
- src/spu/src/services/public/stream_fetch.rs:test_stream_fetch