### PR TITLE
[Merged by Bors] - Crate bumps for 0.8.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "log",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "fluvio-dataplane-protocol",

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -40,7 +40,7 @@ siphasher = "0.3.5"
 fluvio-future = { version = "0.3.0", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.1", path = "../sc-schema", default-features = false }
-fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema" }
+fluvio-spu-schema = { version = "0.6.1", path = "../spu-schema", features = ["file"] }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -16,16 +16,16 @@ store = ["fluvio-future", "fluvio-protocol-api", "bytes"]
 
 [dependencies]
 tracing = "0.1"
-fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
-fluvio-protocol-derive = { version = "0.2.0", path = "fluvio-protocol-derive", optional = true }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api", optional = true }
+fluvio-protocol-core = { version = "0.3.1", path = "fluvio-protocol-core" }
 fluvio-protocol-codec = { version = "0.3.1", path = "fluvio-protocol-codec", optional = true }
+fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 flv-util = { version = "0.5.2" }
-fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive" }
-fluvio-protocol-core = { version = "0.3.0", path = "fluvio-protocol-core" }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api" }
-fluvio-future = { version = "0.3.0", features = ["subscriber"]}
+fluvio-protocol-core = { version = "0.3.1", path = "fluvio-protocol-core" }
+fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive" }
+fluvio-future = { version = "0.3.0", features = ["subscriber"] }

--- a/src/protocol/fluvio-protocol-api/Cargo.toml
+++ b/src/protocol/fluvio-protocol-api/Cargo.toml
@@ -8,10 +8,8 @@ repository = "https://github.com/infinyon/fluvio-protocol"
 license = "Apache-2.0"
 categories = ["encoding","api-bindings"]
 
-
 [dependencies]
 tracing = "0.1"
-fluvio-protocol = { version = "0.3.0", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
+fluvio-protocol = { version = "0.3.1", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
 fluvio-protocol-derive = { version = "0.2.1", path = "../fluvio-protocol-derive" }
 flv-util = { version = "0.5.0"}
-

--- a/src/protocol/fluvio-protocol-codec/Cargo.toml
+++ b/src/protocol/fluvio-protocol-codec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["encoding","api-bindings"]
 log = "0.4.8"
 bytes = "1.0.0"
 tokio-util = { version = "0.6.4", features = ["codec","compat"]}
-fluvio-protocol = { version = "0.3.0", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
+fluvio-protocol = { version = "0.3.1", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture","timer","net"] }

--- a/src/protocol/fluvio-protocol-core/Cargo.toml
+++ b/src/protocol/fluvio-protocol-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-core"
 edition = "2018"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "encoder and decoder for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "log",

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -31,11 +31,9 @@ async-trait = "0.1.21"
 pin-project = "1.0.1"
 thiserror = "1.0.20"
 
-
 # Fluvio dependencies
 fluvio-future = { version = "0.3.2", features = ["net", "task"] }
 fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
-
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.1", features = ["fixture", "fs", "native2_tls"] }

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
@@ -13,7 +13,6 @@ path = "src/lib.rs"
 
 [features]
 file = ["dataplane/file"]
-
 
 [dependencies]
 log = "0.4.8"


### PR DESCRIPTION
The crates for the 0.8.3 release are all published! These are Cargo.toml updates I needed to make in order to get the versions to work out for publishing.