### PR TITLE
[Merged by Bors] - Partition list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add unstable Admin Watch API for topics, partitions, and SPUs ([#1136](https://github.com/infinyon/fluvio/pull/1136))
 * Make recipes for smoke tests no longer build by default, helps caching. ([#1165](https://github.com/infinyon/fluvio/pull/1165))
 * Relax requirement of `FluvioAdmin` methods from `&mut self` to `&self`. ([#1178](https://github.com/infinyon/fluvio/pull/1178))
+* Sort output of `fluvio partition list` by Topic then Partition. ([#1181](https://github.com/infinyon/fluvio/issues/1181))
  
 ## Platform Version 0.8.4 - 2020-05-29
 * Don't hang when check for non exist topic. ([#697](https://github.com/infinyon/fluvio/pull/697))

--- a/src/cli/src/consumer/partition/list.rs
+++ b/src/cli/src/consumer/partition/list.rs
@@ -96,7 +96,7 @@ mod display {
                 "RESOLUTION",
                 "HW",
                 "LEO",
-                "LSR",
+                "LRS",
                 "FOLLOWER OFFSETS"
             ]
         }

--- a/src/cli/src/consumer/partition/list.rs
+++ b/src/cli/src/consumer/partition/list.rs
@@ -107,7 +107,9 @@ mod display {
         }
 
         fn content(&self) -> Vec<Row> {
-            self.0
+            let mut metadata = self.0.clone();
+            metadata.sort_by(|a, b| a.name.cmp(&b.name));
+            metadata
                 .iter()
                 .map(|metadata| {
                     let spec = &metadata.spec;

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -29,6 +29,8 @@ use super::ElectionScoring;
 pub struct PartitionStatus {
     pub resolution: PartitionResolution,
     pub leader: ReplicaStatus,
+    // TODO: Next time we make a breaking protocol change, rename this to `lrs`
+    // TODO: There is no such thing as `lsr`, it is a typo
     pub lsr: u32,
     pub replicas: Vec<ReplicaStatus>,
     pub is_being_deleted: bool,
@@ -83,6 +85,7 @@ impl PartitionStatus {
         self.resolution != PartitionResolution::Online
     }
 
+    // TODO: At next breaking change, deprecate this and replace with `fn lrs` to fix typo
     pub fn lsr(&self) -> u32 {
         self.lsr
     }

--- a/src/spu/src/replication/leader/replica_state.rs
+++ b/src/spu/src/replication/leader/replica_state.rs
@@ -361,9 +361,9 @@ where
 /// //          Input:  leo: 2, hw: 2,
 /// //          Expect, status change, follower sync  
 ///
-///  Simple HW mark calculation (assume LSR = 2) which is find minimum offset values that satisfy
+///  Simple HW mark calculation (assume LRS = 2) which is find minimum offset values that satisfy
 ///     Assume: Leader leo = 10, hw = 2,
-///         follower: leo(2,4)  =>   no change, since it doesn't satisfy minim LSR
+///         follower: leo(2,4)  =>   no change, since it doesn't satisfy minim LRS
 ///         follower: leo(3,4)  =>   hw = 3  that is smallest leo that satisfy
 ///         follower: leo(4,4)  =>   hw = 4
 ///         follower: leo(6,7,9) =>  hw = 7,
@@ -374,7 +374,7 @@ fn compute_hw(
 ) -> Option<Offset> {
     // assert!(min_replica > 0);
     //  assert!((min_replica - 1) <= followers.len() as u16);
-    let min_lsr = min(min_replica - 1, followers.len() as u16);
+    let min_lrs = min(min_replica - 1, followers.len() as u16);
 
     // compute unique offsets that is greater than min leader's HW
     let qualified_leos: Vec<Offset> = followers
@@ -403,12 +403,12 @@ fn compute_hw(
     let mut hw_list: Vec<Offset> = unique_leos
         .iter()
         .filter_map(|unique_offset| {
-            // leo must have at least must have replicated min_lsr
+            // leo must have at least must have replicated min_lrs
             if (qualified_leos
                 .iter()
                 .filter(|leo| unique_offset <= leo)
                 .count() as u16)
-                >= min_lsr
+                >= min_lrs
             {
                 Some(*unique_offset)
             } else {
@@ -434,20 +434,20 @@ mod test_hw_updates {
         offsets.into_iter().collect()
     }
 
-    /// test min lsr check
+    /// test min lrs check
     /*
     #[test]
     #[should_panic]
-    fn test_hw_min_lsr_invalid_hw() {
+    fn test_hw_min_lrs_invalid_hw() {
         compute_hw(&OffsetInfo { hw: 0, leo: 10 }, 0, &offsets_maps(vec![]));
     }
     */
 
     /*
-    TODO: Revisit check of min lsr
+    TODO: Revisit check of min lrs
     #[test]
     #[should_panic]
-    fn test_hw_min_lsr_too_much() {
+    fn test_hw_min_lrs_too_much() {
         compute_hw(
             &OffsetInfo { hw: 0, leo: 10 },
             3,
@@ -554,7 +554,7 @@ mod test_hw_updates {
             Some(4)
         );
 
-        // we take maximum leo since min lsr = 2
+        // we take maximum leo since min lrs = 2
         assert_eq!(
             compute_hw(
                 &OffsetInfo { leo: 10, hw: 0 },

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -87,7 +87,7 @@ impl ReplicaStorage for FileReplica {
 
     /// write records to this replica
     /// if update_highwatermark is set, set high watermark is end
-    //  this is used when LSR = 1
+    //  this is used when LRS = 1
     #[instrument(skip(self, records, update_highwatermark))]
     async fn write_recordset(
         &mut self,


### PR DESCRIPTION
Closes #1181 and fixes the typo of `LSR` to `LRS`, per @ajhunyady's request.

- Note I only fixed the typos in non-breaking ways (i.e. comments and local variables), I did not edit spec fields