### PR TITLE
[Merged by Bors] - Make helm push idempotent using --force

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,8 @@ jobs:
         run: |
           helm plugin install https://github.com/chartmuseum/helm-push.git
           helm repo add chartmuseum https://gitops:${{ secrets.HELM_PASSWORD }}@charts.fluvio.io
-          helm push k8-util/helm/fluvio-sys --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
-          helm push k8-util/helm/fluvio-app --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
+          helm push k8-util/helm/fluvio-sys --force --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
+          helm push k8-util/helm/fluvio-app --force --version="$(cat VERSION)-$(git rev-parse HEAD)" chartmuseum
 
   # Download the `fluvio` release artifact for each target and publish them to packages.fluvio.io
   fluvio:


### PR DESCRIPTION
This will cause the Helm Publish step not to fail in the case that we want to manually re-run the `publish.yml` workflow

Would fix https://github.com/infinyon/fluvio/runs/3077788112?check_suite_focus=true