### PR TITLE
[Merged by Bors] - Re-enable apple-darwin client publish to fluvio-packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,11 +435,9 @@ jobs:
     strategy:
       matrix:
         target:
-          [
-            x86_64-unknown-linux-musl,
-            x86_64-apple-darwin,
-            armv7-unknown-linux-gnueabihf,
-          ]
+          - x86_64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
         artifact: [fluvio]
         include:
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,8 +79,8 @@ jobs:
           mv fluvio-x86_64-unknown-linux-musl target/x86_64-unknown-linux-musl/release/fluvio
           mv fluvio-run-x86_64-unknown-linux-musl target/x86_64-unknown-linux-musl/release/fluvio-run
 
-        #   mkdir -p target/x86_64-apple-darwin/release/
-        #   mv fluvio-x86_64-apple-darwin target/x86_64-apple-darwin/release/fluvio
+          mkdir -p target/x86_64-apple-darwin/release/
+          mv fluvio-x86_64-apple-darwin target/x86_64-apple-darwin/release/fluvio
         #   mv fluvio-run-x86_64-apple-darwin target/x86_64-apple-darwin/release/fluvio-run
       - name: Publish to Fluvio Packages
         run: |
@@ -88,8 +88,7 @@ jobs:
           ${HOME}/.fluvio/bin/fluvio package publish \
             --version="${VERSION}+${{ github.sha }}" \
             target/x86_64-unknown-linux-musl/release/fluvio
-            
-            
+
           ${HOME}/.fluvio/bin/fluvio package publish \
             --version="${VERSION}+${{ github.sha }}" \
             target/x86_64-unknown-linux-musl/release/fluvio-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,5 +113,5 @@ jobs:
           version: "0.32.9"
       - name: Bump latest version of Fluvio CLI on fluvio-packages
         env:
-          RUST_LOG: debug
+          RUST_LOG: info
         run: cargo make bump-fluvio-latest


### PR DESCRIPTION
This should fix failing package bump: https://github.com/infinyon/fluvio/runs/3053841900?check_suite_focus=true