### PR TITLE
[Merged by Bors] - feat: Add batch mode for CLI producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Release Notes
+
 ## Unreleased
-* Added builder for fluvio_storage::config::ConfigOption. (#1076)[https://github.com/infinyon/fluvio/pull/1076]
+* Added builder for fluvio_storage::config::ConfigOption. ([#1076](https://github.com/infinyon/fluvio/pull/1076))
+* Use batch record sending in CLI producer ([#915](https://github.com/infinyon/fluvio/issues/915))
 
 ## Platform Version 0.8.2 - 2020-05-06
 * Fix Replication fail over with duplication ([#1052](https://github.com/infinyon/fluvio/pull/1052))
 * Relax platform version requirement for upgrade check ([#1055](https://github.com/infinyon/fluvio/pull/1055))
 * Update logic for finding latest package release ([#1061](https://github.com/infinyon/fluvio/pull/1061))
+
 ## Platform Version 0.8.1 - 2020-05-03
 * Use file name for the external commands (fixes #889) ([#1008](https://github.com/infinyon/fluvio/pull/1008))
 * Fix Fluvio log directory on K8 ([#1043](https://github.com/infinyon/fluvio/pull/1043))
 * Add RecordKey API for sending records without keys ([#985](https://github.com/infinyon/fluvio/pull/985))
 * Make Fluvio Client compatitble with WASM ([#1042](https://github.com/infinyon/fluvio/pull/1042))
 * Update Replication logic for SPU ([#1011](https://github.com/infinyon/fluvio/pull/1011))
+
 ## Platform Version 0.8.0 - 2020-04-27
 * Added Partitioner trait for assigning partitions based on record keys ([#965](https://github.com/infinyon/fluvio/pull/965))
 * Deprecated the `TopicProducer::send_record` method ([#965](https://github.com/infinyon/fluvio/pull/965))

--- a/src/cli/src/consumer/produce/mod.rs
+++ b/src/cli/src/consumer/produce/mod.rs
@@ -36,10 +36,6 @@ pub struct ProduceOpt {
     #[structopt(long, validator = validate_key_separator)]
     pub key_separator: Option<String>,
 
-    /// Specifies the number of records to send in a batch. Only used for files.
-    #[structopt(long, default_value = "50")]
-    pub batch_size: usize,
-
     /// Path to a file to produce to the topic. If absent, producer will read stdin.
     #[structopt(short, long)]
     pub file: Option<PathBuf>,
@@ -62,7 +58,7 @@ impl ProduceOpt {
             Some(path) => {
                 let reader = BufReader::new(File::open(path)?);
                 let lines: Vec<_> = reader.lines().filter_map(|it| it.ok()).collect();
-                let batches: Vec<_> = lines.chunks(self.batch_size).collect();
+                let batches: Vec<_> = lines.chunks(50).collect();
                 for batch in batches {
                     let batch: Vec<_> = batch.iter().map(|it| &**it).collect();
                     self.produce_lines(&mut producer, &batch).await?;

--- a/src/cli/src/consumer/produce/mod.rs
+++ b/src/cli/src/consumer/produce/mod.rs
@@ -9,6 +9,8 @@ use fluvio_types::print_cli_ok;
 use crate::common::FluvioExtensionMetadata;
 use crate::consumer::error::ConsumerError;
 
+const DEFAULT_BATCH_SIZE: usize = 50;
+
 // -----------------------------------
 // CLI Options
 // -----------------------------------
@@ -58,7 +60,7 @@ impl ProduceOpt {
             Some(path) => {
                 let reader = BufReader::new(File::open(path)?);
                 let lines: Vec<_> = reader.lines().filter_map(|it| it.ok()).collect();
-                let batches: Vec<_> = lines.chunks(50).collect();
+                let batches: Vec<_> = lines.chunks(DEFAULT_BATCH_SIZE).collect();
                 for batch in batches {
                     let batch: Vec<_> = batch.iter().map(|it| &**it).collect();
                     self.produce_lines(&mut producer, &batch).await?;


### PR DESCRIPTION
Closes #915 

- When using `fluvio produce topic -f <file>`, the producer will send lines in batches of 50 by defualt
- The `fluvio produce topic --batch-size=X` argument can be used to adjust the size of the batch