### PR TITLE
fix: install k8_types dependency with the 'core' feature

### DIFF
--- a/src/stream-model/Cargo.toml
+++ b/src/stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2018"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"
@@ -23,7 +23,7 @@ event-listener = "2.5.1"
 once_cell = "1.5"
 
 # Fluvio dependencies
-k8-types = { version = "0.2.0", optional = true }
+k8-types = { version = "0.2.0", features = ["core"], optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Trying to compile a crate that depends on this failed with:

```rust
5 | use fluvio_stream_model::k8_types::core::secret::{SecretHeader, SecretSpec};
  |                                    ^^^^ could not find `core` in `k8_types`
```

That is behind the [core](https://github.com/infinyon/k8-api/blob/e4b0a0929b01fd0e7c3a9ec268c63dcfb09d7bf1/src/k8-types/src/lib.rs#L5) feature config.
So, it looks like that this feature is needed in order to use that. Not sure why it is failing for me and not in the CI.