### PR TITLE
[Merged by Bors] - Stabilize upgrade testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,15 +463,39 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [infinyon-ubuntu-bionic]
+        os: [ubuntu-latest]
         rust: [stable]
+        include:
+          - os: ubuntu-latest
+            sccache-path: /home/runner/.cache/sccache
+            target: x86_64-unknown-linux-musl
     env:
       FLV_SOCKET_WAIT: 600
       FLV_CLUSTER_MAX_SC_VERSION_LOOP: 120
       FLV_CLUSTER_MAX_SC_NETWORK_LOOP: 60
       FLV_TEST_CONSUMER_WAIT: 300000
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: sccache
+      RUSTV: ${{ matrix.rust }}
+      TARGET: ${{ matrix.target }}
+      SCCACHE_CACHE_SIZE: 2G
+      SCCACHE_DIR: ${{ matrix.sccache-path }}
+      # SCCACHE_RECACHE: 1 # Uncomment this to clear cache, then comment it back out
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install sccache (ubuntu-latest)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: 0.2.13
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" | tee -a $GITHUB_PATH
+
       - run: helm version
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
@@ -479,6 +503,45 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
+
+      - name: Install Musl Tools
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        run: |
+          sudo apt install -y musl-tools
+          sudo ln -s /usr/bin/musl-gcc /usr/local/bin/x86_64-linux-musl-gcc
+          echo "TARGET_CC=musl-gcc" | tee -a $GITHUB_ENV
+          rustup target add x86_64-unknown-linux-musl
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Save sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: ${{ matrix.sccache-path }}
+          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-
+
+      - name: Install Minikube for Github runner 
+        if: matrix.os == 'ubuntu-latest' 
+        uses: manusa/actions-setup-minikube@v2.3.1
+        with:
+          minikube version: 'v1.16.0'
+          kubernetes version: 'v1.19.2'
+
+      - name: Open tunnel for Github runner
+        if: matrix.os != 'infinyon-ubuntu-bionic'
+        run: |
+          nohup  minikube tunnel --alsologtostderr > /tmp/tunnel.out 2> /tmp/tunnel.out &
+
       - name: Setup Minikube for Linux
         if: startsWith(matrix.os, 'infinyon-ubuntu')
         run: |
@@ -490,57 +553,31 @@ jobs:
         run: |
           minikube profile list
           minikube status
-      - name: Install stable Fluvio CLI and start cluster
+
+      - name: Setup for upgrade test
         run: |
+          gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
-          ~/.fluvio/bin/fluvio cluster start
-          ~/.fluvio/bin/fluvio version
-      # Build, upgrade and test current version
-      - name: Build
-        run: |
-          make RELEASE=release TARGET=x86_64-unknown-linux-musl build_test
-      - name: Setup installation pre-requisites
-        run: |
-          make RELEASE=true TARGET=x86_64-unknown-linux-musl  k8-setup
-      - name: Make image
-        run: make RELEASE=true minikube_image
-      - name: Upgrade cluster
-        run: |
-          cargo run --release --bin fluvio -- cluster upgrade --chart-version=$(cat VERSION) --develop 
-          cargo run --release --bin fluvio -- version 
-      - name: Run smoke-test-k8-tls-root
-        timeout-minutes: 5
-        run: |
-          make RELEASE=true TARGET=x86_64-unknown-linux-musl UNINSTALL=noclean smoke-test-k8-tls-root
-          cargo run --release --bin flv-test --	smoke --develop --disable-install -- --producer-iteration=1000
+
+      - name: Start sccache server
+        run: sccache --start-server
+
+      - name: Run upgrade test
+        env:
+          TEST_DATA_BYTES: 10000
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          command: |
+            export PATH=~/.fluvio/bin:$PATH
+            cd tests
+            ./upgrade-test.sh `gh release -R infinyon/fluvio list | head -3 | tail -2 | awk '{print $1}' | sed 's/v//' | tac | xargs`
+
+      - name: Stop sccache server
+        run: sccache --stop-server || true
+
       - name: Clean minikube
         run: |
           minikube delete
           pkill -f "minikube tunnel" || true
-      - name: Save logs
-        if: failure()
-        run: |
-          echo "minikube profile list"
-          minikube profile list
-          echo "helm list"
-          helm list
-          echo "get statefulset"
-          kubectl get statefulset
-          echo "kubectl get pvc"
-          kubectl get pvc
-          echo "kubectl get pods"
-          kubectl get pods
-          echo "kubectl get svc"
-          kubectl get svc
-          echo "kubectl get spu"
-          kubectl get spu
-          echo "kubectl get spg"
-          kubectl get spg
-          kubectl logs -l app=fluvio-sc > /tmp/flv_sc.log
-      - name: Upload logs
-        timeout-minutes: 5
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: fluvio-k8-logs
-          path: /tmp/flv_sc.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,8 +534,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest' 
         uses: manusa/actions-setup-minikube@v2.3.1
         with:
