### PR TITLE
[Merged by Bors] - Fix wasm build problem

### DIFF
--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -40,13 +40,15 @@ siphasher = "0.3.5"
 fluvio-future = { version = "0.3.0", features = ["task", "native2_tls"] }
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.1", path = "../sc-schema", default-features = false }
-fluvio-spu-schema = { version = "0.6.1", path = "../spu-schema", features = ["file"] }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-protocol = { path = "../protocol", version = "0.5.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "1.0.2"
+fluvio-spu-schema = { version = "0.6.1", path = "../spu-schema", features = ["file"] }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fluvio-spu-schema = { version = "0.6.1", path = "../spu-schema" }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", default-features = false }


### PR DESCRIPTION
Closes #1129 

- This builds the `file` feature for `spu-schema` only if the target_arch is not `wasm32`