### PR TITLE
[Merged by Bors] - Build tests when not in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
         run: sccache --start-server
 
       - name: Build artifacts
-        run: make build_cli build_cluster build_test
+        run: make build-cli build-cluster build-test
 
       - name: Unit tests
         run: make run-all-unit-test
@@ -314,7 +314,7 @@ jobs:
           minikube status
       - name: Build Test
         run: |
-          make RELEASE=release build_test
+          make RELEASE=release build-test
       - name: Setup installation pre-requisites
         run: |
           cargo run --release --bin fluvio -- cluster start --setup --local --develop

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ install_tools_mac:
 	brew install yq
 	brew install helm
 
-build_cli:
+build-cli:
 	cargo build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-build_cluster: install_test_target
+build-cluster: install_test_target
 	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-build_test:	build_cluster build_cli
+build-test:	build-cluster build-cli
 	cargo build --bin flv-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 install_test_target:
@@ -65,6 +65,12 @@ endif
 # List of smoke test steps.  This is used by CI
 #
 
+# In CI mode, do not run any build steps
+ifeq (${CI},true)
+else
+# When not in CI (i.e. development), build before testing
+smoke-test: build-test
+endif
 smoke-test: test-setup
 	# Set ENV
 	$(TEST_ENV_AUTH_POLICY) \


### PR DESCRIPTION
GitHub Actions CI always sets the env variable `CI=true`, so this change leverages that for running smoke-tests from the Makefile. 

- In development mode (i.e. no CI=true), the `make smoke-test` family of commands will build tests as needed.
- In CI mode (i.e. CI=true), `make smoke-test` will not run any build commands, and use cached artifacts instead