-          minikube version: 'v1.16.0'
-          kubernetes version: 'v1.19.2'
+          minikube version: 'v1.18.1'
+          kubernetes version: 'v1.19.6'
 
       - name: Open tunnel for Github runner
         if: matrix.os != 'infinyon-ubuntu-bionic'
@@ -572,7 +572,8 @@ jobs:
           command: |
             export PATH=~/.fluvio/bin:$PATH
             cd tests
-            ./upgrade-test.sh `gh release -R infinyon/fluvio list | head -3 | tail -2 | awk '{print $1}' | sed 's/v//' | tac | xargs`
+            # Use gh cli to collect the last and current release version numbers
+            ./upgrade-test.sh `gh api repos/infinyon/fluvio/releases -q '.[2,1].tag_name' | sed 's/v//'`
 
       - name: Stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,7 +573,7 @@ jobs:
             export PATH=~/.fluvio/bin:$PATH
             cd tests
             # Use gh cli to collect the last and current release version numbers
-            ./upgrade-test.sh `gh api repos/infinyon/fluvio/releases -q '.[2,1].tag_name' | sed 's/v//'`
+            ./upgrade-test.sh $(gh api repos/infinyon/fluvio/releases -q '.[2,1].tag_name' | sed 's/v//')
 
       - name: Stop sccache server
         run: sccache --stop-server || true

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+# The strategy for this test is to write to the cluster and roll forward
+# with release upgrades
+# We track the previous release, current release and the prerelease
+#
+# We create new topic per round.
+# We'll produce and consume from all test topics per round.
+# Content is verified via checksum
+
+set -exu
+#set -e
+
+echo command: $0 $*
+
+STABLE_MINUS_ONE=${1:?Starting cluster version [pos 1]}
+STABLE=${2:?Second cluster version [pos 2]}
+PRERELEASE=${3:-$(cat ../VERSION)-$(git rev-parse HEAD)}
+
+CI_SLEEP=${CI_SLEEP:-10}
+CI=${CI:-}
+
+# Change to this script's directory 
+pushd "$(dirname "$(readlink -f "$0")")" > /dev/null
+
+function cleanup() {
+    echo Clean up test data
+    rm -f --verbose ./*.txt.tmp;
+    rm -f --verbose ./*.checksum;
+    echo Delete cluster if possible
+    fluvio cluster delete || true
+}
+
+function ci_check() {
+    if [[ ! -z "$CI" ]];
+    then
+        echo "CI, pausing for ${CI_SLEEP} second";
+        w | head -1
+        sleep ${CI_SLEEP};
+    fi
+}
+
+function round1() {
+
+    create_test_data;
+
+    echo Install ${STABLE_MINUS_ONE} CLI 
+    curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${STABLE_MINUS_ONE} bash
+
+    echo Start ${STABLE_MINUS_ONE} cluster
+    fluvio cluster start
+    ci_check;
+
+    fluvio version
+    ci_check;
+
+    echo Create round 1 topic
+    fluvio topic create round1-topic 
+    ci_check;
+
+    cat data1.txt.tmp | fluvio produce round1-topic
+    ci_check;
+
+    echo Validate test data matches expected data before upgrade
+    fluvio consume -B -d round1-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round1-topic1.checksum; then
+        echo Round 1 topic 1 validated
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round1-topic1.checksum | awk '{print $1}')"
+        exit 1
+    fi
+}
+
+function round2() {
+
+    echo "Install ${STABLE} CLI"
+    curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${STABLE} bash
+
+    fluvio cluster upgrade
+    ci_check;
+
+    fluvio version
+    ci_check;
+
+    echo Create round 2 topic
+    fluvio topic create round2-topic 
+    ci_check;
+
+    cat data2.txt.tmp | fluvio produce round2-topic
+    ci_check;
+
+    echo Validate test data matches expected data before upgrade
+    fluvio consume -B -d round2-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round2-topic2.checksum; then
+        echo Round 2 topic 2 validated
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round2-topic2.checksum | awk '{print $1}')"
+        exit 1
+    fi
+
+    # Exercise older topics
+    cat data2.txt.tmp | fluvio produce round1-topic
+    ci_check;
+
+    echo "Validate test data matches expected data before upgrade"
+    fluvio consume -B -d round1-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round2-topic1.checksum; then
+        echo "Round 2 topic 1 validated"
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round2-topic2.checksum | awk '{print $1}')"
+        exit 1
+    fi
+
+}
+
+function round3() {
+
+    if [[ ! -z "$CI" ]];
+    then
+        echo "We're in CI. Build and test the dev image"
+        pushd ..
+        make RELEASE=release TARGET=x86_64-unknown-linux-musl build_test
+        make RELEASE=release minikube_image
+        
+        FLUVIO_BIN="$(pwd)/target/x86_64-unknown-linux-musl/release/fluvio"
+        $FLUVIO_BIN cluster upgrade --chart-version=${PRERELEASE} --develop
+        popd
+    else 
+        echo "Build and test the latest published dev image"
+        echo "Install prerelease CLI"
+        curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash
+        FLUVIO_BIN=`which fluvio`
+        $FLUVIO_BIN cluster upgrade --chart-version=${PRERELEASE}
+    fi
+
+    ci_check;
+
+    $FLUVIO_BIN version
+    ci_check;
+
+    echo "Create round 3 topic"
+    $FLUVIO_BIN topic create round3-topic
+    ci_check;
+
+    cat data3.txt.tmp | fluvio produce round3-topic
+    ci_check;
+
+    echo "Validate test data matches expected data before upgrade"
+    $FLUVIO_BIN consume -B -d round3-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round3-topic3.checksum; then
+        echo "Round 3 topic 3 validated"
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round3-topic3.checksum | awk '{print $1}')"
+        exit 1
+    fi
+
+    # Exercise older topics
+    cat data3.txt.tmp | fluvio produce round2-topic
+    ci_check;
+
+    echo "Validate test data matches expected data before upgrade"
+    $FLUVIO_BIN consume -B -d round2-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round3-topic2.checksum; then
+        echo "Round 3 topic 2 validated"
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round3-topic2.checksum | awk '{print $1}')"
+        exit 1
+    fi
+
+    cat data3.txt.tmp | fluvio produce round1-topic
+    ci_check;
+
+    echo "Validate test data matches expected data before upgrade"
+    $FLUVIO_BIN consume -B -d round1-topic | tee output.txt.tmp
+    ci_check;
+
+    if cat output.txt.tmp | shasum -c round3-topic1.checksum; then
+        echo "Round 3 topic 1 validated"
+    else
+        echo "Got: $(cat output.txt.tmp | awk '{print $1}')"
+        echo "Expected: $(cat round3-topic1.checksum | awk '{print $1}')"
+        exit 1
+    fi
+
+}
+
+function create_test_data() {
+
+    # Create 3 base data files, checksums.
+    # Build produce/consume with generated data to validate integrity across upgrades
+
+    TEST_DATA_BYTES=${TEST_DATA_BYTES:-100}
+
+    # The baseline files
+    for BASE in {1..3}
+    do
+        echo "Create the baseline file \#${BASE}"
+        RANDOM_DATA=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w${TEST_DATA_BYTES} | head -n1)
+        echo ${RANDOM_DATA} | tee -a data${BASE}.txt.tmp
+    done
+
+    # Round 1
+    # Topic 1 expected output
+    cat data1.txt.tmp | shasum | tee -a round1-topic1.checksum
+
+    # Round 2
+    # Topic 2 expected output
+    echo "Create expected topic contents for topic 1 in round 2"
+    cat data1.txt.tmp data2.txt.tmp | tee -a round2-topic1.txt.tmp
+    echo "Create expected topic checksum for topic 1 in round 2"
+    cat round2-topic1.txt.tmp | shasum | tee -a round2-topic1.checksum
+
+    ## Topic 2 expected output
+    cat data2.txt.tmp | shasum | tee -a round2-topic2.checksum
+
+    # Round 3
+    # Topic 1 expected output
+    echo "Create expected topic contents for topic 1 in round 3"
+    cat data1.txt.tmp data2.txt.tmp data3.txt.tmp | tee -a round3-topic1.txt.tmp
+    echo "Create expected topic checksum for topic 1 in round 3"
+    cat round3-topic1.txt.tmp | shasum | tee -a round3-topic1.checksum
+
+    # Topic 2 expected output
+    echo "Create expected topic contents for topic 2 in round 3"
+    cat data2.txt.tmp data3.txt.tmp | tee -a round3-topic2.txt.tmp
+    echo "Create expected topic checksum for topic 2 in round 3"
+    cat round3-topic2.txt.tmp | shasum | tee -a round3-topic2.checksum
+
+    # Topic 3 expected output
+    cat data3.txt.tmp | shasum | tee -a round3-topic3.checksum
+}
+
+cleanup;
+
+echo "First ${STABLE_MINUS_ONE}"
+round1;
+
+echo "then ${STABLE}"
+round2;
+
+echo "finally $(cat ../VERSION)-$(git rev-parse HEAD)"
+round3;
+
+cleanup;
+
+# Change back to original directory
+popd > /dev/null


### PR DESCRIPTION
Fixes #1066

We've found more stability in CI by slowing down calls to the `fluvio` cluster. (The test output prints cpu load avgs, which are frequently overscheduled.)

Upgrade test is driven by shell script `test/upgrade-test.sh`. 

---

We've found more stability in CI by slowing down calls to the `fluvio` cluster. (The test output prints cpu load avgs, which are frequently overscheduled.)

Test data and checksums are generated prior to cluster installation.

We test 3 versions: Last stable, current stable and then we compile and install the repo version.

---

For each version, we create a new topic, produce and consume then verify content w/ checksum. Then we verify functionality old topics after upgrade with a consume, produce, consume + checksum verification.