### PR TITLE
[Merged by Bors] - Parallelize CI for fluvio, fluvio-run, flv-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,34 +29,53 @@ jobs:
   # build binaries. use release for staging
   # this requires check and test
   build_binaries:
-    name: Build binaries for Target (${{ matrix.rust_target }}) on ${{ matrix.os }}
+    name: Build ${{ matrix.binary }} for ${{ matrix.target }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_target:
+        target:
 #          - aarch64-unknown-linux-musl
 #          - armv7-unknown-linux-gnueabihf
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
         rust: [stable]
+        binary: [fluvio]
         include:
-#          - rust_target: aarch64-unknown-linux-musl
-#            os: ubuntu-latest
-#            binaries: [fluvio]
-#          - rust_target: armv7-unknown-linux-gnueabihf
-#            os: ubuntu-latest
-#            binaries: [fluvio]
-          - rust_target: x86_64-apple-darwin
-            os: macos-latest
-            binaries: [fluvio]
-          - rust_target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            binaries: [fluvio, fluvio-run, flv-test]
+#          - os: ubuntu-latest
+#            rust: stable
+#            target: aarch64-unknown-linux-musl
+#            binary: fluvio
+#            run: make build-cli
+#          - os: ubuntu-latest
+#            rust: stable
+#            target: armv7-unknown-linux-gnueabihf
+#            binary: fluvio
+#            run: make build-cli
+          - os: macos-latest
+            rust: stable
+            target: x86_64-apple-darwin
+            binary: fluvio
+            run: make build-cli
+          - os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-musl
+            binary: fluvio
+            run: make build-cli
+          - os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-musl
+            binary: fluvio-run
+            run: make build-cluster
+          - os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-musl
+            binary: flv-test
+            run: make build-test
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.rust_target }}
-      RUST_BIN_DIR: target/${{ matrix.rust_target }}/debug
+      TARGET: ${{ matrix.target }}
+      RUST_BIN_DIR: target/${{ matrix.target }}/debug
       RELEASE_NAME: debug
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +87,7 @@ jobs:
         run: |
           echo "RELEASE=true" | tee -a $GITHUB_ENV
           echo "RELEASE_NAME=release" | tee -a $GITHUB_ENV
-          echo "RUST_BIN_DIR=target/${{ matrix.rust_target }}/release" | tee -a $GITHUB_ENV
+          echo "RUST_BIN_DIR=target/${{ matrix.target }}/release" | tee -a $GITHUB_ENV
 
       - name: Print env
         run: |
@@ -83,57 +102,41 @@ jobs:
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v1
 
-      - name: Rustfmt
-        run: make check-fmt
-
-      - name: Build CLI
-        if: ${{ contains(matrix.binaries, 'fluvio') }}
-        run: make build-cli
-
-      - name: Build Cluster CLI
-        if: ${{ contains(matrix.binaries, 'fluvio-run') }}
-        run: make build-cluster
-
-      - name: Build Test CLI
-        if: ${{ contains(matrix.binaries, 'flv-test') }}
-        run: make build-test
+      - name: Build ${{ matrix.binary }}
+        run: ${{ matrix.run }}
 
       # Upload artifacts
-      - name: Upload artifact - fluvio
-        if: ${{ contains(matrix.binaries, 'fluvio') }}
+      - name: Upload artifact - ${{ matrix.binary }}
         uses: actions/upload-artifact@v2
         with:
