### PR TITLE
[Merged by Bors] - Add OpenTelemetry/Jaeger tracing backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "pin-project",
+ "pin-project 1.0.7",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ dependencies = [
  "log",
  "native-tls",
  "openssl",
- "pin-project",
+ "pin-project 1.0.7",
  "thiserror",
  "tracing",
 ]
@@ -1579,7 +1579,7 @@ dependencies = [
  "nix 0.20.0",
  "openssl",
  "openssl-sys",
- "pin-project",
+ "pin-project 1.0.7",
  "pin-utils",
  "thiserror",
  "tracing",
@@ -1694,10 +1694,15 @@ dependencies = [
  "fluvio-future 0.3.3",
  "fluvio-sc",
  "fluvio-spu",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "semver 0.11.0",
  "serde_json",
  "structopt",
  "thiserror",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1809,7 +1814,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.7",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2492,7 +2497,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 1.0.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2556,6 +2561,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "inventory"
@@ -3061,6 +3072,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3434e2a9d2aec539d91f4251bf9047cd53b4d3f386f9d336f4c8076c72a5256"
+dependencies = [
+ "async-trait",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project 0.4.28",
+ "rand 0.7.3",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c604a73595f605a852c431ef9c6bbacc7b911f094900905fd2f684b6fc44b4"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "opentelemetry",
+ "thiserror",
+ "thrift",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,11 +3211,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+dependencies = [
+ "pin-project-internal 0.4.28",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.7",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4206,6 +4276,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,7 +4452,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
@@ -4373,6 +4465,19 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1706e1f42970e09aa0635deb4f4607e8704a4390427d5f0062bf59240338bcc"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/runner/Cargo.toml
+++ b/src/runner/Cargo.toml
@@ -17,7 +17,21 @@ name = "fluvio-run"
 path = "src/bin/main.rs"
 doc = false
 
+[features]
+default = ["telemetry"]
+telemetry = [
+    "tracing-opentelemetry",
+    "opentelemetry",
+    "opentelemetry-jaeger",
+]
+
 [dependencies]
+tracing = "0.1"
+tracing-subscriber = "0.2"
+tracing-opentelemetry = { version = "0.10", optional = true }
+opentelemetry = { version = "0.11", optional = true }
+opentelemetry-jaeger = { version = "0.10", optional = true }
+
 structopt = { version = "0.3.16", default-features = false }
 thiserror = "1.0.20"
 semver = "0.11.0"

--- a/src/runner/Cargo.toml
+++ b/src/runner/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/main.rs"
 doc = false
 
 [features]
-default = ["telemetry"]
+default = []
 telemetry = [
     "tracing-opentelemetry",
     "opentelemetry",

--- a/src/runner/src/bin/main.rs
+++ b/src/runner/src/bin/main.rs
@@ -1,15 +1,15 @@
 use structopt::StructOpt;
 use fluvio_run::RunCmd;
 
-use tracing::Level;
-use tracing_subscriber::{Registry, prelude::*};
-use tracing_subscriber::filter::Directive;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cmd: RunCmd = RunCmd::from_args();
 
     #[cfg(feature = "telemetry")]
     let _jaeger_guard = {
+        use tracing::Level;
+        use tracing_subscriber::{Registry, prelude::*};
+        use tracing_subscriber::filter::Directive;
+
         let service_name = match cmd {
             RunCmd::SC(_) => "fluvio-sc",
             RunCmd::SPU(_) => "fluvio-spu",

--- a/src/runner/src/bin/main.rs
+++ b/src/runner/src/bin/main.rs
@@ -1,10 +1,41 @@
 use structopt::StructOpt;
-use fluvio_future::task::run_block_on;
 use fluvio_run::RunCmd;
 
+use tracing::Level;
+use tracing_subscriber::{Registry, prelude::*};
+use tracing_subscriber::filter::Directive;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cmd: RunCmd = RunCmd::from_args();
+
+    #[cfg(feature = "telemetry")]
+    let _jaeger_guard = {
+        let service_name = match cmd {
+            RunCmd::SC(_) => "fluvio-sc",
+            RunCmd::SPU(_) => "fluvio-spu",
+            _ => "fluvio-run",
+        };
+
+        let (tracer, guard) = opentelemetry_jaeger::new_pipeline()
+            .with_service_name(service_name)
+            .install()
+            .unwrap();
+
+        Registry::default()
+            .with(
+                tracing_subscriber::EnvFilter::from_default_env()
+                    .add_directive(Directive::from(Level::DEBUG)),
+            )
+            .with(tracing_subscriber::fmt::layer())
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .init();
+
+        guard
+    };
+
+    #[cfg(not(feature = "telemetry"))]
     fluvio_future::subscriber::init_tracer(None);
-    let cmd = RunCmd::from_args();
-    run_block_on(cmd.process())?;
+
+    cmd.process()?;
     Ok(())
 }

--- a/src/runner/src/lib.rs
+++ b/src/runner/src/lib.rs
@@ -25,7 +25,7 @@ pub enum RunCmd {
 }
 
 impl RunCmd {
-    pub async fn process(self) -> Result<()> {
+    pub fn process(self) -> Result<()> {
         match self {
             Self::SPU(opt) => {
                 fluvio_spu::main_loop(opt);


### PR DESCRIPTION
This is the first step towards improving our observability within Fluvio. This adds a jaeger backend to our tracing setup, so you can now run a jaeger instance and collect traces.

- Adds Jaeger backend to tracing subscriber for SC and SPU
- Adds more tracing instrumentation to the SPU

To try this out for yourself, run Jaeger in a docker container with the following command:

```
docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
```

Then open up `http://localhost:16686` in your browser. Try running some Fluvio commands to interact with the cluster, then view traces sorted by `fluvio-spu` or `fluvio-sc`.

I don't know what we want the ultimate scope of this PR to be. It could potentially be merged now, but do we want to explore any of the following first?

- Add more instrumentation to SC? I think that'd be a good idea
- Add instrumentation to the client, i.e. Fluvio CLI? If yes, we would want to make sure it is optional and probably disabled by default
- Try adding prometheus metrics? There are examples showing how this works, but I believe it requires creating a metrics route on an HTTP server, so it would really only make sense for the SC and SPU. This is probably out of scope for this.