### PR TITLE
[Merged by Bors] - Instrument client

### DIFF
--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -104,6 +104,7 @@ impl PartitionConsumer {
     ///
     /// [`Offset`]: struct.Offset.html
     /// [`fetch_with_config`]: struct.PartitionConsumer.html#method.fetch_with_config
+    #[instrument(skip(self, offset))]
     pub async fn fetch(
         &self,
         offset: Offset,
@@ -149,6 +150,7 @@ impl PartitionConsumer {
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     /// [`fetch`]: struct.PartitionConsumer.html#method.fetch
     /// [`Offset`]: struct.Offset.html
+    #[instrument(skip(self, offset, option))]
     pub async fn fetch_with_config(
         &self,
         offset: Offset,
@@ -240,6 +242,7 @@ impl PartitionConsumer {
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     /// [`stream_with_config`]: struct.ConsumerConfig.html#method.stream_with_config
+    #[instrument(skip(self, offset))]
     pub async fn stream(
         &self,
         offset: Offset,
@@ -288,6 +291,7 @@ impl PartitionConsumer {
     ///
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
+    #[instrument(skip(self, offset, config))]
     pub async fn stream_with_config(
         &self,
         offset: Offset,
@@ -338,6 +342,7 @@ impl PartitionConsumer {
     /// # Ok(())
     /// # }
     /// ```
+    #[instrument(skip(self, offset, config))]
     pub async fn stream_batches_with_config(
         &self,
         offset: Offset,

--- a/src/client/src/fluvio.rs
+++ b/src/client/src/fluvio.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use tracing::debug;
+use tracing::{debug, instrument};
 use tokio::sync::OnceCell;
 //use once_cell::sync::OnceCell;
 
@@ -63,6 +63,7 @@ impl Fluvio {
     /// # Ok(())
     /// # }
     /// ```
+    #[instrument(skip(config))]
     pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
         let connector = DomainConnector::try_from(config.tls.clone())?;
         Self::connect_with_connector(connector, config).await

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -93,6 +93,7 @@ mod spu;
 
 pub mod config;
 
+use tracing::instrument;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{TopicProducer, RecordKey};
@@ -147,6 +148,7 @@ const MINIMUM_PLATFORM_VERSION: &str = "0.8.0";
 /// ```
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
+#[instrument(skip(topic))]
 pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, FluvioError> {
     let fluvio = Fluvio::connect().await?;
     let producer = fluvio.topic_producer(topic).await?;
@@ -180,6 +182,7 @@ pub async fn producer<S: Into<String>>(topic: S) -> Result<TopicProducer, Fluvio
 /// ```
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
+#[instrument(skip(topic, partition))]
 pub async fn consumer<S: Into<String>>(
     topic: S,
     partition: i32,

--- a/src/client/src/sockets.rs
+++ b/src/client/src/sockets.rs
@@ -208,7 +208,7 @@ impl VersionedSerialSocket {
     }
 
     /// send and wait for reply serially
-    #[instrument(skip(self, request))]
+    #[instrument(level = "trace", skip(self, request))]
     pub async fn send_receive<R>(&mut self, request: R) -> Result<R::Response, FlvSocketError>
     where
         R: Request + Send + Sync,
@@ -220,7 +220,7 @@ impl VersionedSerialSocket {
     }
 
     /// create new request based on version
-    #[instrument(skip(self, request, version))]
+    #[instrument(level = "trace", skip(self, request, version))]
     fn new_request<R>(&self, request: R, version: Option<i16>) -> RequestMessage<R>
     where
         R: Request + Send,

--- a/src/client/src/spu.rs
+++ b/src/client/src/spu.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::collections::HashMap;
 
-use tracing::{debug, trace};
+use tracing::{debug, trace, instrument};
 use async_lock::Mutex;
 
 use dataplane::ReplicaKey;
@@ -76,6 +76,7 @@ impl SpuPool {
     }
 
     /// create new spu socket
+    #[instrument(skip(self))]
     async fn connect_to_leader(&self, leader: SpuId) -> Result<SpuSocket, FluvioError> {
         let spu = self.metadata.spus().look_up_by_id(leader).await?;
 
@@ -98,6 +99,7 @@ impl SpuPool {
     /// All sockets to same SPU use a single TCP connection.
     /// First this looks up SPU address in SPU metadata and try to see if there is an existing TCP connection.
     /// If not, it will create a new connection and creates socket to it
+    #[instrument(skip(self, replica))]
     pub async fn create_serial_socket(
         &self,
         replica: &ReplicaKey,
@@ -117,6 +119,7 @@ impl SpuPool {
         Ok(socket)
     }
 
+    #[instrument(skip(self))]
     pub async fn create_serial_socket_from_leader(
         &self,
         leader_id: SpuId,
@@ -136,6 +139,7 @@ impl SpuPool {
     }
 
     /// create stream to leader replica
+    #[instrument(skip(self, replica, request, version))]
     pub async fn create_stream_with_version<R: Request>(
         &self,
         replica: &ReplicaKey,


### PR DESCRIPTION
- Adds `#[tracing::instrument]` to more areas in the client to support better tracing e.g. with otel/jaeger