### PR TITLE
[Merged by Bors] - Clean up stream_fetch code

### DIFF
--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -395,7 +395,7 @@ impl StreamFetchHandler {
             }
         } else {
             debug!("empty records, skipping");
-            return Ok((offset.isolation(&self.isolation), false));
+            Ok((offset.isolation(&self.isolation), false))
         }
     }
 }

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -323,7 +323,7 @@ impl StreamFetchHandler {
                 let consumer_wait = !filter_batch.records().is_empty();
                 if !consumer_wait {
                     debug!(next_offset, "filter, no records send back, skipping");
-                    return Ok((next_offset, false));
+                    return Ok((next_offset, consumer_wait));
                 }
 
                 trace!("filter batch: {:#?}", filter_batch);
@@ -365,7 +365,7 @@ impl StreamFetchHandler {
                     .send_response(&filter_response_msg, self.header.api_version())
                     .await?;
 
-                Ok((next_offset, true))
+                Ok((next_offset, consumer_wait))
             } else {
                 debug!("no filter, sending back entire");
 


### PR DESCRIPTION
This is just a small cleanup task as I am working on aggregate SmartStreams. Right now all of the SmartStream engine stuff is in the `filter.rs` module in the SPU, but if we are going to be reusing it (e.g. in `aggregate.rs`) then we should move this stuff up one level to be more "common" code.

There should not be any changes in here except for moving the location of this code.