### PR TITLE
[Merged by Bors] - Instrument SPU

### DIFF
--- a/src/spu/src/control_plane/message_sink.rs
+++ b/src/spu/src/control_plane/message_sink.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::sync::Arc;
-use tracing::instrument;
 
 use async_lock::Mutex;
 
@@ -13,20 +12,17 @@ pub type SharedStatusUpdate = Arc<StatusMessageSink>;
 pub struct StatusMessageSink(Mutex<HashSet<LrsRequest>>);
 
 impl StatusMessageSink {
-    #[instrument]
     pub fn shared() -> Arc<Self> {
         Arc::new(Self(Mutex::new(HashSet::new())))
     }
 
     /// send lrs request sc
     /// newer entry will overwrite previous if it has not been cleared
-    #[instrument(skip(self, request))]
     pub async fn send(&self, request: LrsRequest) {
         let mut lock = self.0.lock().await;
         lock.replace(request);
     }
 
-    #[instrument(skip(self))]
     pub async fn remove_all(&self) -> Vec<LrsRequest> {
         let mut lock = self.0.lock().await;
         lock.drain().collect()

--- a/src/spu/src/control_plane/message_sink.rs
+++ b/src/spu/src/control_plane/message_sink.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use tracing::instrument;
 
 use async_lock::Mutex;
 
@@ -12,17 +13,20 @@ pub type SharedStatusUpdate = Arc<StatusMessageSink>;
 pub struct StatusMessageSink(Mutex<HashSet<LrsRequest>>);
 
 impl StatusMessageSink {
+    #[instrument]
     pub fn shared() -> Arc<Self> {
         Arc::new(Self(Mutex::new(HashSet::new())))
     }
 
     /// send lrs request sc
     /// newer entry will overwrite previous if it has not been cleared
+    #[instrument(skip(self, request))]
     pub async fn send(&self, request: LrsRequest) {
         let mut lock = self.0.lock().await;
         lock.replace(request);
     }
 
+    #[instrument(skip(self))]
     pub async fn remove_all(&self) -> Vec<LrsRequest> {
         let mut lock = self.0.lock().await;
         lock.drain().collect()

--- a/src/spu/src/replication/leader/replica_state.rs
+++ b/src/spu/src/replication/leader/replica_state.rs
@@ -274,7 +274,6 @@ where
     }
 
     /// convert myself as
-    #[instrument(skip(self))]
     async fn as_lrs_request(&self) -> LrsRequest {
         let leader = (self.leader(), self.hw(), self.leo()).into();
         let replicas = self

--- a/src/spu/src/replication/leader/replica_state.rs
+++ b/src/spu/src/replication/leader/replica_state.rs
@@ -274,6 +274,7 @@ where
     }
 
     /// convert myself as
+    #[instrument(skip(self))]
     async fn as_lrs_request(&self) -> LrsRequest {
         let leader = (self.leader(), self.hw(), self.leo()).into();
         let replicas = self
@@ -298,6 +299,7 @@ where
 
     /// write records to storage
     /// then update our follower's leo
+    #[instrument(skip(self, records, notifiers))]
     pub async fn write_record_set(
         &self,
         records: &mut RecordSet,

--- a/src/spu/src/services/public/api_versions.rs
+++ b/src/spu/src/services/public/api_versions.rs
@@ -1,5 +1,5 @@
 use std::io::Error;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use dataplane::api::{RequestMessage, ResponseMessage, Request};
 use dataplane::produce::DefaultProduceRequest;
@@ -11,6 +11,7 @@ use fluvio_spu_schema::server::stream_fetch::DefaultStreamFetchRequest;
 use fluvio_spu_schema::server::update_offset::UpdateOffsetsRequest;
 use fluvio_spu_schema::{ApiVersionsRequest, ApiVersionsResponse};
 
+#[instrument(skip(request))]
 pub async fn handle_kf_lookup_version_request(
     request: RequestMessage<ApiVersionsRequest>,
 ) -> Result<ResponseMessage<ApiVersionsResponse>, Error> {

--- a/src/spu/src/services/public/fetch_handler.rs
+++ b/src/spu/src/services/public/fetch_handler.rs
@@ -1,5 +1,4 @@
-use tracing::trace;
-use tracing::debug;
+use tracing::{debug, trace, instrument};
 
 use fluvio_socket::ExclusiveFlvSink;
 use fluvio_socket::FlvSocketError;
@@ -10,6 +9,7 @@ use fluvio_controlplane_metadata::partition::ReplicaKey;
 use crate::core::DefaultSharedGlobalContext;
 
 /// perform log fetch request using zero copy write
+#[instrument(skip(request, ctx, sink))]
 pub async fn handle_fetch_request(
     request: RequestMessage<FileFetchRequest>,
     ctx: DefaultSharedGlobalContext,

--- a/src/spu/src/services/public/offset_request.rs
+++ b/src/spu/src/services/public/offset_request.rs
@@ -1,6 +1,6 @@
 use std::io::Error as IoError;
 
-use tracing::trace;
+use tracing::{trace, instrument};
 
 use dataplane::api::{RequestMessage, ResponseMessage};
 use fluvio_spu_schema::server::fetch_offset::FetchOffsetsRequest;
@@ -12,6 +12,7 @@ use dataplane::ErrorCode;
 
 use crate::core::DefaultSharedGlobalContext;
 
+#[instrument(skip(req_msg, ctx))]
 pub async fn handle_offset_request(
     req_msg: RequestMessage<FetchOffsetsRequest>,
     ctx: DefaultSharedGlobalContext,

--- a/src/spu/src/services/public/service_impl.rs
+++ b/src/spu/src/services/public/service_impl.rs
@@ -1,13 +1,12 @@
-use std::{sync::Arc};
+use std::sync::Arc;
 
-use tracing::debug;
-use tracing::trace;
+use tracing::{debug, trace, instrument};
 use async_trait::async_trait;
 use futures_util::stream::StreamExt;
 use tokio::select;
 
 use fluvio_types::event::SimpleEvent;
-use fluvio_socket::{FluvioSocket};
+use fluvio_socket::FluvioSocket;
 use fluvio_socket::FlvSocketError;
 use fluvio_service::{call_service, FlvService};
 use fluvio_spu_schema::server::{SpuServerApiKey, SpuServerRequest};
@@ -34,6 +33,7 @@ impl FlvService for PublicService {
     type Context = DefaultSharedGlobalContext;
     type Request = SpuServerRequest;
 
+    #[instrument(skip(self, context, socket))]
     async fn respond(
         self: Arc<Self>,
         context: DefaultSharedGlobalContext,
@@ -130,7 +130,7 @@ mod offset {
 
     use std::{io::Error as IoError};
 
-    use tracing::{debug, error};
+    use tracing::{debug, error, instrument};
     use fluvio_spu_schema::server::update_offset::{
         OffsetUpdateStatus, UpdateOffsetsRequest, UpdateOffsetsResponse,
     };
@@ -138,6 +138,7 @@ mod offset {
 
     use super::{DefaultSharedGlobalContext, RequestMessage, ErrorCode};
 
+    #[instrument(skip(ctx, request))]
     pub async fn handle_offset_update(
         ctx: &DefaultSharedGlobalContext,
         request: RequestMessage<UpdateOffsetsRequest>,

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -3,8 +3,7 @@ use std::time::{Instant};
 use std::io::ErrorKind;
 use std::io::Error as IoError;
 
-use tracing::{debug, trace, error};
-use tracing::instrument;
+use tracing::{debug, trace, error, instrument};
 use tokio::select;
 
 use fluvio_types::event::{SimpleEvent, offsets::OffsetPublisher};
@@ -47,6 +46,7 @@ pub struct StreamFetchHandler {
 
 impl StreamFetchHandler {
     /// handle fluvio continuous fetch request
+    #[instrument(skip(request, ctx, sink, end_event))]
     pub async fn start(
         request: RequestMessage<FileStreamFetchRequest>,
         ctx: DefaultSharedGlobalContext,

--- a/src/spu/src/smart_stream/filter.rs
+++ b/src/spu/src/smart_stream/filter.rs
@@ -7,7 +7,7 @@ use std::os::unix::io::RawFd;
 use anyhow::{Result, Error, anyhow};
 
 // use bytes::{Bytes, BytesMut};
-use tracing::{debug, warn};
+use tracing::{debug, warn, instrument};
 use nix::sys::uio::pread;
 use wasmtime::{Caller, Engine, Extern, Func, Instance, Module, Store, Trap, TypedFunc, Memory};
 
@@ -30,10 +30,12 @@ impl SmartStreamEngine {
     }
 
     #[allow(unused)]
+    #[instrument(skip(self, path))]
     pub fn create_module_from_path(&self, path: impl AsRef<Path>) -> Result<SmartStreamModule> {
         SmartStreamModule::from_path(&self.0, path)
     }
 
+    #[instrument(skip(self, binary))]
     pub fn create_module_from_binary(&self, binary: &[u8]) -> Result<SmartStreamModule> {
         SmartStreamModule::from_binary(&self.0, binary)
     }

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::fmt::Debug;
 use std::time::Instant;
 
-use tracing::{debug};
+use tracing::{debug, instrument};
 use async_rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use fluvio_controlplane_metadata::partition::{ReplicaKey};
@@ -101,6 +101,7 @@ where
 
     /// read records into partition response
     /// return leo and hw
+    #[instrument(skip(self, offset, max_len, isolation, partition_response))]
     pub async fn read_records<P>(
         &self,
         offset: Offset,
@@ -128,6 +129,7 @@ where
         }
     }
 
+    #[instrument(skip(self, records, hw_update))]
     pub async fn write_record_set(
         &self,
         records: &mut RecordSet,


### PR DESCRIPTION
- Adds `#[tracing::instrument]` to more areas in the SPU to support better tracing e.g. with otel/jaeger