### PR TITLE
[Merged by Bors] - make easier to support different platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
  "dirs 1.0.5",
  "event-listener",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-sc-schema",
  "fluvio-socket",
@@ -1347,7 +1347,7 @@ dependencies = [
  "async-trait",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-socket",
  "fluvio-types",
@@ -1378,7 +1378,7 @@ dependencies = [
  "fluvio-command 0.2.0",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-package-index",
  "fluvio-sc-schema",
  "fluvio-types",
@@ -1419,7 +1419,7 @@ dependencies = [
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-helm",
  "flv-util",
  "futures-lite",
@@ -1480,7 +1480,7 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-stream-model",
  "fluvio-types",
@@ -1499,7 +1499,7 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "derive_builder 0.9.0",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-socket",
  "flv-util",
@@ -1551,9 +1551,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61587e440c936984e7dab40903de1c9adc39ab13e8446b52c50852da5cd6fbcb"
+version = "0.3.2"
+source = "git+https://github.com/infinyon/future-aio.git#1b39405e3bd4ad469c05778498371a32a6686472"
 dependencies = [
  "async-fs",
  "async-io",
@@ -1561,7 +1560,9 @@ dependencies = [
  "async-net",
  "async-std",
  "async-trait",
+ "cfg-if 1.0.0",
  "fluvio-test-derive",
+ "fluvio-wasm-timer",
  "futures-lite",
  "futures-util",
  "log",
@@ -1575,7 +1576,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
- "wasm-timer",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ name = "fluvio-integration-derive"
 version = "0.1.0"
 dependencies = [
  "fluvio",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-test-util",
  "inflections",
  "proc-macro2",
@@ -1637,7 +1637,7 @@ name = "fluvio-protocol"
 version = "0.5.1"
 dependencies = [
  "bytes",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol-api 0.4.0",
  "fluvio-protocol-codec",
  "fluvio-protocol-core 0.3.0",
@@ -1673,7 +1673,7 @@ name = "fluvio-protocol-codec"
 version = "0.3.1"
 dependencies = [
  "bytes",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol-core 0.3.0",
  "flv-util",
  "futures",
@@ -1727,7 +1727,7 @@ name = "fluvio-run"
 version = "0.2.0"
 dependencies = [
  "fluvio-extension-common",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-sc",
  "fluvio-spu",
  "semver 0.11.0",
@@ -1751,7 +1751,7 @@ dependencies = [
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-sc-schema",
  "fluvio-service",
@@ -1798,7 +1798,7 @@ name = "fluvio-service"
 version = "0.6.0"
 dependencies = [
  "async-trait",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-socket",
  "fluvio-types",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1828,7 +1828,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "event-listener",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "flv-util",
  "futures-util",
@@ -1859,7 +1859,7 @@ dependencies = [
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-service",
  "fluvio-socket",
@@ -1907,7 +1907,7 @@ dependencies = [
  "bytes",
  "derive_builder 0.10.2",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-protocol 0.5.1",
  "fluvio-socket",
  "fluvio-storage",
@@ -1929,7 +1929,7 @@ dependencies = [
  "async-rwlock",
  "async-trait",
  "event-listener",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1950,7 +1950,7 @@ version = "0.5.1"
 dependencies = [
  "async-rwlock",
  "event-listener",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "k8-types",
  "once_cell",
  "serde",
@@ -1970,8 +1970,7 @@ dependencies = [
 [[package]]
 name = "fluvio-test-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18fef80a26d3533f4fcbc95ff51cfd161f975f544b48e423368fa69aadc478e"
+source = "git+https://github.com/infinyon/future-aio.git#1b39405e3bd4ad469c05778498371a32a6686472"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1989,7 +1988,7 @@ dependencies = [
  "fluvio-cluster",
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "futures-lite",
  "inventory",
  "log",
@@ -2010,9 +2009,23 @@ name = "fluvio-types"
 version = "0.2.4"
 dependencies = [
  "event-listener",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "fluvio-wasm-timer"
+version = "0.2.5"
+source = "git+https://github.com/infinyon/wasm-timer.git?branch=fluvio-wasm-timer#4a3361ca02b186b57ebd4141001c07d1913db643"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.1",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2027,7 +2040,7 @@ dependencies = [
  "fluvio-command 0.2.1",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "fluvio-integration-derive",
  "fluvio-system-util",
  "fluvio-test-util",
@@ -2054,7 +2067,7 @@ dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
  "event-listener",
- "fluvio-future 0.3.1",
+ "fluvio-future 0.3.2",
  "futures-lite",
  "futures-util",
  "log",
@@ -2564,6 +2577,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3481,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -3493,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -4483,11 +4499,12 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
 dependencies = [
  "ctor",
+ "version_check",
 ]
 
 [[package]]
@@ -4601,21 +4618,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.1",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ members = [
 ]
 resolver = "2"
 
+[patch.crates-io]
+fluvio-future = { git = "https://github.com/infinyon/future-aio.git" }
 
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -26,7 +26,7 @@ fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-meta
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
 fluvio-protocol = { path = "../protocol",  version = "0.5.1" }
-fluvio-socket = { path = "../socket", version = "0.8.2" }
+fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 flv-tls-proxy = { version = "0.5.0" }
 futures-util = { version = "0.3.5" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -43,7 +43,7 @@ fluvio-future = { version = "0.3.0", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.0", path = "../sc-schema", default-features = false }
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
-fluvio-socket = { path = "../socket", version = "0.8.2" }
+fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 categories = ["encoding", "api-bindings"]
 
 [features]
-default = ["file"]
 file = ["fluvio-protocol/store"]
 fixture = ["derive_builder"]
 
@@ -26,11 +25,11 @@ once_cell = "1.5.2"
 derive_builder = { version = "0.9.0", optional =  true }
 
 # Fluvio dependencies
-fluvio-future = { version = "0.3.0" }
+fluvio-future = { version = "0.3.1" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { path = "../socket", version = "0.8.2" }
-fluvio-future = { version = "0.3.0", features = ["fixture","fs"] }
+fluvio-socket = { path = "../socket", version = "0.8.1" }
+fluvio-future = { version = "0.3.1", features = ["fixture","fs"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -55,7 +55,7 @@ k8-client = { version = "5.0.0", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.2.1", features = ["app"] }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-fluvio-socket = { path = "../socket", version = "0.8.2" }
+fluvio-socket = { path = "../socket", version = "0.8.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.3.0", features = ["macros"] }
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.3.0" }
-fluvio-socket = { version = "0.8.2", path = "../socket" }
+fluvio-socket = { version = "0.8.1", path = "../socket" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
 fluvio-types = { version = "0.2.3", features = ["events"], path = "../types" }
 

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.8.2"
+version = "0.8.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
@@ -12,6 +12,8 @@ categories = ["encoding"]
 name = "fluvio_socket"
 path = "src/lib.rs"
 
+[features]
+file = ["fluvio-future/zero_copy", "fluvio-protocol/store"]
 
 [dependencies]
 log = "0.4.0"
@@ -32,8 +34,8 @@ thiserror = "1.0.20"
 
 
 # Fluvio dependencies
-fluvio-future = { version = "0.3.0", features = ["net", "zero_copy"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec", "store"] }
+fluvio-future = { version = "0.3.2", features = ["net"] }
+fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
 
 
 [dev-dependencies]

--- a/src/socket/src/error.rs
+++ b/src/socket/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "file")]
 use fluvio_future::zero_copy::SendFileError;
 use std::io::Error as IoError;
 use thiserror::Error;
@@ -8,6 +9,7 @@ pub enum FlvSocketError {
     IoError(#[from] IoError),
     #[error("Socket closed")]
     SocketClosed,
+    #[cfg(feature = "file")]
     #[error("Zero-copy IO error")]
     SendFileError(#[from] SendFileError),
 }

--- a/src/socket/src/lib.rs
+++ b/src/socket/src/lib.rs
@@ -1,40 +1,35 @@
-cfg_if::cfg_if! {
-    if #[cfg(unix)] {
-        mod error;
-        mod multiplexing;
-        mod sink;
-        mod socket;
-        mod stream;
+mod error;
+mod multiplexing;
+mod sink;
+mod socket;
+mod stream;
 
-        #[cfg(test)]
-        pub mod test_request;
+#[cfg(test)]
+pub mod test_request;
 
-        pub use fluvio_future::net::{BoxConnection,Connection};
-        pub use self::error::FlvSocketError;
-        pub use self::socket::FluvioSocket;
-        pub use multiplexing::*;
-        pub use sink::*;
-        pub use socket::*;
-        pub use stream::*;
+pub use fluvio_future::net::{BoxConnection, Connection};
+pub use self::error::FlvSocketError;
+pub use self::socket::FluvioSocket;
+pub use multiplexing::*;
+pub use sink::*;
+pub use socket::*;
+pub use stream::*;
 
-        use fluvio_protocol::api::Request;
-        use fluvio_protocol::api::RequestMessage;
-        use fluvio_protocol::api::ResponseMessage;
+use fluvio_protocol::api::Request;
+use fluvio_protocol::api::RequestMessage;
+use fluvio_protocol::api::ResponseMessage;
 
-        /// send request and return response from calling server at socket addr
-        pub async fn send_and_receive<R>(
-            addr: &str,
-            request: &RequestMessage<R>,
-        ) -> Result<ResponseMessage<R::Response>, FlvSocketError>
-        where
-            R: Request,
-        {
-            let mut client = FluvioSocket::connect(addr).await?;
+/// send request and return response from calling server at socket addr
+pub async fn send_and_receive<R>(
+    addr: &str,
+    request: &RequestMessage<R>,
+) -> Result<ResponseMessage<R::Response>, FlvSocketError>
+where
+    R: Request,
+{
+    let mut client = FluvioSocket::connect(addr).await?;
 
-            let msgs: ResponseMessage<R::Response> = client.send(&request).await?;
+    let msgs: ResponseMessage<R::Response> = client.send(&request).await?;
 
-            Ok(msgs)
-        }
-
-    }
+    Ok(msgs)
 }

--- a/src/socket/src/sink.rs
+++ b/src/socket/src/sink.rs
@@ -2,29 +2,19 @@ use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use std::os::unix::io::AsRawFd;
-use std::os::unix::io::RawFd;
-
+use tracing::trace;
+use futures_util::{SinkExt};
 use async_lock::Mutex;
 use async_lock::MutexGuard;
-use tracing::trace;
-use tokio_util::compat::FuturesAsyncWriteCompatExt;
-use futures_util::{SinkExt, AsyncWriteExt};
+use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
+use tokio_util::codec::{FramedWrite};
 
-use tokio_util::compat::Compat;
-use bytes::BytesMut;
 
-use fluvio_future::zero_copy::ZeroCopy;
-use fluvio_protocol::api::RequestMessage;
-use fluvio_protocol::api::ResponseMessage;
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_protocol::codec::FluvioCodec;
-use fluvio_protocol::store::FileWrite;
-use fluvio_protocol::store::StoreValue;
 use fluvio_protocol::Encoder as FlvEncoder;
 use fluvio_protocol::Version;
-use fluvio_future::net::BoxWriteConnection;
-
-use tokio_util::codec::{FramedWrite};
+use fluvio_future::net::{BoxWriteConnection, ConnectionFd};
 
 use crate::FlvSocketError;
 
@@ -32,7 +22,7 @@ type SinkFrame = FramedWrite<Compat<BoxWriteConnection>, FluvioCodec>;
 
 pub struct FluvioSink {
     inner: SinkFrame,
-    fd: RawFd,
+    fd: ConnectionFd,
 }
 
 impl fmt::Debug for FluvioSink {
@@ -46,7 +36,7 @@ impl FluvioSink {
         &mut self.inner
     }
 
-    pub fn id(&self) -> RawFd {
+    pub fn id(&self) -> ConnectionFd {
         self.fd
     }
 
@@ -56,7 +46,7 @@ impl FluvioSink {
         ExclusiveFlvSink::new(self)
     }
 
-    pub fn new(sink: BoxWriteConnection, fd: RawFd) -> Self {
+    pub fn new(sink: BoxWriteConnection, fd: ConnectionFd) -> Self {
         Self {
             fd,
             inner: SinkFrame::new(sink.compat_write(), FluvioCodec::new()),
@@ -91,73 +81,97 @@ impl FluvioSink {
     }
 }
 
-impl FluvioSink {
-    /// write
-    pub async fn encode_file_slices<T>(
-        &mut self,
-        msg: &T,
-        version: Version,
-    ) -> Result<(), FlvSocketError>
-    where
-        T: FileWrite,
-    {
-        trace!("encoding file slices version: {}", version);
-        let mut buf = BytesMut::with_capacity(1000);
-        let mut data: Vec<StoreValue> = vec![];
-        msg.file_encode(&mut buf, &mut data, version)?;
-        trace!("encoded buffer len: {}", buf.len());
-        // add remainder
-        data.push(StoreValue::Bytes(buf.freeze()));
-        self.write_store_values(data).await
-    }
+#[cfg(unix)]
+mod fd {
 
-    /// write store values to socket
-    async fn write_store_values(&mut self, values: Vec<StoreValue>) -> Result<(), FlvSocketError> {
-        trace!("writing store values to socket values: {}", values.len());
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::io::RawFd;
 
-        for value in values {
-            match value {
-                StoreValue::Bytes(bytes) => {
-                    trace!("writing store bytes to socket len: {}", bytes.len());
-                    // These bytes should be already encoded so don't need to pass
-                    // through the FluvioCodec
-                    self.get_mut_tcp_sink()
-                        .get_mut()
-                        .get_mut()
-                        .write(&bytes)
-                        .await?;
-                }
-                StoreValue::FileSlice(f_slice) => {
-                    if f_slice.is_empty() {
-                        trace!("empty slice, skipping");
-                    } else {
-                        trace!(
-                            "writing file slice pos: {} len: {} to socket",
-                            f_slice.position(),
-                            f_slice.len()
-                        );
-                        let writer = ZeroCopy::raw(self.fd);
-                        writer.copy_slice(&f_slice).await?;
-                        trace!("finish writing file slice");
-                    }
-                }
-            }
+    use super::FluvioSink;
+
+    impl AsRawFd for FluvioSink {
+        fn as_raw_fd(&self) -> RawFd {
+            self.fd
         }
-
-        Ok(())
     }
 }
 
-impl AsRawFd for FluvioSink {
-    fn as_raw_fd(&self) -> RawFd {
-        self.fd
+#[cfg(feature = "file")]
+mod file {
+
+    use bytes::BytesMut;
+    use futures_util::AsyncWriteExt;
+
+    use fluvio_protocol::store::{FileWrite, StoreValue};
+    use fluvio_future::zero_copy::ZeroCopy;
+
+    use super::*;
+
+    impl FluvioSink {
+        /// write
+        pub async fn encode_file_slices<T>(
+            &mut self,
+            msg: &T,
+            version: Version,
+        ) -> Result<(), FlvSocketError>
+        where
+            T: FileWrite,
+        {
+            trace!("encoding file slices version: {}", version);
+            let mut buf = BytesMut::with_capacity(1000);
+            let mut data: Vec<StoreValue> = vec![];
+            msg.file_encode(&mut buf, &mut data, version)?;
+            trace!("encoded buffer len: {}", buf.len());
+            // add remainder
+            data.push(StoreValue::Bytes(buf.freeze()));
+            self.write_store_values(data).await
+        }
+
+        /// write store values to socket
+        async fn write_store_values(
+            &mut self,
+            values: Vec<StoreValue>,
+        ) -> Result<(), FlvSocketError> {
+            trace!("writing store values to socket values: {}", values.len());
+
+            for value in values {
+                match value {
+                    StoreValue::Bytes(bytes) => {
+                        trace!("writing store bytes to socket len: {}", bytes.len());
+                        // These bytes should be already encoded so don't need to pass
+                        // through the FluvioCodec
+                        self.get_mut_tcp_sink()
+                            .get_mut()
+                            .get_mut()
+                            .write(&bytes)
+                            .await?;
+                    }
+                    StoreValue::FileSlice(f_slice) => {
+                        if f_slice.is_empty() {
+                            trace!("empty slice, skipping");
+                        } else {
+                            trace!(
+                                "writing file slice pos: {} len: {} to socket",
+                                f_slice.position(),
+                                f_slice.len()
+                            );
+                            let writer = ZeroCopy::raw(self.fd);
+                            writer.copy_slice(&f_slice).await?;
+                            trace!("finish writing file slice");
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
     }
 }
 
 /// Multi-thread aware Sink.  Only allow sending request one a time.
 pub struct ExclusiveFlvSink {
     inner: Arc<Mutex<FluvioSink>>,
-    fd: RawFd,
+    fd: ConnectionFd,
 }
 
 impl ExclusiveFlvSink {
@@ -196,7 +210,7 @@ impl ExclusiveFlvSink {
         inner_sink.send_response(resp_msg, version).await
     }
 
-    pub fn id(&self) -> RawFd {
+    pub fn id(&self) -> ConnectionFd {
         self.fd
     }
 }

--- a/src/socket/src/sink.rs
+++ b/src/socket/src/sink.rs
@@ -9,7 +9,6 @@ use async_lock::MutexGuard;
 use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 use tokio_util::codec::{FramedWrite};
 
-
 use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_protocol::codec::FluvioCodec;
 use fluvio_protocol::Encoder as FlvEncoder;

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 name = "fluvio_spu_schema"
 path = "src/lib.rs"
 
+[features]
+file = ["dataplane/file"]
+
+
 [dependencies]
 log = "0.4.8"
 tracing = "0.1.19"

--- a/src/spu-schema/src/server/api_key.rs
+++ b/src/spu-schema/src/server/api_key.rs
@@ -14,6 +14,7 @@ pub enum SpuServerApiKey {
     ApiVersion = 18, // API_VERSIONS_KEY
 
     Produce = 0,
+    #[cfg(feature = "file")]
     Fetch = 1,
 
     FetchOffsets = 1002,

--- a/src/spu-schema/src/server/mod.rs
+++ b/src/spu-schema/src/server/mod.rs
@@ -1,8 +1,11 @@
 mod api_key;
+#[cfg(feature = "file")]
 mod api;
 pub mod fetch_offset;
 pub mod stream_fetch;
 pub mod update_offset;
 
 pub use self::api_key::*;
+
+#[cfg(feature = "file")]
 pub use self::api::SpuServerRequest;

--- a/src/spu-schema/src/server/stream_fetch.rs
+++ b/src/spu-schema/src/server/stream_fetch.rs
@@ -4,27 +4,19 @@
 //! Stream records to client
 //!
 use std::fmt::Debug;
-use std::io::Error as IoError;
 use std::marker::PhantomData;
 
-use log::trace;
-use bytes::BytesMut;
-
-use dataplane::core::Version;
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;
 use dataplane::api::Request;
 use dataplane::derive::Decode;
 use dataplane::derive::Encode;
-use dataplane::store::StoreValue;
-use dataplane::record::FileRecordSet;
-use dataplane::store::FileWrite;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
 use dataplane::Isolation;
 
 pub type DefaultStreamFetchResponse = StreamFetchResponse<RecordSet>;
-pub type FileStreamFetchRequest = StreamFetchRequest<FileRecordSet>;
+
 pub type DefaultStreamFetchRequest = StreamFetchRequest<RecordSet>;
 
 use super::SpuServerApiKey;
@@ -68,18 +60,39 @@ where
     pub partition: FetchablePartitionResponse<R>,
 }
 
-impl FileWrite for StreamFetchResponse<FileRecordSet> {
-    fn file_encode(
-        &self,
-        src: &mut BytesMut,
-        data: &mut Vec<StoreValue>,
-        version: Version,
-    ) -> Result<(), IoError> {
-        trace!("file encoding FlvContinuousFetchResponse");
-        trace!("topic {}", self.topic);
-        self.topic.encode(src, version)?;
-        self.stream_id.encode(src, version)?;
-        self.partition.file_encode(src, data, version)?;
-        Ok(())
+#[cfg(feature = "file")]
+pub use file::*;
+
+#[cfg(feature = "file")]
+mod file {
+
+    use std::io::Error as IoError;
+
+    use log::trace;
+    use bytes::BytesMut;
+
+    use dataplane::core::Version;
+    use dataplane::store::StoreValue;
+    use dataplane::record::FileRecordSet;
+    use dataplane::store::FileWrite;
+
+    pub type FileStreamFetchRequest = StreamFetchRequest<FileRecordSet>;
+
+    use super::*;
+
+    impl FileWrite for StreamFetchResponse<FileRecordSet> {
+        fn file_encode(
+            &self,
+            src: &mut BytesMut,
+            data: &mut Vec<StoreValue>,
+            version: Version,
+        ) -> Result<(), IoError> {
+            trace!("file encoding FlvContinuousFetchResponse");
+            trace!("topic {}", self.topic);
+            self.topic.encode(src, version)?;
+            self.stream_id.encode(src, version)?;
+            self.partition.file_encode(src, data, version)?;
+            Ok(())
+        }
     }
 }

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -47,14 +47,14 @@ fluvio-types = { version = "0.2.3", features = ["events"], path = "../types" }
 fluvio-storage = { version = "0.5.0", path = "../storage" }
 fluvio-controlplane = { version = "0.7.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.9.0", path = "../controlplane-metadata" }
-fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
+fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema", features = ["file"]}
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
-fluvio-socket = { path = "../socket", version = "0.8.2" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-socket = { path = "../socket", version = "0.8.1", features = ["file"] }
+dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }
-fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "zero_copy"] }
+fluvio-future = { version = "0.3.1", features = ["subscriber", "openssl_tls", "zero_copy"] }
 
 [dev-dependencies]
 once_cell = "1.5.2"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -40,6 +40,6 @@ dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluv
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { path = "../socket", version = "0.8.2" }
+fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-storage = { path = ".", features = ["fixture"]}
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,13 +33,13 @@ derive_builder = "0.10.2"
 
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
-fluvio-future = { version = "0.3.0", features = ["fs", "mmap"] }
+fluvio-future = { version = "0.3.2", features = ["fs", "mmap","zero_copy"] }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { path = "../socket", version = "0.8.1" }
+fluvio-socket = { path = "../socket", version = "0.8.1",features = ["file"] }
 fluvio-storage = { path = ".", features = ["fixture"]}
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }


### PR DESCRIPTION
* Upgrade to `fluvio_future` 0.3.2 which supports OS independent connection
* Separate file related features from Socket and Schema which make it easier to support other targets

#933 