### PR TITLE
[Merged by Bors] - ensure buid is done before test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,8 +305,7 @@ jobs:
           override: true
       - name: Setup Minikube for Linux
         run: |
-          minikube delete
-          minikube start --driver=docker --kubernetes-version 1.19.6
+          ./k8-util/minikube/reset-minikube.sh 
           sleep 30
       - name: Test minikube
         run: |
@@ -392,8 +391,7 @@ jobs:
       - name: Setup Minikube for Linux
         if: startsWith(matrix.os, 'infinyon-ubuntu')
         run: |
-          minikube delete
-          minikube start --driver=docker --kubernetes-version 1.19.6
+          ./k8-util/minikube/reset-minikube.sh
       - name: Test minikube
         run: |
           minikube profile list

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,6 @@ endif
 # List of smoke test steps.  This is used by CI
 #
 
-# In CI mode, do not run any build steps
-ifeq (${CI},true)
-else
-# When not in CI (i.e. development), build before testing
-smoke-test: build-test
-endif
 smoke-test: test-setup
 	# Set ENV
 	$(TEST_ENV_AUTH_POLICY) \
@@ -149,7 +143,16 @@ smoke-test-k8-tls-root: smoke-test-k8-tls-policy test-permission-k8
 test-rbac:
 	AUTH_POLICY=$(POLICY_FILE) X509_AUTH_SCOPES=$(SCOPE) make smoke-test-tls DEFAULT_LOG=fluvio=debug
 
-test-setup:
+# In CI mode, do not run any build steps
+ifeq (${CI},true)
+build-test-ci:
+else
+# When not in CI (i.e. development), build before testing
+build-test-ci: build-test
+endif
+
+
+test-setup:	build-test-ci
 ifeq ($(UNINSTALL),noclean)
 	echo "no clean"
 else

--- a/k8-util/minikube/reset-minikube.sh
+++ b/k8-util/minikube/reset-minikube.sh
@@ -3,7 +3,5 @@
 # this defaults to docker and assume you have have sudo access
 set -e
 ARG1=${1:-docker}
-sudo pkill -f "minikube tunnel"
 minikube delete
 minikube start --driver $ARG1 --kubernetes-version 1.19.6
-fluvio cluster start --sys


### PR DESCRIPTION
This fixes smoke test not building binaries when not in CI mode which was introduced by #1165