### PR TITLE
[Merged by Bors] - Add license to fluvio-smartstream-derive

### DIFF
--- a/src/smartstream/derive/Cargo.toml
+++ b/src/smartstream/derive/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "fluvio-smartstream-derive"
 version = "0.1.0"
-authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+license = "Apache-2.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["wasm", "database", "encoding"]
 keywords = ["streaming", "stream", "wasm", "fluvio"]
 repository = "https://github.com/infinyon/fluvio"


### PR DESCRIPTION
This was required in order to publish the crate to crates.io