### PR TITLE
[Merged by Bors] - Instrument misc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,7 @@ dependencies = [
  "fluvio-future 0.3.5",
  "tokio",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/src/socket/src/multiplexing.rs
+++ b/src/socket/src/multiplexing.rs
@@ -17,7 +17,7 @@ use event_listener::Event;
 use futures_util::stream::{Stream, StreamExt};
 use pin_project::{pin_project, pinned_drop};
 use tokio::select;
-use tracing::{debug, error, instrument, trace};
+use tracing::{debug, error, trace, instrument};
 
 use fluvio_future::timer::sleep;
 use fluvio_protocol::api::Request;
@@ -100,6 +100,7 @@ impl MultiplexerSocket {
     }
 
     /// create socket to perform request and response
+    #[instrument(skip(self, req_msg))]
     pub async fn send_and_receive<R>(
         &self,
         mut req_msg: RequestMessage<R>,
@@ -185,6 +186,7 @@ impl MultiplexerSocket {
     }
 
     /// create stream response
+    #[instrument(skip(self, req_msg, queue_len))]
     pub async fn create_stream<R>(
         &self,
         mut req_msg: RequestMessage<R>,
@@ -369,6 +371,7 @@ impl MultiPlexingResponseDispatcher {
     }
 
     /// send message to correct receiver
+    #[instrument(skip(self, msg))]
     pub async fn send(&mut self, correlation_id: i32, msg: BytesMut) -> Result<(), FlvSocketError> {
         let mut senders = self.senders.lock().await;
         if let Some(sender) = senders.get_mut(&correlation_id) {

--- a/src/socket/src/socket.rs
+++ b/src/socket/src/socket.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use fluvio_protocol::api::Request;
 use fluvio_protocol::api::RequestMessage;
@@ -85,6 +85,7 @@ impl FluvioSocket {
     }
 
     /// connect to target address with connector
+    #[instrument(skip(connector))]
     pub async fn connect_with_connector(
         addr: &str,
         connector: &dyn TcpDomainConnector,

--- a/src/types/Cargo.toml
+++ b/src/types/Cargo.toml
@@ -12,6 +12,7 @@ events = ["event-listener"]
 
 [dependencies]
 tracing = "0.1.19"
+tracing-futures = "0.2.5"
 event-listener = { version = "2.5.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
- Adds `#[tracing::instrument]` to more areas in misc crates to support better tracing e.g. with otel/jaeger