### PR TITLE
[Merged by Bors] - Protocol derive enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.8.6 - UNRELEASED
 * Add k8s feature flag to cli. ([#1257](https://github.com/infinyon/fluvio/pull/1257))
+* Improve `#[derive(Encoder, Decoder)]` to work with data enums. ([#1232](https://github.com/infinyon/fluvio/pull/1232))
 
 ## Platform Version 0.8.5 - 2021-07-14
 * Add unstable Admin Watch API for topics, partitions, and SPUs ([#1136](https://github.com/infinyon/fluvio/pull/1136))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "fluvio-future",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "fluvio-protocol",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tokio",
- "trybuild",
+ "trybuild 1.0.42 (git+https://github.com/sehz/trybuild?branch=check_option)",
 ]
 
 [[package]]
@@ -1678,6 +1678,7 @@ dependencies = [
  "quote",
  "syn",
  "tracing",
+ "trybuild 1.0.42 (git+https://github.com/infinyon/trybuild?branch=check_option)",
 ]
 
 [[package]]
@@ -1788,7 +1789,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "trybuild",
+ "trybuild 1.0.42 (git+https://github.com/sehz/trybuild?branch=check_option)",
 ]
 
 [[package]]
@@ -4558,6 +4559,19 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "trybuild"
+version = "1.0.42"
+source = "git+https://github.com/infinyon/trybuild?branch=check_option#271081028a8b10104c5ab6eb1861e35fd23e156e"
+dependencies = [
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "trybuild"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -24,7 +24,7 @@ x509-parser = "0.9.1"
 fluvio-controlplane-metadata = { version = "0.9.1", path = "../controlplane-metadata" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
-fluvio-protocol = { path = "../protocol",  version = "0.5.1" }
+fluvio-protocol = { path = "../protocol",  version = "0.6" }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 flv-tls-proxy = { version = "0.5.0" }

--- a/src/auth/src/x509/request.rs
+++ b/src/auth/src/x509/request.rs
@@ -4,14 +4,14 @@ use std::fmt::Debug;
 
 use dataplane::bytes::Buf;
 use dataplane::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
-use dataplane::derive::{Encode, Decode};
+use dataplane::derive::{Encoder, Decoder};
 
 pub type AuthorizationScopes = Vec<String>;
 
 pub const AUTH_REQUEST_API_KEY: u16 = 8;
 
 // Auth Test Request & Response
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct AuthRequest {
     pub principal: String,
     pub scopes: AuthorizationScopes,
@@ -28,7 +28,7 @@ impl Request for AuthRequest {
     type Response = AuthResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct AuthResponse {
     pub success: bool,
 }
@@ -38,7 +38,7 @@ pub enum AuthorizationApiRequest {
     AuthRequest(RequestMessage<AuthRequest>),
 }
 
-// Added to satisfy Encode/Decode traits
+// Added to satisfy Encoder/Decoder traits
 impl Default for AuthorizationApiRequest {
     fn default() -> AuthorizationApiRequest {
         AuthorizationApiRequest::AuthRequest(RequestMessage::default())

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -43,7 +43,7 @@ fluvio-future = { version = "0.3.5", features = ["task", "openssl_tls", "task_un
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.1", path = "../sc-schema", default-features = false }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2018"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -26,7 +26,7 @@ fluvio-future = { version = "0.3.0" }
 flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-stream-model = { path = "../stream-model", version = "0.5.0" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]

--- a/src/controlplane-metadata/src/message/msg_type.rs
+++ b/src/controlplane-metadata/src/message/msg_type.rs
@@ -9,14 +9,14 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::{Decoder, Encoder};
 
 use crate::store::actions::*;
 use crate::core::*;
 use crate::store::*;
 
-#[derive(Decode, Encode, Debug, PartialEq, Clone)]
+#[derive(Decoder, Encoder, Debug, PartialEq, Clone)]
 pub enum MsgType {
     UPDATE,
     DELETE,
@@ -28,7 +28,7 @@ impl ::std::default::Default for MsgType {
     }
 }
 
-#[derive(Decode, Encode, Debug, PartialEq, Clone, Default)]
+#[derive(Decoder, Encoder, Debug, PartialEq, Clone, Default)]
 pub struct Message<C>
 where
     C: Encoder + Decoder + Debug,

--- a/src/controlplane-metadata/src/message/msg_type.rs
+++ b/src/controlplane-metadata/src/message/msg_type.rs
@@ -9,8 +9,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt;
 
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 
 use crate::store::actions::*;
 use crate::core::*;

--- a/src/controlplane-metadata/src/message/replica_msg.rs
+++ b/src/controlplane-metadata/src/message/replica_msg.rs
@@ -12,7 +12,7 @@
 //!
 use std::fmt;
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use fluvio_types::SpuId;
 
 use crate::partition::*;

--- a/src/controlplane-metadata/src/message/replica_msg.rs
+++ b/src/controlplane-metadata/src/message/replica_msg.rs
@@ -12,7 +12,7 @@
 //!
 use std::fmt;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use fluvio_types::SpuId;
 
 use crate::partition::*;
@@ -26,7 +26,7 @@ pub type ReplicaMsg = Message<Replica>;
 // Data Structures
 // -----------------------------------
 
-#[derive(Decode, Encode, Debug, PartialEq, Clone, Default)]
+#[derive(Decoder, Encoder, Debug, PartialEq, Clone, Default)]
 pub struct ReplicaMsgs {
     pub messages: Vec<ReplicaMsg>,
 }

--- a/src/controlplane-metadata/src/partition/replica.rs
+++ b/src/controlplane-metadata/src/partition/replica.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use fluvio_types::SpuId;
 use crate::partition::ReplicaKey;
 use crate::core::{MetadataItem};

--- a/src/controlplane-metadata/src/partition/replica.rs
+++ b/src/controlplane-metadata/src/partition/replica.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use fluvio_types::SpuId;
 use crate::partition::ReplicaKey;
 use crate::core::{MetadataItem};
@@ -11,7 +11,7 @@ use crate::partition::PartitionSpec;
 use super::store::*;
 
 /// Metadata about Replica send from SC
-#[derive(Decode, Encode, Debug, PartialEq, Clone, Default)]
+#[derive(Decoder, Encoder, Debug, PartialEq, Clone, Default)]
 pub struct Replica {
     pub id: ReplicaKey,
     pub leader: SpuId,
@@ -73,7 +73,7 @@ impl fmt::Display for Replica {
 }
 
 /// given replica, where is leader
-#[derive(Decode, Encode, Debug, PartialEq, Clone, Default)]
+#[derive(Decoder, Encoder, Debug, PartialEq, Clone, Default)]
 pub struct ReplicaLeader {
     pub id: ReplicaKey,
     pub leader: SpuId,

--- a/src/controlplane-metadata/src/partition/spec.rs
+++ b/src/controlplane-metadata/src/partition/spec.rs
@@ -5,7 +5,7 @@
 //!
 //!
 use fluvio_types::SpuId;
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 
 /// Spec for Partition
 /// Each partition has replicas spread among SPU

--- a/src/controlplane-metadata/src/partition/spec.rs
+++ b/src/controlplane-metadata/src/partition/spec.rs
@@ -5,12 +5,12 @@
 //!
 //!
 use fluvio_types::SpuId;
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 
 /// Spec for Partition
 /// Each partition has replicas spread among SPU
 /// one of replica is leader which is duplicated in the leader field
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::slice::Iter;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::Offset;
 use fluvio_types::SpuId;
 
@@ -20,7 +20,7 @@ use super::ElectionScoring;
 // Data Structures
 // -----------------------------------
 
-#[derive(Decode, Encode, Default, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -189,7 +189,7 @@ fn find_status(status: &mut Vec<ReplicaStatus>, spu: SpuId) -> Option<&'_ mut Re
     status.iter_mut().find(|status| status.spu == spu)
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PartitionResolution {
     Offline,             // No leader available for serving partition
@@ -204,7 +204,7 @@ impl Default for PartitionResolution {
     }
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::slice::Iter;
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use dataplane::Offset;
 use fluvio_types::SpuId;
 

--- a/src/controlplane-metadata/src/spg/spec.rs
+++ b/src/controlplane-metadata/src/spg/spec.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use fluvio_types::defaults::{SPU_LOG_BASE_DIR, SPU_LOG_SIZE};
 
 #[derive(Encoder, Decoder, Default, Debug, PartialEq, Clone)]

--- a/src/controlplane-metadata/src/spg/spec.rs
+++ b/src/controlplane-metadata/src/spg/spec.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use fluvio_types::defaults::{SPU_LOG_BASE_DIR, SPU_LOG_SIZE};
 
-#[derive(Encode, Decode, Default, Debug, PartialEq, Clone)]
+#[derive(Encoder, Decoder, Default, Debug, PartialEq, Clone)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -21,7 +21,7 @@ pub struct SpuGroupSpec {
     pub spu_config: SpuConfig,
 }
 
-#[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -44,7 +44,7 @@ impl SpuConfig {
     }
 }
 
-#[derive(Encode, Decode, Default, Debug, PartialEq, Clone)]
+#[derive(Encoder, Decoder, Default, Debug, PartialEq, Clone)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -54,7 +54,7 @@ pub struct ReplicationConfig {
     pub in_sync_replica_min: Option<u16>,
 }
 
-#[derive(Encode, Decode, Debug, Default, PartialEq, Clone)]
+#[derive(Encoder, Decoder, Debug, Default, PartialEq, Clone)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -85,7 +85,7 @@ pub struct RealStorageConfig {
     pub size: String,
 }
 
-#[derive(Encode, Decode, Default, Debug, PartialEq, Clone)]
+#[derive(Encoder, Decoder, Default, Debug, PartialEq, Clone)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/src/controlplane-metadata/src/spg/status.rs
+++ b/src/controlplane-metadata/src/spg/status.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use dataplane::derive::*;
 
-#[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -45,7 +45,7 @@ impl SpuGroupStatus {
 }
 
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Encode, Decode, Debug, Clone, PartialEq)]
+#[derive(Encoder, Decoder, Debug, Clone, PartialEq)]
 pub enum SpuGroupStatusResolution {
     Init,
     Invalid,

--- a/src/controlplane-metadata/src/spg/status.rs
+++ b/src/controlplane-metadata/src/spg/status.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use dataplane::derive::*;
+use dataplane::core::{Encoder, Decoder};
 
 #[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/spu/spec.rs
+++ b/src/controlplane-metadata/src/spu/spec.rs
@@ -17,8 +17,7 @@ use fluvio_types::defaults::SPU_PUBLIC_PORT;
 use fluvio_types::SpuId;
 use flv_util::socket_helpers::ServerAddress;
 
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::core::Version;
 

--- a/src/controlplane-metadata/src/spu/spec.rs
+++ b/src/controlplane-metadata/src/spu/spec.rs
@@ -17,12 +17,12 @@ use fluvio_types::defaults::SPU_PUBLIC_PORT;
 use fluvio_types::SpuId;
 use flv_util::socket_helpers::ServerAddress;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::{Decoder, Encoder};
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::core::Version;
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -143,7 +143,7 @@ impl SpuSpec {
 
 /// Custom Spu Spec
 /// This is not real spec since when this is stored on metadata store, it will be stored as SPU
-#[derive(Decode, Encode, Debug, Clone, Default, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, Default, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -187,7 +187,7 @@ impl From<SpuSpec> for CustomSpuSpec {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -249,7 +249,7 @@ impl IngressPort {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IngressAddr {
     pub hostname: Option<String>,
@@ -276,7 +276,7 @@ impl IngressAddr {
     }
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -346,7 +346,7 @@ impl Endpoint {
     }
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EncryptionEnum {
     PLAINTEXT,
@@ -359,7 +359,7 @@ impl Default for EncryptionEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Encoder, Decoder)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpuType {
     Managed,

--- a/src/controlplane-metadata/src/spu/status.rs
+++ b/src/controlplane-metadata/src/spu/status.rs
@@ -7,9 +7,9 @@
 //!
 use std::fmt;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpuStatus {
     pub resolution: SpuStatusResolution,
@@ -65,7 +65,7 @@ impl SpuStatus {
     }
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SpuStatusResolution {
     Online,

--- a/src/controlplane-metadata/src/spu/status.rs
+++ b/src/controlplane-metadata/src/spu/status.rs
@@ -7,7 +7,7 @@
 //!
 use std::fmt;
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 
 #[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/controlplane-metadata/src/topic/spec.rs
+++ b/src/controlplane-metadata/src/topic/spec.rs
@@ -16,7 +16,7 @@ use fluvio_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAss
 
 use dataplane::core::Version;
 use dataplane::bytes::{Buf, BufMut};
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::{Decoder, Encoder};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -261,7 +261,7 @@ impl Encoder for TopicSpec {
 }
 
 /// Topic param
-#[derive(Debug, Clone, Default, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, Default, PartialEq, Encoder, Decoder)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -313,7 +313,7 @@ impl std::fmt::Display for TopicReplicaParam {
 }
 
 /// Hack: field instead of new type to get around encode and decode limitations
-#[derive(Debug, Default, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Default, Clone, PartialEq, Encoder, Decoder)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PartitionMaps {
     maps: Vec<PartitionMap>,
@@ -518,7 +518,7 @@ impl From<(PartitionCount, ReplicationFactor)> for TopicSpec {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PartitionMap {
     pub id: PartitionId,

--- a/src/controlplane-metadata/src/topic/spec.rs
+++ b/src/controlplane-metadata/src/topic/spec.rs
@@ -16,8 +16,7 @@ use fluvio_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAss
 
 use dataplane::core::Version;
 use dataplane::bytes::{Buf, BufMut};
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/topic/status.rs
+++ b/src/controlplane-metadata/src/topic/status.rs
@@ -8,7 +8,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use fluvio_types::{ReplicaMap, SpuId};
 
 // -----------------------------------

--- a/src/controlplane-metadata/src/topic/status.rs
+++ b/src/controlplane-metadata/src/topic/status.rs
@@ -8,14 +8,14 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use fluvio_types::{ReplicaMap, SpuId};
 
 // -----------------------------------
 // Data Structures
 // -----------------------------------
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -33,7 +33,7 @@ impl fmt::Display for TopicStatus {
     }
 }
 
-#[derive(Decode, Encode, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TopicResolution {
     Init,                  // Initializing this is starting state.
@@ -76,12 +76,12 @@ impl std::fmt::Display for TopicResolution {
 }
 
 // -----------------------------------
-// Encode - from KV Topic Status
+// Encoder - from KV Topic Status
 // -----------------------------------
 
 /*
 // -----------------------------------
-// Encode/Decode - Internal API
+// Encoder/Decoder - Internal API
 // -----------------------------------
 
 impl From<&TopicResolution> for u8 {

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -18,5 +18,5 @@ tracing = "0.1.19"
 # Fluvio dependencies
 fluvio-types = { path = "../types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.9.1" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/controlplane/src/requests/register_spu.rs
+++ b/src/controlplane/src/requests/register_spu.rs
@@ -14,8 +14,8 @@
 //!
 use dataplane::api::Request;
 use dataplane::ErrorCode;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use fluvio_types::SpuId;
 
 use crate::InternalScKey;
@@ -24,7 +24,7 @@ use crate::InternalScKey;
 // Data Structures
 // -----------------------------------
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct RegisterSpuRequest {
     spu: SpuId,
 }
@@ -34,7 +34,7 @@ impl Request for RegisterSpuRequest {
     type Response = RegisterSpuResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct RegisterSpuResponse {
     error_code: ErrorCode,
     error_message: Option<String>,

--- a/src/controlplane/src/requests/remove.rs
+++ b/src/controlplane/src/requests/remove.rs
@@ -3,14 +3,14 @@
 use std::fmt;
 
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use crate::InternalScKey;
 
 /// Confirmation of Replica replica
-#[derive(Decode, Encode, Debug, Default, Clone)]
+#[derive(Decoder, Encoder, Debug, Default, Clone)]
 pub struct ReplicaRemovedRequest {
     pub id: ReplicaKey,
     pub confirm: bool, // replica remove confirmed
@@ -33,5 +33,5 @@ impl Request for ReplicaRemovedRequest {
     type Response = ReplicaRemovedResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ReplicaRemovedResponse {}

--- a/src/controlplane/src/requests/update_lrs.rs
+++ b/src/controlplane/src/requests/update_lrs.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use fluvio_controlplane_metadata::partition::ReplicaStatus;
 
@@ -13,7 +13,7 @@ use crate::InternalScKey;
 
 /// Live Replica Status
 /// First lrs is leader by convention but should not be relied upon
-#[derive(Decode, Encode, Debug, Default, Clone)]
+#[derive(Decoder, Encoder, Debug, Default, Clone)]
 pub struct UpdateLrsRequest {
     replicas: Vec<LrsRequest>,
 }
@@ -40,11 +40,11 @@ impl Request for UpdateLrsRequest {
     type Response = UpdateLrsResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateLrsResponse {}
 
 /// Request to update replica status
-#[derive(Decode, Encode, Debug, Default, Clone)]
+#[derive(Decoder, Encoder, Debug, Default, Clone)]
 pub struct LrsRequest {
     pub id: ReplicaKey,
     pub leader: ReplicaStatus,

--- a/src/controlplane/src/requests/update_replica.rs
+++ b/src/controlplane/src/requests/update_replica.rs
@@ -1,14 +1,14 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::api::Request;
 use fluvio_controlplane_metadata::message::ReplicaMsg;
 use fluvio_controlplane_metadata::partition::Replica;
 use crate::InternalSpuApi;
 
 /// Changes to Replica Specs
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct UpdateReplicaRequest {
     pub epoch: i64,
     pub changes: Vec<ReplicaMsg>,
@@ -38,5 +38,5 @@ impl UpdateReplicaRequest {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateReplicaResponse {}

--- a/src/controlplane/src/requests/update_spu.rs
+++ b/src/controlplane/src/requests/update_spu.rs
@@ -1,15 +1,15 @@
 #![allow(clippy::assign_op_pattern)]
 
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use fluvio_controlplane_metadata::spu::SpuSpec;
 use fluvio_controlplane_metadata::message::SpuMsg;
 
 use crate::InternalSpuApi;
 
 /// Changes to Spu specs
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct UpdateSpuRequest {
     pub epoch: i64,
     pub changes: Vec<SpuMsg>,
@@ -67,5 +67,5 @@ impl UpdateSpuRequest {
     */
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateSpuResponse {}

--- a/src/controlplane/src/sc_api.rs
+++ b/src/controlplane/src/sc_api.rs
@@ -6,9 +6,9 @@ use dataplane::api::ApiMessage;
 use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 use dataplane::bytes::Buf;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 
-use dataplane::derive::Decode;
+use dataplane::derive::Decoder;
 
 use super::RegisterSpuRequest;
 use super::UpdateLrsRequest;
@@ -17,7 +17,7 @@ use super::ReplicaRemovedRequest;
 /// API call from Spu to SC
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum InternalScKey {
     RegisterSpu = 2000,
@@ -32,7 +32,7 @@ impl Default for InternalScKey {
 }
 
 /// Request made to Spu from Sc
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum InternalScRequest {
     RegisterSpuRequest(RequestMessage<RegisterSpuRequest>),
     UpdateLrsRequest(RequestMessage<UpdateLrsRequest>),

--- a/src/controlplane/src/spu_api.rs
+++ b/src/controlplane/src/spu_api.rs
@@ -6,14 +6,14 @@ use dataplane::api::ApiMessage;
 use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 use dataplane::bytes::Buf;
-use dataplane::derive::Encode;
-use dataplane::derive::Decode;
+use dataplane::derive::Encoder;
+use dataplane::derive::Decoder;
 
 use super::UpdateSpuRequest;
 use super::UpdateReplicaRequest;
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum InternalSpuApi {
     UpdateSpu = 1001,
@@ -26,13 +26,13 @@ impl Default for InternalSpuApi {
     }
 }
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum InternalSpuRequest {
     UpdateSpuRequest(RequestMessage<UpdateSpuRequest>),
     UpdateReplicaRequest(RequestMessage<UpdateReplicaRequest>),
 }
 
-// Added to satisfy Encode/Decode traits
+// Added to satisfy Encoder/Decoder traits
 impl Default for InternalSpuRequest {
     fn default() -> Self {
         Self::UpdateSpuRequest(RequestMessage::default())

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -25,7 +25,7 @@ derive_builder = { version = "0.9.0", optional =  true }
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.1" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api"] }
+fluvio-protocol = { path = "../protocol", version = "0.6", features = ["derive", "api"] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -10,8 +10,6 @@ use crate::core::bytes::BufMut;
 use crate::core::Decoder;
 use crate::core::Encoder;
 use crate::core::Version;
-use crate::derive::Decoder;
-use crate::derive::Encoder;
 
 use crate::Offset;
 use crate::Size;

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -10,8 +10,8 @@ use crate::core::bytes::BufMut;
 use crate::core::Decoder;
 use crate::core::Encoder;
 use crate::core::Version;
-use crate::derive::Decode;
-use crate::derive::Encode;
+use crate::derive::Decoder;
+use crate::derive::Encoder;
 
 use crate::Offset;
 use crate::Size;
@@ -222,7 +222,7 @@ where
     }
 }
 
-#[derive(Debug, Decode, Encode)]
+#[derive(Debug, Decoder, Encoder)]
 pub struct BatchHeader {
     pub partition_leader_epoch: i32,
     pub magic: i8,

--- a/src/dataplane-protocol/src/common.rs
+++ b/src/dataplane-protocol/src/common.rs
@@ -1,8 +1,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use crate::derive::Decoder;
-use crate::derive::Encoder;
+use crate::derive::{Encoder, Decoder};
 
 pub type Offset = i64;
 pub type Size = u32;

--- a/src/dataplane-protocol/src/common.rs
+++ b/src/dataplane-protocol/src/common.rs
@@ -1,13 +1,13 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use crate::derive::Decode;
-use crate::derive::Encode;
+use crate::derive::Decoder;
+use crate::derive::Encoder;
 
 pub type Offset = i64;
 pub type Size = u32;
 
-#[derive(Debug, Encode, Decode, Clone)]
+#[derive(Debug, Encoder, Decoder, Clone)]
 #[fluvio(encode_discriminant)]
 #[repr(u8)]
 pub enum Isolation {
@@ -21,7 +21,7 @@ impl Default for Isolation {
     }
 }
 
-#[derive(Hash, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[derive(Hash, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Encoder, Decoder)]
 pub struct ReplicaKey {
     pub topic: String,
     pub partition: i32,

--- a/src/dataplane-protocol/src/error_code.rs
+++ b/src/dataplane-protocol/src/error_code.rs
@@ -5,15 +5,15 @@
 //!
 
 use flv_util::string_helper::upper_cammel_case_to_sentence;
-use crate::derive::Encode;
-use crate::derive::Decode;
+use fluvio_protocol::Encoder;
+use fluvio_protocol::Decoder;
 
 // -----------------------------------
 // Error Definition & Implementation
 // -----------------------------------
 
 #[repr(i16)]
-#[derive(Encode, Decode, PartialEq, Debug, Clone, Copy)]
+#[derive(Encoder, Decoder, PartialEq, Debug, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum ErrorCode {
     UnknownServerError = -1,

--- a/src/dataplane-protocol/src/error_code.rs
+++ b/src/dataplane-protocol/src/error_code.rs
@@ -5,8 +5,7 @@
 //!
 
 use flv_util::string_helper::upper_cammel_case_to_sentence;
-use fluvio_protocol::Encoder;
-use fluvio_protocol::Decoder;
+use fluvio_protocol::{Encoder, Decoder};
 
 // -----------------------------------
 // Error Definition & Implementation

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -6,8 +6,6 @@ use crate::api::Request;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
-use crate::derive::Decoder;
-use crate::derive::Encoder;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -6,8 +6,8 @@ use crate::api::Request;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
-use crate::derive::Decode;
-use crate::derive::Encode;
+use crate::derive::Decoder;
+use crate::derive::Encoder;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;
@@ -16,7 +16,7 @@ use super::FetchResponse;
 
 pub type DefaultFetchRequest = FetchRequest<RecordSet>;
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchRequest<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -63,7 +63,7 @@ where
     type Response = FetchResponse<R>;
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchableTopic {
     /// The name of the topic to fetch.
     pub name: String,
@@ -72,7 +72,7 @@ pub struct FetchableTopic {
     pub fetch_partitions: Vec<FetchPartition>,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct ForgottenTopic {
     /// The partition name.
     #[fluvio(min_version = 7)]
@@ -83,7 +83,7 @@ pub struct ForgottenTopic {
     pub forgotten_partition_indexes: Vec<i32>,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchPartition {
     /// The partition index.
     pub partition_index: i32,

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -3,8 +3,6 @@ use std::marker::PhantomData;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
-use crate::derive::Encoder;
-use crate::derive::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
-use crate::derive::Encode;
-use crate::derive::Decode;
+use crate::derive::Encoder;
+use crate::derive::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::record::RecordSet;
@@ -13,7 +13,7 @@ use crate::Offset;
 
 pub type DefaultFetchResponse = FetchResponse<RecordSet>;
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -51,7 +51,7 @@ where
     }
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchableTopicResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -64,7 +64,7 @@ where
     pub data: PhantomData<R>,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct FetchablePartitionResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -110,7 +110,7 @@ impl FetchablePartitionResponse<RecordSet> {
     }
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct AbortedTransaction {
     pub producer_id: i64,
     pub first_offset: i64,

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -3,9 +3,6 @@ use std::marker::PhantomData;
 
 use crate::core::Encoder;
 use crate::core::Decoder;
-
-use crate::derive::Encoder;
-use crate::derive::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::api::Request;

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 use crate::core::Encoder;
 use crate::core::Decoder;
 
-use crate::derive::Encode;
-use crate::derive::Decode;
+use crate::derive::Encoder;
+use crate::derive::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::api::Request;
@@ -17,7 +17,7 @@ pub type DefaultProduceRequest = ProduceRequest<RecordSet>;
 pub type DefaultPartitionRequest = PartitionProduceData<RecordSet>;
 pub type DefaultTopicRequest = TopicProduceData<RecordSet>;
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct ProduceRequest<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -52,7 +52,7 @@ where
     type Response = ProduceResponse;
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct TopicProduceData<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -65,7 +65,7 @@ where
     pub data: PhantomData<R>,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct PartitionProduceData<R>
 where
     R: Encoder + Decoder + Default + Debug,

--- a/src/dataplane-protocol/src/produce/response.rs
+++ b/src/dataplane-protocol/src/produce/response.rs
@@ -1,5 +1,5 @@
-use crate::derive::Encoder;
-use crate::derive::Decoder;
+use crate::core::Encoder;
+use crate::core::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::ErrorCode;

--- a/src/dataplane-protocol/src/produce/response.rs
+++ b/src/dataplane-protocol/src/produce/response.rs
@@ -1,10 +1,10 @@
-use crate::derive::Encode;
-use crate::derive::Decode;
+use crate::derive::Encoder;
+use crate::derive::Decoder;
 use crate::derive::FluvioDefault;
 
 use crate::ErrorCode;
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct ProduceResponse {
     /// Each produce response
     pub responses: Vec<TopicProduceResponse>,
@@ -37,7 +37,7 @@ impl ProduceResponse {
     }
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct TopicProduceResponse {
     /// The topic name
     pub name: String,
@@ -46,7 +46,7 @@ pub struct TopicProduceResponse {
     pub partitions: Vec<PartitionProduceResponse>,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct PartitionProduceResponse {
     /// The partition index.
     pub partition_index: i32,

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -16,8 +16,8 @@ use crate::core::DecoderVarInt;
 use crate::core::Encoder;
 use crate::core::EncoderVarInt;
 use crate::core::Version;
-use crate::derive::Decode;
-use crate::derive::Encode;
+use crate::derive::Decoder;
+use crate::derive::Encoder;
 
 use crate::batch::Batch;
 use crate::Offset;
@@ -327,7 +327,7 @@ impl Encoder for RecordSet {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct RecordHeader {
     attributes: i8,
     #[varint]

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -11,13 +11,10 @@ use once_cell::sync::Lazy;
 use bytes::Buf;
 use bytes::BufMut;
 
-use crate::core::Decoder;
+use crate::core::{Encoder, Decoder};
 use crate::core::DecoderVarInt;
-use crate::core::Encoder;
 use crate::core::EncoderVarInt;
 use crate::core::Version;
-use crate::derive::Decoder;
-use crate::derive::Encoder;
 
 use crate::batch::Batch;
 use crate::Offset;

--- a/src/dataplane-protocol/src/versions.rs
+++ b/src/dataplane-protocol/src/versions.rs
@@ -4,7 +4,7 @@ use fluvio_protocol::bytes::{BufMut, Buf};
 
 use crate::ErrorCode;
 use crate::api::Request;
-use crate::derive::{Decode, Encode};
+use crate::derive::{Decoder, Encoder};
 
 pub const VERSIONS_API_KEY: u16 = 18;
 
@@ -12,7 +12,7 @@ pub const VERSIONS_API_KEY: u16 = 18;
 // ApiVersionsRequest
 // -----------------------------------
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ApiVersionsRequest {}
 
 impl Request for ApiVersionsRequest {
@@ -26,14 +26,14 @@ impl Request for ApiVersionsRequest {
 
 pub type ApiVersions = Vec<ApiVersionKey>;
 
-#[derive(Decode, Encode, Default, Debug, PartialEq)]
+#[derive(Decoder, Encoder, Default, Debug, PartialEq)]
 pub struct ApiVersionsResponse {
     pub error_code: ErrorCode,
     pub api_keys: ApiVersions,
     pub platform_version: PlatformVersion,
 }
 
-#[derive(Decode, Encode, Default, Clone, Debug, PartialEq)]
+#[derive(Decoder, Encoder, Default, Clone, Debug, PartialEq)]
 pub struct ApiVersionKey {
     pub api_key: i16,
     pub min_version: i16,
@@ -75,7 +75,7 @@ impl Decoder for PlatformVersion {
     where
         T: Buf,
     {
-        // Decode the data as a String
+        // Decoder the data as a String
         let mut string = String::default();
         string.decode(src, version)?;
 

--- a/src/dataplane-protocol/src/versions.rs
+++ b/src/dataplane-protocol/src/versions.rs
@@ -4,7 +4,6 @@ use fluvio_protocol::bytes::{BufMut, Buf};
 
 use crate::ErrorCode;
 use crate::api::Request;
-use crate::derive::{Decoder, Encoder};
 
 pub const VERSIONS_API_KEY: u16 = 18;
 

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2018"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"
@@ -19,7 +19,7 @@ tracing = "0.1"
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api", optional = true }
 fluvio-protocol-core = { version = "0.3.1", path = "fluvio-protocol-core" }
 fluvio-protocol-codec = { version = "0.3.1", path = "fluvio-protocol-codec", optional = true }
-fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive", optional = true }
+fluvio-protocol-derive = { version = "0.3.0", path = "fluvio-protocol-derive", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
@@ -27,5 +27,5 @@ bytes = { version = "1.0.0", optional = true }
 flv-util = { version = "0.5.2" }
 fluvio-protocol-api = { version = "0.4.0", path = "fluvio-protocol-api" }
 fluvio-protocol-core = { version = "0.3.1", path = "fluvio-protocol-core" }
-fluvio-protocol-derive = { version = "0.2.1", path = "fluvio-protocol-derive" }
+fluvio-protocol-derive = { version = "0.3.0", path = "fluvio-protocol-derive" }
 fluvio-future = { version = "0.3.0", features = ["subscriber"] }

--- a/src/protocol/fluvio-protocol-api/Cargo.toml
+++ b/src/protocol/fluvio-protocol-api/Cargo.toml
@@ -11,5 +11,5 @@ categories = ["encoding","api-bindings"]
 [dependencies]
 tracing = "0.1"
 fluvio-protocol = { version = "0.3.1", path = "../fluvio-protocol-core", package = "fluvio-protocol-core" }
-fluvio-protocol-derive = { version = "0.2.1", path = "../fluvio-protocol-derive" }
+fluvio-protocol-derive = { version = "0.3", path = "../fluvio-protocol-derive" }
 flv-util = { version = "0.5.0"}

--- a/src/protocol/fluvio-protocol-api/Cargo.toml
+++ b/src/protocol/fluvio-protocol-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-api"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "fluvio protocol API helpers"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/src/protocol/fluvio-protocol-api/src/api.rs
+++ b/src/protocol/fluvio-protocol-api/src/api.rs
@@ -14,8 +14,8 @@ use tracing::trace;
 
 use crate::core::Decoder;
 use crate::core::Encoder;
-use crate::derive::Decode;
-use crate::derive::Encode;
+use crate::derive::Decoder;
+use crate::derive::Encoder;
 use crate::core::bytes::Buf;
 
 pub trait Request: Encoder + Decoder + Debug {
@@ -72,7 +72,7 @@ pub trait ApiMessage: Sized + Default {
 
 pub trait ApiKey: Sized + Encoder + Decoder + TryFrom<u16> {}
 
-#[derive(Debug, Encode, Decode, Default)]
+#[derive(Debug, Encoder, Decoder, Default)]
 pub struct RequestHeader {
     api_key: u16,
     api_version: i16,

--- a/src/protocol/fluvio-protocol-api/src/request.rs
+++ b/src/protocol/fluvio-protocol-api/src/request.rs
@@ -227,8 +227,9 @@ mod test {
         pub max_version: i16,
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
     #[repr(u16)]
+    #[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+    #[fluvio(encode_discriminant)]
     pub enum TestApiEnum {
         ApiVersion = 18,
     }

--- a/src/protocol/fluvio-protocol-api/src/request.rs
+++ b/src/protocol/fluvio-protocol-api/src/request.rs
@@ -182,8 +182,8 @@ mod test {
     use crate::core::Decoder;
     use crate::core::Encoder;
     use crate::core::Version;
-    use crate::derive::Encode;
-    use crate::derive::Decode;
+    use crate::derive::Encoder;
+    use crate::derive::Decoder;
 
     use super::RequestHeader;
     use super::RequestMessage;
@@ -192,7 +192,7 @@ mod test {
     use crate::Request;
 
     #[repr(u16)]
-    #[derive(PartialEq, Debug, Clone, Copy, Encode, Decode)]
+    #[derive(PartialEq, Debug, Clone, Copy, Encoder, Decoder)]
     #[fluvio(encode_discriminant)]
     pub enum TestApiKey {
         ApiVersion = 0,
@@ -204,7 +204,7 @@ mod test {
         }
     }
 
-    #[derive(Decode, Encode, Debug, Default)]
+    #[derive(Decoder, Encoder, Debug, Default)]
     pub struct ApiVersionRequest {}
 
     impl Request for ApiVersionRequest {
@@ -213,14 +213,14 @@ mod test {
         type Response = ApiVersionResponse;
     }
 
-    #[derive(Encode, Decode, Default, Debug)]
+    #[derive(Encoder, Decoder, Default, Debug)]
     pub struct ApiVersionResponse {
         pub error_code: i16,
         pub api_versions: Vec<ApiVersion>,
         pub throttle_time_ms: i32,
     }
 
-    #[derive(Encode, Decode, Default, Debug)]
+    #[derive(Encoder, Decoder, Default, Debug)]
     pub struct ApiVersion {
         pub api_key: i16,
         pub min_version: i16,
@@ -228,7 +228,7 @@ mod test {
     }
 
     #[repr(u16)]
-    #[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+    #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
     #[fluvio(encode_discriminant)]
     pub enum TestApiEnum {
         ApiVersion = 18,

--- a/src/protocol/fluvio-protocol-derive/Cargo.toml
+++ b/src/protocol/fluvio-protocol-derive/Cargo.toml
@@ -22,4 +22,5 @@ version = "1.0.0"
 features = ["full"]
 
 [dev-dependencies]
+trybuild = { git = "https://github.com/infinyon/trybuild", branch = "check_option" }
 fluvio-protocol = { version = "0.5.1", path = "../", features = ["derive", "api"] }

--- a/src/protocol/fluvio-protocol-derive/Cargo.toml
+++ b/src/protocol/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"
@@ -23,4 +23,4 @@ features = ["full"]
 
 [dev-dependencies]
 trybuild = { git = "https://github.com/infinyon/trybuild", branch = "check_option" }
-fluvio-protocol = { version = "0.5.1", path = "../", features = ["derive", "api"] }
+fluvio-protocol = { version = "0.6", path = "../", features = ["derive", "api"] }

--- a/src/protocol/fluvio-protocol-derive/src/api.rs
+++ b/src/protocol/fluvio-protocol-derive/src/api.rs
@@ -52,7 +52,7 @@ fn generate_encoder(data: &DataStruct, name: &Ident) -> TokenStream {
 
             let definition = quote! {
 
-                #[derive(Encode,Decode,RequestApi,Debug)]
+                #[derive(Encoder,Decoder,RequestApi,Debug)]
                 #[fluvio(default)]
                 pub struct #name {
                     #(#fields_code)*

--- a/src/protocol/fluvio-protocol-derive/src/ast/container.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/container.rs
@@ -5,6 +5,19 @@ use syn::{Attribute, Lit, Meta, NestedMeta, Result};
 pub struct ContainerAttributes {
     pub varint: bool,
     pub default: bool,
+
+    /// Encodes a numeric enum by the value of its descriminant
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// #[derive(fluvio_protocol::derive::Encode)]
+    /// #[fluvio(encode_discriminant)]
+    /// enum ValueEnum {
+    ///     One = 1, // Encodes discriminant "1"
+    ///     Two = 2, // Encodes discriminant "2"
+    /// }
+    /// ```
     pub encode_discriminant: bool,
     pub api_min_version: u16,
     pub api_max_version: Option<u16>,

--- a/src/protocol/fluvio-protocol-derive/src/ast/container.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/container.rs
@@ -11,7 +11,7 @@ pub struct ContainerAttributes {
     /// # Example
     ///
     /// ```rust
-    /// #[derive(fluvio_protocol::derive::Encode)]
+    /// #[derive(fluvio_protocol::derive::Encoder)]
     /// #[fluvio(encode_discriminant)]
     /// enum ValueEnum {
     ///     One = 1, // Encodes discriminant "1"

--- a/src/protocol/fluvio-protocol-derive/src/ast/enum.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/enum.rs
@@ -111,6 +111,7 @@ impl EnumProp {
             }
             _ => FieldKind::Unit,
         };
+
         Ok(prop)
     }
 }

--- a/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
@@ -1,27 +1,21 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
-use syn::{Error, Field, Lit, Meta, NestedMeta};
+use syn::{Attribute, Error, Field, Lit, Meta, NestedMeta};
 
 #[derive(Default)]
-pub(crate) struct Prop {
+pub(crate) struct NamedProp {
     pub field_name: String,
-    pub varint: bool,
-    /// Will default to 0 if not specified.
-    /// Note: `None` is encoded as "-1" so it's i16.
-    pub min_version: i16,
-    /// Optional max version.
-    /// The field won't be decoded from the buffer if it has a larger version than what is specified here.
-    /// Note: `None` is encoded as "-1" so it's i16.
-    pub max_version: Option<i16>,
-    /// Sets this value to the field when it isn't present in the buffer.
-    /// Example: `#[fluvio(default = "-1")]`
-    pub default_value: Option<String>,
+    pub attrs: PropAttrs,
 }
 
-impl Prop {
+#[derive(Default)]
+pub(crate) struct UnnamedProp {
+    pub attrs: PropAttrs,
+}
+
+impl NamedProp {
     pub fn from_ast(field: &Field) -> syn::Result<Self> {
-        let mut prop = Prop::default();
         let field_ident = if let Some(ident) = &field.ident {
             ident.clone()
         } else {
@@ -30,73 +24,28 @@ impl Prop {
                 "Named field must have an `ident`.",
             ));
         };
-        prop.field_name = field_ident.to_string();
-        // Find all supported field level attributes in one go.
-        for attribute in &field.attrs {
-            if attribute.path.is_ident("varint") {
-                prop.varint = true;
-            } else if attribute.path.is_ident("fluvio") {
-                if let Ok(Meta::List(list)) = attribute.parse_meta() {
-                    for kf_attr in list.nested {
-                        if let NestedMeta::Meta(Meta::NameValue(name_value)) = kf_attr {
-                            if name_value.path.is_ident("min_version") {
-                                if let Lit::Int(lit_int) = name_value.lit {
-                                    prop.min_version = lit_int.base10_parse::<i16>()?;
-                                }
-                            } else if name_value.path.is_ident("max_version") {
-                                if let Lit::Int(lit_int) = name_value.lit {
-                                    prop.max_version = Some(lit_int.base10_parse::<i16>()?);
-                                }
-                            } else if name_value.path.is_ident("default") {
-                                if let Lit::Str(lit_str) = name_value.lit {
-                                    prop.default_value = Some(lit_str.value());
-                                }
-                            } else {
-                                tracing::warn!(
-                                    "#[fluvio({})] does nothing on {}.",
-                                    name_value.to_token_stream().to_string(),
-                                    prop.field_name
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if let Some(err) =
-            Self::validate_versions(prop.min_version, prop.max_version, &prop.field_name)
-        {
+        let field_name = field_ident.to_string();
+        let attrs = PropAttrs::from_ast(&field.attrs)?;
+        let prop = NamedProp { field_name, attrs };
+
+        let result = validate_versions(
+            prop.attrs.min_version,
+            prop.attrs.max_version,
+            Some(&prop.field_name),
+        );
+
+        if let Some(err) = result {
             Err(syn::Error::new(field.span(), err))
         } else {
             Ok(prop)
         }
     }
 
-    pub fn validate_versions(min: i16, max: Option<i16>, field: &str) -> Option<String> {
-        if let Some(max) = max {
-            if min > max {
-                Some(format!(
-                    "On {}, max version({}) is less than min({}).",
-                    field, max, min
-                ))
-            } else {
-                None
-            }
-        } else if min < 0 {
-            Some(format!(
-                "On {} min version({}) must be positive.",
-                field, min
-            ))
-        } else {
-            None
-        }
-    }
-
     pub fn version_check_token_stream(&self, field_stream: TokenStream) -> TokenStream {
-        let min = self.min_version;
+        let min = self.attrs.min_version;
         let field_name = &self.field_name;
 
-        if let Some(max) = self.max_version {
+        if let Some(max) = self.attrs.max_version {
             quote! {
                 #[allow(clippy::double_comparisons)]
                 if version >= #min && version <= #max {
@@ -114,5 +63,95 @@ impl Prop {
                 }
             }
         }
+    }
+}
+
+impl UnnamedProp {
+    pub fn from_ast(field: &Field) -> syn::Result<Self> {
+        let attrs = PropAttrs::from_ast(&field.attrs)?;
+        let prop = UnnamedProp { attrs };
+
+        let result = validate_versions(prop.attrs.min_version, prop.attrs.max_version, None);
+
+        if let Some(err) = result {
+            Err(syn::Error::new(field.span(), err))
+        } else {
+            Ok(prop)
+        }
+    }
+}
+
+pub fn validate_versions(min: i16, max: Option<i16>, field: Option<&str>) -> Option<String> {
+    match (max, field) {
+        // Print name in named fields
+        (Some(max), Some(field)) if min > max => Some(format!(
+            "On {}, max version({}) is less than min({}).",
+            field, max, min
+        )),
+        // No name to print in unnamed fields
+        (Some(max), None) if min > max => {
+            Some(format!("Max version({}) is less than min({}).", max, min))
+        }
+        (None, Some(field)) if min < 0 => Some(format!(
+            "On {} min version({}) must be positive.",
+            field, min
+        )),
+        (None, None) if min < 0 => Some(format!("Min version({}) must be positive.", min)),
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct PropAttrs {
+    pub varint: bool,
+    /// Will default to 0 if not specified.
+    /// Note: `None` is encoded as "-1" so it's i16.
+    pub min_version: i16,
+    /// Optional max version.
+    /// The field won't be decoded from the buffer if it has a larger version than what is specified here.
+    /// Note: `None` is encoded as "-1" so it's i16.
+    pub max_version: Option<i16>,
+    /// Sets this value to the field when it isn't present in the buffer.
+    /// Example: `#[fluvio(default = "-1")]`
+    pub default_value: Option<String>,
+}
+
+impl PropAttrs {
+    pub fn from_ast(attrs: &[Attribute]) -> syn::Result<Self> {
+        let mut prop_attrs = Self::default();
+
+        // Find all supported field level attributes in one go.
+        for attribute in attrs.iter() {
+            if attribute.path.is_ident("varint") {
+                prop_attrs.varint = true;
+            } else if attribute.path.is_ident("fluvio") {
+                if let Ok(Meta::List(list)) = attribute.parse_meta() {
+                    for kf_attr in list.nested {
+                        if let NestedMeta::Meta(Meta::NameValue(name_value)) = kf_attr {
+                            if name_value.path.is_ident("min_version") {
+                                if let Lit::Int(lit_int) = name_value.lit {
+                                    prop_attrs.min_version = lit_int.base10_parse::<i16>()?;
+                                }
+                            } else if name_value.path.is_ident("max_version") {
+                                if let Lit::Int(lit_int) = name_value.lit {
+                                    prop_attrs.max_version = Some(lit_int.base10_parse::<i16>()?);
+                                }
+                            } else if name_value.path.is_ident("default") {
+                                if let Lit::Str(lit_str) = name_value.lit {
+                                    prop_attrs.default_value = Some(lit_str.value());
+                                }
+                            } else {
+                                tracing::warn!(
+                                    "#[fluvio({})] does nothing here.",
+                                    name_value.to_token_stream().to_string(),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(prop_attrs)
     }
 }

--- a/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
@@ -9,8 +9,8 @@ pub(crate) struct NamedProp {
     pub attrs: PropAttrs,
 }
 
-#[derive(Default)]
 pub(crate) struct UnnamedProp {
+    pub field_type: Type,
     pub attrs: PropAttrs,
 }
 
@@ -74,7 +74,8 @@ impl NamedProp {
 impl UnnamedProp {
     pub fn from_ast(field: &Field) -> syn::Result<Self> {
         let attrs = PropAttrs::from_ast(&field.attrs)?;
-        let prop = UnnamedProp { attrs };
+        let field_type = field.ty.clone();
+        let prop = UnnamedProp { field_type, attrs };
 
         let result = validate_versions(prop.attrs.min_version, prop.attrs.max_version, None);
 

--- a/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/prop.rs
@@ -1,11 +1,11 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, Field, Lit, Meta, NestedMeta};
+use syn::{Attribute, Error, Field, Lit, Meta, NestedMeta, Type};
 
-#[derive(Default)]
 pub(crate) struct NamedProp {
     pub field_name: String,
+    pub field_type: Type,
     pub attrs: PropAttrs,
 }
 
@@ -25,8 +25,13 @@ impl NamedProp {
             ));
         };
         let field_name = field_ident.to_string();
+        let field_type = field.ty.clone();
         let attrs = PropAttrs::from_ast(&field.attrs)?;
-        let prop = NamedProp { field_name, attrs };
+        let prop = NamedProp {
+            field_name,
+            field_type,
+            attrs,
+        };
 
         let result = validate_versions(
             prop.attrs.min_version,

--- a/src/protocol/fluvio-protocol-derive/src/ast/struct.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ast/struct.rs
@@ -1,19 +1,19 @@
-use crate::ast::prop::Prop;
+use crate::ast::prop::NamedProp;
 use syn::{Fields, Generics, Ident, ItemStruct};
 
 pub(crate) struct FluvioStruct {
     pub struct_ident: Ident,
-    pub props: Vec<Prop>,
+    pub props: Vec<NamedProp>,
     pub generics: Generics,
 }
 
 impl FluvioStruct {
     pub fn from_ast(item: &ItemStruct) -> syn::Result<Self> {
         let struct_ident = item.ident.clone();
-        let props: Vec<Prop> = if let Fields::Named(fields) = &item.fields {
+        let props: Vec<NamedProp> = if let Fields::Named(fields) = &item.fields {
             let mut prp = vec![];
             for field in fields.named.iter() {
-                prp.push(Prop::from_ast(field)?);
+                prp.push(NamedProp::from_ast(field)?);
             }
             prp
         } else {

--- a/src/protocol/fluvio-protocol-derive/src/de.rs
+++ b/src/protocol/fluvio-protocol-derive/src/de.rs
@@ -115,11 +115,12 @@ fn generate_decode_enum_impl(
                 let (decode, fields): (Vec<_>, Punctuated<_, Token![,]>) = props
                     .iter()
                     .enumerate()
-                    .map(|(idx, _)| {
+                    .map(|(idx, prop)| {
                         let var_ident = format_ident!("res_{}", idx);
+                        let var_ty = &prop.field_type;
                         // Type will be inferred when used to construct parent
                         let decode = quote! {
-                            let mut #var_ident = Default::default();
+                            let mut #var_ident: #var_ty = Default::default();
                             #var_ident.decode(src, version)?;
                         };
                         (decode, var_ident)

--- a/src/protocol/fluvio-protocol-derive/src/lib.rs
+++ b/src/protocol/fluvio-protocol-derive/src/lib.rs
@@ -23,7 +23,6 @@ use syn::parse_macro_input;
 /// ```
 /// use std::io::Cursor;
 /// use fluvio_protocol::Decoder;
-/// use fluvio_protocol::derive::Decoder;
 ///
 /// #[derive(Default, Decoder)]
 /// pub struct SimpleRecord {
@@ -45,7 +44,7 @@ use syn::parse_macro_input;
 /// So this works
 ///
 /// ```
-/// # use fluvio_protocol::derive::Decoder;
+/// # use fluvio_protocol::Decoder;
 /// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
 /// #[derive(Decoder)]
 /// pub enum ThreeChoice {
@@ -58,7 +57,7 @@ use syn::parse_macro_input;
 /// Also, enum without integer literal works as well
 ///
 /// ```
-/// # use fluvio_protocol::derive::Decoder;
+/// # use fluvio_protocol::Decoder;
 /// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
 /// #[derive(Decoder)]
 /// pub enum ThreeChoice {
@@ -95,7 +94,6 @@ pub fn fluvio_decode(tokens: TokenStream) -> TokenStream {
 ///
 /// ```
 /// use fluvio_protocol::Encoder;
-/// use fluvio_protocol::derive::Encoder;
 ///
 /// #[derive(Encoder)]
 /// pub struct SimpleRecord {
@@ -135,8 +133,7 @@ pub fn fluvio_api(tokens: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use fluvio_protocol::derive::Decoder;
-/// use fluvio_protocol::derive::Encoder;
+/// use fluvio_protocol::{Encoder, Decoder};
 /// use fluvio_protocol::api::Request;
 /// use fluvio_protocol::derive::RequestApi as Request;
 ///

--- a/src/protocol/fluvio-protocol-derive/src/lib.rs
+++ b/src/protocol/fluvio-protocol-derive/src/lib.rs
@@ -23,9 +23,9 @@ use syn::parse_macro_input;
 /// ```
 /// use std::io::Cursor;
 /// use fluvio_protocol::Decoder;
-/// use fluvio_protocol::derive::Decode;
+/// use fluvio_protocol::derive::Decoder;
 ///
-/// #[derive(Default, Decode)]
+/// #[derive(Default, Decoder)]
 /// pub struct SimpleRecord {
 ///     val: u8
 /// }
@@ -39,15 +39,15 @@ use syn::parse_macro_input;
 /// ```
 ///
 ///
-/// Decode applies to either Struct of Enum.  For enum, it implements `TryFrom` trait.  
+/// Decoder applies to either Struct of Enum.  For enum, it implements `TryFrom` trait.  
 /// Currently it only supports integer variants.  
 ///
 /// So this works
 ///
 /// ```
-/// # use fluvio_protocol::derive::Decode;
+/// # use fluvio_protocol::derive::Decoder;
 /// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
-/// #[derive(Decode)]
+/// #[derive(Decoder)]
 /// pub enum ThreeChoice {
 ///     First = 1,
 ///     Second = 2,
@@ -58,9 +58,9 @@ use syn::parse_macro_input;
 /// Also, enum without integer literal works as well
 ///
 /// ```
-/// # use fluvio_protocol::derive::Decode;
+/// # use fluvio_protocol::derive::Decoder;
 /// # impl Default for ThreeChoice { fn default() -> Self { unimplemented!() } }
-/// #[derive(Decode)]
+/// #[derive(Decoder)]
 /// pub enum ThreeChoice {
 ///     First,
 ///     Second,
@@ -73,14 +73,14 @@ use syn::parse_macro_input;
 /// Currently, mixing enum variants are not supported.
 ///
 ///
-/// Decode support container and field level attributes.
+/// Decoder support container and field level attributes.
 /// Container level applies to struct.
 /// For field attributes
 /// * `#[varint]` force decode using varint format.
 /// * `#fluvio(min_version = <version>)]` decodes only if version is equal or greater than min_version
 /// * `#fluvio(max_version = <version>)]`decodes only if version is less or equal than max_version
 ///
-#[proc_macro_derive(Decode, attributes(varint, fluvio))]
+#[proc_macro_derive(Decoder, attributes(varint, fluvio))]
 pub fn fluvio_decode(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input![tokens as ast::DeriveItem];
     let expanded = generate_decode_trait_impls(&input);
@@ -95,9 +95,9 @@ pub fn fluvio_decode(tokens: TokenStream) -> TokenStream {
 ///
 /// ```
 /// use fluvio_protocol::Encoder;
-/// use fluvio_protocol::derive::Encode;
+/// use fluvio_protocol::derive::Encoder;
 ///
-/// #[derive(Encode)]
+/// #[derive(Encoder)]
 /// pub struct SimpleRecord {
 ///     val: u8
 /// }
@@ -110,10 +110,10 @@ pub fn fluvio_decode(tokens: TokenStream) -> TokenStream {
 /// assert_eq!(data[0],4);
 /// ```
 ///
-/// Encode applies to either Struct of Enum.  
+/// Encoder applies to either Struct of Enum.  
 ///
-/// Encode respects version attributes.  See Decode derive.
-#[proc_macro_derive(Encode, attributes(varint, fluvio))]
+/// Encoder respects version attributes.  See Decoder derive.
+#[proc_macro_derive(Encoder, attributes(varint, fluvio))]
 pub fn fluvio_encode(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input![tokens as ast::DeriveItem];
     let expanded = generate_encode_trait_impls(&input);
@@ -135,18 +135,18 @@ pub fn fluvio_api(tokens: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// use fluvio_protocol::derive::Decode;
-/// use fluvio_protocol::derive::Encode;
+/// use fluvio_protocol::derive::Decoder;
+/// use fluvio_protocol::derive::Encoder;
 /// use fluvio_protocol::api::Request;
 /// use fluvio_protocol::derive::RequestApi as Request;
 ///
 /// #[fluvio(default,api_min_version = 5, api_max_version = 6, api_key = 10, response = "SimpleResponse")]
-/// #[derive(Debug, Default, Encode, Decode, Request)]
+/// #[derive(Debug, Default, Encoder, Decoder, Request)]
 /// pub struct SimpleRequest {
 ///     val: u8
 /// }
 ///
-/// #[derive(Debug, Default, Encode, Decode)]
+/// #[derive(Debug, Default, Encoder, Decoder)]
 /// #[fluvio(default)]
 /// pub struct SimpleResponse {
 ///     pub value: i8,

--- a/src/protocol/fluvio-protocol-derive/tests/parse.rs
+++ b/src/protocol/fluvio-protocol-derive/tests/parse.rs
@@ -1,0 +1,7 @@
+#[test]
+fn derive_ui() {
+    let t = trybuild::TestCases::check_only();
+
+    t.pass("ui-tests/pass_*.rs");
+    t.compile_fail("ui-tests/fail_*.rs");
+}

--- a/src/protocol/fluvio-protocol-derive/ui-tests/pass_derive_decode.rs
+++ b/src/protocol/fluvio-protocol-derive/ui-tests/pass_derive_decode.rs
@@ -1,0 +1,63 @@
+use fluvio_protocol::Decoder;
+
+fn main() {}
+
+#[derive(Default, Decoder)]
+struct PassTupleStruct(u16, String);
+
+#[derive(Default, Decoder)]
+struct PassNamedStruct {
+    number: u16,
+    string: String,
+}
+
+#[repr(u16)]
+#[derive(Decoder)]
+#[fluvio(encode_discriminant)]
+enum PassUnitEnum {
+    One = 1,
+    Two = 2,
+    #[fluvio(tag = 5)]
+    Three = 3,
+}
+
+impl Default for PassUnitEnum {
+    fn default() -> Self {
+        Self::One
+    }
+}
+
+#[derive(Decoder)]
+enum PassTupleEnum {
+    First(String),
+    Second(u16),
+    #[fluvio(tag = 50)]
+    Third(Vec<u8>),
+}
+
+impl Default for PassTupleEnum {
+    fn default() -> Self {
+        Self::First(Default::default())
+    }
+}
+
+#[derive(Decoder)]
+enum PassNamedEnum {
+    Alpha {
+        name: String,
+        number: i32,
+    },
+    #[fluvio(tag = 30)]
+    Beta {
+        data: Vec<u8>,
+    },
+}
+
+impl Default for PassNamedEnum {
+    fn default() -> Self {
+        Self::Alpha {
+            name: Default::default(),
+            number: Default::default(),
+        }
+    }
+}

--- a/src/protocol/fluvio-protocol-derive/ui-tests/pass_derive_encode.rs
+++ b/src/protocol/fluvio-protocol-derive/ui-tests/pass_derive_encode.rs
@@ -1,0 +1,34 @@
+use fluvio_protocol::Encoder;
+
+fn main() {}
+
+#[derive(Encoder)]
+struct PassTupleStruct(u16, String);
+
+#[derive(Encoder)]
+struct PassNamedStruct {
+    number: u16,
+    string: String,
+}
+
+#[repr(u16)]
+#[derive(Encoder)]
+#[fluvio(encode_discriminant)]
+enum PassUnitEnum {
+    One = 1,
+    Two = 2,
+    Three = 3,
+}
+
+#[derive(Encoder)]
+enum PassTupleEnum {
+    First(String),
+    Second(u16),
+    Third(Vec<u8>),
+}
+
+#[derive(Encoder)]
+enum PassNamedEnum {
+    Alpha { name: String, number: i32 },
+    Beta { data: Vec<u8> },
+}

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -9,15 +9,12 @@ pub mod bytes {
 }
 
 #[cfg(feature = "derive")]
+pub use fluvio_protocol_derive::{Encoder, Decoder};
+
+#[cfg(feature = "derive")]
 pub mod derive {
     pub use fluvio_protocol_derive::*;
 }
-
-#[cfg(feature = "derive")]
-pub use fluvio_protocol_derive::Encoder as Encoder;
-
-#[cfg(feature = "derive")]
-pub use fluvio_protocol_derive::Decoder as Decoder;
 
 #[cfg(feature = "api")]
 pub mod api {

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -14,10 +14,10 @@ pub mod derive {
 }
 
 #[cfg(feature = "derive")]
-pub use fluvio_protocol_derive::Encode as Encoder;
+pub use fluvio_protocol_derive::Encoder as Encoder;
 
 #[cfg(feature = "derive")]
-pub use fluvio_protocol_derive::Decode as Decoder;
+pub use fluvio_protocol_derive::Decoder as Decoder;
 
 #[cfg(feature = "api")]
 pub mod api {

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -13,6 +13,12 @@ pub mod derive {
     pub use fluvio_protocol_derive::*;
 }
 
+#[cfg(feature = "derive")]
+pub use fluvio_protocol_derive::Encode as Encoder;
+
+#[cfg(feature = "derive")]
+pub use fluvio_protocol_derive::Decode as Decoder;
+
 #[cfg(feature = "api")]
 pub mod api {
     pub use fluvio_protocol_api::*;

--- a/src/protocol/tests/api.rs
+++ b/src/protocol/tests/api.rs
@@ -2,9 +2,9 @@ use std::io::Cursor;
 
 use fluvio_protocol_api::Request;
 use fluvio_protocol_core::{Decoder, Encoder};
-use fluvio_protocol_derive::{Decode, Encode, FluvioDefault, RequestApi};
+use fluvio_protocol_derive::{Decoder, Encoder, FluvioDefault, RequestApi};
 
-#[derive(Encode, Decode, FluvioDefault, RequestApi, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, RequestApi, Debug)]
 #[fluvio(
     api_min_version = 5,
     api_max_version = 6,
@@ -21,7 +21,7 @@ pub struct TestRequest {
     pub value3: i8,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct TestResponse {
     pub value: i8,
 
@@ -32,7 +32,7 @@ pub struct TestResponse {
     pub value3: i8,
 }
 
-#[derive(Encode, Decode, FluvioDefault, Debug)]
+#[derive(Encoder, Decoder, FluvioDefault, Debug)]
 pub struct KfMetadataResponse {
     #[fluvio(min_version = 2)]
     pub cluster_id: Option<String>,

--- a/src/protocol/tests/btreemap.rs
+++ b/src/protocol/tests/btreemap.rs
@@ -3,9 +3,9 @@ use std::io::Cursor;
 use std::io::Error;
 
 use fluvio_protocol_core::{Decoder, Encoder};
-use fluvio_protocol_derive::{Decode, Encode};
+use fluvio_protocol_derive::{Decoder, Encoder};
 
-#[derive(Encode, Default, Decode, Debug)]
+#[derive(Encoder, Default, Decoder, Debug)]
 pub struct MapHolder {
     values: BTreeMap<i32, Vec<i32>>,
 }

--- a/src/protocol/tests/decode.rs
+++ b/src/protocol/tests/decode.rs
@@ -1,16 +1,16 @@
 use std::io::Cursor;
 
 use fluvio_protocol_core::{Decoder, DecoderVarInt};
-use fluvio_protocol_derive::Decode;
+use fluvio_protocol_derive::Decoder;
 
-#[derive(Decode, Default, Debug)]
+#[derive(Decoder, Default, Debug)]
 pub struct SimpleRecord {
     #[varint]
     len: i64,
     attributes: i8,
 }
 
-#[derive(Decode, Default, Debug)]
+#[derive(Decoder, Default, Debug)]
 pub struct RecordSet {
     records: Vec<SimpleRecord>,
 }

--- a/src/protocol/tests/encode.rs
+++ b/src/protocol/tests/encode.rs
@@ -1,14 +1,14 @@
 use fluvio_protocol_core::{Encoder, EncoderVarInt};
-use fluvio_protocol_derive::Encode;
+use fluvio_protocol_derive::Encoder;
 
-#[derive(Encode, Default, Debug)]
+#[derive(Encoder, Default, Debug)]
 pub struct SimpleRecord {
     #[varint]
     len: i64,
     attributes: i8,
 }
 
-#[derive(Encode, Default, Debug)]
+#[derive(Encoder, Default, Debug)]
 pub struct RecordSet {
     records: Vec<SimpleRecord>,
 }

--- a/src/protocol/tests/enum.rs
+++ b/src/protocol/tests/enum.rs
@@ -88,6 +88,23 @@ fn test_var_encode() {
     assert_eq!(v1.write_size(0), 8);
 }
 
+#[derive(Encode, Debug)]
+pub enum NamedEnum {
+    Apple { seeds: u16 },
+    Banana { peel: bool },
+}
+
+#[test]
+fn test_named_encode() {
+    let apple = NamedEnum::Apple { seeds: 13 };
+    let mut dest = Vec::new();
+    apple.encode(&mut dest, 0).unwrap();
+    assert_eq!(dest.len(), 3);
+    assert_eq!(dest[0], 0x00);
+    assert_eq!(dest[1], 0x00);
+    assert_eq!(dest[2], 0x0d);
+}
+
 #[derive(Encode, PartialEq, Decode, Debug)]
 #[repr(u8)]
 pub enum EnumNoExprTest {

--- a/src/protocol/tests/enum.rs
+++ b/src/protocol/tests/enum.rs
@@ -6,7 +6,7 @@ use std::io::ErrorKind;
 
 use fluvio_protocol_core::bytes::{Buf, BufMut};
 use fluvio_protocol_core::{Decoder, Encoder, Version};
-use fluvio_protocol_derive::{Decode, Encode};
+use fluvio_protocol_derive::{Decoder, Encoder};
 
 // manual encode
 pub enum Mix {
@@ -72,7 +72,7 @@ impl Decoder for Mix {
     }
 }
 
-#[derive(Encode, Debug)]
+#[derive(Encoder, Debug)]
 pub enum VariantEnum {
     A(u16),
     C(String),
@@ -88,7 +88,7 @@ fn test_var_encode() {
     assert_eq!(v1.write_size(0), 8);
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encoder, Decoder, Debug)]
 pub enum NamedEnum {
     Apple { seeds: u16, color: String },
     Banana { peel: bool },
@@ -126,7 +126,7 @@ fn test_named_decode() {
     }
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encoder, Decoder, Debug)]
 enum NamedCustomTag {
     #[fluvio(tag = 22)]
     One { a: String, b: i32 },
@@ -172,7 +172,7 @@ fn test_named_custom_tag_decode() {
     }
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encoder, Decoder, Debug)]
 pub enum MultiUnnamedEnum {
     Apple(u16, String),
     Banana(bool),
@@ -209,7 +209,7 @@ fn test_multi_unnamed_decode() {
     }
 }
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Encoder, Decoder)]
 enum MultiUnnamedCustomTag {
     #[fluvio(tag = 7)]
     RGB(u8, u8, u8),
@@ -247,7 +247,7 @@ fn test_multi_unnamed_custom_tag_decode() {
     }
 }
 
-#[derive(Encode, PartialEq, Decode, Debug)]
+#[derive(Encoder, PartialEq, Decoder, Debug)]
 #[repr(u8)]
 pub enum EnumNoExprTest {
     A,
@@ -291,7 +291,7 @@ fn test_enum_decode() {
     assert_eq!(val, EnumNoExprTest::A);
 }
 
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encoder, Decoder, PartialEq, Debug)]
 #[repr(u8)]
 pub enum EnumExprTest {
     #[fluvio(tag = 5)]
@@ -329,7 +329,7 @@ fn test_enum_expr_decode() {
 }
 
 #[repr(u16)]
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encoder, Decoder, PartialEq, Debug)]
 #[fluvio(encode_discriminant)]
 pub enum WideEnum {
     #[fluvio(tag = 5)]
@@ -361,7 +361,7 @@ fn test_try_decode() {
     assert_eq!(e, WideEnum::E);
 }
 
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encoder, Decoder, PartialEq, Debug)]
 pub enum GlColor {
     #[fluvio(tag = 1)]
     GlTextureRedType = 0x8C10,
@@ -392,7 +392,7 @@ fn test_gl_colors() {
     assert_eq!(dest[1], 2);
 }
 
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encoder, Decoder, PartialEq, Debug)]
 #[fluvio(encode_discriminant)]
 enum EvenOdd {
     Even = 2,
@@ -420,7 +420,7 @@ fn test_encode_discriminant() {
     assert_eq!(dest[1], 1);
 }
 
-#[derive(Encode, Decode, PartialEq, Debug, Clone, Copy)]
+#[derive(Encoder, Decoder, PartialEq, Debug, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 #[repr(u16)]
 pub enum TestWideEnum {
@@ -441,7 +441,7 @@ fn test_simple_conversion() {
 }
 
 #[repr(i16)]
-#[derive(PartialEq, Debug, Encode, Decode)]
+#[derive(PartialEq, Debug, Encoder, Decoder)]
 #[fluvio(encode_discriminant)]
 pub enum TestErrorCode {
     // The server experienced an unexpected error when processing the request

--- a/src/protocol/tests/enum.rs
+++ b/src/protocol/tests/enum.rs
@@ -126,6 +126,28 @@ fn test_named_decode() {
     }
 }
 
+#[derive(Encode, Decode, Debug)]
+pub enum MultiUnnamedEnum {
+    Apple(u16, String),
+    Banana(bool),
+}
+
+impl Default for MultiUnnamedEnum {
+    fn default() -> Self {
+        Self::Banana(true)
+    }
+}
+
+#[test]
+fn test_multi_unnamed_encode() {
+    let apple = MultiUnnamedEnum::Apple(13, "Red".into());
+    let mut dest = Vec::new();
+    apple.encode(&mut dest, 0).unwrap();
+
+    let expected = vec![0x00, 0x00, 0x0d, 0x00, 0x03, 0x52, 0x65, 0x64];
+    assert_eq!(expected, dest);
+}
+
 #[derive(Encode, PartialEq, Decode, Debug)]
 #[repr(u8)]
 pub enum EnumNoExprTest {

--- a/src/protocol/tests/enum.rs
+++ b/src/protocol/tests/enum.rs
@@ -116,7 +116,7 @@ fn test_named_encode() {
 fn test_named_decode() {
     let data = vec![0x00, 0x00, 0x0d, 0x00, 0x03, 0x52, 0x65, 0x64];
     let mut value = NamedEnum::default();
-    value.decode(&mut std::io::Cursor(data), 0).unwrap();
+    value.decode(&mut std::io::Cursor::new(data), 0).unwrap();
     match value {
         NamedEnum::Apple { seeds, color } => {
             assert_eq!(seeds, 13);
@@ -207,8 +207,9 @@ fn test_enum_expr_decode() {
     assert_eq!(val, EnumExprTest::D);
 }
 
-#[derive(Encode, Decode, PartialEq, Debug)]
 #[repr(u16)]
+#[derive(Encode, Decode, PartialEq, Debug)]
+#[fluvio(encode_discriminant)]
 pub enum WideEnum {
     #[fluvio(tag = 5)]
     D = 5,

--- a/src/protocol/tests/generic.rs
+++ b/src/protocol/tests/generic.rs
@@ -2,9 +2,9 @@ use std::fmt::Debug;
 use std::io::Cursor;
 
 use fluvio_protocol_core::{Decoder, Encoder};
-use fluvio_protocol_derive::{Decode, Encode};
+use fluvio_protocol_derive::{Decoder, Encoder};
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct GenericRecord<R>
 where
     R: Encoder + Decoder + Debug,

--- a/src/protocol/tests/option.rs
+++ b/src/protocol/tests/option.rs
@@ -1,14 +1,14 @@
 use std::io::Cursor;
 
 use fluvio_protocol_core::{Decoder, Encoder};
-use fluvio_protocol_derive::{Decode, Encode};
+use fluvio_protocol_derive::{Decoder, Encoder};
 
-#[derive(Encode, Default, Decode, Debug)]
+#[derive(Encoder, Default, Decoder, Debug)]
 pub struct Parent {
     child: Option<Child>,
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct Child {
     flag: bool,
 }

--- a/src/protocol/tests/version.rs
+++ b/src/protocol/tests/version.rs
@@ -1,9 +1,9 @@
 use std::io::Cursor;
 
 use fluvio_protocol_core::{Decoder, Encoder};
-use fluvio_protocol_derive::{Decode, Encode};
+use fluvio_protocol_derive::{Decoder, Encoder};
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 struct TestRecord {
     value: i8,
     #[fluvio(min_version = 1, max_version = 1)]

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -24,5 +24,5 @@ static_assertions = "1.1.0"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.9.1", default-features = false, path = "../controlplane-metadata" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc-schema/src/apis.rs
+++ b/src/sc-schema/src/apis.rs
@@ -4,7 +4,7 @@
 //! Stores Api Keys supported by the SC.
 //!
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(

--- a/src/sc-schema/src/apis.rs
+++ b/src/sc-schema/src/apis.rs
@@ -4,7 +4,7 @@
 //! Stores Api Keys supported by the SC.
 //!
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(
@@ -14,7 +14,7 @@ static_assertions::const_assert_eq!(
 
 /// API call from client to SPU
 #[repr(u16)]
-#[derive(Encode, Decode, PartialEq, Debug, Clone, Copy)]
+#[derive(Encoder, Decoder, PartialEq, Debug, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum AdminPublicApiKey {
     ApiVersion = 18, // VERSIONS_API_KEY

--- a/src/sc-schema/src/objects/create.rs
+++ b/src/sc-schema/src/objects/create.rs
@@ -2,9 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use crate::Status;

--- a/src/sc-schema/src/objects/create.rs
+++ b/src/sc-schema/src/objects/create.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;
 use dataplane::api::Request;
@@ -13,7 +13,7 @@ use crate::AdminRequest;
 
 pub use create::AllCreatableSpec;
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct CreateRequest {
     pub name: String,
     pub dry_run: bool,

--- a/src/sc-schema/src/objects/delete.rs
+++ b/src/sc-schema/src/objects/delete.rs
@@ -8,9 +8,7 @@ use std::io::ErrorKind;
 
 use tracing::trace;
 
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
-use dataplane::core::Version;
+use dataplane::core::{Encoder, Decoder, Version};
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::api::Request;
 use fluvio_controlplane_metadata::topic::TopicSpec;

--- a/src/sc-schema/src/objects/list.rs
+++ b/src/sc-schema/src/objects/list.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;
 use dataplane::api::Request;
@@ -76,7 +76,7 @@ impl Default for ListResponse {
     }
 }
 
-#[derive(Encode, Decode, Default, Clone, Debug)]
+#[derive(Encoder, Decoder, Default, Clone, Debug)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/src/sc-schema/src/objects/list.rs
+++ b/src/sc-schema/src/objects/list.rs
@@ -7,9 +7,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use fluvio_controlplane_metadata::core::*;

--- a/src/sc-schema/src/objects/watch.rs
+++ b/src/sc-schema/src/objects/watch.rs
@@ -2,9 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::derive::{Decoder, Encoder};
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use fluvio_controlplane_metadata::core::*;

--- a/src/sc-schema/src/objects/watch.rs
+++ b/src/sc-schema/src/objects/watch.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;
 use dataplane::api::Request;
@@ -66,7 +66,7 @@ impl Default for WatchResponse {
 }
 
 /// updates on metadata
-#[derive(Encode, Decode, Default, Clone, Debug)]
+#[derive(Encoder, Decoder, Default, Clone, Debug)]
 pub struct MetadataUpdate<S>
 where
     S: Spec + Debug + Encoder + Decoder,

--- a/src/sc-schema/src/request.rs
+++ b/src/sc-schema/src/request.rs
@@ -15,7 +15,7 @@ use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 
 use dataplane::api::api_decode;
-use dataplane::derive::Encoder;
+use dataplane::core::Encoder;
 use dataplane::versions::ApiVersionsRequest;
 
 use super::objects::*;

--- a/src/sc-schema/src/request.rs
+++ b/src/sc-schema/src/request.rs
@@ -15,13 +15,13 @@ use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 
 use dataplane::api::api_decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 use dataplane::versions::ApiVersionsRequest;
 
 use super::objects::*;
 use super::AdminPublicApiKey;
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum AdminPublicRequest {
     // Mixed
     ApiVersionsRequest(RequestMessage<ApiVersionsRequest>),

--- a/src/sc-schema/src/response.rs
+++ b/src/sc-schema/src/response.rs
@@ -5,13 +5,13 @@
 //!
 //! Response sent to client. Sends entity name, error code and error message.
 //!
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::ErrorCode;
 
 use crate::ApiError;
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct Status {
     pub name: String,
     pub error_code: ErrorCode,

--- a/src/sc-schema/src/response.rs
+++ b/src/sc-schema/src/response.rs
@@ -5,8 +5,7 @@
 //!
 //! Response sent to client. Sends entity name, error code and error message.
 //!
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::ErrorCode;
 
 use crate::ApiError;

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -53,7 +53,7 @@ fluvio-stream-dispatcher = { version = "0.6.0", path = "../stream-dispatcher" }
 k8-client = { version = "5.0.0", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 k8-types = { version = "0.2.1", features = ["app"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../service", version = "0.6.0" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.3.0", features = ["macros"] }
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.3.0" }
 fluvio-socket = { version = "0.8.1", path = "../socket" }
-fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
+fluvio-protocol = { path = "../protocol", version = "0.6", features = ["derive", "api", "codec"] }
 fluvio-types = { version = "0.2.3", features = ["events"], path = "../types" }
 
 [dev-dependencies]

--- a/src/service/src/test_request.rs
+++ b/src/service/src/test_request.rs
@@ -10,8 +10,8 @@ use fluvio_protocol::api::{
     api_decode, ApiMessage, Request, RequestHeader, RequestMessage, ResponseMessage,
 };
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::derive::Decode;
-use fluvio_protocol::derive::Encode;
+use fluvio_protocol::derive::Decoder;
+use fluvio_protocol::derive::Encoder;
 
 use fluvio_socket::FlvSocketError;
 use fluvio_socket::FluvioSocket;
@@ -21,7 +21,7 @@ use crate::call_service;
 use crate::FlvService;
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub(crate) enum TestKafkaApiEnum {
     Echo = 1000,
@@ -34,7 +34,7 @@ impl Default for TestKafkaApiEnum {
     }
 }
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub(crate) struct EchoRequest {
     msg: String,
 }
@@ -50,28 +50,28 @@ impl Request for EchoRequest {
     type Response = EchoResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub(crate) struct EchoResponse {
     pub msg: String,
 }
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub(crate) struct SaveRequest {}
 impl Request for SaveRequest {
     const API_KEY: u16 = TestKafkaApiEnum::Save as u16;
     type Response = SaveResponse;
 }
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub(crate) struct SaveResponse {}
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub(crate) enum TestApiRequest {
     EchoRequest(RequestMessage<EchoRequest>),
     SaveRequest(RequestMessage<SaveRequest>),
 }
 
-// Added to satisfy Encode/Decode traits
+// Added to satisfy Encoder/Decoder traits
 impl Default for TestApiRequest {
     fn default() -> TestApiRequest {
         TestApiRequest::EchoRequest(RequestMessage::default())

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "fluvio-protocol-api",
  "fluvio-protocol-core",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.20"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.2", features = ["net", "task"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.1", features = ["derive", "api", "codec"] }
+fluvio-protocol = { path = "../protocol", version = "0.6", features = ["derive", "api", "codec"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.1", features = ["fixture", "fs", "native2_tls"] }

--- a/src/socket/src/test_request.rs
+++ b/src/socket/src/test_request.rs
@@ -7,10 +7,10 @@ use log::debug;
 
 use fluvio_protocol::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::derive::{Decode, Encode};
+use fluvio_protocol::derive::{Decoder, Encoder};
 
 #[repr(u16)]
-#[derive(Encode, Decode, PartialEq, Debug, Clone, Copy)]
+#[derive(Encoder, Decoder, PartialEq, Debug, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum TestKafkaApiEnum {
     Echo = 1000,
@@ -23,7 +23,7 @@ impl Default for TestKafkaApiEnum {
     }
 }
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct EchoRequest {
     pub msg: String,
 }
@@ -40,7 +40,7 @@ impl Request for EchoRequest {
 }
 
 /// request to send back status
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct AsyncStatusRequest {
     pub count: i32,
 }
@@ -56,19 +56,19 @@ impl Request for AsyncStatusRequest {
     type Response = AsyncStatusResponse;
 }
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct AsyncStatusResponse {
     pub status: i32,
 }
 
-#[derive(Encode, Debug)]
+#[derive(Encoder, Debug)]
 pub enum TestApiRequest {
     EchoRequest(RequestMessage<EchoRequest>),
     AsyncStatusRequest(RequestMessage<AsyncStatusRequest>),
     Noop(bool),
 }
 
-// Added to satisfy Encode/Decode traits
+// Added to satisfy Encoder/Decoder traits
 impl Default for TestApiRequest {
     fn default() -> TestApiRequest {
         TestApiRequest::Noop(true)
@@ -95,7 +95,7 @@ impl ApiMessage for TestApiRequest {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct EchoResponse {
     pub msg: String,
 }

--- a/src/socket/tests/enum.rs
+++ b/src/socket/tests/enum.rs
@@ -1,9 +1,9 @@
 use std::convert::TryInto;
 
-use fluvio_protocol::derive::{Decode, Encode};
+use fluvio_protocol::derive::{Decoder, Encoder};
 
 #[repr(u16)]
-#[derive(Encode, Decode, PartialEq, Debug, Clone, Copy)]
+#[derive(Encoder, Decoder, PartialEq, Debug, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum TestKafkaApiEnum {
     Echo = 1000,

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -22,5 +22,5 @@ serde = { version = "1.0.103", features = ['derive'] }
 static_assertions = "1.1.0"
 
 # Fluvio dependencies
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/spu-schema/src/client/api.rs
+++ b/src/spu-schema/src/client/api.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 
 use dataplane::api::RequestMessage;
 
@@ -18,7 +18,7 @@ use super::SpuClientApiKey;
 use super::offset::ReplicaOffsetUpdateRequest;
 
 /// Request from Spu Server to Client
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum SpuClientRequest {
     ReplicaOffsetUpdateRequest(RequestMessage<ReplicaOffsetUpdateRequest>),
 }

--- a/src/spu-schema/src/client/api.rs
+++ b/src/spu-schema/src/client/api.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
-use dataplane::derive::Encoder;
+use dataplane::core::Encoder;
 
 use dataplane::api::RequestMessage;
 

--- a/src/spu-schema/src/client/api_key.rs
+++ b/src/spu-schema/src/client/api_key.rs
@@ -1,5 +1,4 @@
-use dataplane::derive::Encoder;
-use dataplane::derive::Decoder;
+use dataplane::core::{Encoder, Decoder};
 
 /// Api Key for Spu Client API (from server to client)
 #[repr(u16)]

--- a/src/spu-schema/src/client/api_key.rs
+++ b/src/spu-schema/src/client/api_key.rs
@@ -1,9 +1,9 @@
-use dataplane::derive::Encode;
-use dataplane::derive::Decode;
+use dataplane::derive::Encoder;
+use dataplane::derive::Decoder;
 
 /// Api Key for Spu Client API (from server to client)
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum SpuClientApiKey {
     ReplicaOffsetUpdate = 1001,

--- a/src/spu-schema/src/client/offset.rs
+++ b/src/spu-schema/src/client/offset.rs
@@ -1,6 +1,5 @@
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::ReplicaKey;
 use dataplane::Offset;
 use dataplane::ErrorCode;

--- a/src/spu-schema/src/client/offset.rs
+++ b/src/spu-schema/src/client/offset.rs
@@ -1,6 +1,6 @@
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::ReplicaKey;
 use dataplane::Offset;
 use dataplane::ErrorCode;
@@ -12,12 +12,12 @@ use super::SpuClientApiKey;
 // -----------------------------------
 
 /// sets of offset update send by SPU to clients
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ReplicaOffsetUpdateRequest {
     pub offsets: Vec<ReplicaOffsetUpdate>,
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ReplicaOffsetUpdate {
     pub replica: ReplicaKey,
     pub error_code: ErrorCode,
@@ -36,5 +36,5 @@ impl Request for ReplicaOffsetUpdateRequest {
 }
 
 // no content, this is one way request
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ReplicaOffsetUpdateResponse {}

--- a/src/spu-schema/src/server/api.rs
+++ b/src/spu-schema/src/server/api.rs
@@ -7,7 +7,7 @@ use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
 use dataplane::core::Decoder;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 use dataplane::api::ApiMessage;
 use dataplane::api::api_decode;
 use dataplane::api::RequestHeader;
@@ -24,7 +24,7 @@ use super::stream_fetch::FileStreamFetchRequest;
 use super::update_offset::UpdateOffsetsRequest;
 
 /// Request to Spu Server
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum SpuServerRequest {
     /// list of versions supported
     ApiVersionsRequest(RequestMessage<ApiVersionsRequest>),

--- a/src/spu-schema/src/server/api.rs
+++ b/src/spu-schema/src/server/api.rs
@@ -6,8 +6,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
-use dataplane::core::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::ApiMessage;
 use dataplane::api::api_decode;
 use dataplane::api::RequestHeader;

--- a/src/spu-schema/src/server/api_key.rs
+++ b/src/spu-schema/src/server/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(
@@ -8,7 +8,7 @@ static_assertions::const_assert_eq!(
 
 /// Api Key for Spu Server API
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum SpuServerApiKey {
     ApiVersion = 18, // API_VERSIONS_KEY

--- a/src/spu-schema/src/server/api_key.rs
+++ b/src/spu-schema/src/server/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Decoder, Encoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(

--- a/src/spu-schema/src/server/fetch_offset.rs
+++ b/src/spu-schema/src/server/fetch_offset.rs
@@ -5,8 +5,8 @@
 use std::fmt;
 
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::PartitionOffset;
 use dataplane::ReplicaKey;
 
@@ -18,7 +18,7 @@ use super::SpuServerApiKey;
 // -----------------------------------
 
 /// Fetch offsets
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct FetchOffsetsRequest {
     /// Each topic in the request.
     pub topics: Vec<FetchOffsetTopic>,
@@ -44,7 +44,7 @@ impl FetchOffsetsRequest {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct FetchOffsetTopic {
     /// The topic name.
     pub name: String,
@@ -53,7 +53,7 @@ pub struct FetchOffsetTopic {
     pub partitions: Vec<FetchOffsetPartition>,
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct FetchOffsetPartition {
     /// The partition index.
     pub partition_index: i32,
@@ -63,7 +63,7 @@ pub struct FetchOffsetPartition {
 // FlvFetchOffsetsResponse
 // -----------------------------------
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct FetchOffsetsResponse {
     /// Each topic offset in the response.
     pub topics: Vec<FetchOffsetTopicResponse>,
@@ -85,7 +85,7 @@ impl FetchOffsetsResponse {
     }
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct FetchOffsetTopicResponse {
     /// The topic name
     pub name: String,
@@ -94,7 +94,7 @@ pub struct FetchOffsetTopicResponse {
     pub partitions: Vec<FetchOffsetPartitionResponse>,
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct FetchOffsetPartitionResponse {
     /// The partition error code, None for no error
     pub error_code: ErrorCode,

--- a/src/spu-schema/src/server/fetch_offset.rs
+++ b/src/spu-schema/src/server/fetch_offset.rs
@@ -5,8 +5,7 @@
 use std::fmt;
 
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::PartitionOffset;
 use dataplane::ReplicaKey;
 

--- a/src/spu-schema/src/server/stream_fetch.rs
+++ b/src/spu-schema/src/server/stream_fetch.rs
@@ -9,8 +9,8 @@ use std::marker::PhantomData;
 use dataplane::core::Encoder;
 use dataplane::core::Decoder;
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
 use dataplane::Isolation;
@@ -26,7 +26,7 @@ pub const WASM_MODULE_API: i16 = 11;
 
 /// Fetch records continuously
 /// Output will be send back as stream
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct StreamFetchRequest<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -50,7 +50,7 @@ where
     type Response = StreamFetchResponse<R>;
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct StreamFetchResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,

--- a/src/spu-schema/src/server/stream_fetch.rs
+++ b/src/spu-schema/src/server/stream_fetch.rs
@@ -6,11 +6,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
 use dataplane::Isolation;

--- a/src/spu-schema/src/server/update_offset.rs
+++ b/src/spu-schema/src/server/update_offset.rs
@@ -3,21 +3,21 @@
 //!
 
 use dataplane::api::Request;
-use dataplane::derive::Decode;
-use dataplane::derive::Encode;
+use dataplane::derive::Decoder;
+use dataplane::derive::Encoder;
 use dataplane::Offset;
 
 use crate::errors::ErrorCode;
 use super::SpuServerApiKey;
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct OffsetUpdate {
     pub offset: Offset,
     pub session_id: u32,
 }
 
 /// send out current offset to SPU
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateOffsetsRequest {
     pub offsets: Vec<OffsetUpdate>,
 }
@@ -34,13 +34,13 @@ impl UpdateOffsetsRequest {
     }
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct OffsetUpdateStatus {
     pub session_id: u32,
     pub error: ErrorCode,
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct UpdateOffsetsResponse {
     pub status: Vec<OffsetUpdateStatus>,
 }

--- a/src/spu-schema/src/server/update_offset.rs
+++ b/src/spu-schema/src/server/update_offset.rs
@@ -3,8 +3,7 @@
 //!
 
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::Offset;
 
 use crate::errors::ErrorCode;

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -48,7 +48,7 @@ fluvio-storage = { version = "0.5.0", path = "../storage" }
 fluvio-controlplane = { version = "0.7.1", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.9.1", path = "../controlplane-metadata" }
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema", features = ["file"]}
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 fluvio-socket = { path = "../socket", version = "0.8.1", features = ["file"] }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
 fluvio-service = { path = "../service", version = "0.6.0" }

--- a/src/spu/src/replication/follower/api_key.rs
+++ b/src/spu/src/replication/follower/api_key.rs
@@ -1,7 +1,7 @@
-use dataplane::derive::{Encode, Decode};
+use dataplane::derive::{Encoder, Decoder};
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum FollowerPeerApiEnum {
     SyncRecords = 0,

--- a/src/spu/src/replication/follower/api_key.rs
+++ b/src/spu/src/replication/follower/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::derive::{Encoder, Decoder};
+use dataplane::core::{Encoder, Decoder};
 
 #[repr(u16)]
 #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]

--- a/src/spu/src/replication/follower/peer_api.rs
+++ b/src/spu/src/replication/follower/peer_api.rs
@@ -5,14 +5,14 @@ use tracing::trace;
 
 use dataplane::bytes::Buf;
 use dataplane::core::Decoder;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::FollowerPeerApiEnum;
 use super::sync::DefaultSyncRequest;
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum FollowerPeerRequest {
     SyncRecords(RequestMessage<DefaultSyncRequest>),
 }

--- a/src/spu/src/replication/follower/peer_api.rs
+++ b/src/spu/src/replication/follower/peer_api.rs
@@ -4,9 +4,7 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::Decoder;
-use dataplane::derive::Encoder;
-
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::FollowerPeerApiEnum;

--- a/src/spu/src/replication/follower/sync.rs
+++ b/src/spu/src/replication/follower/sync.rs
@@ -10,7 +10,7 @@ use bytes::BytesMut;
 use tracing::trace;
 
 use dataplane::core::{Encoder, Decoder, Version};
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::record::{RecordSet, FileRecordSet};
 use dataplane::api::Request;
 use dataplane::ErrorCode;
@@ -28,7 +28,7 @@ pub type PeerFileTopicResponse = PeerFetchableTopicResponse<FileRecordSet>;
 
 /// used for sending records and commits
 /// re purpose topic response since it has records and commit offsets
-#[derive(Default, Encode, Decode, Debug)]
+#[derive(Default, Encoder, Decoder, Debug)]
 pub struct SyncRequest<R>
 where
     R: Encoder + Decoder + Debug,
@@ -61,7 +61,7 @@ where
     type Response = SyncResponse;
 }
 
-#[derive(Default, Encode, Decode, Debug)]
+#[derive(Default, Encoder, Decoder, Debug)]
 pub struct SyncResponse {}
 
 /// allow sync request to be encoded for zerocopy
@@ -78,7 +78,7 @@ impl FileWrite for FileSyncRequest {
     }
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct PeerFetchableTopicResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,
@@ -101,7 +101,7 @@ where
     }
 }
 
-#[derive(Encode, Decode, Default, Debug)]
+#[derive(Encoder, Decoder, Default, Debug)]
 pub struct PeerFetchablePartitionResponse<R>
 where
     R: Encoder + Decoder + Default + Debug,

--- a/src/spu/src/replication/follower/sync.rs
+++ b/src/spu/src/replication/follower/sync.rs
@@ -10,7 +10,6 @@ use bytes::BytesMut;
 use tracing::trace;
 
 use dataplane::core::{Encoder, Decoder, Version};
-use dataplane::derive::{Decoder, Encoder};
 use dataplane::record::{RecordSet, FileRecordSet};
 use dataplane::api::Request;
 use dataplane::ErrorCode;

--- a/src/spu/src/replication/leader/api_key.rs
+++ b/src/spu/src/replication/leader/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::derive::{Encoder, Decoder};
+use dataplane::core::{Encoder, Decoder};
 
 #[repr(u16)]
 #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]

--- a/src/spu/src/replication/leader/api_key.rs
+++ b/src/spu/src/replication/leader/api_key.rs
@@ -1,7 +1,7 @@
-use dataplane::derive::{Encode, Decode};
+use dataplane::derive::{Encoder, Decoder};
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum LeaderPeerApiEnum {
     UpdateOffsets = 0,

--- a/src/spu/src/replication/leader/peer_api.rs
+++ b/src/spu/src/replication/leader/peer_api.rs
@@ -5,13 +5,13 @@ use tracing::trace;
 
 use dataplane::bytes::Buf;
 use dataplane::core::Decoder;
-use dataplane::derive::Encode;
+use dataplane::derive::Encoder;
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::LeaderPeerApiEnum;
 use super::UpdateOffsetRequest;
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum LeaderPeerRequest {
     UpdateOffsets(RequestMessage<UpdateOffsetRequest>),
 }

--- a/src/spu/src/replication/leader/peer_api.rs
+++ b/src/spu/src/replication/leader/peer_api.rs
@@ -4,8 +4,7 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::Decoder;
-use dataplane::derive::Encoder;
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::LeaderPeerApiEnum;

--- a/src/spu/src/replication/leader/update_offsets.rs
+++ b/src/spu/src/replication/leader/update_offsets.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::{Decoder, Encoder};
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
 use dataplane::Offset;
 use fluvio_controlplane_metadata::partition::ReplicaKey;

--- a/src/spu/src/replication/leader/update_offsets.rs
+++ b/src/spu/src/replication/leader/update_offsets.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use dataplane::api::Request;
 use dataplane::Offset;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use super::LeaderPeerApiEnum;
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateOffsetRequest {
     pub replicas: Vec<ReplicaOffsetRequest>,
 }
@@ -18,7 +18,7 @@ impl Request for UpdateOffsetRequest {
     type Response = UpdateOffsetResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct ReplicaOffsetRequest {
     pub replica: ReplicaKey,
     pub leo: Offset,
@@ -26,5 +26,5 @@ pub struct ReplicaOffsetRequest {
 }
 
 // no content, this is one way request
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateOffsetResponse {}

--- a/src/spu/src/services/internal/api.rs
+++ b/src/spu/src/services/internal/api.rs
@@ -4,9 +4,7 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::Decoder;
-use dataplane::derive::{Encoder, Decoder};
-
+use dataplane::core::{Encoder, Decoder};
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::fetch_stream_request::FetchStreamRequest;

--- a/src/spu/src/services/internal/api.rs
+++ b/src/spu/src/services/internal/api.rs
@@ -5,14 +5,14 @@ use tracing::trace;
 
 use dataplane::bytes::Buf;
 use dataplane::core::Decoder;
-use dataplane::derive::{Encode, Decode};
+use dataplane::derive::{Encoder, Decoder};
 
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::fetch_stream_request::FetchStreamRequest;
 
 #[repr(u16)]
-#[derive(PartialEq, Debug, Encode, Decode, Clone, Copy)]
+#[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
 #[fluvio(encode_discriminant)]
 pub enum SPUPeerApiEnum {
     FetchStream = 0,
@@ -24,7 +24,7 @@ impl Default for SPUPeerApiEnum {
     }
 }
 
-#[derive(Debug, Encode)]
+#[derive(Debug, Encoder)]
 pub enum SpuPeerRequest {
     FetchStream(RequestMessage<FetchStreamRequest>),
 }

--- a/src/spu/src/services/internal/fetch_stream_request.rs
+++ b/src/spu/src/services/internal/fetch_stream_request.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::assign_op_pattern)]
 
 use dataplane::api::Request;
-use dataplane::derive::{Decode, Encode};
+use dataplane::derive::{Decoder, Encoder};
 use fluvio_types::SpuId;
 
 use super::SPUPeerApiEnum;
 
-#[derive(Decode, Encode, Debug, Default)]
+#[derive(Decoder, Encoder, Debug, Default)]
 pub struct FetchStreamRequest {
     pub spu_id: SpuId,
     pub min_bytes: i32,
@@ -18,7 +18,7 @@ impl Request for FetchStreamRequest {
     type Response = FetchStreamResponse;
 }
 
-#[derive(Decode, Encode, Default, Debug)]
+#[derive(Decoder, Encoder, Default, Debug)]
 pub struct FetchStreamResponse {
     pub spu_id: SpuId,
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ derive_builder = "0.10.2"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-future = { version = "0.3.2", features = ["fs", "mmap","zero_copy"] }
-fluvio-protocol = { path = "../protocol", version = "0.5.1" }
+fluvio-protocol = { path = "../protocol", version = "0.6" }
 dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #1228 

- Adds support for named (struct-like) enums in `Encode` and `Decode` derives
- Adds support for unnamed enums with multiple fields
- Only adds `impl TryFrom<int> for type` when `#[fluvio(encode_discriminant)]` is used

Having a bug right now, after that is fixed it should be ready.