### PR TITLE
[Merged by Bors] - Clean up dataplane::record module with cleaner types and interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -23,7 +23,7 @@ tracing-futures = "0.2.4"
 x509-parser = "0.9.1"
 
 fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-metadata" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
 fluvio-protocol = { path = "../protocol",  version = "0.5.1" }
 fluvio-socket = { path = "../socket", version = "0.8.2" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -45,7 +45,7 @@ fluvio-sc-schema = { version = "0.8.0", path = "../sc-schema", default-features 
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
 fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", default-features = false }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -15,8 +15,8 @@ use dataplane::fetch::FetchPartition;
 use dataplane::fetch::FetchableTopic;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
-use dataplane::record::DefaultRecord;
-use dataplane::batch::DefaultBatch;
+use dataplane::record::Record as DefaultRecord;
+use dataplane::batch::Batch;
 use fluvio_types::event::offsets::OffsetPublisher;
 
 use crate::FluvioError;
@@ -296,7 +296,7 @@ impl PartitionConsumer {
     ) -> Result<impl Stream<Item = Result<Record, FluvioError>>, FluvioError> {
         let stream = self.stream_batches_with_config(offset, config).await?;
         let flattened =
-            stream.flat_map(|result: Result<DefaultBatch, _>| match result {
+            stream.flat_map(|result: Result<Batch, _>| match result {
                 Err(e) => Either::Right(once(err(e))),
                 Ok(batch) => {
                     let base_offset = batch.base_offset;
@@ -343,7 +343,7 @@ impl PartitionConsumer {
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item = Result<DefaultBatch, FluvioError>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Batch, FluvioError>>, FluvioError> {
         let stream = self.request_stream(offset, config).await?;
         let flattened = stream.flat_map(|batch_result: Result<DefaultStreamFetchResponse, _>| {
             let response: DefaultStreamFetchResponse = match batch_result {

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -8,7 +8,7 @@ use dataplane::ReplicaKey;
 use dataplane::produce::DefaultProduceRequest;
 use dataplane::produce::DefaultPartitionRequest;
 use dataplane::produce::DefaultTopicRequest;
-use dataplane::batch::{Batch, MemoryBatch};
+use dataplane::batch::{Batch, MemoryRecords};
 use dataplane::record::Record;
 pub use dataplane::record::{RecordKey, RecordData};
 
@@ -162,8 +162,8 @@ async fn group_by_spu(
     topic: &str,
     partitions: &StoreContext<PartitionSpec>,
     records_by_partition: Vec<(PartitionId, Record)>,
-) -> Result<HashMap<SpuId, HashMap<PartitionId, MemoryBatch>>, FluvioError> {
-    let mut map: HashMap<SpuId, HashMap<i32, MemoryBatch>> = HashMap::new();
+) -> Result<HashMap<SpuId, HashMap<PartitionId, MemoryRecords>>, FluvioError> {
+    let mut map: HashMap<SpuId, HashMap<i32, MemoryRecords>> = HashMap::new();
     for (partition, record) in records_by_partition {
         let replica_key = ReplicaKey::new(topic, partition);
         let partition_spec = partitions
@@ -184,7 +184,7 @@ async fn group_by_spu(
 
 fn assemble_requests(
     topic: &str,
-    partitions_by_spu: HashMap<SpuId, HashMap<PartitionId, MemoryBatch>>,
+    partitions_by_spu: HashMap<SpuId, HashMap<PartitionId, MemoryRecords>>,
 ) -> Vec<(SpuId, DefaultProduceRequest)> {
     let mut requests: Vec<(SpuId, DefaultProduceRequest)> =
         Vec::with_capacity(partitions_by_spu.len());

--- a/src/client/src/producer.rs
+++ b/src/client/src/producer.rs
@@ -8,9 +8,9 @@ use dataplane::ReplicaKey;
 use dataplane::produce::DefaultProduceRequest;
 use dataplane::produce::DefaultPartitionRequest;
 use dataplane::produce::DefaultTopicRequest;
-use dataplane::batch::DefaultBatch;
-use dataplane::record::DefaultRecord;
-use dataplane::record::DefaultAsyncBuffer;
+use dataplane::batch::{Batch, MemoryBatch};
+use dataplane::record::Record;
+pub use dataplane::record::{RecordKey, RecordData};
 
 use crate::FluvioError;
 use crate::spu::SpuPool;
@@ -92,14 +92,7 @@ impl TopicProducer {
         let entries = records
             .into_iter()
             .map::<(RecordKey, RecordData), _>(|(k, v)| (k.into(), v.into()))
-            .map(|(key, value)| {
-                let key = match key.0 {
-                    RecordKeyInner::Null => None,
-                    RecordKeyInner::Key(key) => Some(DefaultAsyncBuffer::new(key.0)),
-                };
-                let value = DefaultAsyncBuffer::new(value.0);
-                DefaultRecord::from((key, value))
-            });
+            .map(Record::from);
 
         // Calculate the partition for each entry
         // Use a block scope to ensure we drop the partitioner lock
@@ -168,9 +161,9 @@ impl TopicProducer {
 async fn group_by_spu(
     topic: &str,
     partitions: &StoreContext<PartitionSpec>,
-    records_by_partition: Vec<(PartitionId, DefaultRecord)>,
-) -> Result<HashMap<SpuId, HashMap<PartitionId, Vec<DefaultRecord>>>, FluvioError> {
-    let mut map: HashMap<SpuId, HashMap<i32, Vec<DefaultRecord>>> = HashMap::new();
+    records_by_partition: Vec<(PartitionId, Record)>,
+) -> Result<HashMap<SpuId, HashMap<PartitionId, MemoryBatch>>, FluvioError> {
+    let mut map: HashMap<SpuId, HashMap<i32, MemoryBatch>> = HashMap::new();
     for (partition, record) in records_by_partition {
         let replica_key = ReplicaKey::new(topic, partition);
         let partition_spec = partitions
@@ -191,7 +184,7 @@ async fn group_by_spu(
 
 fn assemble_requests(
     topic: &str,
-    partitions_by_spu: HashMap<SpuId, HashMap<PartitionId, Vec<DefaultRecord>>>,
+    partitions_by_spu: HashMap<SpuId, HashMap<PartitionId, MemoryBatch>>,
 ) -> Vec<(SpuId, DefaultProduceRequest)> {
     let mut requests: Vec<(SpuId, DefaultProduceRequest)> =
         Vec::with_capacity(partitions_by_spu.len());
@@ -209,10 +202,7 @@ fn assemble_requests(
                 partition_index: partition,
                 ..Default::default()
             };
-            partition_request
-                .records
-                .batches
-                .push(DefaultBatch::new(records));
+            partition_request.records.batches.push(Batch::from(records));
             topic_request.partitions.push(partition_request);
         }
 
@@ -223,49 +213,6 @@ fn assemble_requests(
     }
 
     requests
-}
-
-/// A key for determining which partition a record should be sent to.
-///
-/// This type is used to support conversions from any other type that
-/// may be converted to a `Vec<u8>`, while still allowing the ability
-/// to explicitly state that a record may have no key (`RecordKey::NULL`).
-///
-/// # Examples
-///
-/// ```
-/// # use fluvio::{TopicProducer, FluvioError, RecordKey};
-/// # async fn example(producer: &TopicProducer) -> Result<(), FluvioError> {
-/// producer.send("Hello", String::from("World!")).await?;
-/// producer.send(RecordKey::NULL, "World!").await?;
-/// # Ok(())
-/// # }
-/// ```
-pub struct RecordKey(RecordKeyInner);
-
-impl RecordKey {
-    pub const NULL: Self = Self(RecordKeyInner::Null);
-}
-
-enum RecordKeyInner {
-    Null,
-    Key(RecordData),
-}
-
-impl<K: Into<Vec<u8>>> From<K> for RecordKey {
-    fn from(k: K) -> Self {
-        Self(RecordKeyInner::Key(RecordData::from(k)))
-    }
-}
-
-/// A type to hold the contents of a record's value.
-pub struct RecordData(bytes::Bytes);
-
-impl<V: Into<Vec<u8>>> From<V> for RecordData {
-    fn from(v: V) -> Self {
-        let value: Vec<u8> = v.into();
-        Self(value.into())
-    }
 }
 
 /// A trait for defining a partitioning strategy for key/value records.
@@ -370,12 +317,12 @@ mod tests {
         .collect();
         partitions.store().sync_all(partition_specs).await;
         let records_by_partition = vec![
-            (0, DefaultRecord::new("A")),
-            (1, DefaultRecord::new("B")),
-            (2, DefaultRecord::new("C")),
-            (0, DefaultRecord::new("D")),
-            (1, DefaultRecord::new("E")),
-            (2, DefaultRecord::new("F")),
+            (0, Record::new("A")),
+            (1, Record::new("B")),
+            (2, Record::new("C")),
+            (0, Record::new("D")),
+            (1, Record::new("E")),
+            (2, Record::new("F")),
         ];
 
         let grouped = group_by_spu("TOPIC", &partitions, records_by_partition)
@@ -455,8 +402,8 @@ mod tests {
 
             let spu_0 = {
                 let mut s0_partitions = HashMap::new();
-                let partition_0_records = vec![DefaultRecord::new("A"), DefaultRecord::new("B")];
-                let partition_1_records = vec![DefaultRecord::new("C"), DefaultRecord::new("D")];
+                let partition_0_records = vec![Record::new("A"), Record::new("B")];
+                let partition_1_records = vec![Record::new("C"), Record::new("D")];
                 s0_partitions.insert(0, partition_0_records);
                 s0_partitions.insert(1, partition_1_records);
                 s0_partitions
@@ -464,8 +411,8 @@ mod tests {
 
             let spu_1 = {
                 let mut s1_partitions = HashMap::new();
-                let partition_2_records = vec![DefaultRecord::new("E"), DefaultRecord::new("F")];
-                let partition_3_records = vec![DefaultRecord::new("G"), DefaultRecord::new("H")];
+                let partition_2_records = vec![Record::new("E"), Record::new("F")];
+                let partition_3_records = vec![Record::new("G"), Record::new("H")];
                 s1_partitions.insert(2, partition_2_records);
                 s1_partitions.insert(3, partition_3_records);
                 s1_partitions

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -27,8 +27,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-stream-model = { path = "../stream-model", version = "0.5.0" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
-
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -19,4 +19,4 @@ tracing = "0.1.19"
 fluvio-types = { path = "../types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.9.0" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/src/dataplane-protocol/src/fixture.rs
+++ b/src/dataplane-protocol/src/fixture.rs
@@ -6,13 +6,13 @@ use std::path::Path;
 use tracing::info;
 use derive_builder::Builder;
 
-use crate::record::{DefaultRecord, RecordSet};
-use crate::batch::DefaultBatch;
+use crate::record::{Record, RecordSet};
+use crate::batch::Batch;
 
 const DEFAULT_TEST_BYTE: u8 = 5;
 
-fn default_record_producer(_record_index: usize, producer: &BatchProducer) -> DefaultRecord {
-    let mut record = DefaultRecord::default();
+fn default_record_producer(_record_index: usize, producer: &BatchProducer) -> Record {
+    let mut record = Record::default();
     let bytes: Vec<u8> = vec![DEFAULT_TEST_BYTE; producer.per_record_bytes];
     record.value = bytes.into();
     record
@@ -29,7 +29,7 @@ pub struct BatchProducer {
     pub per_record_bytes: usize,
     /// generate record
     #[builder(setter, default = "Arc::new(default_record_producer)")]
-    pub record_generator: Arc<dyn Fn(usize, &BatchProducer) -> DefaultRecord>,
+    pub record_generator: Arc<dyn Fn(usize, &BatchProducer) -> Record>,
 }
 
 impl BatchProducer {
@@ -37,8 +37,8 @@ impl BatchProducer {
         BatchProducerBuilder::default()
     }
 
-    fn generate_batch(&self) -> DefaultBatch {
-        let mut batches = DefaultBatch::default();
+    fn generate_batch(&self) -> Batch {
+        let mut batches = Batch::default();
         let header = batches.get_mut_header();
         header.magic = 2;
         header.producer_id = self.producer_id;
@@ -56,7 +56,7 @@ impl BatchProducer {
     }
 }
 
-pub fn create_batch() -> DefaultBatch {
+pub fn create_batch() -> Batch {
     create_batch_with_producer(12, 2)
 }
 
@@ -68,15 +68,15 @@ pub fn create_recordset(num_records: u16) -> RecordSet {
 pub const TEST_RECORD: &[u8] = &[10, 20];
 
 /// create batches with produce and records count
-pub fn create_batch_with_producer(producer: i64, records: u16) -> DefaultBatch {
-    let mut batches = DefaultBatch::default();
+pub fn create_batch_with_producer(producer: i64, records: u16) -> Batch {
+    let mut batches = Batch::default();
     let header = batches.get_mut_header();
     header.magic = 2;
     header.producer_id = producer;
     header.producer_epoch = -1;
 
     for _ in 0..records {
-        let mut record = DefaultRecord::default();
+        let mut record = Record::default();
         let bytes: Vec<u8> = TEST_RECORD.to_owned();
         record.value = bytes.into();
         batches.add_record(record);

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -22,7 +22,7 @@ use crate::derive::Encode;
 use crate::batch::Batch;
 use crate::Offset;
 
-#[deprecated(since = "0.6.0", note = "Use 'Record' instead")]
+#[deprecated(since = "0.5.1", note = "Use 'Record' instead")]
 pub type DefaultRecord = Record<RecordData>;
 
 /// maximum text to display
@@ -70,14 +70,23 @@ impl<K: Into<Vec<u8>>> From<K> for RecordKey {
     }
 }
 
-#[deprecated(since = "0.6.0", note = "Use 'RecordData' instead")]
+#[deprecated(since = "0.5.1", note = "Use 'RecordData' instead")]
 pub type DefaultAsyncBuffer = RecordData;
 
+/// A type containing the data contents of a Record.
+///
+/// The `RecordData` type provides useful conversions for
+/// constructing it from any type that may convert into a `Vec<u8>`.
+/// This is the basis for flexible APIs that allow users to supply
+/// various different argument types as record contents. See
+/// [the Producer API] as an example.
+///
+/// [the Producer API]: https://docs.rs/fluvio/producer/TopicProducer::send
 #[derive(Default)]
 pub struct RecordData(Bytes);
 
 impl RecordData {
-    #[deprecated(since = "0.6.0", note = "Use 'From::from' instead")]
+    #[deprecated(since = "0.5.1", note = "Use 'From::from' instead")]
     pub fn new<T>(val: T) -> Self
     where
         T: Into<Bytes>,

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -8,9 +8,8 @@ use content_inspector::{inspect, ContentType};
 use log::{trace, warn};
 use once_cell::sync::Lazy;
 
-use crate::core::bytes::Bytes;
-use crate::core::bytes::Buf;
-use crate::core::bytes::BufMut;
+use bytes::Buf;
+use bytes::BufMut;
 
 use crate::core::Decoder;
 use crate::core::DecoderVarInt;
@@ -20,10 +19,11 @@ use crate::core::Version;
 use crate::derive::Decode;
 use crate::derive::Encode;
 
-use crate::batch::DefaultBatch;
+use crate::batch::Batch;
 use crate::Offset;
 
-pub type DefaultRecord = Record<DefaultAsyncBuffer>;
+#[deprecated(since = "0.6.0", note = "Use 'Record' instead")]
+pub type DefaultRecord = Record<RecordData>;
 
 /// maximum text to display
 static MAX_STRING_DISPLAY: Lazy<usize> = Lazy::new(|| {
@@ -31,22 +31,58 @@ static MAX_STRING_DISPLAY: Lazy<usize> = Lazy::new(|| {
     var_value.parse().unwrap_or(16384)
 });
 
-/// slice that can works in Async Context
-pub trait AsyncBuffer {
-    fn len(&self) -> usize;
+/// A key for determining which partition a record should be sent to.
+///
+/// This type is used to support conversions from any other type that
+/// may be converted to a `Vec<u8>`, while still allowing the ability
+/// to explicitly state that a record may have no key (`RecordKey::NULL`).
+///
+/// # Examples
+///
+/// ```
+/// # use fluvio_dataplane_protocol::record::RecordKey;
+/// let key = RecordKey::NULL;
+/// let key: RecordKey = "Hello, world!".into();
+/// let key: RecordKey = String::from("Hello, world!").into();
+/// let key: RecordKey = vec![1, 2, 3, 4].into();
+/// ```
+pub struct RecordKey(RecordKeyInner);
+
+impl RecordKey {
+    pub const NULL: Self = Self(RecordKeyInner::Null);
+
+    fn into_option(self) -> Option<RecordData> {
+        match self.0 {
+            RecordKeyInner::Key(key) => Some(key),
+            RecordKeyInner::Null => None,
+        }
+    }
 }
 
-pub trait Records {}
+enum RecordKeyInner {
+    Null,
+    Key(RecordData),
+}
+
+impl<K: Into<Vec<u8>>> From<K> for RecordKey {
+    fn from(k: K) -> Self {
+        Self(RecordKeyInner::Key(RecordData::from(k)))
+    }
+}
+
+#[deprecated(since = "0.6.0", note = "Use 'RecordData' instead")]
+pub type DefaultAsyncBuffer = RecordData;
 
 #[derive(Default)]
-pub struct DefaultAsyncBuffer(Bytes);
+pub struct RecordData(Bytes);
 
-impl DefaultAsyncBuffer {
+impl RecordData {
+    #[deprecated(since = "0.6.0", note = "Use 'From::from' instead")]
     pub fn new<T>(val: T) -> Self
     where
         T: Into<Bytes>,
     {
-        DefaultAsyncBuffer(val.into())
+        Self(val.into())
     }
 
     pub fn len(&self) -> usize {
@@ -68,19 +104,19 @@ impl DefaultAsyncBuffer {
     }
 }
 
-impl AsRef<[u8]> for DefaultAsyncBuffer {
+impl<V: Into<Vec<u8>>> From<V> for RecordData {
+    fn from(value: V) -> Self {
+        Self(Bytes::from(value.into()))
+    }
+}
+
+impl AsRef<[u8]> for RecordData {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl AsyncBuffer for DefaultAsyncBuffer {
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-
-impl Debug for DefaultAsyncBuffer {
+impl Debug for RecordData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = &self.0;
         if matches!(inspect(value), ContentType::BINARY) {
@@ -97,7 +133,7 @@ impl Debug for DefaultAsyncBuffer {
     }
 }
 
-impl Display for DefaultAsyncBuffer {
+impl Display for RecordData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = &self.0;
         if matches!(inspect(value), ContentType::BINARY) {
@@ -114,26 +150,7 @@ impl Display for DefaultAsyncBuffer {
     }
 }
 
-impl From<String> for DefaultAsyncBuffer {
-    fn from(value: String) -> Self {
-        Self::new(value.into_bytes())
-    }
-}
-
-impl From<Vec<u8>> for DefaultAsyncBuffer {
-    fn from(value: Vec<u8>) -> Self {
-        Self::new(value)
-    }
-}
-
-impl<'a> From<&'a [u8]> for DefaultAsyncBuffer {
-    fn from(bytes: &'a [u8]) -> Self {
-        let value = bytes.to_owned();
-        Self::new(value)
-    }
-}
-
-impl Encoder for DefaultAsyncBuffer {
+impl Encoder for RecordData {
     fn write_size(&self, version: Version) -> usize {
         let len = self.0.len() as i64;
         self.0.iter().fold(len.var_write_size(), |sum, val| {
@@ -154,7 +171,7 @@ impl Encoder for DefaultAsyncBuffer {
     }
 }
 
-impl Decoder for DefaultAsyncBuffer {
+impl Decoder for RecordData {
     fn decode<T>(&mut self, src: &mut T, _: Version) -> Result<(), Error>
     where
         T: Buf,
@@ -167,11 +184,11 @@ impl Decoder for DefaultAsyncBuffer {
 
         // Take `len` bytes from `src` and put them into a new BytesMut buffer
         let slice = src.take(len);
-        let mut bytes_mut = bytes::BytesMut::with_capacity(len);
-        bytes_mut.put(slice);
+        let mut bytes = BytesMut::with_capacity(len);
+        bytes.put(slice);
 
-        // Replace the inner Bytes buffer of this DefaultAsyncBuffer
-        self.0 = bytes_mut.freeze();
+        // Replace the inner Bytes buffer of this RecordData
+        self.0 = bytes.freeze();
         Ok(())
     }
 }
@@ -180,7 +197,7 @@ impl Decoder for DefaultAsyncBuffer {
 //  It is written consequently with len as prefix
 #[derive(Default, Debug)]
 pub struct RecordSet {
-    pub batches: Vec<DefaultBatch>,
+    pub batches: Vec<Batch>,
 }
 
 impl fmt::Display for RecordSet {
@@ -190,7 +207,7 @@ impl fmt::Display for RecordSet {
 }
 
 impl RecordSet {
-    pub fn add(mut self, batch: DefaultBatch) -> Self {
+    pub fn add(mut self, batch: Batch) -> Self {
         self.batches.push(batch);
         self
     }
@@ -249,7 +266,7 @@ impl Decoder for RecordSet {
                 count,
                 buf.remaining()
             );
-            let mut batch = DefaultBatch::default();
+            let mut batch = Batch::default();
             match batch.decode(&mut buf, version) {
                 Ok(_) => self.batches.push(batch),
                 Err(err) => match err.kind() {
@@ -319,20 +336,14 @@ impl RecordHeader {
 }
 
 #[derive(Default)]
-pub struct Record<B>
-where
-    B: Default,
-{
+pub struct Record<B = RecordData> {
     pub preamble: RecordHeader,
     pub key: Option<B>,
     pub value: B,
     pub headers: i64,
 }
 
-impl<B> Record<B>
-where
-    B: Default,
-{
+impl<B: Default> Record<B> {
     pub fn get_offset_delta(&self) -> Offset {
         self.preamble.offset_delta
     }
@@ -363,80 +374,42 @@ where
     }
 }
 
-impl DefaultRecord {
+impl Record {
     pub fn new<V>(value: V) -> Self
     where
-        V: Into<Vec<u8>>,
+        V: Into<RecordData>,
     {
-        DefaultRecord {
-            value: DefaultAsyncBuffer::new(value.into()),
+        Record {
+            value: value.into(),
             ..Default::default()
         }
     }
 
     pub fn new_key_value<K, V>(key: K, value: V) -> Self
     where
-        K: Into<Vec<u8>>,
-        V: Into<Vec<u8>>,
+        K: Into<RecordKey>,
+        V: Into<RecordData>,
     {
-        DefaultRecord {
-            key: Some(DefaultAsyncBuffer::new(key.into())),
-            value: DefaultAsyncBuffer::new(value.into()),
-            ..Default::default()
-        }
-    }
-}
-
-impl<B: Default> From<(Option<B>, B)> for Record<B> {
-    fn from((key, value): (Option<B>, B)) -> Self {
+        let key = key.into().into_option();
         Record {
             key,
-            value,
-            ..Default::default()
-        }
-    }
-}
-
-impl<B> From<String> for Record<B>
-where
-    B: From<String> + Default,
-{
-    fn from(value: String) -> Self {
-        Record {
             value: value.into(),
             ..Default::default()
         }
     }
 }
 
-impl<B> From<Vec<u8>> for Record<B>
+impl<K, V> From<(K, V)> for Record
 where
-    B: From<Vec<u8>> + Default,
+    K: Into<RecordKey>,
+    V: Into<RecordData>,
 {
-    fn from(value: Vec<u8>) -> Self {
-        Record {
-            value: value.into(),
-            ..Default::default()
-        }
+    fn from((key, value): (K, V)) -> Self {
+        Self::new_key_value(key, value)
     }
 }
 
-impl<'a, B> From<&'a [u8]> for Record<B>
-where
-    B: From<&'a [u8]> + Default,
-{
-    fn from(slice: &'a [u8]) -> Self {
-        Record {
-            value: B::from(slice),
-            ..Default::default()
-        }
-    }
-}
-
-impl<B> Debug for Record<B>
-where
-    B: AsyncBuffer + Debug + Default,
-{
+impl<B: Debug> Debug for Record<B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{:?}", &self.preamble)?;
         writeln!(f, "{:?}", &self.key)?;
@@ -507,18 +480,18 @@ where
 
 #[cfg(test)]
 mod test {
-
+    use super::*;
     use std::io::Cursor;
     use std::io::Error as IoError;
 
     use crate::core::Decoder;
     use crate::core::Encoder;
-    use crate::record::DefaultRecord;
+    use crate::record::Record;
 
     #[test]
     fn test_decode_encode_record() -> Result<(), IoError> {
         /* Below is how you generate the vec<u8> for the `data` varible below.
-        let mut record = DefaultRecord::from(String::from("dog"));
+        let mut record = Record::from(String::from("dog"));
         record.preamble.set_offset_delta(1);
         let mut out = vec![];
         record.encode(&mut out, 0)?;
@@ -526,7 +499,7 @@ mod test {
         */
         let data = [0x12, 0x0, 0x0, 0x2, 0x0, 0x6, 0x64, 0x6f, 0x67, 0x0];
 
-        let record = DefaultRecord::decode_from(&mut Cursor::new(&data), 0)?;
+        let record = Record::<RecordData>::decode_from(&mut Cursor::new(&data), 0)?;
         assert_eq!(record.as_bytes(0)?.len(), data.len());
 
         assert_eq!(record.write_size(0), data.len());
@@ -544,13 +517,13 @@ mod test {
     #[test]
     fn test_decode_batch_truncation() {
         use super::RecordSet;
-        use crate::batch::DefaultBatch;
-        use crate::record::DefaultRecord;
+        use crate::batch::Batch;
+        use crate::record::Record;
 
-        fn create_batch() -> DefaultBatch {
+        fn create_batch() -> Batch {
             let value = vec![0x74, 0x65, 0x73, 0x74];
-            let record = DefaultRecord::new(value);
-            let mut batch = DefaultBatch::default();
+            let record = Record::new(value);
+            let mut batch = Batch::default();
             batch.add_record(record);
             batch
         }
@@ -585,16 +558,16 @@ mod test {
     fn test_key_value_encoding() {
         let key = "KKKKKKKKKK".to_string();
         let value = "VVVVVVVVVV".to_string();
-        let record = DefaultRecord::new_key_value(key, value);
+        let record = Record::new_key_value(key, value);
 
         let mut encoded = Vec::new();
         record.encode(&mut encoded, 0).unwrap();
-        let decoded = DefaultRecord::decode_from(&mut Cursor::new(encoded), 0).unwrap();
+        let decoded = Record::<RecordData>::decode_from(&mut Cursor::new(encoded), 0).unwrap();
 
         let record_key = record.key.unwrap();
         let decoded_key = decoded.key.unwrap();
-        assert_eq!(record_key.0.as_ref(), decoded_key.0.as_ref());
-        assert_eq!(record.value.0.as_ref(), decoded.value.0.as_ref());
+        assert_eq!(record_key.as_ref(), decoded_key.as_ref());
+        assert_eq!(record.value.as_ref(), decoded.value.as_ref());
     }
 
     // Test Specification:
@@ -602,10 +575,10 @@ mod test {
     // A record was encoded and written to a file, using the following code:
     //
     // ```rust
-    // use fluvio_dataplane_protocol::record::{DefaultRecord, DefaultAsyncBuffer};
+    // use fluvio_dataplane_protocol::record::{Record, DefaultAsyncBuffer};
     // use fluvio_protocol::Encoder;
     // let value = "VVVVVVVVVV".to_string();
-    // let record = DefaultRecord {
+    // let record = Record {
     //     key: DefaultAsyncBuffer::default(),
     //     value: DefaultAsyncBuffer::new(value.into_bytes()),
     //     ..Default::default()
@@ -629,7 +602,7 @@ mod test {
     #[test]
     fn test_decode_old_record_empty_key() {
         let old_encoded = std::fs::read("./tests/test_old_record_empty_key.bin").unwrap();
-        let decoded = DefaultRecord::decode_from(&mut Cursor::new(old_encoded), 0).unwrap();
+        let decoded = Record::<RecordData>::decode_from(&mut Cursor::new(old_encoded), 0).unwrap();
         assert_eq!(
             std::str::from_utf8(decoded.value.0.as_ref()).unwrap(),
             "VVVVVVVVVV"
@@ -640,6 +613,7 @@ mod test {
 
 #[cfg(feature = "file")]
 pub use file::*;
+use crate::bytes::{Bytes, BytesMut};
 
 #[cfg(feature = "file")]
 mod file {

--- a/src/dataplane-protocol/tests/file_fetch.rs
+++ b/src/dataplane-protocol/tests/file_fetch.rs
@@ -14,8 +14,8 @@ use fluvio_future::fs::AsyncFileExtension;
 use fluvio_future::net::TcpListener;
 use fluvio_protocol::Encoder;
 use fluvio_protocol::api::{Request, ResponseMessage, RequestMessage};
-use fluvio_dataplane_protocol::batch::DefaultBatch;
-use fluvio_dataplane_protocol::record::{DefaultRecord, DefaultAsyncBuffer};
+use fluvio_dataplane_protocol::batch::Batch;
+use fluvio_dataplane_protocol::record::Record;
 use fluvio_dataplane_protocol::fetch::{
     DefaultFetchRequest, FileFetchResponse, FileFetchRequest, FilePartitionResponse,
     FileTopicResponse,
@@ -26,8 +26,8 @@ use flv_util::fixture::ensure_clean_file;
 use fluvio_socket::FluvioSocket;
 
 /// create sample batches with message
-fn create_batches(records: u16) -> DefaultBatch {
-    let mut batches = DefaultBatch::default();
+fn create_batches(records: u16) -> Batch {
+    let mut batches = Batch::default();
     let header = batches.get_mut_header();
     header.magic = 2;
     header.producer_id = 20;
@@ -36,11 +36,7 @@ fn create_batches(records: u16) -> DefaultBatch {
     for i in 0..records {
         let key = format!("key {}", i);
         let value = format!("value {}", i);
-        let record = DefaultRecord {
-            key: Some(DefaultAsyncBuffer::new(key.into_bytes())),
-            value: DefaultAsyncBuffer::new(value.into_bytes()),
-            ..Default::default()
-        };
+        let record = Record::from((key, value));
         batches.add_record(record);
     }
     batches

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -25,4 +25,4 @@ static_assertions = "1.1.0"
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.9.0", default-features = false, path = "../controlplane-metadata" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -55,11 +55,10 @@ k8-client = { version = "5.0.0", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.2.1", features = ["app"] }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-socket = { path = "../socket", version = "0.8.2" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
-
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/src/smartstream-wasm/Cargo.toml
+++ b/src/smartstream-wasm/Cargo.toml
@@ -12,6 +12,5 @@ description = "Fluvio SmartStream WASM library"
 [lib]
 crate-type = ['lib']
 
-
 [dependencies]
-fluvio-dataplane-protocol = { version = "0.5.0", path = "../dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.5.1", path = "../dataplane-protocol", default-features = false }

--- a/src/smartstream-wasm/src/lib.rs
+++ b/src/smartstream-wasm/src/lib.rs
@@ -1,4 +1,5 @@
 pub use fluvio_dataplane_protocol as dataplane;
+pub use dataplane::record::{Record, RecordData};
 
 pub mod memory {
     /// Allocate memory into the module's linear memory

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -20,4 +20,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -49,17 +49,16 @@ fluvio-controlplane = { version = "0.7.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-metadata" }
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-socket = { path = "../socket", version = "0.8.2" }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "zero_copy"] }
 
-
 [dev-dependencies]
 once_cell = "1.5.2"
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-future = { version = "0.3.1", features = ["fixture", "subscriber"] }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
 derive_builder = { version = "0.9.0" }

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -497,7 +497,7 @@ mod test {
     use dataplane::{
         Isolation,
         fixture::BatchProducer,
-        record::{DefaultAsyncBuffer, DefaultRecord},
+        record::{RecordData, Record},
     };
     use dataplane::fixture::{create_batch, TEST_RECORD};
     use fluvio_spu_schema::server::update_offset::{UpdateOffsetsRequest, OffsetUpdate};
@@ -820,17 +820,14 @@ mod test {
         debug!("terminated controller");
     }
 
-    fn generate_record(record_index: usize, _producer: &BatchProducer) -> DefaultRecord {
+    fn generate_record(record_index: usize, _producer: &BatchProducer) -> Record {
         let msg = match record_index {
             0 => "b".repeat(100),
             1 => "a".repeat(100),
             _ => "z".repeat(100),
         };
 
-        DefaultRecord {
-            value: DefaultAsyncBuffer::new(msg.into_bytes()),
-            ..Default::default()
-        }
+        Record::new(RecordData::from(msg))
     }
 
     /// create records that can be filtered

--- a/src/spu/src/smart_stream/filter.rs
+++ b/src/spu/src/smart_stream/filter.rs
@@ -14,10 +14,8 @@ use wasmtime::{Caller, Engine, Extern, Func, Instance, Module, Store, Trap, Type
 use fluvio_future::file_slice::AsyncFileSlice;
 use dataplane::core::{Decoder, Encoder};
 use dataplane::Offset;
-use dataplane::{
-    batch::{BATCH_FILE_HEADER_SIZE, BATCH_HEADER_SIZE, Batch, DefaultBatch},
-    record::{DefaultRecord},
-};
+use dataplane::batch::{BATCH_FILE_HEADER_SIZE, BATCH_HEADER_SIZE, Batch};
+use dataplane::batch::MemoryBatch;
 // use fluvio_future::task::spawn_blocking;
 
 // use fluvio_storage::config::DEFAULT_MAX_BATCH_SIZE;
@@ -203,7 +201,7 @@ impl SmartFilter {
     }
 
     /// filter batches with maximum bytes to be send back consumer
-    pub fn filter(&self, slice: AsyncFileSlice, max_bytes: usize) -> Result<DefaultBatch, Error> {
+    pub fn filter(&self, slice: AsyncFileSlice, max_bytes: usize) -> Result<Batch, Error> {
         use std::os::unix::io::AsRawFd;
 
         let fd = slice.as_raw_fd();
@@ -211,7 +209,7 @@ impl SmartFilter {
         let mut batch_iterator =
             FileBatchIterator::new(fd, slice.position() as i64, slice.len() as i64);
 
-        let mut filter_batch = DefaultBatch::default();
+        let mut filter_batch = Batch::<MemoryBatch>::default();
         filter_batch.base_offset = -1; // indicate this is unitialized
         filter_batch.set_offset_delta(-1); // make add_to_offset_delta correctly
 
@@ -255,7 +253,7 @@ impl SmartFilter {
                     .unwrap_or_default();
                 debug!(out_filter_bytes = bytes.len());
                 // this is inefficient for now
-                let mut records: Vec<DefaultRecord> = vec![];
+                let mut records: MemoryBatch = vec![];
                 records.decode(&mut Cursor::new(bytes), 0)?;
 
                 // there are filtered records!!
@@ -331,7 +329,7 @@ async fn read<'a>(fd: RawFd, bytes: &'a mut [u8], position: i64) -> Result<usize
 
 // only encode information necessary to decode batches efficiently
 struct FileBatch {
-    batch: DefaultBatch,
+    batch: Batch,
     records: Vec<u8>,
 }
 

--- a/src/spu/src/smart_stream/filter.rs
+++ b/src/spu/src/smart_stream/filter.rs
@@ -15,7 +15,7 @@ use fluvio_future::file_slice::AsyncFileSlice;
 use dataplane::core::{Decoder, Encoder};
 use dataplane::Offset;
 use dataplane::batch::{BATCH_FILE_HEADER_SIZE, BATCH_HEADER_SIZE, Batch};
-use dataplane::batch::MemoryBatch;
+use dataplane::batch::MemoryRecords;
 // use fluvio_future::task::spawn_blocking;
 
 // use fluvio_storage::config::DEFAULT_MAX_BATCH_SIZE;
@@ -209,7 +209,7 @@ impl SmartFilter {
         let mut batch_iterator =
             FileBatchIterator::new(fd, slice.position() as i64, slice.len() as i64);
 
-        let mut filter_batch = Batch::<MemoryBatch>::default();
+        let mut filter_batch = Batch::<MemoryRecords>::default();
         filter_batch.base_offset = -1; // indicate this is unitialized
         filter_batch.set_offset_delta(-1); // make add_to_offset_delta correctly
 
@@ -253,7 +253,7 @@ impl SmartFilter {
                     .unwrap_or_default();
                 debug!(out_filter_bytes = bytes.len());
                 // this is inefficient for now
-                let mut records: MemoryBatch = vec![];
+                let mut records: MemoryRecords = vec![];
                 records.decode(&mut Cursor::new(bytes), 0)?;
 
                 // there are filtered records!!

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -31,17 +31,15 @@ serde = { version = "1.0.103", features = ['derive'] }
 async-lock = "2.4.0"
 derive_builder = "0.10.2"
 
-
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-future = { version = "0.3.0", features = ["fs", "mmap"] }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
-
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-socket = { path = "../socket", version = "0.8.2" }
 fluvio-storage = { path = ".", features = ["fixture"]}
-dataplane = { version = "0.5.0", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -13,7 +13,7 @@ use futures_lite::io::AsyncSeekExt;
 use fluvio_future::fs::File;
 use dataplane::batch::{
     Batch, BatchRecords, BATCH_PREAMBLE_SIZE, BATCH_HEADER_SIZE, BATCH_FILE_HEADER_SIZE,
-    MemoryBatch,
+    MemoryRecords,
 };
 use dataplane::Size;
 use dataplane::Offset;
@@ -168,7 +168,7 @@ where
 }
 
 // stream to iterate batch
-pub struct FileBatchStream<R = MemoryBatch> {
+pub struct FileBatchStream<R = MemoryRecords> {
     pos: Size,
     invalid: Option<IoError>,
     file: File,

--- a/src/storage/src/batch.rs
+++ b/src/storage/src/batch.rs
@@ -12,15 +12,13 @@ use futures_lite::io::AsyncSeekExt;
 
 use fluvio_future::fs::File;
 use dataplane::batch::{
-    Batch, BatchRecords, DefaultBatchRecords, BATCH_PREAMBLE_SIZE, BATCH_HEADER_SIZE,
-    BATCH_FILE_HEADER_SIZE,
+    Batch, BatchRecords, BATCH_PREAMBLE_SIZE, BATCH_HEADER_SIZE, BATCH_FILE_HEADER_SIZE,
+    MemoryBatch,
 };
 use dataplane::Size;
 use dataplane::Offset;
 
 use crate::StorageError;
-
-pub type DefaultFileBatchStream = FileBatchStream<DefaultBatchRecords>;
 
 /// hold information about position of batch in the file
 pub struct FileBatchPos<R>
@@ -170,10 +168,7 @@ where
 }
 
 // stream to iterate batch
-pub struct FileBatchStream<R>
-where
-    R: Default + Debug,
-{
+pub struct FileBatchStream<R = MemoryBatch> {
     pos: Size,
     invalid: Option<IoError>,
     file: File,

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -371,7 +371,7 @@ mod tests {
 
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_clean_file;
-    use dataplane::batch::{Batch, MemoryBatch};
+    use dataplane::batch::{Batch, MemoryRecords};
     use dataplane::core::{Decoder, Encoder};
     use dataplane::fixture::create_batch;
     use dataplane::fixture::read_bytes_from_file;
@@ -412,7 +412,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
         debug!("read ok");
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();
@@ -467,7 +467,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
 
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();
@@ -559,7 +559,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
 
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -19,7 +19,7 @@ use fluvio_future::file_slice::AsyncFileSlice;
 use fluvio_future::fs::BoundedFileSink;
 use fluvio_future::fs::BoundedFileOption;
 use fluvio_future::fs::BoundedFileSinkError;
-use dataplane::batch::DefaultBatch;
+use dataplane::batch::Batch;
 use dataplane::{Offset, Size};
 use dataplane::core::Encoder;
 
@@ -150,7 +150,7 @@ impl MutFileRecords {
 
     /// try to write batch
     /// if there is enough room, return true, false otherwise
-    pub async fn write_batch(&mut self, item: &DefaultBatch) -> Result<bool, StorageError> {
+    pub async fn write_batch(&mut self, item: &Batch) -> Result<bool, StorageError> {
         trace!("start sending using batch {:#?}", item.get_header());
         self.item_last_offset_delta = item.get_last_offset_delta();
         let mut buffer: Vec<u8> = vec![];
@@ -371,7 +371,7 @@ mod tests {
 
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_clean_file;
-    use dataplane::batch::DefaultBatch;
+    use dataplane::batch::{Batch, MemoryBatch};
     use dataplane::core::{Decoder, Encoder};
     use dataplane::fixture::create_batch;
     use dataplane::fixture::read_bytes_from_file;
@@ -412,7 +412,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
         debug!("read ok");
-        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();
@@ -467,7 +467,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
 
-        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();
@@ -559,7 +559,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_file).expect("read bytes");
         assert_eq!(bytes.len(), write_size, "incorrect size for write");
 
-        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         let mut records = batch.own_records();

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -388,7 +388,7 @@ mod tests {
     use dataplane::core::{Decoder, Encoder};
     use dataplane::fetch::FilePartitionResponse;
     use dataplane::record::RecordSet;
-    use dataplane::batch::MemoryBatch;
+    use dataplane::batch::MemoryRecords;
     use dataplane::fixture::{BatchProducer, create_batch};
     use dataplane::fixture::read_bytes_from_file;
     use flv_util::fixture::ensure_clean_dir;
@@ -458,7 +458,7 @@ mod tests {
         debug!("using test file: {:#?}", test_file);
         let bytes = read_bytes_from_file(&test_file)?;
 
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.get_base_offset(), START_OFFSET);
         assert_eq!(batch.get_header().last_offset_delta, 1);
@@ -596,7 +596,7 @@ mod tests {
         let seg2_file = replica_dir.join(TEST_SE2_NAME);
         let bytes = read_bytes_from_file(&seg2_file)?;
 
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         assert_eq!(batch.get_base_offset(), 22);

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 
 use fluvio_future::fs::{create_dir_all, remove_dir_all};
 use dataplane::{ErrorCode, Isolation, Offset, ReplicaKey, Size};
-use dataplane::batch::DefaultBatch;
+use dataplane::batch::Batch;
 use dataplane::record::RecordSet;
 
 use crate::{OffsetInfo, checkpoint::CheckPoint};
@@ -352,7 +352,7 @@ impl FileReplica {
         OffsetInfo { hw, leo }
     }
 
-    async fn write_batch(&mut self, item: &mut DefaultBatch) -> Result<(), StorageError> {
+    async fn write_batch(&mut self, item: &mut Batch) -> Result<(), StorageError> {
         trace!("start_send");
         if !(self.active_segment.write_batch(item).await?) {
             debug!("segment has no room, rolling over previous segment");
@@ -383,11 +383,12 @@ mod tests {
     use std::io::Cursor;
 
     use fluvio_future::test_async;
-    use dataplane::{Isolation, batch::DefaultBatch};
+    use dataplane::{Isolation, batch::Batch};
     use dataplane::{Offset, ErrorCode};
     use dataplane::core::{Decoder, Encoder};
     use dataplane::fetch::FilePartitionResponse;
     use dataplane::record::RecordSet;
+    use dataplane::batch::MemoryBatch;
     use dataplane::fixture::{BatchProducer, create_batch};
     use dataplane::fixture::read_bytes_from_file;
     use flv_util::fixture::ensure_clean_dir;
@@ -457,7 +458,7 @@ mod tests {
         debug!("using test file: {:#?}", test_file);
         let bytes = read_bytes_from_file(&test_file)?;
 
-        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.get_base_offset(), START_OFFSET);
         assert_eq!(batch.get_header().last_offset_delta, 1);
@@ -595,7 +596,7 @@ mod tests {
         let seg2_file = replica_dir.join(TEST_SE2_NAME);
         let bytes = read_bytes_from_file(&seg2_file)?;
 
-        let batch = DefaultBatch::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 2);
         assert_eq!(batch.get_base_offset(), 22);

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -380,7 +380,7 @@ mod tests {
 
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_new_dir;
-    use dataplane::batch::{Batch, MemoryBatch};
+    use dataplane::batch::{Batch, MemoryRecords};
     use dataplane::Size;
     use dataplane::core::Decoder;
     use dataplane::fixture::create_batch_with_producer;
@@ -434,7 +434,8 @@ mod tests {
         debug!("read {} bytes", bytes.len());
 
         // read batches from raw bytes to see if it can be parsed
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0).expect("decode");
+        let batch =
+            Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0).expect("decode");
         assert_eq!(batch.get_base_offset(), 20);
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 1);
@@ -478,7 +479,7 @@ mod tests {
         let bytes = read_bytes_from_file(&test_dir.join(TEST_FILE_NAME))?;
         debug!("read {} bytes", bytes.len());
 
-        let batch = Batch::<MemoryBatch>::decode_from(&mut Cursor::new(bytes), 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(&mut Cursor::new(bytes), 0)?;
         assert_eq!(batch.get_base_offset(), 20);
         assert_eq!(batch.get_header().magic, 2, "check magic");
         assert_eq!(batch.records().len(), 4);
@@ -524,11 +525,11 @@ mod tests {
         debug!("read {} bytes", bytes.len());
 
         let cursor = &mut Cursor::new(bytes);
-        let batch = Batch::<MemoryBatch>::decode_from(cursor, 0)?;
+        let batch = Batch::<MemoryRecords>::decode_from(cursor, 0)?;
         assert_eq!(batch.get_base_offset(), 40);
         assert_eq!(batch.get_header().last_offset_delta, 1);
 
-        let batch2 = Batch::<MemoryBatch>::decode_from(cursor, 0)?;
+        let batch2 = Batch::<MemoryRecords>::decode_from(cursor, 0)?;
         assert_eq!(batch2.get_base_offset(), 42);
         assert_eq!(batch2.get_header().last_offset_delta, 1);
 

--- a/src/storage/src/validator.rs
+++ b/src/storage/src/validator.rs
@@ -124,8 +124,8 @@ mod tests {
     use fluvio_future::fs::BoundedFileOption;
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_clean_file;
-    use dataplane::record::DefaultRecord;
-    use dataplane::batch::DefaultBatch;
+    use dataplane::record::Record;
+    use dataplane::batch::Batch;
     use dataplane::Offset;
 
     use crate::mut_records::MutFileRecords;
@@ -136,20 +136,18 @@ mod tests {
 
     const PRODUCER: i64 = 33;
 
-    pub fn create_batch(base_offset: Offset, records: u16) -> DefaultBatch {
-        let mut batches = DefaultBatch::default();
-        batches.set_base_offset(base_offset);
-        let header = batches.get_mut_header();
+    pub fn create_batch(base_offset: Offset, records: u16) -> Batch {
+        let mut batch = Batch::default();
+        batch.set_base_offset(base_offset);
+        let header = batch.get_mut_header();
         header.magic = 2;
         header.producer_id = PRODUCER;
         header.producer_epoch = -1;
         for _ in 0..records {
-            let mut record = DefaultRecord::default();
-            let bytes: Vec<u8> = vec![10, 20];
-            record.value = bytes.into();
-            batches.add_record(record);
+            let record = Record::new(vec![10, 20]);
+            batch.add_record(record);
         }
-        batches
+        batch
     }
 
     const TEST_FILE_NAME: &str = "00000000000000000301.log"; // for offset 301

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -19,8 +19,7 @@ use dataplane::{
     record::RecordSet,
 };
 use dataplane::api::RequestMessage;
-use dataplane::record::DefaultRecord;
-use dataplane::record::DefaultAsyncBuffer;
+use dataplane::record::Record;
 use dataplane::Offset;
 use dataplane::fixture::BatchProducer;
 
@@ -43,12 +42,9 @@ fn default_option() -> ConfigOption {
     }
 }
 
-fn generate_record(record_index: usize, _producer: &BatchProducer) -> DefaultRecord {
+fn generate_record(record_index: usize, _producer: &BatchProducer) -> Record {
     let msg = format!("record {}", record_index);
-    DefaultRecord {
-        value: DefaultAsyncBuffer::new(msg.into_bytes()),
-        ..Default::default()
-    }
+    Record::new(msg)
 }
 
 /// create sample batches with variable number of records


### PR DESCRIPTION
This PR will help our Record type and its helper types be much more user-friendly and allow us to stop wrapping the dataplane::Record API with other types in order to make the user-facing API look nicer. Here's a breakdown of changes:

- Remove `DefaultRecord` and `DefaultBatch` in favor of using default generics, e.g. `Record<B = RecordData>`
- Push down the `RecordKey` and `RecordData` types from the client producer module into dataplane
- Replace `DefaultAsyncBuffer` with `RecordData`
- Re-export `Record`, `RecordKey`, and `RecordData` in client's `producer` module (therefore no breaking changes in client)
- Massage conversion implementations for `Record`, `RecordKey` and `RecordData` in order to make the types more user-friendly

These changes were made specifically in order to support a nicer SmartStream API for authors of new SmartStreams. This will allow us to expose these dataplane types directly and have them be much more friendly and usable, rather than needing to wrap the lower-level API with sugar to present to users, like SimpleRecord was used for before.