### PR TITLE
[Merged by Bors] - Allow setting ingress when not using NodePort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-sc"
 edition = "2018"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Controller"
 repository = "https://github.com/infinyon/fluvio"


### PR DESCRIPTION
Currently errors out with `SPU service missing NodePort` when service is of type `ClusterIP`