### PR TITLE
[Merged by Bors] - Fix publish flow by adding installer_version input to workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,15 @@ on:
         description: "Set --verbose to get verbose build output"
         required: false
         default: ""
+      installer_version:
+        required: false
+        description: "The version of Fluvio to download with install.sh"
+        default: "stable"
 
 env:
   VERBOSE: ${{ github.events.input.verbose }}
   FORCE_RELEASE: ${{ github.events.inputs.force }}
+  INSTALLER_VERSION: ${{ github.events.input.installer_version }}
 
 jobs:
   # Re-tag the docker image for this commit as 'latest'
@@ -67,7 +72,7 @@ jobs:
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
       - name: Install fluvio-package
         run: |
-          curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+          curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${{ env.INSTALLER_VERSION }} bash
           ${HOME}/.fluvio/bin/fluvio install fluvio-package
 
       - name: Download dev release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,14 @@ on:
         required: false 
         description: 'Fluvio git commit override (latest `master` by default)'
         default: ''
+      installer_version:
+        required: false
+        description: ''
+        default: 'stable'
 env:
   USE_COMMIT: ${{ github.event.inputs.commit }}
   FORCE_RELEASE: ${{ github.event.inputs.force }}
+  INSTALLER_VERSION: ${{ github.event.inputs.installer_version }}
 
 jobs:
   setup_job:
@@ -160,7 +165,7 @@ jobs:
           helm push k8-util/helm/fluvio-sys --force --version="${{ env.VERSION }}" chartmuseum
           helm push k8-util/helm/fluvio-app --force --version="${{ env.VERSION }}" chartmuseum
 
-  # Check for Fluvio cli
+  # Check for Fluvio CLI
   release_fluvio:
     name: Release Fluvio CLI package
     needs: [setup_job]
@@ -171,7 +176,7 @@ jobs:
       VERSION: ${{ needs.setup_job.outputs.VERSION }}
     steps:
       # Check that this release does not already exist by trying to download it
-      - name: Attempt to install Fluvio cli
+      - name: Attempt to install Fluvio CLI
         id: check_fluvio
         continue-on-error: true
         run: curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${{ env.VERSION }} bash
@@ -183,7 +188,7 @@ jobs:
       - name: Install fluvio-package
         run: |
           unset VERSION
-          curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+          curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${{ env.INSTALLER_VERSION }} bash
           ${HOME}/.fluvio/bin/fluvio install fluvio-package
 
       - name: Download dev release
@@ -246,7 +251,7 @@ jobs:
     steps:
       - name: Install fluvio-package
         run: |
-          curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+          curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=${{ env.INSTALLER_VERSION }} bash
           ${HOME}/.fluvio/bin/fluvio install fluvio-package
 
       - name: Bump Fluvio CLI

--- a/install.sh
+++ b/install.sh
@@ -485,8 +485,18 @@ main() {
     # If a VERSION env variable is set:
     if [ -n "${VERSION:-""}" ]; then
 
+        # If VERSION is equal to exactly "stable", use STABLE channel
+        if [ "${VERSION}" == "stable" ]; then
+            # Fetch the latest STABLE version information
+            _version=$(fetch_latest_version_for_architecture "${_target}")
+            _status=$?
+            if [ $_status -ne 0 ]; then
+                err "❌ Failed to fetch latest version information!"
+                err "    Error downloading from ${FLUVIO_STABLE}"
+                abort_prompt_issue
+            fi
         # If VERSION is equal to exactly "prerelease", use PRERELEASE channel
-        if [ "${VERSION}" == "prerelease" ]; then
+        elif [ "${VERSION}" == "prerelease" ]; then
             _version=$(fetch_latest_version_for_architecture "${_target}" "${FLUVIO_PRERELEASE}")
             _status=$?
             if [ $_status -ne 0 ]; then


### PR DESCRIPTION
The publisher flow is currently failing when it tries to install the Fluvio CLI in order to download `fluvio-package`:

```
Run curl -fsS https://packages.fluvio.io/v1/install.sh | bash
  curl -fsS https://packages.fluvio.io/v1/install.sh | bash
  ${HOME}/.fluvio/bin/fluvio install fluvio-package
  shell: /usr/bin/bash -e {0}
  env:
    VERBOSE: 
    FORCE_RELEASE: 
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
fluvio: ⏳ Downloading Fluvio 0.8.4 for x86_64-unknown-linux-musl...
fluvio: ⬇️ Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio
fluvio: ☁️ Installing Fluvio Cloud...
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.5...
fluvio: 🔑 Downloaded and verified package file
Error: 
   0: Package index error
   1: Http error: unknown variant `armv7-unknown-linux-gnueabihf`, expected `x86_64-apple-darwin` or `x86_64-unknown-linux-musl` at line 1 column 29313
```

This happens because the current `stable` Fluvio CLI (0.8.4) is unable to parse the new targets in the registry, a feature added by #1234. To fix this, we need to run the publisher flow using `VERSION=latest` rather than stable.

In this PR, I've added a workflow_dispatch input for `installer_input` so that we can manually trigger the publish step to use `VERSION=latest` and successfully complete the flow. Normal workflows will still be run with `VERSION=stable`