### PR TITLE
[Merged by Bors] - Fix upgrade test version selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
             export PATH=~/.fluvio/bin:$PATH
             cd tests
             # Use gh cli to collect the last and current release version numbers
-            ./upgrade-test.sh $(gh api repos/infinyon/fluvio/releases -q '.[2,1].tag_name' | sed 's/v//')
+            ./upgrade-test.sh $(gh api repos/infinyon/fluvio/releases -q '.[].tag_name' | grep -v dev | sed 's/v//' | head -2 | tac | xargs)
 
       - name: Stop sccache server
         run: sccache --stop-server || true


### PR DESCRIPTION
Filter out the `dev` release before picking two most recent versioned releases.

Tested locally and the one-liner change correctly resolves as:

```
./upgrade-test.sh $(gh api repos/infinyon/fluvio/releases -q '.[].tag_name' | grep -v dev | sed 's/v//' | head -2 | tac | xargs)
+ echo command: ./upgrade-test.sh 0.8.3 0.8.4
command: ./upgrade-test.sh 0.8.3 0.8.4
```

Resolves #1156