### PR TITLE
[Merged by Bors] - Fix smoke-test-k8 by removing --skip-checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ k8-setup:
 
 # Kubernetes Tests
 
-smoke-test-k8: TEST_ARG_EXTRA=--skip-checks $(EXTRA_ARG)
+smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
 smoke-test-k8: build_k8_image smoke-test
 
 smoke-test-k8-tls: TEST_ARG_EXTRA=--tls --skip-checks $(EXTRA_ARG)
@@ -126,7 +126,7 @@ smoke-test-k8-tls-policy-setup:
 	kubectl delete configmap authorization --ignore-not-found
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
 smoke-test-k8-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization --skip-checks --keep-cluster
+smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization --keep-cluster
 smoke-test-k8-tls-policy: build_k8_image smoke-test-k8-tls-policy-setup smoke-test
 
 test-permission-k8:	SC_HOST=$(shell kubectl get node -o json | jq '.items[].status.addresses[0].address' | tr -d '"' )


### PR DESCRIPTION
`make smoke-test-k8` was failing due to missing system charts. This happened because `--skip-checks` was added by default, but the checks are the point where system charts are detected and installed if missing.