### PR TITLE
[Merged by Bors] - Fix placement of the producer CLI > prompt

### DIFF
--- a/src/cli/src/consumer/produce/mod.rs
+++ b/src/cli/src/consumer/produce/mod.rs
@@ -68,6 +68,9 @@ impl ProduceOpt {
             }
             None => {
                 let mut lines = BufReader::new(std::io::stdin()).lines();
+                if self.interactive_mode() {
+                    eprint!("> ");
+                }
                 while let Some(Ok(line)) = lines.next() {
                     self.produce_lines(&mut producer, &[&line]).await?;
                 }
@@ -86,10 +89,6 @@ impl ProduceOpt {
         producer: &mut TopicProducer,
         lines: &[&str],
     ) -> Result<(), ConsumerError> {
-        if self.interactive_mode() {
-            eprint!("> ");
-        }
-
         self.produce_strs(producer, lines).await?;
         if self.interactive_mode() {
             print_cli_ok!();


### PR DESCRIPTION
Before this PR, the producer would not print `>` before the first stdin prompt, making it appear that the CLI was hanging:

<img width="503" alt="A screenshot of a terminal showing the producer does not print a caret before the user is expected to type" src="https://user-images.githubusercontent.com/4210949/119819761-b8e4d400-bebe-11eb-8f19-aa0e28940309.png">

After the first caret prompt, it also mistakenly printed `>` before the Ok! acknowledgement.

Now, it has been corrected to print `>` before each stdin prompt, but not before each Ok!

<img width="490" alt="A screenshot of a terminal where the producer CLI is printing carets correctly for each prompt" src="https://user-images.githubusercontent.com/4210949/119819984-006b6000-bebf-11eb-8554-8e693a7af2ef.png">
