### PR TITLE
[Merged by Bors] - Update filter-json example with LogLevel

### DIFF
--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd29a0773ef0ab97eb91e621093b4b64218456941e33fd63d9647fbe57a439cf"
+checksum = "61587e440c936984e7dab40903de1c9adc39ab13e8446b52c50852da5cd6fbcb"
 dependencies = [
  "log",
  "thiserror",

--- a/src/smartstream/examples/filter_json/src/lib.rs
+++ b/src/smartstream/examples/filter_json/src/lib.rs
@@ -47,9 +47,18 @@
 
 use fluvio_smartstream::{smartstream, Record};
 
+#[derive(PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
 #[derive(serde::Deserialize)]
 struct StructuredLog {
-    level: String,
+    level: LogLevel,
     #[serde(rename = "message")]
     _message: String,
 }
@@ -64,6 +73,5 @@ pub fn filter_log_level(record: &Record) -> bool {
         Err(_) => return false,
     };
 
-    // Keep any logs tagged as "info", "warn", or "error"
-    log.level == "info" || log.level == "warn" || log.level == "error"
+    log.level > LogLevel::Debug
 }


### PR DESCRIPTION
This updates the `src/smartstream/examples/filter_json` example code to match what I wrote about in the Filer page on our website.