### PR TITLE
[Merged by Bors] - Extract SmartStreamEngine and Module from filter

### DIFF
--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -24,7 +24,7 @@ use fluvio_types::event::offsets::OffsetChangeListener;
 
 use crate::core::DefaultSharedGlobalContext;
 use crate::replication::leader::SharedFileLeaderState;
-use crate::smart_stream::filter::{SmartStreamModule, SmartStreamEngine};
+use crate::smart_stream::{SmartStreamModule, SmartStreamEngine};
 use publishers::INIT_OFFSET;
 
 /// Fetch records as stream
@@ -479,7 +479,6 @@ pub mod publishers {
 }
 
 #[cfg(test)]
-#[cfg(target_os = "linux")]
 mod test {
 
     use std::{

--- a/src/spu/src/smart_stream/mod.rs
+++ b/src/spu/src/smart_stream/mod.rs
@@ -1,2 +1,74 @@
+use std::path::Path;
+use std::sync::RwLock;
+
+use anyhow::Result;
+use tracing::instrument;
+use wasmtime::{Engine, Module, Store};
+use crate::smart_stream::filter::SmartFilter;
+
 pub mod filter;
 mod memory;
+
+pub struct SmartStreamEngine(Engine);
+
+impl SmartStreamEngine {
+    pub fn new() -> Self {
+        Self(Engine::default())
+    }
+
+    #[allow(unused)]
+    #[instrument(skip(self, path))]
+    pub fn create_module_from_path(&self, path: impl AsRef<Path>) -> Result<SmartStreamModule> {
+        SmartStreamModule::from_path(&self.0, path)
+    }
+
+    #[instrument(skip(self, binary))]
+    pub fn create_module_from_binary(&self, binary: &[u8]) -> Result<SmartStreamModule> {
+        SmartStreamModule::from_binary(&self.0, binary)
+    }
+}
+
+pub struct SmartStreamModule(RwLock<SmartStreamModuleInner>);
+
+impl SmartStreamModule {
+    #[allow(unused)]
+    fn from_path(engine: &Engine, path: impl AsRef<Path>) -> Result<Self> {
+        Ok(Self(RwLock::new(SmartStreamModuleInner::create_from_path(
+            engine, path,
+        )?)))
+    }
+
+    fn from_binary(engine: &Engine, binary: &[u8]) -> Result<Self> {
+        Ok(Self(RwLock::new(
+            SmartStreamModuleInner::create_from_binary(engine, binary)?,
+        )))
+    }
+
+    pub fn create_filter(&self) -> Result<SmartFilter> {
+        let write_inner = self.0.write().unwrap();
+        write_inner.create_filter()
+    }
+}
+
+unsafe impl Send for SmartStreamModuleInner {}
+unsafe impl Sync for SmartStreamModuleInner {}
+
+pub struct SmartStreamModuleInner {
+    module: Module,
+    store: Store,
+}
+
+impl SmartStreamModuleInner {
+    #[allow(unused)]
+    pub fn create_from_path(engine: &Engine, path: impl AsRef<Path>) -> Result<Self> {
+        let store = Store::new(&engine);
+        let module = Module::from_file(store.engine(), path)?;
+        Ok(Self { module, store })
+    }
+
+    pub fn create_from_binary(engine: &Engine, binary: &[u8]) -> Result<Self> {
+        let store = Store::new(&engine);
+        let module = Module::from_binary(store.engine(), binary)?;
+        Ok(Self { module, store })
+    }
+}

--- a/src/spu/src/smart_stream/mod.rs
+++ b/src/spu/src/smart_stream/mod.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
-use std::sync::RwLock;
+use std::sync::{RwLock, Mutex};
 
-use anyhow::Result;
-use tracing::instrument;
-use wasmtime::{Engine, Module, Store};
+use anyhow::{Result, Error};
+use tracing::{debug, instrument};
+use wasmtime::{Engine, Module, Store, Instance, Memory};
 use crate::smart_stream::filter::SmartFilter;
 
 pub mod filter;
@@ -70,5 +70,68 @@ impl SmartStreamModuleInner {
         let store = Store::new(&engine);
         let module = Module::from_binary(store.engine(), binary)?;
         Ok(Self { module, store })
+    }
+}
+
+pub struct SmartStreamInstance(Instance);
+
+impl SmartStreamInstance {
+    fn new(instance: Instance) -> Self {
+        Self(instance)
+    }
+
+    pub fn copy_memory_to(&self, bytes: &[u8]) -> Result<isize, Error> {
+        use self::memory::copy_memory_to_instance;
+        copy_memory_to_instance(bytes, &self.0)
+    }
+}
+
+#[derive(Clone)]
+pub struct RecordsMemory {
+    ptr: i32,
+    len: i32,
+    memory: Memory,
+}
+
+impl RecordsMemory {
+    fn copy_memory_from(&self) -> Vec<u8> {
+        unsafe {
+            if let Some(data) = self
+                .memory
+                .data_unchecked()
+                .get(self.ptr as u32 as usize..)
+                .and_then(|arr| arr.get(..self.len as u32 as usize))
+            {
+                debug!(wasm_mem_len = self.len, "copying from wasm");
+                let mut bytes = vec![0u8; self.len as u32 as usize];
+                bytes.copy_from_slice(data);
+                bytes
+            } else {
+                vec![]
+            }
+        }
+    }
+}
+
+pub struct RecordsCallBack(Mutex<Option<RecordsMemory>>);
+
+impl RecordsCallBack {
+    fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    fn set(&self, records: RecordsMemory) {
+        let mut write_inner = self.0.lock().unwrap();
+        write_inner.replace(records);
+    }
+
+    fn clear(&self) {
+        let mut write_inner = self.0.lock().unwrap();
+        write_inner.take();
+    }
+
+    fn get(&self) -> Option<RecordsMemory> {
+        let reader = self.0.lock().unwrap();
+        reader.clone()
     }
 }


### PR DESCRIPTION
This is a bit of cleanup that was originally in #1188 but I have now split out. I must have fat-fingered something when I cleaned this up the first time because it caused the stream_fetch tests to fail before. I don't know what I changed but now these changes pass all of the tests locally for me, so I imagine they will pass CI (I hope).