### PR TITLE
[Merged by Bors] - Generalize target type in fluivo-package-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Change C compiler to `zig` and linker to `lld`. Resolves segaults when cross compiling to musl. ([#464](https://github.com/infinyon/fluvio/pull/464))
 * Consumer CLI prints a status when consuming from the end of a partition. ([#1171](https://github.com/infinyon/fluvio/pull/1171))
 * Upgrade wasmtime to thread-safe API. ([#1200](https://github.com/infinyon/fluvio/issues/1200))
+* Update fluvio-package to support arbitrary Targets. ([#1234](https://github.com/infinyon/fluvio/pull/1234))
  
 ## Platform Version 0.8.4 - 2020-05-29
 * Don't hang when check for non exist topic. ([#697](https://github.com/infinyon/fluvio/pull/697))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "http-types",
  "lazy_static",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -64,7 +64,7 @@ k8-client = { version = "5.0.0" }
 fluvio = { version = "0.8.0", path = "../client", default-features = false }
 fluvio-cluster = { version = "0.9.1", path = "../cluster", default-features = false, features = ["cli"] }
 fluvio-command = { version = "0.2.0" }
-fluvio-package-index = { version = "0.3.0", path = "../package-index" }
+fluvio-package-index = { version = "0.4", path = "../package-index" }
 fluvio-extension-common = { version = "0.4.0", path = "../extension-common", features = ["target"]}
 fluvio-controlplane-metadata = { version = "0.9.1", path = "../controlplane-metadata", features = ["use_serde", "k8"] }
 k8-types = { version = "0.2.0", features = ["core"]}

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -63,7 +63,7 @@ pub(crate) fn get_extensions() -> Result<Vec<PathBuf>, CliError> {
 async fn fetch_latest_version<T>(
     agent: &HttpAgent,
     id: &PackageId<T>,
-    target: Target,
+    target: &Target,
     prerelease: bool,
 ) -> Result<Version, CliError> {
     let request = agent.request_package(id)?;
@@ -76,7 +76,7 @@ async fn fetch_latest_version<T>(
     let latest_release = package.latest_release_for_target(target, prerelease)?;
     debug!(release = ?latest_release, "Latest release for package:");
     if !latest_release.target_exists(target) {
-        return Err(fluvio_index::Error::MissingTarget(target).into());
+        return Err(fluvio_index::Error::MissingTarget(target.clone()).into());
     }
     Ok(latest_release.version.clone())
 }
@@ -89,7 +89,7 @@ async fn fetch_latest_version<T>(
 async fn fetch_package_file(
     agent: &HttpAgent,
     id: &PackageId<WithVersion>,
-    target: Target,
+    target: &Target,
 ) -> Result<Vec<u8>, CliError> {
     // Download the package file from the package registry
     let download_request = agent.request_release_download(&id, target)?;

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -69,7 +69,7 @@ impl InstallOpt {
                     "🎣 Fetching latest version for package: {}...",
                     &id
                 ));
-                let version = fetch_latest_version(agent, &id, target, self.develop).await?;
+                let version = fetch_latest_version(agent, &id, &target, self.develop).await?;
                 let id = id.into_versioned(version);
                 install_println(format!(
                     "⏳ Downloading package with latest version: {}...",
@@ -80,7 +80,7 @@ impl InstallOpt {
         };
 
         // Download the package file from the package registry
-        let package_file = fetch_package_file(agent, &id, target).await?;
+        let package_file = fetch_package_file(agent, &id, &target).await?;
         install_println("🔑 Downloaded and verified package file");
 
         // Install the package to the ~/.fluvio/bin/ dir

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -83,7 +83,7 @@ impl UpdateOpt {
 
         // Find the latest version of this package
         install_println("🎣 Fetching latest version for fluvio...");
-        let latest_version = fetch_latest_version(agent, &id, target, self.develop).await?;
+        let latest_version = fetch_latest_version(agent, &id, &target, self.develop).await?;
         let id = id.into_versioned(latest_version);
 
         // Download the package file from the package registry
@@ -91,7 +91,7 @@ impl UpdateOpt {
             "⏳ Downloading Fluvio CLI with latest version: {}...",
             &id.version()
         ));
-        let package_file = fetch_package_file(agent, &id, target).await?;
+        let package_file = fetch_package_file(agent, &id, &target).await?;
         install_println("🔑 Downloaded and verified package file");
 
         // Install the update over the current executable
@@ -115,7 +115,7 @@ impl UpdateOpt {
         let target = fluvio_index::package_target()?;
         debug!(%target, %id, "Fluvio CLI updating plugin:");
 
-        let version = fetch_latest_version(agent, id, target, self.develop).await?;
+        let version = fetch_latest_version(agent, id, &target, self.develop).await?;
 
         println!(
             "⏳ Downloading plugin {} with version {}",
@@ -123,7 +123,7 @@ impl UpdateOpt {
             version
         );
         let id = id.clone().into_versioned(version);
-        let package_file = fetch_package_file(agent, &id, target).await?;
+        let package_file = fetch_package_file(agent, &id, &target).await?;
         println!("🔑 Downloaded and verified package file");
 
         println!("✅ Successfully updated {} at ({})", id, path.display());
@@ -165,7 +165,7 @@ pub async fn check_update_available(
     let response = crate::http::execute(request).await?;
     let package = agent.package_from_response(response).await?;
 
-    let release = package.latest_release_for_target(target, prerelease)?;
+    let release = package.latest_release_for_target(&target, prerelease)?;
     let latest_version = release.version.clone();
     let current_version =
         Version::parse(&*crate::VERSION).expect("Fluvio CLI 'VERSION' should be a valid semver");
@@ -186,7 +186,7 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
     let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");
-    let latest_version = fetch_latest_version(agent, &id, target, false).await?;
+    let latest_version = fetch_latest_version(agent, &id, &target, false).await?;
 
     println!("⚠️ A major update to Fluvio has been detected!");
     println!("⚠️ You must complete this update before using any 'install' command");

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -28,4 +28,4 @@ thiserror = "1.0.20"
 semver = { version = "0.11.0", features = ["serde"] }
 
 fluvio = { version = "0.8.0", path = "../client",  optional = true }
-fluvio-package-index = { version = "0.3.0", path = "../package-index" }
+fluvio-package-index = { version = "0.4", path = "../package-index" }

--- a/src/package-index/Cargo.toml
+++ b/src/package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -51,7 +51,7 @@ impl HttpAgent {
     pub fn request_release_download(
         &self,
         id: &PackageId<WithVersion>,
-        target: Target,
+        target: &Target,
     ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}",
@@ -67,7 +67,7 @@ impl HttpAgent {
     pub fn request_release_checksum(
         &self,
         id: &PackageId<WithVersion>,
-        target: Target,
+        target: &Target,
     ) -> Result<Request> {
         let url = self.base_url.join(&format!(
             "packages/{group}/{name}/{version}/{target}/{name}.sha256",

--- a/src/package-index/src/target.rs
+++ b/src/package-index/src/target.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use serde::{Serialize, Deserialize};
 use crate::Error;
+use std::borrow::Cow;
 
 const PACKAGE_TARGET: &str = env!("PACKAGE_TARGET");
 
@@ -14,36 +15,57 @@ pub fn package_target() -> Result<Target, Error> {
     Ok(target)
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(non_camel_case_types)]
-pub enum Target {
-    #[serde(rename = "x86_64-apple-darwin")]
-    X86_64AppleDarwin,
-    #[serde(rename = "x86_64-unknown-linux-musl")]
-    X86_64UnknownLinuxMusl,
-}
+/// An object representing a specific build target for an artifact
+/// being managed by fluvio-index.
+///
+/// This type is generally constructed using `FromStr` via the
+/// `parse` method.
+///
+/// # Example
+///
+/// ```
+/// # use fluvio_index::Target;
+/// let target: Target = "x86_64-unknown-linux-musl".parse().unwrap();
+/// ```
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct Target(Cow<'static, str>);
 
+#[allow(non_upper_case_globals)]
 impl Target {
+    // These constants are from back when `Target` was an enum.
+    // Their variants are now constants, so constructors should not have broken
+    pub const X86_64AppleDarwin: Target = Target(Cow::Borrowed("x86_64-apple-darwin"));
+    pub const X86_64UnknownLinuxMusl: Target = Target(Cow::Borrowed("x86_64-unknown-linux-musl"));
     pub const ALL_TARGETS: &'static [Target] =
         &[Target::X86_64AppleDarwin, Target::X86_64UnknownLinuxMusl];
 
     pub fn as_str(&self) -> &str {
-        match self {
-            Self::X86_64AppleDarwin => "x86_64-apple-darwin",
-            Self::X86_64UnknownLinuxMusl => "x86_64-unknown-linux-musl",
-        }
+        self.0.as_ref()
     }
 }
 
 impl std::str::FromStr for Target {
     type Err = Error;
 
+    /// When parsing from a string, here is the chance to make any
+    /// edits or to collapse multiple target names into one. An
+    /// example of this is how we transform the target name
+    /// `x86_64-unknown-linux-gnu` into `x86_64-unknown-linux-musl`.
+    ///
+    /// Additionally, if there are any "target strings" that we
+    /// know for a fact that we cannot support, we can identify
+    /// those strings here and manually reject them in order to
+    /// prevent downstream tooling from incorrectly allowing those
+    /// targets.
+    ///
+    /// All other target names should pass through unchanged.
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let platform = match s {
             "x86_64-apple-darwin" => Self::X86_64AppleDarwin,
             "x86_64-unknown-linux-musl" => Self::X86_64UnknownLinuxMusl,
             "x86_64-unknown-linux-gnu" => Self::X86_64UnknownLinuxMusl,
-            invalid => return Err(Error::InvalidTarget(invalid.to_string())),
+            other => Self(Cow::Owned(other.to_owned())),
         };
         Ok(platform)
     }
@@ -52,5 +74,21 @@ impl std::str::FromStr for Target {
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Target {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        let me: Self = std::str::FromStr::from_str(&string).map_err(|e: Error| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Other(&e.to_string()),
+                &"valid Target",
+            )
+        })?;
+        Ok(me)
     }
 }


### PR DESCRIPTION
This, followed by changes to `fluvio-packages`, will unblock us from publishing binaries from more targets than just `x86_64-unknown-linux-musl` and `x86_64-apple-darwin`.