-          name: fluvio-${{ matrix.rust_target }}
-          path: ${{ env.RUST_BIN_DIR }}/fluvio
-      - name: Upload artifact - fluvio-run
-        if: ${{ contains(matrix.binaries, 'fluvio-run') }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: fluvio-run-${{ matrix.rust_target }}
-          path: ${{ env.RUST_BIN_DIR }}/fluvio-run
-      - name: Upload atrifact - flv-test
-        if: ${{ contains(matrix.binaries, 'flv-test') }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: flv-test-${{ matrix.rust_target }}
-          path: ${{ env.RUST_BIN_DIR }}/flv-test
+          name: ${{ matrix.binary }}-${{ matrix.target }}
+          path: ${{ env.RUST_BIN_DIR }}/${{ matrix.binary }}
 
   # Run all checks and unit test. This always run on debug mode
   check:
-    name: Check (${{ matrix.rust_target }}) (${{ matrix.check }})
-
+    name: ${{ matrix.check.name }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        rust_target: [x86_64-unknown-linux-gnu]
-        check: [clippy, test, unstable]
+        target: [x86_64-unknown-linux-gnu]
+        check:
+          - name: Rustfmt
+            run: make check-fmt
+          - name: Clippy
+            run: make check-clippy
+          - name: Unit/Doc tests
+            run: |
+              make run-all-doc-test
+              make run-all-unit-test
+          - name: Unstable tests
+            run: make run-unstable-test
 
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.rust_target }}
+      TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v2
 
@@ -147,20 +150,8 @@ jobs:
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v1
 
-      - name: Clippy
-        if: ${{ matrix.check == 'clippy' }}
-        run: make check-clippy
-
-      - name: Test
-        if: ${{ matrix.check == 'test' }}
-        run: |
-          make run-all-doc-test
-          make run-all-unit-test
-
-      - name: Unstable test
-        if: ${{ matrix.check == 'unstable' }}
-        run: |
-          make run-unstable-test
+      - name: ${{ matrix.check.name }}
+        run: ${{ matrix.check.run }}
 
   check_wasm:
     name: Build WASM crates (${{ matrix.wasm-crate }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
   # build binaries. use release for staging
   # this requires check and test
   build_binaries:
-    name: Build ${{ matrix.binary }} for ${{ matrix.target }} (${{ matrix.os }})
+    name: Build ${{ matrix.binary }} for ${{ matrix.rust-target }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target:
+        rust-target:
 #          - aarch64-unknown-linux-musl
 #          - armv7-unknown-linux-gnueabihf
           - x86_64-apple-darwin
@@ -43,39 +43,39 @@ jobs:
         include:
 #          - os: ubuntu-latest
 #            rust: stable
-#            target: aarch64-unknown-linux-musl
+#            rust-target: aarch64-unknown-linux-musl
 #            binary: fluvio
 #            run: make build-cli
 #          - os: ubuntu-latest
 #            rust: stable
-#            target: armv7-unknown-linux-gnueabihf
+#            rust-target: armv7-unknown-linux-gnueabihf
 #            binary: fluvio
 #            run: make build-cli
           - os: macos-latest
             rust: stable
-            target: x86_64-apple-darwin
+            rust-target: x86_64-apple-darwin
             binary: fluvio
             run: make build-cli
           - os: ubuntu-latest
             rust: stable
-            target: x86_64-unknown-linux-musl
+            rust-target: x86_64-unknown-linux-musl
             binary: fluvio
             run: make build-cli
           - os: ubuntu-latest
             rust: stable
-            target: x86_64-unknown-linux-musl
+            rust-target: x86_64-unknown-linux-musl
             binary: fluvio-run
             run: make build-cluster
           - os: ubuntu-latest
             rust: stable
-            target: x86_64-unknown-linux-musl
+            rust-target: x86_64-unknown-linux-musl
             binary: flv-test
             run: make build-test
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.target }}
-      RUST_BIN_DIR: target/${{ matrix.target }}/debug
+      TARGET: ${{ matrix.rust-target }}
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
       RELEASE_NAME: debug
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo "RELEASE=true" | tee -a $GITHUB_ENV
           echo "RELEASE_NAME=release" | tee -a $GITHUB_ENV
-          echo "RUST_BIN_DIR=target/${{ matrix.target }}/release" | tee -a $GITHUB_ENV
+          echo "RUST_BIN_DIR=target/${{ matrix.rust-target }}/release" | tee -a $GITHUB_ENV
 
       - name: Print env
         run: |
@@ -109,18 +109,18 @@ jobs:
       - name: Upload artifact - ${{ matrix.binary }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.binary }}-${{ matrix.target }}
+          name: ${{ matrix.binary }}-${{ matrix.rust-target }}
           path: ${{ env.RUST_BIN_DIR }}/${{ matrix.binary }}
 
   # Run all checks and unit test. This always run on debug mode
   check:
-    name: ${{ matrix.check.name }} (${{ matrix.target }})
+    name: ${{ matrix.check.name }} (${{ matrix.rust-target }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        target: [x86_64-unknown-linux-gnu]
+        rust-target: [x86_64-unknown-linux-gnu]
         check:
           - name: Rustfmt
             run: make check-fmt
@@ -136,7 +136,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.target }}
+      TARGET: ${{ matrix.rust-target }}
     steps:
       - uses: actions/checkout@v2
 
@@ -421,20 +421,20 @@ jobs:
 
   # Upload the build artifacts to the `dev` GH release, overwriting old artifacts
   github_release:
-    name: Publish to GitHub Releases dev (${{ matrix.artifact }}-${{ matrix.target }})
+    name: Publish to GitHub Releases dev (${{ matrix.artifact }}-${{ matrix.rust-target }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     needs: bump_github_release
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target:
+        rust-target:
 #          - aarch64-unknown-linux-musl
 #          - armv7-unknown-linux-gnueabihf
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
         artifact: [fluvio]
         include:
-          - target: x86_64-unknown-linux-musl
+          - rust-target: x86_64-unknown-linux-musl
             artifact: fluvio-run
     permissions: write-all
     steps:
@@ -443,13 +443,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.artifact }}-${{ matrix.target }}
+          name: ${{ matrix.artifact }}-${{ matrix.rust-target }}
       - name: Publish artifact
         run: |
           ls -la
-          echo "${{ matrix.target }}" > .target
-          zip "${{ matrix.artifact }}-${{ matrix.target }}.zip" "${{ matrix.artifact }}" .target
-          gh release upload -R infinyon/fluvio --clobber dev "${{ matrix.artifact }}-${{ matrix.target }}.zip"
+          echo "${{ matrix.rust-target }}" > .target
+          zip "${{ matrix.artifact }}-${{ matrix.rust-target }}.zip" "${{ matrix.artifact }}" .target
+          gh release upload -R infinyon/fluvio --clobber dev "${{ matrix.artifact }}-${{ matrix.rust-target }}.zip"
 
   # Job that follows the success of all required jobs in this workflow.
   # Used by Bors to detect that all required jobs have completed successfully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,22 +55,18 @@ jobs:
             rust: stable
             rust-target: x86_64-apple-darwin
             binary: fluvio
-            run: make build-cli
           - os: ubuntu-latest
             rust: stable
             rust-target: x86_64-unknown-linux-musl
             binary: fluvio
-            run: make build-cli
           - os: ubuntu-latest
             rust: stable
             rust-target: x86_64-unknown-linux-musl
             binary: fluvio-run
-            run: make build-cluster
           - os: ubuntu-latest
             rust: stable
             rust-target: x86_64-unknown-linux-musl
             binary: flv-test
-            run: make build-test
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
@@ -102,8 +98,17 @@ jobs:
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v1
 
-      - name: Build ${{ matrix.binary }}
-        run: ${{ matrix.run }}
+      - name: Build fluvio
+        if: ${{ matrix.binary == 'fluvio' }}
+        run: make build-cli
+
+      - name: Build fluvio-run
+        if: ${{ matrix.binary == 'fluvio-run' }}
+        run: make build-cluster
+
+      - name: Build flv-test
+        if: ${{ matrix.binary == 'flv-test' }}
+        run: make build-test
 
       # Upload artifacts
       - name: Upload artifact - ${{ matrix.binary }}


### PR DESCRIPTION
This seems to reduce the CI run time (in debug mode, not on `staging`) from about 17-18 mins to about 11 mins

![image](https://user-images.githubusercontent.com/4210949/125850699-1437a781-712b-40b4-a38e-02607b89901e.png)
