### PR TITLE
[WIP] fix: make symmetric encode-decoder for api structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 * Added builder for fluvio_storage::config::ConfigOption. ([#1076](https://github.com/infinyon/fluvio/pull/1076))
 * Use batch record sending in CLI producer ([#915](https://github.com/infinyon/fluvio/issues/915))
+* Make ResponseMessage, ApiMessage and RequestMessage decode-encoder implementation symmetric.
+* FluvioCodec decoder no longer strips the lenght of the data.
 
 ## Platform Version 0.8.2 - 2020-05-06
 * Fix Replication fail over with duplication ([#1052](https://github.com/infinyon/fluvio/pull/1052))

--- a/src/protocol/fluvio-protocol-api/src/response.rs
+++ b/src/protocol/fluvio-protocol-api/src/response.rs
@@ -44,6 +44,23 @@ where
     where
         T: Buf,
     {
+        if src.remaining() < 4 {
+            return Err(IoError::new(
+                ErrorKind::UnexpectedEof,
+                "not enought for response",
+            ));
+        }
+        let mut size: i32 = 0;
+        size.decode(src, version)?;
+        trace!("decoded response size: {} bytes", size);
+
+        if src.remaining() < size as usize {
+            return Err(IoError::new(
+                ErrorKind::UnexpectedEof,
+                "not enought for response",
+            ));
+        }
+
         let mut correlation_id: i32 = 0;
         correlation_id.decode(src, version)?;
         trace!("decoded correlation id: {}", correlation_id);
@@ -67,17 +84,6 @@ where
         let data = buffer.to_vec();
 
         let mut src = Cursor::new(&data);
-
-        let mut size: i32 = 0;
-        size.decode(&mut src, version)?;
-        trace!("decoded response size: {} bytes", size);
-
-        if src.remaining() < size as usize {
-            return Err(IoError::new(
-                ErrorKind::UnexpectedEof,
-                "not enought for response",
-            ));
-        }
 
         Self::decode_from(&mut src, version)
     }

--- a/src/protocol/fluvio-protocol-codec/src/codec.rs
+++ b/src/protocol/fluvio-protocol-codec/src/codec.rs
@@ -44,8 +44,7 @@ impl Decoder for FluvioCodec {
                     packet_len + 4,
                     bytes.len() - (packet_len + 4) as usize
                 );
-                let mut buf = bytes.split_to((packet_len + 4) as usize);
-                let message = buf.split_off(4); // truncate length
+                let message = bytes.split_to((packet_len + 4) as usize);
                 Ok(Some(message))
             } else {
                 trace!(
@@ -132,13 +131,6 @@ mod test {
                     );
                     assert_eq!(buf.len(), 9); //  4(array len)+ 5 bytes
 
-                    // write buffer length since encoder doesn't write
-                    // need to send out len
-                    let mut len_buf = vec![];
-                    let len = buf.len() as i32;
-                    len.encode(&mut len_buf, 0).expect("encoding");
-                    sink.send(Bytes::from(len_buf)).await.expect("sending");
-
                     sink.send(Bytes::from(buf)).await.expect("sending");
                 }
 
@@ -151,13 +143,6 @@ mod test {
                         buf.len()
                     );
                     assert_eq!(buf.len(), 9); //  4(array len)+ 5 bytes
-
-                    // write buffer length since encoder doesn't write
-                    // need to send out len
-                    let mut len_buf = vec![];
-                    let len = buf.len() as i32;
-                    len.encode(&mut len_buf, 0).expect("encoding");
-                    sink.send(Bytes::from(len_buf)).await.expect("sending");
 
                     // split buf into two segments, decode should reassembly them
                     let buf2 = buf.split_off(5);


### PR DESCRIPTION
This PR makes ResponseMessage, ApiMessage and RequestMessage encoder-decoder symmetrics.
In order to do this, FluvioCodec decoder implementation no longer strips the size of the packet.