### PR TITLE
[Merged by Bors] - Separate out unstable integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,32 @@ jobs:
           name: fluvio-run-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/fluvio-run
 
+
+  unstable_test:
+    name: Unstable Integration test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [infinyon-ubuntu-bionic]
+        rust: [stable]
+        task:
+          - name: Unstable Test
+            run: make run-unstable-test
+            publish: true
+        include:
+          - os: ubuntu-latest
+            sccache-path: /home/runner/.cache/sccache
+            target: x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
   # When all required jobs pass, bump the `dev` GH prerelease to this commit
   bump_github_release:
     name: Bump dev tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,19 +178,17 @@ jobs:
           name: fluvio-run-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/fluvio-run
 
-
-  unstable_test:
-    name: Unstable Integration test
+  # Since this runs on custom runner, no need to control sc-cache
+  unstable_test_linux:
+    name: Unstable Integration test Linux
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [infinyon-ubuntu-bionic]
         rust: [stable]
-        task:
-          - name: Unstable Test
-            run: make run-unstable-test
-            publish: true
+    env:
+      FLV_SOCKET_WAIT: 600
     steps:
       - uses: actions/checkout@v2
       - name: Install ${{ matrix.rust }}
@@ -199,6 +197,72 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
+      - name: Run integration tests
+        run:  make run-unstable-test
+        timeout-minutes: 10
+
+
+  unstable_test_mac:
+      name: Unstable Integration test Mac
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [macos-latest]
+          rust: [stable]
+          include:
+            - os: macos-latest
+              sccache-path: /Users/runner/Library/Caches/Mozilla.sccache
+              target: x86_64-apple-darwin
+          task:
+            - name: Run integration tests
+              run: make run-unstable-test
+              timeout-minutes: 20
+      env:
+        RUST_BACKTRACE: full
+        RUSTC_WRAPPER: sccache
+        RUSTV: ${{ matrix.rust }}
+        SCCACHE_CACHE_SIZE: 2G
+        SCCACHE_DIR: ${{ matrix.sccache-path }}
+        # SCCACHE_RECACHE: 1 # Uncomment this to clear cache, then comment it back out
+      steps:
+        - uses: actions/checkout@v2
+        - name: Install sccache (macos-latest)
+          run: |
+            brew update
+            brew install sccache
+        - name: Install Rust ${{ matrix.rust }}
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: ${{ matrix.rust }}
+            profile: minimal
+            override: true
+        - name: Cache cargo registry
+          uses: actions/cache@v2
+          continue-on-error: false
+          with:
+            path: |
+              ~/.cargo/registry
+              ~/.cargo/git
+            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-cargo-
+        - name: Save sccache
+          uses: actions/cache@v2
+          continue-on-error: false
+          with:
+            path: ${{ matrix.sccache-path }}
+            key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-sccache-
+        - name: Start sccache server
+          run: sccache --start-server
+        - name: ${{ matrix.task.name }}
+          run: ${{ matrix.task.run }}
+        - name: Stop sccache server
+          run: sccache --stop-server || true
+      
+
 
   # When all required jobs pass, bump the `dev` GH prerelease to this commit
   bump_github_release:
@@ -263,7 +327,6 @@ jobs:
         os: [infinyon-ubuntu-bionic]
         rust: [stable]
     env:
-      FLUVIO_CMD: true
       FLV_SOCKET_WAIT: 600
     steps:
       - uses: actions/checkout@v2
@@ -318,7 +381,6 @@ jobs:
         os: [infinyon-ubuntu-bionic]
         rust: [stable]
     env:
-      FLUVIO_CMD: true
       FLV_SOCKET_WAIT: 600
       FLV_CLUSTER_MAX_SC_VERSION_LOOP: 120
       FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 60
@@ -404,7 +466,6 @@ jobs:
         os: [infinyon-ubuntu-bionic]
         rust: [stable]
     env:
-      FLUVIO_CMD: true
       FLV_SOCKET_WAIT: 600
       FLV_CLUSTER_MAX_SC_VERSION_LOOP: 120
       FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,13 +191,9 @@ jobs:
           - name: Unstable Test
             run: make run-unstable-test
             publish: true
-        include:
-          - os: ubuntu-latest
-            sccache-path: /home/runner/.cache/sccache
-            target: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust ${{ matrix.rust }}
+      - name: Install ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
  "dirs 1.0.5",
  "event-listener",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-sc-schema",
  "fluvio-socket",
