### PR TITLE
[Merged by Bors] - Give user feedback when consuming in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Sort output of `fluvio partition list` by Topic then Partition. ([#1181](https://github.com/infinyon/fluvio/issues/1181))
 * Add SmartStream Map (`#[smartstream(map)]`) API for transforming records. ([#1174](https://github.com/infinyon/fluvio/pull/1174))
 * Change C compiler to `zig` and linker to `lld`. Resolves segaults when cross compiling to musl. ([#464](https://github.com/infinyon/fluvio/pull/464))
+* Consumer CLI prints a status when consuming from the end of a partition. ([#1171](https://github.com/infinyon/fluvio/pull/1171))
  
 ## Platform Version 0.8.4 - 2020-05-29
 * Don't hang when check for non exist topic. ([#697](https://github.com/infinyon/fluvio/pull/697))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "async-h1",
  "atty",
  "color-eyre",
+ "colored",
  "content_inspector",
  "ctrlc",
  "dirs 1.0.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-helm"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b05916eebbf6759f6d28c4be42b9b637563b7dba178ad66251f28ab02502a07"
+checksum = "e925a69b64cb86b021e697a087053c07eca04a5207bb116326d44c0c675e61ed"
 dependencies = [
  "fluvio-command 0.2.0",
  "serde",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -54,6 +54,7 @@ tempdir = "0.3.7"
 sysinfo = "0.16.1"
 atty = { version = "0.2.14", optional = true }
 ctrlc = { version = "3.1.3", optional = true}
+colored = "2"
 hostname-validator = { version = "1.0.0", optional = true}
 content_inspector = { version = "0.2.4", optional = true}
 

--- a/src/cli/src/consumer/consume/mod.rs
+++ b/src/cli/src/consumer/consume/mod.rs
@@ -249,7 +249,7 @@ impl ConsumeOpt {
                 eprintln!(
                     "{}",
                     format!(
-                        "Consuming records {} from the end of topic '{}'",
+                        "Consuming records starting {} from the end of topic '{}'",
                         -offset, &self.topic
                     )
                     .bold()


### PR DESCRIPTION
Closes #700 

When using the Consumer CLI in "interactive mode", the CLI will now print a little message about how it is going to consume.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/4210949/122231966-e0f5a080-ce88-11eb-8073-d11d3ca12848.png">

The most important one here is in the case that no flags are given, e.g. `fluvio consume one`. This was confusing to the user in the past because it would appear to just hang as if it were loading, when it was actually consuming from the end of the partition and just waiting for records to arrive. Now there's a message to say that.