### PR TITLE
[Merged by Bors] - Remove remaining dependencies on 'log' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,6 @@ dependencies = [
  "fluvio-types",
  "flv-tls-proxy",
  "futures-util",
- "log",
  "serde",
  "serde_json",
  "thiserror",
@@ -1503,7 +1502,6 @@ dependencies = [
  "fluvio-socket",
  "flv-util",
  "futures-util",
- "log",
  "once_cell",
  "semver 0.11.0",
  "tracing",
@@ -1628,7 +1626,7 @@ checksum = "d461d8c93b1fd2756a0602f493db0bb58f3a0702306c2598f138f41a2d0af244"
 dependencies = [
  "fluvio-protocol-api 0.3.0",
  "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-derive 0.2.0",
 ]
 
 [[package]]
@@ -1640,7 +1638,7 @@ dependencies = [
  "fluvio-protocol-api 0.4.0",
  "fluvio-protocol-codec",
  "fluvio-protocol-core 0.3.0",
- "fluvio-protocol-derive 0.2.0",
+ "fluvio-protocol-derive 0.2.1",
  "flv-util",
  "log",
 ]
@@ -1652,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae66072f907fffff49299438a9afe0379aa4718587f408eb5d98545445ff0c6c"
 dependencies = [
  "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol-derive 0.2.0",
  "flv-util",
  "log",
 ]
@@ -1662,9 +1660,9 @@ name = "fluvio-protocol-api"
 version = "0.4.0"
 dependencies = [
  "fluvio-protocol-core 0.3.0",
- "fluvio-protocol-derive 0.2.0",
+ "fluvio-protocol-derive 0.2.1",
  "flv-util",
- "log",
+ "tracing",
 ]
 
 [[package]]
@@ -1701,8 +1699,9 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-derive"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
 dependencies = [
- "fluvio-protocol 0.5.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1711,14 +1710,13 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
+version = "0.2.1"
 dependencies = [
- "log",
+ "fluvio-protocol 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
+ "tracing",
 ]
 
 [[package]]
@@ -1764,7 +1762,6 @@ dependencies = [
  "k8-client",
  "k8-metadata-client",
  "k8-types",
- "log",
  "once_cell",
  "rand 0.8.3",
  "regex",
@@ -2002,7 +1999,6 @@ dependencies = [
  "fluvio-future 0.3.2",
  "futures-lite",
  "inventory",
- "log",
  "once_cell",
  "prettytable-rs",
  "proc-macro2",
@@ -2058,7 +2054,6 @@ dependencies = [
  "fluvio-types",
  "futures-lite",
  "inventory",
- "log",
  "md-5",
  "prettytable-rs",
  "rand 0.8.3",
@@ -2067,6 +2062,7 @@ dependencies = [
  "structopt",
  "syn",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
  "event-listener",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1347,7 +1347,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1466,7 +1466,7 @@ version = "0.7.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-types",
  "log",
  "tracing",
@@ -1479,7 +1479,7 @@ dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1498,7 +1498,7 @@ dependencies = [
  "crc32c",
  "derive_builder 0.9.0",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-socket",
  "flv-util",
  "futures-util",
@@ -1620,47 +1620,24 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d461d8c93b1fd2756a0602f493db0bb58f3a0702306c2598f138f41a2d0af244"
-dependencies = [
- "fluvio-protocol-api 0.3.0",
- "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-derive 0.2.0",
-]
-
-[[package]]
-name = "fluvio-protocol"
 version = "0.5.1"
 dependencies = [
  "bytes",
  "fluvio-future 0.3.2",
- "fluvio-protocol-api 0.4.0",
+ "fluvio-protocol-api",
  "fluvio-protocol-codec",
- "fluvio-protocol-core 0.3.0",
- "fluvio-protocol-derive 0.2.1",
+ "fluvio-protocol-core",
+ "fluvio-protocol-derive",
  "flv-util",
- "log",
-]
-
-[[package]]
-name = "fluvio-protocol-api"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae66072f907fffff49299438a9afe0379aa4718587f408eb5d98545445ff0c6c"
-dependencies = [
- "fluvio-protocol-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluvio-protocol-derive 0.2.0",
- "flv-util",
- "log",
+ "tracing",
 ]
 
 [[package]]
 name = "fluvio-protocol-api"
 version = "0.4.0"
 dependencies = [
- "fluvio-protocol-core 0.3.0",
- "fluvio-protocol-derive 0.2.1",
+ "fluvio-protocol-core",
+ "fluvio-protocol-derive",
  "flv-util",
  "tracing",
 ]
@@ -1671,7 +1648,7 @@ version = "0.3.1"
 dependencies = [
  "bytes",
  "fluvio-future 0.3.2",
- "fluvio-protocol-core 0.3.0",
+ "fluvio-protocol-core",
  "flv-util",
  "futures",
  "log",
@@ -1687,32 +1664,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-protocol-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c950608da27edf870cdebb301e64a09c8de3bda11c9b374ffa892e80bab2024a"
-dependencies = [
- "bytes",
- "log",
-]
-
-[[package]]
-name = "fluvio-protocol-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
-dependencies = [
- "log",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "fluvio-protocol-derive"
 version = "0.2.1"
 dependencies = [
- "fluvio-protocol 0.5.0",
+ "fluvio-protocol",
  "proc-macro2",
  "quote",
  "syn",
@@ -1749,7 +1704,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -1780,7 +1735,7 @@ version = "0.8.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-types",
  "log",
  "serde",
@@ -1795,7 +1750,7 @@ version = "0.6.0"
 dependencies = [
  "async-trait",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-socket",
  "fluvio-types",
  "futures-util",
@@ -1837,7 +1792,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "flv-util",
  "futures-util",
  "log",
@@ -1868,7 +1823,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-service",
  "fluvio-socket",
  "fluvio-spu-schema",
@@ -1898,7 +1853,7 @@ version = "0.6.0"
 dependencies = [
  "bytes",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "log",
  "serde",
  "static_assertions",
@@ -1916,7 +1871,7 @@ dependencies = [
  "derive_builder 0.10.2",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.2",
- "fluvio-protocol 0.5.1",
+ "fluvio-protocol",
  "fluvio-socket",
  "fluvio-storage",
  "fluvio-types",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,11 +14,10 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.41"
-log = "0.4.11"
 serde = { version = "1.0.103", features = ['derive'] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"
-tracing = "0.1.21"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 x509-parser = "0.9.1"
 

--- a/src/auth/src/x509/authenticator.rs
+++ b/src/auth/src/x509/authenticator.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::Path};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::os::unix::io::AsRawFd;
 
-use log::{debug, trace};
+use tracing::{debug, trace};
 use x509_parser::{certificate::X509Certificate, parse_x509_certificate};
 use async_trait::async_trait;
 

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -13,7 +13,6 @@ file = ["fluvio-protocol/store"]
 fixture = ["derive_builder"]
 
 [dependencies]
-log = "0.4.0"
 tracing = "0.1.19"
 cfg-if = "1.0.0"
 bytes = "1.0.0"

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -2,7 +2,7 @@ use std::io::Error;
 use std::mem::size_of;
 use std::fmt::Debug;
 
-use log::trace;
+use tracing::trace;
 
 use crate::core::bytes::Buf;
 use crate::core::bytes::BufMut;

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -145,7 +145,7 @@ mod file {
 
     use std::io::Error as IoError;
 
-    use log::trace;
+    use tracing::trace;
     use bytes::BytesMut;
 
     use crate::record::FileRecordSet;
@@ -175,7 +175,7 @@ mod file {
             if version >= 11 {
                 self.next_filter_offset.encode(src, version)?;
             } else {
-                log::trace!("v: {} is less than last fetched version 11", version);
+                tracing::trace!("v: {} is less than last fetched version 11", version);
             }
             self.log_start_offset.encode(src, version)?;
             self.aborted.encode(src, version)?;

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -84,7 +84,7 @@ pub use file::*;
 mod file {
     use std::io::Error as IoError;
 
-    use log::trace;
+    use tracing::trace;
     use bytes::BytesMut;
 
     use crate::core::Version;

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -5,7 +5,7 @@ use std::io::Error;
 use std::io::ErrorKind;
 
 use content_inspector::{inspect, ContentType};
-use log::{trace, warn};
+use tracing::{trace, warn};
 use once_cell::sync::Lazy;
 
 use bytes::Buf;
@@ -633,7 +633,7 @@ mod file {
     use std::io::Error as IoError;
     use std::io::ErrorKind;
 
-    use log::trace;
+    use tracing::trace;
     use bytes::BufMut;
     use bytes::BytesMut;
 

--- a/src/dataplane-protocol/tests/file_fetch.rs
+++ b/src/dataplane-protocol/tests/file_fetch.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 use std::env::temp_dir;
 use std::time::Duration;
 
-use log::debug;
+use tracing::debug;
 use futures_util::io::AsyncWriteExt;
 use futures_util::future::join;
 use futures_util::stream::StreamExt;

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["encoding", "api-bindings"]
 derive = ["fluvio-protocol-derive"]
 api = ["fluvio-protocol-api"]
 codec = ["fluvio-protocol-codec"]
-store = ["fluvio-future", "fluvio-protocol-api", "log", "bytes"]
+store = ["fluvio-future", "fluvio-protocol-api", "bytes"]
 
 [dependencies]
+tracing = "0.1"
 fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
 fluvio-protocol-derive = { version = "0.2.0", path = "fluvio-protocol-derive", optional = true }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api", optional = true }
 fluvio-protocol-codec = { version = "0.3.1", path = "fluvio-protocol-codec", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
-log = { version = "0.4.8", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
@@ -28,5 +28,4 @@ flv-util = { version = "0.5.2" }
 fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive" }
 fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api" }
-log = { version = "0.4.8" }
 fluvio-future = { version = "0.3.0", features = ["subscriber"]}

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 flv-util = { version = "0.5.2" }
-fluvio-protocol-derive = { version = "0.2.0", path = "fluvio-protocol-derive" }
+fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive" }
 fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api" }
 log = { version = "0.4.8" }

--- a/src/protocol/fluvio-protocol-api/Cargo.toml
+++ b/src/protocol/fluvio-protocol-api/Cargo.toml
@@ -10,8 +10,8 @@ categories = ["encoding","api-bindings"]
 
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1"
 fluvio-protocol = { version = "0.3.0", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
-fluvio-protocol-derive = { version = "0.2.0", path = "../fluvio-protocol-derive" }
+fluvio-protocol-derive = { version = "0.2.1", path = "../fluvio-protocol-derive" }
 flv-util = { version = "0.5.0"}
 

--- a/src/protocol/fluvio-protocol-api/src/api.rs
+++ b/src/protocol/fluvio-protocol-api/src/api.rs
@@ -9,8 +9,8 @@ use std::fmt::Debug;
 use std::fmt;
 use std::convert::TryFrom;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use crate::core::Decoder;
 use crate::core::Encoder;

--- a/src/protocol/fluvio-protocol-api/src/request.rs
+++ b/src/protocol/fluvio-protocol-api/src/request.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::fmt;
 use std::fmt::Display;
 
-use log::trace;
+use tracing::trace;
 
 use crate::core::bytes::Buf;
 use crate::core::bytes::BufMut;

--- a/src/protocol/fluvio-protocol-api/src/response.rs
+++ b/src/protocol/fluvio-protocol-api/src/response.rs
@@ -5,8 +5,8 @@ use std::io::ErrorKind;
 use std::io::Read;
 use std::path::Path;
 
-use log::debug;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 use crate::core::bytes::Buf;
 use crate::core::bytes::BufMut;

--- a/src/protocol/fluvio-protocol-derive/Cargo.toml
+++ b/src/protocol/fluvio-protocol-derive/Cargo.toml
@@ -22,4 +22,4 @@ version = "1.0.0"
 features = ["full"]
 
 [dev-dependencies]
-fluvio-protocol = { version = "0.5.0", features = ["derive", "api"] }
+fluvio-protocol = { version = "0.5.1", path = "../", features = ["derive", "api"] }

--- a/src/protocol/fluvio-protocol-derive/Cargo.toml
+++ b/src/protocol/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 proc-macro2 = "1.0.0"
 quote = "1.0.0"
-log = "0.4.8"
+tracing = "0.1"
 
 [dependencies.syn]
 version = "1.0.0"

--- a/src/protocol/fluvio-protocol-derive/src/ast/container.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/container.rs
@@ -42,7 +42,7 @@ impl ContainerAttributes {
                                     cont_attr.response = Some(lit_str.value());
                                 }
                             } else {
-                                log::warn!(
+                                tracing::warn!(
                                     "#[fluvio({})] does nothing on the container.",
                                     name_value.to_token_stream().to_string()
                                 )
@@ -53,7 +53,7 @@ impl ContainerAttributes {
                             } else if path.is_ident("encode_discriminant") {
                                 cont_attr.encode_discriminant = true;
                             } else {
-                                log::warn!(
+                                tracing::warn!(
                                     "#[fluvio({})] does nothing on the container.",
                                     path.to_token_stream().to_string()
                                 )

--- a/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
@@ -52,7 +52,7 @@ impl Prop {
                                     prop.default_value = Some(lit_str.value());
                                 }
                             } else {
-                                log::warn!(
+                                tracing::warn!(
                                     "#[fluvio({})] does nothing on {}.",
                                     name_value.to_token_stream().to_string(),
                                     prop.field_name
@@ -102,7 +102,7 @@ impl Prop {
                 if version >= #min && version <= #max {
                     #field_stream
                 } else {
-                    log::trace!("Field: <{}> is skipped because version: {} is outside min: {}, max: {}",stringify!(#field_name),version,#min,#max);
+                    tracing::trace!("Field: <{}> is skipped because version: {} is outside min: {}, max: {}",stringify!(#field_name),version,#min,#max);
                 }
             }
         } else {
@@ -110,7 +110,7 @@ impl Prop {
                 if version >= #min {
                     #field_stream
                 } else {
-                    log::trace!("Field: <{}> is skipped because version: {} is less than min: {}",stringify!(#field_name),version,#min);
+                    tracing::trace!("Field: <{}> is skipped because version: {} is less than min: {}",stringify!(#field_name),version,#min);
                 }
             }
         }

--- a/src/protocol/fluvio-protocol-derive/src/de.rs
+++ b/src/protocol/fluvio-protocol-derive/src/de.rs
@@ -18,7 +18,7 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
             quote! {
                 impl #impl_generics fluvio_protocol::Decoder for #ident #ty_generics #where_clause {
                     fn decode<T>(&mut self, src: &mut T,version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::Buf {
-                        log::trace!("decoding struct: {}",stringify!(#ident));
+                        tracing::trace!("decoding struct: {}",stringify!(#ident));
                         #field_tokens
                         Ok(())
                     }
@@ -55,23 +55,23 @@ pub(crate) fn generate_struct_fields(props: &[Prop], struct_ident: &Ident) -> To
         let fname = format_ident!("{}", prop.field_name);
         if prop.varint {
             quote! {
-                log::trace!("start decoding varint field <{}>", stringify!(#fname));
+                tracing::trace!("start decoding varint field <{}>", stringify!(#fname));
                 let result = self.#fname.decode_varint(src);
                 if result.is_ok() {
-                    log::trace!("decoding ok varint <{}> => {:?}",stringify!(#fname),&self.#fname);
+                    tracing::trace!("decoding ok varint <{}> => {:?}",stringify!(#fname),&self.#fname);
                 } else {
-                    log::trace!("decoding varint error <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
+                    tracing::trace!("decoding varint error <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
                     return result;
                 }
             }
         } else {
             let base = quote! {
-                log::trace!("start decoding struct: <{}> field: <{}>",stringify!(#struct_ident),stringify!(#fname));
+                tracing::trace!("start decoding struct: <{}> field: <{}>",stringify!(#struct_ident),stringify!(#fname));
                 let result = self.#fname.decode(src,version);
                 if result.is_ok() {
-                    log::trace!("decoding struct: <{}> field: <{}> => {:#?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
+                    tracing::trace!("decoding struct: <{}> field: <{}> => {:#?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
                 } else {
-                    log::trace!("error decoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
+                    tracing::trace!("error decoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
                     return result;
                 }
             };
@@ -89,7 +89,7 @@ fn generate_variant_tokens(int_type: &Ident) -> TokenStream {
         use std::convert::TryInto;
         let mut typ: #int_type = 0;
         typ.decode(src, version)?;
-        log::trace!("decoded type: {}", typ);
+        tracing::trace!("decoded type: {}", typ);
 
         let convert: Self = typ.try_into()?;
         *self = convert;

--- a/src/protocol/fluvio-protocol-derive/src/ser.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ser.rs
@@ -17,13 +17,13 @@ pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
             quote! {
                 impl #impl_generics fluvio_protocol::Encoder for #ident #ty_generics #where_clause {
                     fn encode<T>(&self, dest: &mut T, version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::BufMut {
-                        log::trace!("encoding struct: {} version: {}",stringify!(#ident),version);
+                        tracing::trace!("encoding struct: {} version: {}",stringify!(#ident),version);
                         #encoded_field_tokens
                         Ok(())
                     }
 
                     fn write_size(&self, version: fluvio_protocol::Version) -> usize {
-                        log::trace!("write size for struct: {} version {}",stringify!(#ident),version);
+                        tracing::trace!("write size for struct: {} version {}",stringify!(#ident),version);
                         let mut len: usize = 0;
                         #size_field_tokens
                         len
@@ -39,13 +39,13 @@ pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
             quote! {
                 impl #impl_generics fluvio_protocol::Encoder for #ident #ty_generics #where_clause {
                     fn encode<T>(&self, dest: &mut T, version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::BufMut {
-                        log::trace!("encoding struct: {} version: {}",stringify!(#ident),version);
+                        tracing::trace!("encoding struct: {} version: {}",stringify!(#ident),version);
                         #encoded_variant_tokens
                         Ok(())
                     }
 
                     fn write_size(&self, version: fluvio_protocol::Version) -> usize {
-                        log::trace!("write size for struct: {} version {}",stringify!(#ident),version);
+                        tracing::trace!("write size for struct: {} version {}",stringify!(#ident),version);
                         #size_variant_tokens
                     }
                 }
@@ -60,19 +60,19 @@ fn parse_struct_props_encoding(props: &[Prop], struct_ident: &Ident) -> TokenStr
 
         if prop.varint {
             quote! {
-                log::trace!("encoding varint struct: <{}> field <{}> => {:?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
+                tracing::trace!("encoding varint struct: <{}> field <{}> => {:?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
                 let result = self.#fname.encode_varint(dest);
                 if result.is_err() {
-                    log::error!("error varint encoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
+                    tracing::error!("error varint encoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
                     return result;
                 }
             }
         } else {
             let base = quote! {
-                log::trace!("encoding struct: <{}>, field <{}> => {:?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
+                tracing::trace!("encoding struct: <{}>, field <{}> => {:?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
                 let result = self.#fname.encode(dest,version);
                 if result.is_err() {
-                    log::error!("Error Encoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
+                    tracing::error!("Error Encoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
                     return result;
                 }
             };
@@ -92,13 +92,13 @@ fn parse_struct_props_size(props: &[Prop], struct_ident: &Ident) -> TokenStream 
         if prop.varint {
             quote! {
                 let write_size = self.#fname.var_write_size();
-                log::trace!("varint write size: <{}>, field: <{}> is: {}",stringify!(#struct_ident),stringify!(#fname),write_size);
+                tracing::trace!("varint write size: <{}>, field: <{}> is: {}",stringify!(#struct_ident),stringify!(#fname),write_size);
                 len += write_size;
             }
         } else {
             let base = quote! {
                 let write_size = self.#fname.write_size(version);
-                log::trace!("write size: <{}> field: <{}> => {}",stringify!(#struct_ident),stringify!(#fname),write_size);
+                tracing::trace!("write size: <{}> field: <{}> => {}",stringify!(#struct_ident),stringify!(#fname),write_size);
                 len += write_size;
             };
             prop.version_check_token_stream(base)

--- a/src/protocol/src/store.rs
+++ b/src/protocol/src/store.rs
@@ -1,6 +1,6 @@
 use std::io::Error as IoError;
 
-use log::trace;
+use tracing::trace;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -68,7 +68,7 @@ where
         version: Version,
     ) -> Result<(), IoError> {
         let len = self.write_size(version) as i32;
-        log::debug!(
+        tracing::debug!(
             "encoding file write response: {} version: {}, len: {}",
             std::any::type_name::<P>(),
             version,

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -23,7 +23,6 @@ k8 = ["k8-client"]
 
 [dependencies]
 rand = "0.8.3"
-log = "0.4.0"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
 serde = { version = "1.0.103", features = ['derive'] }

--- a/src/sc/src/k8/mod.rs
+++ b/src/sc/src/k8/mod.rs
@@ -60,7 +60,7 @@ pub fn main_k8_loop(opt: ScOpt) {
 
 mod proxy {
     use std::process;
-    use log::info;
+    use tracing::info;
 
     use fluvio_types::print_cli_err;
     pub use fluvio_future::openssl::TlsAcceptor;

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -51,7 +51,6 @@ dependencies = [
  "fluvio-protocol",
  "flv-util",
  "futures-util",
- "log",
  "once_cell",
  "semver",
  "tracing",
@@ -59,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd29a0773ef0ab97eb91e621093b4b64218456941e33fd63d9647fbe57a439cf"
+checksum = "61587e440c936984e7dab40903de1c9adc39ab13e8446b52c50852da5cd6fbcb"
 dependencies = [
  "log",
  "thiserror",
@@ -85,7 +84,7 @@ dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
  "flv-util",
- "log",
+ "tracing",
 ]
 
 [[package]]
@@ -98,12 +97,12 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
- "log",
  "proc-macro2",
  "quote",
  "syn",
+ "tracing",
 ]
 
 [[package]]

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "fluvio-protocol-api",
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
+ "tracing",
 ]
 
 [[package]]

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 autotests = false
 
 [dependencies]
-log = "0.4.8"
+tracing = "0.1"
 bytes = "1.0"
 futures-lite = "1.11.0"
 structopt = "0.3.5"

--- a/tests/runner/src/tests/smoke/consume.rs
+++ b/tests/runner/src/tests/smoke/consume.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use log::{info, debug};
+use tracing::{info, debug};
 use futures_lite::stream::StreamExt;
 
 use fluvio_system_util::bin::get_fluvio;

--- a/tests/runner/src/tests/smoke/produce.rs
+++ b/tests/runner/src/tests/smoke/produce.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use log::info;
+use tracing::info;
 
 use super::SmokeTestCase;
 use super::message::*;

--- a/tests/runner/src/utils/Cargo.toml
+++ b/tests/runner/src/utils/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4.8"
 bytes = "1.0"
 futures-lite = "1.11.0"
 structopt = "0.3.5"


### PR DESCRIPTION
- Removes remaining dependencies on 'log'
- Replaces all usages of 'log' with 'tracing'
- The last sticking point was Encode/Decode generating log usages, which this PR takes care of