### PR TITLE
[Merged by Bors] - restore integration tests using ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,19 +163,17 @@ build-all-test:
 check-all-test:
 	cargo check --lib --tests --all-features $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-test_tls_multiplex:
-	cd src/socket; cargo test test_multiplexing_native_tls
 
 build_filter_wasm:
 	rustup target add wasm32-unknown-unknown 
 	make -C smart_filter build_test
 
-run-all-unit-test: test_tls_multiplex build_filter_wasm
+run-all-unit-test:
 	cargo test --lib --all-features $(RELEASE_FLAG) $(TARGET_FLAG)
 	cargo test -p fluvio-storage $(RELEASE_FLAG) $(TARGET_FLAG)
 	make test-all -C src/protocol	
 
-run-unstable-test:
+run-unstable-test:	build_filter_wasm
 	cargo test --lib --all-features $(RELEASE_FLAG) $(TARGET_FLAG) -- --ignored
 
 run-all-doc-test:

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -60,6 +60,6 @@ fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "z
 [dev-dependencies]
 once_cell = "1.5.2"
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-future = { version = "0.3.0", features = ["fixture", "subscriber"] }
+fluvio-future = { version = "0.3.1", features = ["fixture", "subscriber"] }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
 derive_builder = { version = "0.9.0" }

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -492,7 +492,6 @@ mod test {
     use flv_util::fixture::ensure_clean_dir;
     use futures_util::StreamExt;
 
-    use fluvio_future::{test_async};
     use fluvio_future::timer::sleep;
     use fluvio_socket::{FluvioSocket, MultiplexerSocket};
     use dataplane::{
@@ -509,9 +508,8 @@ mod test {
     use crate::services::create_public_server;
     use super::*;
 
-    // #[test_async] Disable because flaky
-    #[allow(unused)]
-    async fn test_stream_fetch() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_stream_fetch() {
         let test_path = temp_dir().join("stream_test");
         ensure_clean_dir(&test_path);
 
@@ -658,8 +656,6 @@ mod test {
 
         server_end_event.notify();
         debug!("terminated controller");
-
-        Ok(())
     }
 
     fn read_filter_from_path(filter_path: impl AsRef<Path>) -> Vec<u8> {
@@ -683,8 +679,8 @@ mod test {
         read_filter_from_path(wasm_path)
     }
 
-    #[test_async]
-    async fn test_stream_filter_fetch() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_stream_filter_fetch() {
         let test_path = temp_dir().join("filter_stream_fetch");
         ensure_clean_dir(&test_path);
 
@@ -822,8 +818,6 @@ mod test {
 
         server_end_event.notify();
         debug!("terminated controller");
-
-        Ok(())
     }
 
     fn generate_record(record_index: usize, _producer: &BatchProducer) -> DefaultRecord {
@@ -850,8 +844,8 @@ mod test {
     }
 
     /// test filter with max bytes
-    #[test_async]
-    async fn test_stream_filter_max() -> Result<(), ()> {
+    #[fluvio_future::test(ignore)]
+    async fn test_stream_filter_max() {
         let test_path = temp_dir().join("filter_stream_max");
         ensure_clean_dir(&test_path);
 
@@ -973,8 +967,5 @@ mod test {
         drop(response);
 
         server_end_event.notify();
-        debug!("terminated controller");
-
-        Ok(())
     }
 }


### PR DESCRIPTION
restore running WASM and stream fetch tests as unstable integration tests