@@ -1281,7 +1281,7 @@ dependencies = [
  "async-trait",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-socket",
  "fluvio-types",
@@ -1312,7 +1312,7 @@ dependencies = [
  "fluvio-command 0.2.0",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-package-index",
  "fluvio-sc-schema",
  "fluvio-types",
@@ -1353,7 +1353,7 @@ dependencies = [
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-helm",
  "flv-util",
  "futures-lite",
@@ -1414,7 +1414,7 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-stream-model",
  "fluvio-types",
@@ -1433,7 +1433,7 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "derive_builder",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-socket",
  "flv-util",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd29a0773ef0ab97eb91e621093b4b64218456941e33fd63d9647fbe57a439cf"
+checksum = "61587e440c936984e7dab40903de1c9adc39ab13e8446b52c50852da5cd6fbcb"
 dependencies = [
  "async-fs",
  "async-io",
@@ -1530,7 +1530,7 @@ name = "fluvio-integration-derive"
 version = "0.1.0"
 dependencies = [
  "fluvio",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-test-util",
  "inflections",
  "proc-macro2",
@@ -1560,7 +1560,7 @@ name = "fluvio-protocol"
 version = "0.5.0"
 dependencies = [
  "bytes",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol-api 0.3.0",
  "fluvio-protocol-codec",
  "fluvio-protocol-core 0.3.0",
@@ -1607,7 +1607,7 @@ name = "fluvio-protocol-codec"
 version = "0.3.0"
 dependencies = [
  "bytes",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol-core 0.3.0",
  "flv-util",
  "futures",
@@ -1661,7 +1661,7 @@ name = "fluvio-run"
 version = "0.2.0"
 dependencies = [
  "fluvio-extension-common",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-sc",
  "fluvio-spu",
  "semver 0.11.0",
@@ -1685,7 +1685,7 @@ dependencies = [
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-sc-schema",
  "fluvio-service",
@@ -1732,7 +1732,7 @@ name = "fluvio-service"
 version = "0.6.0"
 dependencies = [
  "async-trait",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-socket",
  "fluvio-types",
@@ -1762,7 +1762,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "event-listener",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "flv-util",
  "futures-util",
@@ -1793,7 +1793,7 @@ dependencies = [
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-service",
  "fluvio-socket",
@@ -1840,7 +1840,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-protocol 0.5.0",
  "fluvio-socket",
  "fluvio-storage",
@@ -1862,7 +1862,7 @@ dependencies = [
  "async-rwlock",
  "async-trait",
  "event-listener",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1883,7 +1883,7 @@ version = "0.5.1"
 dependencies = [
  "async-rwlock",
  "event-listener",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "k8-types",
  "once_cell",
  "serde",
@@ -1902,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-test-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9e4cb09caa5ff039928399ef5aa99206fd1b9a59df208cf6d94e2764fe5ce0"
+checksum = "c18fef80a26d3533f4fcbc95ff51cfd161f975f544b48e423368fa69aadc478e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1922,7 +1922,7 @@ dependencies = [
  "fluvio-cluster",
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "futures-lite",
  "inventory",
  "log",
@@ -1943,7 +1943,7 @@ name = "fluvio-types"
 version = "0.2.4"
 dependencies = [
  "event-listener",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "tokio",
  "tracing",
 ]
@@ -1960,7 +1960,7 @@ dependencies = [
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "fluvio-integration-derive",
  "fluvio-system-util",
  "fluvio-test-util",
@@ -1987,7 +1987,7 @@ dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
  "event-listener",
- "fluvio-future 0.3.0",
+ "fluvio-future 0.3.1",
  "futures-lite",
  "futures-util",
  "log",

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ run-all-unit-test: test_tls_multiplex build_filter_wasm
 	cargo test -p fluvio-storage $(RELEASE_FLAG) $(TARGET_FLAG)
 	make test-all -C src/protocol	
 
-
+run-unstable-test:
+	cargo test --lib --all-features $(RELEASE_FLAG) $(TARGET_FLAG) -- --ignored
 
 run-all-doc-test:
 	cargo test --all-features --doc $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ run-all-unit-test: test_tls_multiplex build_filter_wasm
 	cargo test -p fluvio-storage $(RELEASE_FLAG) $(TARGET_FLAG)
 	make test-all -C src/protocol	
 
+
+
 run-all-doc-test:
 	cargo test --all-features --doc $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -37,5 +37,5 @@ fluvio-protocol = { path = "../protocol", version = "0.5.0", features = ["derive
 
 
 [dev-dependencies]
-fluvio-future = { version = "0.3.0", features = ["fixture", "fs", "native2_tls"] }
+fluvio-future = { version = "0.3.1", features = ["fixture", "fs", "native2_tls"] }
 flv-util = { version = "0.5.0", features = ["fixture"] }

--- a/src/socket/src/multiplexing.rs
+++ b/src/socket/src/multiplexing.rs
@@ -433,13 +433,11 @@ mod tests {
     use fluvio_future::net::TcpListener;
     use fluvio_future::net::TcpStream;
     use fluvio_future::task::spawn;
-    use fluvio_future::test_async;
     use fluvio_future::timer::sleep;
     use fluvio_protocol::api::RequestMessage;
 
     use super::MultiplexerSocket;
     use crate::test_request::*;
-    use crate::FlvSocketError;
     use crate::ExclusiveFlvSink;
     use crate::FluvioSocket;
 
@@ -637,8 +635,8 @@ mod tests {
         assert!(slow > fast);
     }
 
-    #[test_async]
-    async fn test_multiplexing() -> Result<(), FlvSocketError> {
+    #[fluvio_future::test(ignore)]
+    async fn test_multiplexing() {
         debug!("start testing");
         let addr = "127.0.0.1:6000";
 
@@ -647,7 +645,6 @@ mod tests {
             test_server(addr, TcpStreamHandler {}),
         )
         .await;
-        Ok(())
     }
 
     #[cfg(unix)]
@@ -732,8 +729,8 @@ mod tests {
             }
         }
 
-        #[test_async]
-        async fn test_multiplexing_native_tls() -> Result<(), FlvSocketError> {
+        #[fluvio_future::test(ignore)]
+        async fn test_multiplexing_native_tls() {
             debug!("start testing");
             let addr = "127.0.0.1:6001";
 
@@ -742,7 +739,6 @@ mod tests {
                 test_server(addr, TlsAcceptorHandler::new()),
             )
             .await;
-            Ok(())
         }
     }
 }

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -14,7 +14,6 @@ mod replica_test {
     use derive_builder::Builder;
     use once_cell::sync::Lazy;
 
-    use fluvio_future::{test_async};
     use fluvio_future::timer::sleep;
     use flv_util::fixture::ensure_clean_dir;
     use fluvio_types::SpuId;
@@ -194,10 +193,10 @@ mod replica_test {
     /// Test 2 replica
     /// Replicating with existing records
     ///    
-    #[test_async]
-    async fn test_just_leader() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_just_leader() {
         let builder = TestConfig::builder()
-            .base_port(13000 as u16)
+            .base_port(13000_u16)
             .generate("just_leader");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -229,25 +228,15 @@ mod replica_test {
         assert_eq!(lrs.leader.spu, LEADER);
         assert_eq!(lrs.leader.hw, 2);
         assert_eq!(lrs.leader.leo, 2);
-
-        Ok(())
     }
-
-    #[test]
-#[ignore]
-fn expensive_test() {
-    // code that takes an hour to run
-}
 
     /// Test 2 replica
     /// Replicating with existing records
-    ///    
-    #[test_async]
-    #[ignore]
-    async fn test_replication2_existing() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_replication2_existing() {
         let builder = TestConfig::builder()
-            .followers(1 as u16)
-            .base_port(13010 as u16)
+            .followers(1_u16)
+            .base_port(13010_u16)
             .generate("replication2_existing");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -302,19 +291,16 @@ fn expensive_test() {
         sleep(Duration::from_millis(WAIT_TERMINATE)).await;
 
         spu_server.notify();
-
-        Ok(())
     }
 
     /// Test 2 replica
     /// Replicating new records
     ///    
-    #[test_async]
-    #[ignore]
-    async fn test_replication2_new_records() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_replication2_new_records() {
         let builder = TestConfig::builder()
-            .followers(1 as u16)
-            .base_port(13020 as u16)
+            .followers(1_u16)
+            .base_port(13020_u16)
             .generate("replication2_new");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -377,17 +363,14 @@ fn expensive_test() {
         sleep(Duration::from_millis(WAIT_TERMINATE)).await;
 
         spu_server.notify();
-
-        Ok(())
     }
 
     /// test with 3 SPU
-    #[test_async]
-    #[ignore]
-    async fn test_replication3_existing() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_replication3_existing() {
         let builder = TestConfig::builder()
-            .followers(2 as u16)
-            .base_port(13030 as u16)
+            .followers(2_u16)
+            .base_port(13030_u16)
             .generate("replication3_existing");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -436,19 +419,16 @@ fn expensive_test() {
         sleep(Duration::from_millis(WAIT_TERMINATE)).await;
 
         spu_server.notify();
-
-        Ok(())
     }
 
     /// Test 2 replica
     /// Replicating new records
     ///    
-    #[test_async]
-    #[ignore]
-    async fn test_replication3_new_records() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_replication3_new_records() {
         let builder = TestConfig::builder()
-            .followers(2 as u16)
-            .base_port(13040 as u16)
+            .followers(2_u16)
+            .base_port(13040_u16)
             .generate("replication3_new");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -509,19 +489,16 @@ fn expensive_test() {
         sleep(Duration::from_millis(WAIT_TERMINATE)).await;
 
         spu_server.notify();
-
-        Ok(())
     }
 
     /// Test 2 replica
     /// Replicating new records
     ///    
-    #[test_async]
-    #[ignore]
-    async fn test_replication2_promote() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_replication2_promote() {
         let builder = TestConfig::builder()
-            .followers(1 as u16)
-            .base_port(13050 as u16)
+            .followers(1_u16)
+            .base_port(13050_u16)
             .generate("replication2_new");
 
         let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -569,7 +546,5 @@ fn expensive_test() {
         sleep(Duration::from_millis(WAIT_TERMINATE)).await;
 
         spu_server.notify();
-
-        Ok(())
     }
 }

--- a/src/spu/src/replication/mod.rs
+++ b/src/spu/src/replication/mod.rs
@@ -233,10 +233,17 @@ mod replica_test {
         Ok(())
     }
 
+    #[test]
+#[ignore]
+fn expensive_test() {
+    // code that takes an hour to run
+}
+
     /// Test 2 replica
     /// Replicating with existing records
     ///    
     #[test_async]
+    #[ignore]
     async fn test_replication2_existing() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .followers(1 as u16)
@@ -302,8 +309,8 @@ mod replica_test {
     /// Test 2 replica
     /// Replicating new records
     ///    
-    //#[test_async]
-    #[allow(unused)]
+    #[test_async]
+    #[ignore]
     async fn test_replication2_new_records() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .followers(1 as u16)
@@ -322,7 +329,7 @@ mod replica_test {
         // give leader controller time to startup
         sleep(Duration::from_millis(MAX_WAIT_LEADER)).await;
 
-        let (follower_ctx, follower_replica) = builder.follower_replica(0).await;
+        let (_, follower_replica) = builder.follower_replica(0).await;
 
         // at this point, follower replica should be empty since we didn't have time to sync up with leader
         assert_eq!(follower_replica.leo(), 0);
@@ -375,8 +382,8 @@ mod replica_test {
     }
 
     /// test with 3 SPU
-    //#[test_async]
-    #[allow(unused)]
+    #[test_async]
+    #[ignore]
     async fn test_replication3_existing() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .followers(2 as u16)
@@ -436,8 +443,8 @@ mod replica_test {
     /// Test 2 replica
     /// Replicating new records
     ///    
-    //#[test_async]
-    #[allow(unused)]
+    #[test_async]
+    #[ignore]
     async fn test_replication3_new_records() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .followers(2 as u16)
@@ -509,8 +516,8 @@ mod replica_test {
     /// Test 2 replica
     /// Replicating new records
     ///    
-    //#[test_async]
-    #[allow(unused)]
+    #[test_async]
+    #[ignore]
     async fn test_replication2_promote() -> Result<(), ()> {
         let builder = TestConfig::builder()
             .followers(1 as u16)


### PR DESCRIPTION
This PR separate out time dependent integration tests (that uses multiple async tasks) into separate job.  They are marked as `ignore` which will not be run in unit-test job.  They will not be required in `bors` for now. 

Some of the tests may be only run in Linux since Mac is not `tier1`.  