### PR TITLE
Use nodeports for local kubernetes environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,9 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4398c021446513c306633ae67ae6dfd7166e3d733f0ff19fe20c358446e71a"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ members = [
     "tests/runner"
 ]
 
+[patch.crates-io]
+k8-types = { path = "../k8-api/src/k8-types" }
 
 # profile to make image sizer smaller
 # comment out for now

--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -22,3 +22,6 @@ spec:
   - protocol: TCP
     port: 9003
     targetPort: 9003
+    {{ if .Values.useNodePorts }}
+    nodePort: 9003
+    {{ end }}

--- a/k8-util/helm/fluvio-app/templates/sc-public.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-public.yaml
@@ -5,7 +5,11 @@ metadata:
   annotations:
     {{- toYaml .Values.loadBalancer.serviceAnnotations | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  {{ if .Values.useNodePorts }}
+  type: NodePort
+  {{ else }}
+  type: LoadBalancer
+  {{ end }}
   selector:
     app: fluvio-sc
 {{ if .Values.service.externalTrafficPolicy }}

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -38,3 +38,4 @@ serviceAccount:
   name: fluvio
 podSecurityContext: {}
 spuStorageClass: fluvio-spu
+useNodePorts: false

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -52,7 +52,7 @@ flv-util = "0.5.2"
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
 k8-metadata-client = { version = "3.0.0" }
-k8-types = { version = "0.2.0", features = ["app"]}
+k8-types = { version = "0.2.3", features = ["app"]}
 
 [dev-dependencies]
 fluvio-future = { version = "0.2.0", features = ["task"] }

--- a/src/cluster/src/check/mod.rs
+++ b/src/cluster/src/check/mod.rs
@@ -606,7 +606,7 @@ impl ClusterChecker {
             Box::new(CreateServicePermission),
             Box::new(CreateCrdPermission),
             Box::new(CreateServiceAccountPermission),
-            Box::new(LoadBalancer),
+            // Box::new(LoadBalancer),
         ];
         self.checks.extend(checks);
         self
@@ -624,7 +624,7 @@ impl ClusterChecker {
         let checks: Vec<Box<(dyn ClusterCheck)>> = vec![
             Box::new(LoadableConfig),
             Box::new(HelmVersion),
-            Box::new(LoadBalancer),
+            // Box::new(LoadBalancer),
         ];
         self.checks.extend(checks);
         self

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -37,6 +37,7 @@ pub async fn process_k8(
         .chart_values(opt.k8_config.chart_values)
         .render_checks(true)
         .upgrade(upgrade)
+        .use_cluster_ip(true)
         .with_if(skip_sys, |b| b.install_sys(false))
         .with_if(opt.skip_checks, |b| b.skip_checks(true));
 

--- a/src/sc/src/k8/controllers/spu.rs
+++ b/src/sc/src/k8/controllers/spu.rs
@@ -199,6 +199,10 @@ impl SpuController {
         // check if ingress exists
         let spu_ingress = &spu_md.spec.public_endpoint.ingress;
 
+        // If using node port
+        // {}
+
+        // If not using node port
         let svc_lb_ingresses = svc_md.status.ingress();
         let mut computed_spu_ingress: Vec<IngressAddr> =
             svc_lb_ingresses.iter().map(convert).collect();


### PR DESCRIPTION
Closes #668.

- Add `useNodePorts` configuration to Fluvio helm chart
- Discover host_ip from SC pod during installation