### PR TITLE
[Merged by Bors] - Relax platform version requirement for upgrade check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,7 @@ dependencies = [
  "prettytable-rs",
  "proc-macro2",
  "quote",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "structopt",

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -143,7 +143,8 @@ impl RootCmd {
                 profile.process(out).await?;
             }
             Self::Cluster(cluster) => {
-                cluster.process(out, &*crate::VERSION, root.target).await?;
+                let version = semver::Version::parse(&crate::VERSION).unwrap();
+                cluster.process(out, version, root.target).await?;
             }
             Self::Install(install) => {
                 install.process().await?;

--- a/src/cluster/src/cli/check.rs
+++ b/src/cluster/src/cli/check.rs
@@ -1,4 +1,5 @@
 use structopt::StructOpt;
+use semver::Version;
 
 use crate::{ClusterChecker, SysConfig, ClusterError};
 use crate::cli::ClusterCliError;
@@ -9,7 +10,7 @@ use crate::check::SysChartCheck;
 pub struct CheckOpt {}
 
 impl CheckOpt {
-    pub async fn process(self, default_chart_version: &str) -> Result<(), ClusterCliError> {
+    pub async fn process(self, default_chart_version: Version) -> Result<(), ClusterCliError> {
         use colored::*;
         println!("{}", "Running pre-startup checks...".bold());
         let sys_config: SysConfig = SysConfig::builder(default_chart_version)

--- a/src/cluster/src/cli/mod.rs
+++ b/src/cluster/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use structopt::StructOpt;
+use semver::Version;
 
 mod group;
 mod spu;
@@ -68,7 +69,7 @@ impl ClusterCmd {
     pub async fn process<O: Terminal>(
         self,
         out: Arc<O>,
-        default_chart_version: &str,
+        default_chart_version: Version,
         target: ClusterTarget,
     ) -> Result<(), ClusterCliError> {
         match self {

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use fluvio::config::TlsPolicy;
+use semver::Version;
 
 use crate::{ClusterInstaller, ClusterError, K8InstallError, StartStatus, ClusterConfig};
 use crate::cli::ClusterCliError;
@@ -10,17 +11,13 @@ use crate::check::render::{
 
 pub async fn process_k8(
     opt: StartOpt,
-    default_chart_version: &str,
+    default_chart_version: Version,
     upgrade: bool,
     skip_sys: bool,
 ) -> Result<(), ClusterCliError> {
     let (client, server): (TlsPolicy, TlsPolicy) = opt.tls.try_into()?;
 
-    let chart_version = opt
-        .k8_config
-        .chart_version
-        .as_deref()
-        .unwrap_or(default_chart_version);
+    let chart_version = opt.k8_config.chart_version.unwrap_or(default_chart_version);
 
     let mut builder = ClusterConfig::builder(chart_version);
 

--- a/src/cluster/src/cli/start/local.rs
+++ b/src/cluster/src/cli/start/local.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use semver::Version;
 
 use fluvio::config::TlsPolicy;
 
@@ -14,7 +15,7 @@ use crate::check::render::{render_statuses_next_steps, render_results_next_steps
 /// reported, or `Err(e)` if something unexpected occurred.
 pub async fn process_local(
     opt: StartOpt,
-    default_chart_version: &str,
+    default_chart_version: Version,
 ) -> Result<(), ClusterCliError> {
     let mut builder = LocalConfig::builder(default_chart_version);
     builder

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -1,7 +1,7 @@
 use std::{fmt, str::FromStr};
 use std::path::PathBuf;
-
 use structopt::StructOpt;
+use semver::Version;
 
 mod local;
 mod k8;
@@ -48,7 +48,7 @@ impl FromStr for DefaultLogDirectory {
 pub struct K8Install {
     /// k8: use specific chart version
     #[structopt(long)]
-    pub chart_version: Option<String>,
+    pub chart_version: Option<semver::Version>,
 
     /// k8: use specific image version
     #[structopt(long)]
@@ -132,7 +132,7 @@ pub struct StartOpt {
 impl StartOpt {
     pub async fn process(
         self,
-        default_chart_version: &str,
+        default_chart_version: Version,
         upgrade: bool,
         skip_sys: bool,
     ) -> Result<(), ClusterCliError> {
@@ -162,7 +162,7 @@ pub struct UpgradeOpt {
 }
 
 impl UpgradeOpt {
-    pub async fn process(self, default_chart_version: &str) -> Result<(), ClusterCliError> {
+    pub async fn process(self, default_chart_version: Version) -> Result<(), ClusterCliError> {
         self.start
             .process(default_chart_version, true, self.skip_sys)
             .await?;

--- a/src/cluster/src/cli/start/sys.rs
+++ b/src/cluster/src/cli/start/sys.rs
@@ -1,3 +1,4 @@
+use semver::Version;
 use crate::cli::start::StartOpt;
 use crate::cli::ClusterCliError;
 use crate::sys::{SysConfig, SysInstaller};
@@ -6,7 +7,7 @@ use crate::error::SysInstallError;
 
 pub fn process_sys(
     opt: StartOpt,
-    default_chart_version: &str,
+    default_chart_version: Version,
     upgrade: bool,
 ) -> Result<(), ClusterCliError> {
     install_sys_impl(opt, default_chart_version, upgrade).map_err(ClusterError::InstallSys)?;
@@ -15,13 +16,13 @@ pub fn process_sys(
 
 fn install_sys_impl(
     opt: StartOpt,
-    default_chart_version: &str,
+    default_chart_version: Version,
     upgrade: bool,
 ) -> Result<(), SysInstallError> {
     let chart_version = opt
         .k8_config
         .chart_version
-        .as_deref()
+        .clone()
         .unwrap_or(default_chart_version);
 
     let config = SysConfig::builder(chart_version)

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -10,8 +10,9 @@
 //!
 //! ```
 //! use fluvio_cluster::{ClusterInstaller, ClusterConfig, ClusterError};
+//! use semver::Version;
 //! # async fn example() -> Result<(), ClusterError> {
-//! let config = ClusterConfig::builder("0.7.0-alpha.1").build()?;
+//! let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
 //! let installer = ClusterInstaller::from_config(config)?;
 //! installer.install_fluvio().await?;
 //! # Ok(())

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -1231,9 +1231,13 @@ mod tests {
 
     #[test]
     fn test_build_config() {
-        let config: ClusterConfig = ClusterConfig::builder("0.7.0-alpha.1")
-            .build()
-            .expect("should succeed with required config options");
-        assert_eq!(config.chart_version, "0.7.0-alpha.1")
+        let config: ClusterConfig =
+            ClusterConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
+                .build()
+                .expect("should succeed with required config options");
+        assert_eq!(
+            config.chart_version,
+            semver::Version::parse("0.7.0-alpha.1").unwrap()
+        )
     }
 }

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -975,10 +975,9 @@ impl ClusterInstaller {
             };
 
             // The major.minor.patch versions should match after upgrade
-            let compatible = versions_compatible(
-                fluvio.platform_version().clone(),
-                self.config.chart_version.clone(),
-            );
+            let platform_version = fluvio.platform_version();
+            let compatible =
+                versions_compatible(platform_version.clone(), self.config.chart_version.clone());
 
             if compatible {
                 // Success

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -156,8 +156,9 @@ pub struct ClusterConfig {
     /// ```
     /// # use fluvio_cluster::{ClusterConfig, ClusterConfigBuilder, ClusterError};
     /// # fn example(builder: &mut ClusterConfigBuilder) -> Result<(), ClusterError> {
+    /// use semver::Version;
     /// let config = builder
-    ///     .chart_version("0.6.0")
+    ///     .chart_version(Version::parse("0.6.0").unwrap())
     ///     .build()?;
     /// # Ok(())
     /// # }

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 use crate::check::render::render_check_progress;
 use fluvio_command::CommandExt;
+use semver::Version;
 
 const DEFAULT_REGISTRY: &str = "infinyon";
 const DEFAULT_APP_NAME: &str = "fluvio-app";
@@ -164,7 +165,7 @@ pub struct ClusterConfig {
     ///
     /// [Semver]: https://docs.rs/semver/0.10.0/semver/
     #[builder(setter(into))]
-    chart_version: String,
+    chart_version: Version,
     /// The location to search for the Helm charts to install
     #[builder(
         private,
@@ -363,9 +364,10 @@ impl ClusterConfig {
     ///
     /// ```
     /// # use fluvio_cluster::ClusterConfig;
-    /// let builder = ClusterConfig::builder("0.7.0-alpha.1");
+    /// use semver::Version;
+    /// let builder = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap());
     /// ```
-    pub fn builder<S: Into<String>>(chart_version: S) -> ClusterConfigBuilder {
+    pub fn builder(chart_version: Version) -> ClusterConfigBuilder {
         let mut builder = ClusterConfigBuilder::default();
         builder.chart_version(chart_version);
         builder
@@ -384,7 +386,8 @@ impl ClusterConfigBuilder {
     /// ```
     /// # use fluvio_cluster::{ClusterConfig, ClusterConfigBuilder, ClusterError};
     /// # fn example(builder: &mut ClusterConfigBuilder) -> Result<(), ClusterError> {
-    /// let config = ClusterConfig::builder("0.7.0-alpha.1").build()?;
+    /// use semver::Version;
+    /// let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -487,6 +490,7 @@ impl ClusterConfigBuilder {
     /// # fn example(builder: &mut ClusterConfigBuilder) -> Result<(), ClusterError> {
     /// use std::path::PathBuf;
     /// use fluvio::config::TlsPaths;
+    /// use semver::Version;
     ///
     /// let cert_path = PathBuf::from("/tmp/certs");
     /// let client = TlsPaths {
@@ -502,7 +506,7 @@ impl ClusterConfigBuilder {
     ///     key: cert_path.join("server.key"),
     /// };
     ///
-    /// let config = ClusterConfig::builder("0.7.0-alpha.1")
+    /// let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap())
     ///     .tls(client, server)
     ///     .build()?;
     /// # Ok(())
@@ -549,8 +553,9 @@ impl ClusterConfigBuilder {
     /// ```
     /// # use fluvio_cluster::{ClusterError, ClusterConfig};
     /// # fn example() -> Result<(), ClusterError> {
+    /// use semver::Version;
     /// let custom_namespace = false;
-    /// let config = ClusterConfig::builder("0.7.0-alpha.1")
+    /// let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap())
     ///     // Custom namespace is not applied
     ///     .with_if(custom_namespace, |builder| builder.namespace("my-namespace"))
     ///     .build()?;
@@ -585,7 +590,8 @@ impl ClusterConfigBuilder {
 /// ```
 /// # use fluvio_cluster::{ClusterInstaller, ClusterConfig, ClusterError};
 /// # async fn example() -> Result<(), ClusterError> {
-/// let config = ClusterConfig::builder("0.7.0-alpha.1").build()?;
+/// use semver::Version;
+/// let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
 /// let installer = ClusterInstaller::from_config(config)?;
 /// let _status = installer.install_fluvio().await?;
 /// # Ok(())
@@ -775,9 +781,8 @@ impl ClusterInstaller {
         let fluvio_tag = self
             .config
             .image_tag
-            .as_ref()
-            .unwrap_or(&self.config.chart_version)
-            .to_owned();
+            .clone()
+            .unwrap_or(self.config.chart_version.to_string());
 
         // Specify common installation settings to pass to helm
         let mut install_settings: Vec<(_, Cow<str>)> = vec![
@@ -816,10 +821,10 @@ impl ClusterInstaller {
                 self.helm_client
                     .repo_add(DEFAULT_CHART_APP_REPO, chart_location)?;
                 self.helm_client.repo_update()?;
-                if !self
-                    .helm_client
-                    .chart_version_exists(&self.config.chart_name, &self.config.chart_version)?
-                {
+                if !self.helm_client.chart_version_exists(
+                    &self.config.chart_name,
+                    &self.config.chart_version.to_string(),
+                )? {
                     return Err(K8InstallError::HelmChartNotFound(format!(
                         "{}:{}",
                         &self.config.chart_name, &self.config.chart_version
@@ -834,7 +839,7 @@ impl ClusterInstaller {
                     .opts(install_settings)
                     .develop()
                     .values(self.config.chart_values.clone())
-                    .version(&self.config.chart_version);
+                    .version(&self.config.chart_version.to_string());
                 if self.config.upgrade {
                     self.helm_client.upgrade(&args)?;
                 } else {
@@ -854,7 +859,7 @@ impl ClusterInstaller {
                     .opts(install_settings)
                     .develop()
                     .values(self.config.chart_values.clone())
-                    .version(&self.config.chart_version);
+                    .version(&self.config.chart_version.to_string());
                 if self.config.upgrade {
                     self.helm_client.upgrade(&args)?;
                 } else {
@@ -967,13 +972,19 @@ impl ClusterInstaller {
                     continue;
                 }
             };
-            let version = fluvio.platform_version();
-            if version.to_string() == self.config.chart_version {
+            let mut platform_version = fluvio.platform_version().clone();
+            platform_version.pre.clear();
+
+            let mut chart_version = self.config.chart_version.clone();
+            chart_version.pre.clear();
+
+            // The major.minor.patch versions should match after upgrade
+            if platform_version == chart_version {
                 // Success
                 break;
             }
             debug!(
-                platform = %version,
+                platform = %platform_version,
                 chart_version = %self.config.chart_version,
                 "Existing platform version is different than chart version",
             );

--- a/src/cluster/src/start/local.rs
+++ b/src/cluster/src/start/local.rs
@@ -231,7 +231,8 @@ impl LocalConfigBuilder {
     /// ```
     /// # use fluvio_cluster::{ClusterError, LocalConfig};
     /// # fn example() -> Result<(), ClusterError> {
-    /// let config: LocalConfig = LocalConfig::builder("0.7.0-alpha.1").build()?;
+    /// use semver::Version;
+    /// let config: LocalConfig = LocalConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -255,6 +256,7 @@ impl LocalConfigBuilder {
     /// use std::path::PathBuf;
     /// use fluvio::config::TlsPaths;
     /// use fluvio_cluster::LocalInstaller;
+    /// use semver::Version;
     ///
     /// let cert_path = PathBuf::from("/tmp/certs");
     /// let client = TlsPaths {
@@ -270,7 +272,7 @@ impl LocalConfigBuilder {
     ///     key: cert_path.join("server.key"),
     /// };
     ///
-    /// let config = LocalConfig::builder("0.7.0-alpha.1")
+    /// let config = LocalConfig::builder(Version::parse("0.7.0-alpha.1").unwrap())
     ///     .tls(client, server)
     ///     .build()?;
     /// # Ok(())
@@ -351,7 +353,8 @@ impl LocalInstaller {
     /// ```
     /// # use fluvio_cluster::{ClusterError, LocalInstaller, LocalConfig};
     /// # fn example() -> Result<(), ClusterError> {
-    /// let config = LocalConfig::builder("0.7.0-alpha.1").build()?;
+    /// use semver::Version;
+    /// let config = LocalConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
     /// let installer = LocalInstaller::from_config(config);
     /// # Ok(())
     /// # }

--- a/src/cluster/src/start/local.rs
+++ b/src/cluster/src/start/local.rs
@@ -689,9 +689,13 @@ mod tests {
 
     #[test]
     fn test_build_config() {
-        let config: LocalConfig = LocalConfig::builder("0.7.0-alpha.1")
-            .build()
-            .expect("should succeed with required config options");
-        assert_eq!(config.chart_version, "0.7.0-alpha.1")
+        let config: LocalConfig =
+            LocalConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
+                .build()
+                .expect("should succeed with required config options");
+        assert_eq!(
+            config.chart_version,
+            semver::Version::parse("0.7.0-alpha.1").unwrap()
+        )
     }
 }

--- a/src/cluster/src/sys.rs
+++ b/src/cluster/src/sys.rs
@@ -193,7 +193,6 @@ impl SysConfigBuilder {
 /// use semver::Version;
 /// let config = SysConfig::builder(Version::parse("0.7.0-alpha.1").unwrap())
 ///     .namespace("fluvio")
-///     .chart_version("0.7.0-alpha.1")
 ///     .build()?;
 /// let installer = SysInstaller::from_config(config)?;
 /// installer.install()?;

--- a/src/cluster/src/sys.rs
+++ b/src/cluster/src/sys.rs
@@ -308,6 +308,9 @@ mod tests {
             SysConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
                 .build()
                 .expect("should build config with required options");
-        assert_eq!(config.chart_version, "0.7.0-alpha.1");
+        assert_eq!(
+            config.chart_version,
+            semver::Version::parse("0.7.0-alpha.1").unwrap()
+        );
     }
 }

--- a/tests/runner/src/utils/Cargo.toml
+++ b/tests/runner/src/utils/Cargo.toml
@@ -20,6 +20,7 @@ inventory = "0.1"
 prettytable-rs = "0.8"
 once_cell = "1.7.2"
 dyn-clone = "1.0"
+semver = "0.11.0"
 
 fluvio = { path = "../../../../src/client" }
 fluvio-future = { version = "0.3.0", features = ["task", "timer", "subscriber", "fixture"] }

--- a/tests/runner/src/utils/setup/environment/k8.rs
+++ b/tests/runner/src/utils/setup/environment/k8.rs
@@ -24,7 +24,8 @@ impl TestEnvironmentDriver for K8EnvironmentDriver {
     }
 
     async fn start_cluster(&self) -> StartStatus {
-        let mut builder = ClusterConfig::builder(&*crate::VERSION);
+        let version = semver::Version::parse(&*crate::VERSION).unwrap();
+        let mut builder = ClusterConfig::builder(version);
         if self.option.develop_mode() {
             builder.development().expect("should test in develop mode");
         }

--- a/tests/runner/src/utils/setup/environment/local.rs
+++ b/tests/runner/src/utils/setup/environment/local.rs
@@ -26,7 +26,8 @@ impl TestEnvironmentDriver for LocalEnvDriver {
     }
 
     async fn start_cluster(&self) -> StartStatus {
-        let mut builder = LocalConfig::builder(&*crate::VERSION);
+        let version = semver::Version::parse(&*crate::VERSION).unwrap();
+        let mut builder = LocalConfig::builder(version);
         builder.spu_replicas(self.option.spu()).render_checks(true);
 
         // Make sure to use the test build of 'fluvio' for cluster components


### PR DESCRIPTION
Closes #1054.

- Now compares expected platform version to actual platform version using just `major.minor.patch` version components
- Should prevent upgrade error when using a "latest" platform version including a commit hash