### PR TITLE
Consumer wasm api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.8.5 - UNRELEASED
 * Add unstable Admin Watch API for topics, partitions, and SPUs ([#1136](https://github.com/infinyon/fluvio/pull/1136))
 * Make recipes for smoke tests no longer build by default, helps caching. ([#1165](https://github.com/infinyon/fluvio/pull/1165))
+* Add SmartStreamModule in ConsumerConfig for loading WASM using binary or base64. ([#32](https://github.com/infinyon/fluvio-client-wasm/issues/32))
  
 ## Platform Version 0.8.4 - 2020-05-29
 * Don't hang when check for non exist topic. ([#697](https://github.com/infinyon/fluvio/pull/697))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.9.0"
+version = "0.8.6"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ dependencies = [
  "base64",
  "bytes",
  "cfg-if 1.0.0",
+ "derive_builder 0.10.2",
  "dirs 1.0.5",
  "event-listener",
  "fluvio-dataplane-protocol",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -60,7 +60,7 @@ content_inspector = { version = "0.2.4", optional = true}
 # Fluvio dependencies
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
-fluvio = { version = "0.8.0", path = "../client", default-features = false }
+fluvio = { version = "0.9.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.9.1", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -60,7 +60,7 @@ content_inspector = { version = "0.2.4", optional = true}
 # Fluvio dependencies
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }
-fluvio = { version = "0.9.0", path = "../client", default-features = false }
+fluvio = { version = "0.8.6", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.9.1", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/src/cli/src/consumer/consume/mod.rs
+++ b/src/cli/src/consumer/consume/mod.rs
@@ -115,7 +115,7 @@ impl ConsumeOpt {
         if let Some(filter_path) = &self.smart_stream {
             let buffer = std::fs::read(filter_path)?;
             debug!(len = buffer.len(), "read filter bytes");
-            builder.smartstream_binary(buffer);
+            builder.smartstream_filter(buffer);
         }
 
         let consume_config: ConsumerConfig = builder.build().unwrap();

--- a/src/cli/src/consumer/consume/mod.rs
+++ b/src/cli/src/consumer/consume/mod.rs
@@ -115,7 +115,7 @@ impl ConsumeOpt {
         if let Some(filter_path) = &self.smart_stream {
             let buffer = std::fs::read(filter_path)?;
             debug!(len = buffer.len(), "read filter bytes");
-            builder.wasm_filter(buffer);
+            builder.smartstream_binary(buffer);
         }
 
         let consume_config: ConsumerConfig = builder.build().unwrap();

--- a/src/cli/src/consumer/consume/mod.rs
+++ b/src/cli/src/consumer/consume/mod.rs
@@ -107,20 +107,18 @@ impl ConsumeOpt {
         self.init_ctrlc()?;
         let offset = self.calculate_offset()?;
 
-        let mut consume_config = {
-            let mut config = ConsumerConfig::default();
-            if let Some(max_bytes) = self.max_bytes {
-                config = config.with_max_bytes(max_bytes);
-            }
-            config
-        };
+        let mut builder = ConsumerConfig::builder();
+        if let Some(max_bytes) = self.max_bytes {
+            builder.max_bytes(max_bytes);
+        }
 
         if let Some(filter_path) = &self.smart_stream {
             let buffer = std::fs::read(filter_path)?;
             debug!(len = buffer.len(), "read filter bytes");
-            consume_config = consume_config.with_wasm_filter(buffer);
+            builder.wasm_filter(buffer);
         }
 
+        let consume_config: ConsumerConfig = builder.build().unwrap();
         if self.disable_continuous {
             self.consume_records_batch(&consumer, offset, consume_config)
                 .await?;

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -20,6 +20,7 @@ unstable = []
 [dependencies]
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
+derive_builder = "0.10.2"
 futures-util = "0.3.6"
 bytes = "1.0.1"
 toml = "0.5.5"

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.9.0"
+version = "0.8.6"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -422,7 +422,7 @@ impl PartitionConsumer {
                 return Err(FluvioError::Other("SPU does not support WASM".to_owned()));
             }
 
-            stream_request.wasm_module = wasm.binary;
+            stream_request.wasm_module = wasm;
         }
 
         let mut stream = self
@@ -571,20 +571,6 @@ static MAX_FETCH_BYTES: Lazy<i32> = Lazy::new(|| {
     max_bytes
 });
 
-#[derive(Debug, Clone)]
-pub struct SmartStreamModule {
-    binary: Vec<u8>,
-}
-
-impl SmartStreamModule {
-    /// Instantiate a SmartStream from raw WASM binary
-    pub fn from_binary<T: Into<Vec<u8>>>(binary: T) -> Self {
-        Self {
-            binary: binary.into(),
-        }
-    }
-}
-
 /// Configures the behavior of consumer fetching and streaming
 #[derive(derive_builder::Builder, Debug)]
 pub struct ConsumerConfig {
@@ -604,14 +590,8 @@ pub struct ConsumerConfig {
     #[builder(setter(skip))]
     pub(crate) isolation: Isolation,
     /// A WASM module to use as a SmartStream filter
-    ///
-    /// Use the [`smartstream_binary`] or [`smartstream_base64`]
-    /// constructors to configure the SmartStream.
-    ///
-    /// [`smartstream_binary`]: ConsumerConfigBuilder::smartstream_binary
-    /// [`smartstream_base64`]: ConsumerConfigBuilder::smartstream_base64
-    #[builder(private, default, setter(strip_option))]
-    smartstream_filter: Option<SmartStreamModule>,
+    #[builder(setter(into, strip_option), default)]
+    smartstream_filter: Option<Vec<u8>>,
 }
 
 impl Default for ConsumerConfig {
@@ -627,22 +607,14 @@ impl Default for ConsumerConfig {
 impl ConsumerConfig {
     /// Create a builder for collecting Consumer configuration options.
     ///
-    /// # Kitchen Sink Example
+    /// # Example
     ///
-    /// The full set of configurations available are shown below.
-    /// See [ConsumerConfigBuilder] for more details.
-    ///
-    /// ```
+    /// ```no_run
     /// # use fluvio::ConsumerConfig;
+    /// let wasm = std::fs::read("./smartstream.wasm").unwrap();
     /// let consumer = ConsumerConfig::builder()
     ///     .max_bytes(1000)
-    ///
-    ///      // Don't actually use fake data, pass real WASM
-    ///     .smartstream_binary(vec![0x48, 0x65, 0x6c, 0x6c, 0x6f])
-    ///
-    ///      // Also use real WASM. Don't use smartstream_binary and smartstream_base64 together
-    ///     .smartstream_base64("SGVsbG8K").unwrap()
-    ///
+    ///     .smartstream_filter(wasm)
     ///     .build()
     ///     .unwrap();
     /// ```
@@ -660,62 +632,8 @@ impl ConsumerConfig {
     /// set wasm filter
     #[deprecated(since = "0.8.6", note = "Use 'ConsumerConfig::builder()' instead")]
     pub fn with_wasm_filter(mut self, bytes: Vec<u8>) -> Self {
-        self.smartstream_filter = Some(SmartStreamModule::from_binary(bytes));
+        self.smartstream_filter = Some(bytes);
         self
-    }
-}
-
-impl ConsumerConfigBuilder {
-    /// Configure this Consumer to use a SmartStream filter from a WASM binary.
-    ///
-    /// The contents of the given buffer are read as if they were taken directly
-    /// from a `.wasm` file. Prefer this to [`smartstream_base64`] whenever possible.
-    ///
-    /// [`smartstream_base64`]: ConsumerConfigBuilder::smartstream_base64
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use fluvio::ConsumerConfig;
-    /// let wasm = std::fs::read("./smartstream.wasm").unwrap();
-    /// let config = ConsumerConfig::builder()
-    ///     .smartstream_binary(wasm)
-    ///     .build()
-    ///     .unwrap();
-    /// ```
-    pub fn smartstream_binary<T: Into<Vec<u8>>>(&mut self, binary: T) -> &mut Self {
-        self.smartstream_filter(SmartStreamModule::from_binary(binary.into()));
-        self
-    }
-
-    /// Configure the Consumer to use a SmartStream filter from a base64-encoded WASM binary.
-    ///
-    /// This is a convenience method for special use-cases such as loading a WASM
-    /// module from a wrapper like JS where it is easier to deal with base64-encoded strings
-    /// than to pass actual binary buffers. When possible, prefer to use [`smartstream_binary`].
-    ///
-    /// [`smartstream_binary`]: ConsumerConfigBuilder::smartstream_binary
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use fluvio::ConsumerConfig;
-    /// let wasm = std::fs::read("./smartstream.wasm").unwrap();
-    /// let wasm_base64 = base64::encode(wasm);
-    /// let config = ConsumerConfig::builder()
-    ///     .smartstream_base64(wasm_base64).unwrap()
-    ///     .build()
-    ///     .unwrap();
-    /// ```
-    pub fn smartstream_base64<S: Into<String>>(
-        &mut self,
-        base64: S,
-    ) -> Result<&mut Self, FluvioError> {
-        let binary = base64::decode(base64.into()).map_err(|e| {
-            FluvioError::Other(format!("Failed to decode WASM from base64: {:?}", e))
-        })?;
-        self.smartstream_filter(SmartStreamModule::from_binary(binary));
-        Ok(self)
     }
 }
 
@@ -768,11 +686,11 @@ mod tests {
     fn test_consumer_config() {
         let config: ConsumerConfig = ConsumerConfig::builder()
             .max_bytes(1024)
-            .smartstream_binary(vec![1, 2, 3, 4])
+            .smartstream_filter(vec![1, 2, 3, 4])
             .build()
             .unwrap();
 
         assert_eq!(config.max_bytes, 1024);
-        assert_eq!(&config.smartstream_filter.unwrap().binary, &[1, 2, 3, 4]);
+        assert_eq!(&config.smartstream_filter.unwrap(), &[1, 2, 3, 4]);
     }
 }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -138,7 +138,7 @@ impl PartitionConsumer {
     ///     .build()
     ///     .unwrap();
     ///
-    /// let response = consumer.fetch_with_config(Offset::beginning(), fetch_config).await?;
+    /// let response = consumer.fetch_with_config(Offset::beginning(), config).await?;
     /// for batch in response.records.batches {
     ///     for record in batch.records() {
     ///         let string = String::from_utf8_lossy(record.value.as_ref());
@@ -686,11 +686,11 @@ mod tests {
     fn test_consumer_config() {
         let config: ConsumerConfig = ConsumerConfig::builder()
             .max_bytes(1024)
-            .wasm_module(vec![1, 2, 3, 4])
+            .smartstream_binary(vec![1, 2, 3, 4])
             .build()
             .unwrap();
 
         assert_eq!(config.max_bytes, 1024);
-        assert_eq!(&config.wasm_module.unwrap(), &[1, 2, 3, 4]);
+        assert_eq!(&config.smartstream_filter.unwrap().binary, &[1, 2, 3, 4]);
     }
 }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -620,6 +620,20 @@ impl ConsumerConfig {
     pub fn builder() -> ConsumerConfigBuilder {
         ConsumerConfigBuilder::default()
     }
+
+    /// Maximum number of bytes to be fetched at a time.
+    #[deprecated(since = "0.8.6", note = "Use 'ConsumerConfig::builder()' instead")]
+    pub fn with_max_bytes(mut self, max_bytes: i32) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// set wasm filter
+    #[deprecated(since = "0.8.6", note = "Use 'ConsumerConfig::builder()' instead")]
+    pub fn with_wasm_filter(mut self, bytes: Vec<u8>) -> Self {
+        self.wasm_module = bytes;
+        self
+    }
 }
 
 impl ConsumerConfigBuilder {

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -583,14 +583,6 @@ impl SmartStreamModule {
             binary: binary.into(),
         }
     }
-
-    /// Instantiate a SmartStream from a base64-encoded string
-    pub fn from_base64<S: Into<String>>(string: S) -> Result<Self, FluvioError> {
-        let binary = base64::decode(string.into()).map_err(|e| {
-            FluvioError::Other(format!("Failed to decode WASM from base64: {:?}", e))
-        })?;
-        Ok(Self { binary })
-    }
 }
 
 /// Configures the behavior of consumer fetching and streaming
@@ -719,7 +711,10 @@ impl ConsumerConfigBuilder {
         &mut self,
         base64: S,
     ) -> Result<&mut Self, FluvioError> {
-        self.smartstream_filter(SmartStreamModule::from_base64(base64.into())?);
+        let binary = base64::decode(base64.into()).map_err(|e| {
+            FluvioError::Other(format!("Failed to decode WASM from base64: {:?}", e))
+        })?;
+        self.smartstream_filter(SmartStreamModule::from_binary(binary));
         Ok(self)
     }
 }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -293,6 +293,7 @@ impl PartitionConsumer {
     /// # }
     /// ```
     ///
+    /// [`stream`]: PartitionConsumer::stream
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     #[instrument(skip(self, offset, config))]

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -97,7 +97,7 @@ use tracing::instrument;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{TopicProducer, RecordKey};
-pub use consumer::{PartitionConsumer, ConsumerConfig};
+pub use consumer::{PartitionConsumer, ConsumerConfig, ConsumerConfigBuilder};
 pub use offset::Offset;
 
 pub use crate::admin::FluvioAdmin;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -97,7 +97,7 @@ use tracing::instrument;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{TopicProducer, RecordKey};
-pub use consumer::{PartitionConsumer, ConsumerConfig, ConsumerConfigBuilder};
+pub use consumer::{PartitionConsumer, ConsumerConfig, ConsumerConfigBuilder, SmartStreamModule};
 pub use offset::Offset;
 
 pub use crate::admin::FluvioAdmin;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -97,7 +97,7 @@ use tracing::instrument;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{TopicProducer, RecordKey};
-pub use consumer::{PartitionConsumer, ConsumerConfig, ConsumerConfigBuilder, SmartStreamModule};
+pub use consumer::{PartitionConsumer, ConsumerConfig, ConsumerConfigBuilder};
 pub use offset::Offset;
 
 pub use crate::admin::FluvioAdmin;

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -44,7 +44,7 @@ directories = "3.0.2"
 tempfile = "3.2"
 
 # Fluvio dependencies
-fluvio = { version = "0.8.0", path = "../client", default-features = false }
+fluvio = { version = "0.9.0", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.3.0" }
 fluvio-command = { version = "0.2.0", path = "../command" }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -44,7 +44,7 @@ directories = "3.0.2"
 tempfile = "3.2"
 
 # Fluvio dependencies
-fluvio = { version = "0.9.0", path = "../client", default-features = false }
+fluvio = { version = "0.8.6", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.3.0" }
 fluvio-command = { version = "0.2.0", path = "../command" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
-fluvio = { version = "0.9.0", path = "../client",  optional = true }
+fluvio = { version = "0.8.6", path = "../client",  optional = true }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
-fluvio = { version = "0.8.0", path = "../client",  optional = true }
+fluvio = { version = "0.9.0", path = "../client",  optional = true }
 fluvio-package-index = { version = "0.3.0", path = "../package-index" }


### PR DESCRIPTION
Closes https://github.com/infinyon/fluvio-client-wasm/issues/32

- Adds `SmartStreamModule` type for WASM binaries given to the consumer by users
- Turn `ConsumerConfig` into a proper builder that can take WASM by binary or base64 (for web use-cases)