### PR TITLE
[Merged by Bors] - feat: generic implementation of tokio_util::codec::Encoder for FluvioEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 * Added builder for fluvio_storage::config::ConfigOption. ([#1076](https://github.com/infinyon/fluvio/pull/1076))
 * Use batch record sending in CLI producer ([#915](https://github.com/infinyon/fluvio/issues/915))
+* Now ResponseApi and RequestApi encoder-decoders are symmetric ([#1075](https://github.com/infinyon/fluvio/issues/1075))
+* `FluvioCodec` encoder now supports `FluvioEncoder` types. Implementation with bytes::Bytes now is deprecated. ([#1076](https://github.com/infinyon/fluvio/pull/1081))
+* Added implementations of FluvioEncoder for &T: FluvioEncoder. ([#1081](https://github.com/infinyon/fluvio/pull/1081))
 
 ## Platform Version 0.8.2 - 2020-05-06
 * Fix Replication fail over with duplication ([#1052](https://github.com/infinyon/fluvio/pull/1052))

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -25,8 +25,8 @@ x509-parser = "0.9.1"
 fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-metadata" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
-fluvio-protocol = { path = "../protocol",  version = "0.5.0" }
-fluvio-socket = { path = "../socket", version = "0.8.0" }
+fluvio-protocol = { path = "../protocol",  version = "0.5.1" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 flv-tls-proxy = { version = "0.5.0" }
 futures-util = { version = "0.3.5" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -43,8 +43,8 @@ fluvio-future = { version = "0.3.0", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
-fluvio-socket = { path = "../socket", version = "0.8.0" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -26,7 +26,7 @@ fluvio-future = { version = "0.3.0" }
 flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-stream-model = { path = "../stream-model", version = "0.5.0" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -18,5 +18,5 @@ tracing = "0.1.19"
 # Fluvio dependencies
 fluvio-types = { path = "../types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.9.0" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -27,10 +27,10 @@ derive_builder = { version = "0.9.0", optional =  true }
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.0" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0", features = ["derive", "api"] }
+fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { path = "../socket", version = "0.8.0" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-future = { version = "0.3.0", features = ["fixture","fs"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -17,8 +17,8 @@ store = ["fluvio-future", "fluvio-protocol-api", "log", "bytes"]
 [dependencies]
 fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
 fluvio-protocol-derive = { version = "0.2.0", path = "fluvio-protocol-derive", optional = true }
-fluvio-protocol-api = { version = "0.3.0", path = "fluvio-protocol-api", optional = true }
-fluvio-protocol-codec = { version = "0.3.0", path = "fluvio-protocol-codec", optional = true }
+fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api", optional = true }
+fluvio-protocol-codec = { version = "0.3.1", path = "fluvio-protocol-codec", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
 log = { version = "0.4.8", optional = true }
 bytes = { version = "1.0.0", optional = true }
@@ -27,6 +27,6 @@ bytes = { version = "1.0.0", optional = true }
 flv-util = { version = "0.5.2" }
 fluvio-protocol-derive = { version = "0.2.0", path = "fluvio-protocol-derive" }
 fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
-fluvio-protocol-api = { version = "0.3.0", path = "fluvio-protocol-api" }
+fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api" }
 log = { version = "0.4.8" }
 fluvio-future = { version = "0.3.0", features = ["subscriber"]}

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2018"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/src/protocol/fluvio-protocol-api/Cargo.toml
+++ b/src/protocol/fluvio-protocol-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-api"
 edition = "2018"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "fluvio protocol API helpers"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/src/protocol/fluvio-protocol-api/src/api.rs
+++ b/src/protocol/fluvio-protocol-api/src/api.rs
@@ -1,5 +1,6 @@
 use std::default::Default;
 use std::io::Error as IoError;
+use std::io::ErrorKind;
 use std::fs::File;
 use std::io::Cursor;
 use std::path::Path;
@@ -9,6 +10,7 @@ use std::fmt;
 use std::convert::TryFrom;
 
 use log::debug;
+use log::trace;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
@@ -52,6 +54,17 @@ pub trait ApiMessage: Sized + Default {
 
         let data = buffer.to_vec();
         let mut src = Cursor::new(&data);
+
+        let mut size: i32 = 0;
+        size.decode(&mut src, 0)?;
+        trace!("decoded request size: {} bytes", size);
+
+        if src.remaining() < size as usize {
+            return Err(IoError::new(
+                ErrorKind::UnexpectedEof,
+                "not enought bytes for request message",
+            ));
+        }
 
         Self::decode_from(&mut src)
     }

--- a/src/protocol/fluvio-protocol-api/src/api.rs
+++ b/src/protocol/fluvio-protocol-api/src/api.rs
@@ -1,6 +1,5 @@
 use std::default::Default;
 use std::io::Error as IoError;
-use std::io::ErrorKind;
 use std::fs::File;
 use std::io::Cursor;
 use std::path::Path;
@@ -9,7 +8,6 @@ use std::fmt::Debug;
 use std::fmt;
 use std::convert::TryFrom;
 
-use log::trace;
 use log::debug;
 
 use crate::core::Decoder;
@@ -54,17 +52,6 @@ pub trait ApiMessage: Sized + Default {
 
         let data = buffer.to_vec();
         let mut src = Cursor::new(&data);
-
-        let mut size: i32 = 0;
-        size.decode(&mut src, 0)?;
-        trace!("decoded request size: {} bytes", size);
-
-        if src.remaining() < size as usize {
-            return Err(IoError::new(
-                ErrorKind::UnexpectedEof,
-                "not enought bytes for request message",
-            ));
-        }
 
         Self::decode_from(&mut src)
     }

--- a/src/protocol/fluvio-protocol-api/src/request.rs
+++ b/src/protocol/fluvio-protocol-api/src/request.rs
@@ -154,14 +154,13 @@ where
     where
         T: BufMut,
     {
-        let len = self.write_size(version) as i32;
+        let len = self.write_size(version);
         trace!(
             "encoding kf request: {} version: {}, len: {}",
             std::any::type_name::<R>(),
             version,
             len
         );
-        len.encode(out, version)?;
 
         trace!("encoding request header: {:#?}", &self.header);
         self.header.encode(out, version)?;
@@ -343,9 +342,6 @@ mod test {
         message.encode(&mut out, 0).expect("encode work");
         let mut encode_bytes = Cursor::new(&out);
 
-        // decode back
-        let mut len: i32 = 0;
-        len.decode(&mut encode_bytes, 0).expect("cant decode len");
         let res_msg_result: Result<RequestMessage<ApiVersionRequest>, IoError> =
             Decoder::decode_from(&mut encode_bytes, 0);
 

--- a/src/protocol/fluvio-protocol-api/src/response.rs
+++ b/src/protocol/fluvio-protocol-api/src/response.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::Cursor;
 use std::io::Error as IoError;
-use std::io::ErrorKind;
 use std::io::Read;
 use std::path::Path;
 
@@ -68,17 +67,6 @@ where
 
         let mut src = Cursor::new(&data);
 
-        let mut size: i32 = 0;
-        size.decode(&mut src, version)?;
-        trace!("decoded response size: {} bytes", size);
-
-        if src.remaining() < size as usize {
-            return Err(IoError::new(
-                ErrorKind::UnexpectedEof,
-                "not enought for response",
-            ));
-        }
-
         Self::decode_from(&mut src, version)
     }
 }
@@ -95,14 +83,13 @@ where
     where
         T: BufMut,
     {
-        let len = self.write_size(version) as i32;
+        let len = self.write_size(version);
         trace!(
             "encoding kf response: {} version: {}, len: {}",
             std::any::type_name::<P>(),
             version,
             len
         );
-        len.encode(out, version)?;
         self.correlation_id.encode(out, version)?;
         self.response.encode(out, version)?;
         Ok(())

--- a/src/protocol/fluvio-protocol-codec/Cargo.toml
+++ b/src/protocol/fluvio-protocol-codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-codec"
 edition = "2018"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Frame encoder and decoder for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/src/protocol/fluvio-protocol-codec/src/codec.rs
+++ b/src/protocol/fluvio-protocol-codec/src/codec.rs
@@ -6,13 +6,19 @@ use tokio_util::codec::Decoder;
 use tokio_util::codec::Encoder;
 
 use crate::core::Decoder as FluvioDecoder;
+use crate::core::Encoder as FluvioEncoder;
 use crate::core::bytes::{Bytes, BytesMut, BufMut};
+use crate::core::Version;
 
 /// Implement Kafka codec as in https://kafka.apache.org/protocol#The_Messages_ListOffsets
 /// First 4 bytes are size of the message.  Then total buffer = 4 + message content
 ///
 #[derive(Debug, Default)]
 pub struct FluvioCodec {}
+
+/// Type used as input by the [`FluvioCodec`] encoder implementation.
+/// Contains the data of the message and the [`crate::core:Version`].
+pub type FluvioCodecData<T> = (T, Version);
 
 impl FluvioCodec {
     pub fn new() -> Self {
@@ -77,6 +83,28 @@ impl Encoder<Bytes> for FluvioCodec {
     }
 }
 
+/// Implement encoder for Kafka Codec
+impl<T: FluvioEncoder> Encoder<FluvioCodecData<T>> for FluvioCodec {
+    type Error = IoError;
+
+    fn encode(&mut self, src: FluvioCodecData<T>, buf: &mut BytesMut) -> Result<(), IoError> {
+        let (src, version) = src;
+
+        let size = src.write_size(version) as i32;
+        trace!("encoding data with {} bytes.", size);
+        buf.reserve(4 + size as usize);
+
+        // First 4 bytes are the size of the message.
+        // Then the message payload.
+        let mut len_slice = Vec::new();
+        size.encode(&mut len_slice, version)?;
+        buf.extend_from_slice(&len_slice);
+        buf.extend_from_slice(&src.as_bytes(version)?);
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
 
@@ -84,7 +112,6 @@ mod test {
     use std::net::SocketAddr;
     use std::time;
 
-    use bytes::Bytes;
     use futures::future::join;
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
@@ -95,116 +122,167 @@ mod test {
     use fluvio_future::net::TcpStream;
     use fluvio_future::timer::sleep;
     use fluvio_future::test_async;
+    use futures::AsyncWriteExt;
     use fluvio_protocol::Decoder as FluvioDecoder;
     use fluvio_protocol::Encoder as FluvioEncoder;
     use log::debug;
 
     use super::FluvioCodec;
 
+    async fn run_server_raw_data<T: FluvioEncoder>(
+        data: T,
+        addr: &SocketAddr,
+    ) -> Result<(), Error> {
+        debug!("server: binding");
+        let listener = TcpListener::bind(&addr).await.expect("bind");
+        debug!("server: successfully binding. waiting for incoming");
+        let mut incoming = listener.incoming();
+        if let Some(stream) = incoming.next().await {
+            debug!("server: got connection from client");
+            let mut tcp_stream = stream.expect("stream");
+
+            // write message_size since we are not using the encoder
+            let mut len_buf = vec![];
+            let message_size = data.write_size(0) as i32;
+            message_size.encode(&mut len_buf, 0).expect("encoding len");
+            tcp_stream.write(&len_buf).await?;
+
+            let encoded_data = data.as_bytes(0).expect("encoding data");
+            tcp_stream.write(&encoded_data).await?;
+
+            // Now trying partial send:
+            // write message_size since we are not using the encoder
+            let mut len_buf = vec![];
+            let message_size = data.write_size(0) as i32;
+            message_size.encode(&mut len_buf, 0).expect("encoding len");
+            tcp_stream.write(&len_buf).await?;
+
+            let mut encoded_data = data.as_bytes(0).expect("encoding data");
+            let buf2 = encoded_data.split_off(3);
+            tcp_stream.write(&encoded_data).await?;
+            fluvio_future::timer::sleep(time::Duration::from_millis(10)).await;
+            tcp_stream.write(&buf2).await?;
+        }
+        fluvio_future::timer::sleep(time::Duration::from_millis(50)).await;
+        debug!("finishing. terminating server");
+        Ok(())
+    }
+
+    async fn run_server_object<T: FluvioEncoder + Clone>(
+        data: T,
+        addr: &SocketAddr,
+    ) -> Result<(), Error> {
+        debug!("server: binding");
+        let listener = TcpListener::bind(&addr).await.expect("bind");
+        debug!("server: successfully binding. waiting for incoming");
+        let mut incoming = listener.incoming();
+        if let Some(stream) = incoming.next().await {
+            debug!("server: got connection from client");
+            let tcp_stream = stream.expect("stream");
+
+            let framed = Framed::new(tcp_stream.compat(), FluvioCodec {});
+            let (mut sink, _) = framed.split();
+
+            // send 2 times in order
+            for _ in 0..2_u8 {
+                sink.send((data.clone(), 0)).await.expect("sending");
+            }
+        }
+        fluvio_future::timer::sleep(time::Duration::from_millis(50)).await;
+        debug!("finishing. terminating server");
+        Ok(())
+    }
+
+    async fn run_client<
+        T: PartialEq + std::fmt::Debug + Default + FluvioDecoder + FluvioEncoder,
+    >(
+        data: T,
+        addr: &SocketAddr,
+    ) -> Result<(), Error> {
+        debug!("client: sleep to give server chance to come up");
+        sleep(time::Duration::from_millis(100)).await;
+        debug!("client: trying to connect");
+        let tcp_stream = TcpStream::connect(&addr).await.expect("connect");
+        debug!("client: got connection. waiting");
+        let framed = Framed::new(tcp_stream.compat(), FluvioCodec {});
+        let (_, mut stream) = framed.split::<(T, _)>();
+        for _ in 0..2u16 {
+            if let Some(value) = stream.next().await {
+                debug!("client :received first value from server");
+                let mut bytes = value.expect("bytes");
+                let bytes_len = bytes.len();
+                debug!("client: received bytes len: {}", bytes_len);
+                let mut decoded_value = T::default();
+                decoded_value
+                    .decode(&mut bytes, 0)
+                    .expect("decoding failed");
+                assert_eq!(bytes_len, decoded_value.write_size(0));
+                assert_eq!(decoded_value, data);
+                debug!("all test pass");
+            } else {
+                panic!("no first value received");
+            }
+        }
+
+        debug!("finished client");
+        Ok(())
+    }
+
     #[test_async]
-    async fn test_async_tcp() -> Result<(), Error> {
+    async fn test_async_tcp_vec() -> Result<(), Error> {
         debug!("start running test");
 
-        let addr = "127.0.0.1:11122".parse::<SocketAddr>().expect("parse");
+        let addr = "127.0.0.1:11223".parse::<SocketAddr>().expect("parse");
+        let data: Vec<u8> = vec![0x1, 0x02, 0x03, 0x04, 0x5];
 
-        let server_ft = async {
-            debug!("server: binding");
-            let listener = TcpListener::bind(&addr).await.expect("bind");
-            debug!("server: successfully binding. waiting for incoming");
-            let mut incoming = listener.incoming();
-            #[allow(clippy::never_loop)]
-            while let Some(stream) = incoming.next().await {
-                debug!("server: got connection from client");
-                let tcp_stream = stream.expect("stream");
+        let server_ft = run_server_object(data.clone(), &addr);
+        let client_ft = run_client(data, &addr);
 
-                let framed = Framed::new(tcp_stream.compat(), FluvioCodec {});
-                let (mut sink, _) = framed.split();
+        let _rt = join(client_ft, server_ft).await;
 
-                let data: Vec<u8> = vec![0x1, 0x02, 0x03, 0x04, 0x5];
-                // send 2 times in order
-                for _ in 0..2u16 {
-                    //  debug!("server encoding original vector with len: {}", data.len());
-                    let mut buf = vec![];
-                    data.encode(&mut buf, 0)?;
-                    debug!(
-                        "server: writing to client vector encoded len: {}",
-                        buf.len()
-                    );
-                    assert_eq!(buf.len(), 9); //  4(array len)+ 5 bytes
+        Ok(())
+    }
 
-                    // write buffer length since encoder doesn't write
-                    // need to send out len
-                    let mut len_buf = vec![];
-                    let len = buf.len() as i32;
-                    len.encode(&mut len_buf, 0).expect("encoding");
-                    sink.send(Bytes::from(len_buf)).await.expect("sending");
+    #[test_async]
+    async fn test_async_tcp_string() -> Result<(), Error> {
+        debug!("start running test");
 
-                    sink.send(Bytes::from(buf)).await.expect("sending");
-                }
+        let addr = "127.0.0.1:11224".parse::<SocketAddr>().expect("parse");
+        let data: String = String::from("hello");
 
-                // last one, we send split send, to test partial send
-                {
-                    let mut buf = vec![];
-                    data.encode(&mut buf, 0)?;
-                    debug!(
-                        "server: writing to client vector encoded len: {}",
-                        buf.len()
-                    );
-                    assert_eq!(buf.len(), 9); //  4(array len)+ 5 bytes
+        let server_ft = run_server_object(data.clone(), &addr);
+        let client_ft = run_client(data, &addr);
 
-                    // write buffer length since encoder doesn't write
-                    // need to send out len
-                    let mut len_buf = vec![];
-                    let len = buf.len() as i32;
-                    len.encode(&mut len_buf, 0).expect("encoding");
-                    sink.send(Bytes::from(len_buf)).await.expect("sending");
+        let _rt = join(client_ft, server_ft).await;
 
-                    // split buf into two segments, decode should reassembly them
-                    let buf2 = buf.split_off(5);
-                    sink.send(Bytes::from(buf)).await.expect("sending");
-                    fluvio_future::timer::sleep(time::Duration::from_millis(10)).await;
-                    sink.send(Bytes::from(buf2)).await.expect("sending");
-                }
+        Ok(())
+    }
 
-                fluvio_future::timer::sleep(time::Duration::from_millis(50)).await;
-                debug!("finishing. terminating server");
-                return Ok(()) as Result<(), Error>;
-            }
+    #[allow(clippy::clone_on_copy)]
+    #[test_async]
+    async fn test_async_tcp_i32() -> Result<(), Error> {
+        debug!("start running test");
 
-            Ok(()) as Result<(), Error>
-        };
+        let addr = "127.0.0.1:11225".parse::<SocketAddr>().expect("parse");
+        let data: i32 = 1000;
 
-        let client_ft = async {
-            debug!("client: sleep to give server chance to come up");
-            sleep(time::Duration::from_millis(100)).await;
-            debug!("client: trying to connect");
-            let tcp_stream = TcpStream::connect(&addr).await.expect("connect");
-            debug!("client: got connection. waiting");
-            let framed = Framed::new(tcp_stream.compat(), FluvioCodec {});
-            let (_, mut stream) = framed.split();
-            for _ in 0..3u16 {
-                if let Some(value) = stream.next().await {
-                    debug!("client :received first value from server");
-                    let mut bytes = value.expect("bytes");
-                    debug!("client: received bytes len: {}", bytes.len());
-                    assert_eq!(bytes.len(), 9, "total bytes is 6");
-                    let mut decoded_values: Vec<u8> = vec![];
-                    decoded_values
-                        .decode(&mut bytes, 0)
-                        .expect("vector decoding failed");
-                    assert_eq!(decoded_values.len(), 5);
-                    assert_eq!(decoded_values[0], 1);
-                    assert_eq!(decoded_values[1], 2);
-                    debug!("all test pass");
-                } else {
-                    panic!("no first value received");
-                }
-            }
+        let server_ft = run_server_object(data.clone(), &addr);
+        let client_ft = run_client(data, &addr);
 
-            debug!("finished client");
+        let _rt = join(client_ft, server_ft).await;
 
-            Ok(()) as Result<(), Error>
-        };
+        Ok(())
+    }
+
+    #[test_async]
+    async fn test_async_tcp_raw_data() -> Result<(), Error> {
+        debug!("start running test");
+
+        let addr = "127.0.0.1:11226".parse::<SocketAddr>().expect("parse");
+        let data: String = String::from("Raw text");
+
+        let server_ft = run_server_raw_data(data.clone(), &addr);
+        let client_ft = run_client(data, &addr);
 
         let _rt = join(client_ft, server_ft).await;
 

--- a/src/protocol/fluvio-protocol-core/src/encoder.rs
+++ b/src/protocol/fluvio-protocol-core/src/encoder.rs
@@ -364,6 +364,22 @@ impl Encoder for String {
     }
 }
 
+impl<M> Encoder for &M
+where
+    M: Encoder,
+{
+    fn write_size(&self, version: Version) -> usize {
+        (*self).write_size(version)
+    }
+
+    fn encode<T>(&self, dest: &mut T, version: Version) -> Result<(), Error>
+    where
+        T: BufMut,
+    {
+        (*self).encode(dest, version)
+    }
+}
+
 #[cfg(test)]
 mod test {
 

--- a/src/protocol/src/store.rs
+++ b/src/protocol/src/store.rs
@@ -55,7 +55,8 @@ where
     }
 }
 
-/// This is same as encoding in the ResponseMessage but can encode async file slice
+/// This is same as encoding in the ResponseMessage but first
+/// includes the lenght and can encode async file slice
 impl<P> FileWrite for ResponseMessage<P>
 where
     P: FileWrite + Default,
@@ -84,6 +85,8 @@ where
     }
 }
 
+/// This is same as encoding in the RequestMessage but first
+/// includes the lenght and can encode async file slice
 impl<R> FileWrite for RequestMessage<R>
 where
     R: FileWrite + Default + Request,
@@ -94,15 +97,15 @@ where
         data: &mut Vec<StoreValue>,
         version: Version,
     ) -> Result<(), IoError> {
-        trace!("file encoding response message");
+        trace!("file encoding request message");
         let len = self.write_size(version) as i32;
-        trace!("file encoding response len: {}", len);
+        trace!("file encoding request len: {}", len);
         len.encode(dest, version)?;
 
         trace!("file encoding header");
         self.header.encode(dest, version)?;
 
-        trace!("encoding response");
+        trace!("encoding request");
         self.request.file_encode(dest, data, version)?;
         Ok(())
     }

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -24,5 +24,5 @@ static_assertions = "1.1.0"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.9.0", default-features = false, path = "../controlplane-metadata" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -54,9 +54,9 @@ fluvio-stream-dispatcher = { version = "0.6.0", path = "../stream-dispatcher" }
 k8-client = { version = "5.0.0", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.2.1", features = ["app"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { path = "../socket", version = "0.8.0" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -23,8 +23,8 @@ tokio = { version = "1.3.0", features = ["macros"] }
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.3.0" }
-fluvio-socket = { version = "0.8.0", path = "../socket" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0", features = ["derive", "api", "codec"] }
+fluvio-socket = { version = "0.8.2", path = "../socket" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
 fluvio-types = { version = "0.2.3", features = ["events"], path = "../types" }
 
 [dev-dependencies]

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.20"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.0", features = ["net", "zero_copy"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.0", features = ["derive", "api", "codec", "store"] }
+fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec", "store"] }
 
 
 [dev-dependencies]

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0.103", features = ['derive'] }
 static_assertions = "1.1.0"
 
 # Fluvio dependencies
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -48,9 +48,9 @@ fluvio-storage = { version = "0.5.0", path = "../storage" }
 fluvio-controlplane = { version = "0.7.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-metadata" }
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-socket = { path = "../socket", version = "0.8.0" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -35,13 +35,13 @@ derive_builder = "0.10.2"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-future = { version = "0.3.0", features = ["fs", "mmap"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.0" }
+fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { path = "../socket", version = "0.8.0" }
+fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-storage = { path = ".", features = ["fixture"]}
 dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio/issues/1075

* Changes the implementation of ResponseMessage and RequestMessage encoder to not include their lengths so the encode-decoder is symmetric now.
* 
* Added to `FluvioCodec` the capability to handle `FluvioEncoder` types. 

* Add implementations of FluvioEncoder to &T: FluvioEncoder.
