### PR TITLE
[Merged by Bors] - Remove proclist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-cluster"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1451,7 +1451,6 @@ dependencies = [
  "k8-types",
  "once_cell",
  "prettytable-rs",
- "proclist",
  "remoteprocess",
  "semver 0.11.0",
  "serde",
@@ -3403,17 +3402,6 @@ dependencies = [
  "libc",
  "libproc",
  "mach",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "proclist"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275bfe319f16502d8fab42ff8bac075e747a188d1b2cbc223d94aaf8f877b41a"
-dependencies = [
- "errno",
- "libc",
  "winapi 0.3.9",
 ]
 

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-cluster"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -37,7 +37,6 @@ futures-lite = "1.11.0"
 tokio = { version = "1.3.0", features = ["macros"] }
 once_cell = "1.5"
 derive_builder = "0.9.0"
-proclist = "0.9.2"
 remoteprocess = "0.4.2"
 which = "4.1.0"
 directories = "3.0.2"


### PR DESCRIPTION
Dependency is unused and causing build failures in MacOS