### PR TITLE
[Merged by Bors] - Run CD test after publish workflow in 'stable' and 'latest' mode

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -9,14 +9,17 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [master]
+#  push:
+#    branches: [master]
 #  pull_request:
 #    branches: [master]
+  workflow_run:
+    workflows: [CI]
+    branches: [master]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
-
   composite_action_test:
     name: Composite Action Test
     runs-on: ${{ matrix.os }}
@@ -24,11 +27,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
+        version: [stable, latest]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: ./
-        name: Install Fluvio Local Cluster
+      - name: Install Fluvio Local Cluster
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
       - name: Fluvio command test
         continue-on-error: true
         run: |

--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -20,10 +20,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  composite_action_test:
-    name: Composite Action Test
+  fluvio_action_test:
+    name: Fluvio Action Test (${{ matrix.os }}, ${{ matrix.version }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust: [stable]

--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -14,7 +14,7 @@ REPO_VERSION="$(curl -sSf https://raw.githubusercontent.com/infinyon/fluvio/mast
 CHART_VERSION="${REPO_VERSION}-${GITHUB_SHA}"
 
 #
-# Install Fluvio System Charts
+# Install Fluvio Cluster
 #
 
 # Install Local Fluvio Cluster
@@ -22,8 +22,7 @@ if [ "$CLUSTER_TYPE" = "local" ]; then
 
     # If VERSION is equal to exactly "latest", use LATEST channel
     if [ "${VERSION}" == "latest" ]; then
-        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${REPO_VERSION}-c963500f9d985a1a42b67380bf7bb683cdace1d7"
-#        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${CHART_VERSION}"
+        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${CHART_VERSION}"
     else
         fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER
     fi

--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -17,20 +17,6 @@ CHART_VERSION="${REPO_VERSION}-${GITHUB_SHA}"
 # Install Fluvio System Charts
 #
 
-# If VERSION is equal to exactly "latest", use LATEST channel
-if [ "${VERSION}" == "latest" ]; then
-    fluvio cluster start --setup --local --sys --chart-version="${REPO_VERSION}-c963500f9d985a1a42b67380bf7bb683cdace1d7"
-#    fluvio cluster start --setup --local --sys --chart-version="${CHART_VERSION}"
-else
-    fluvio cluster start --setup --local --sys
-fi
-
-#
-# Run Fluvio Cluster Pre-Install Check
-#
-
-fluvio cluster check
-
 # Install Local Fluvio Cluster
 if [ "$CLUSTER_TYPE" = "local" ]; then
 

--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -19,7 +19,8 @@ CHART_VERSION="${REPO_VERSION}-${GITHUB_SHA}"
 
 # If VERSION is equal to exactly "latest", use LATEST channel
 if [ "${VERSION}" == "latest" ]; then
-    fluvio cluster start --setup --local --sys --chart-version="${CHART_VERSION}"
+    fluvio cluster start --setup --local --sys --chart-version="${REPO_VERSION}-c963500f9d985a1a42b67380bf7bb683cdace1d7"
+#    fluvio cluster start --setup --local --sys --chart-version="${CHART_VERSION}"
 else
     fluvio cluster start --setup --local --sys
 fi
@@ -35,7 +36,8 @@ if [ "$CLUSTER_TYPE" = "local" ]; then
 
     # If VERSION is equal to exactly "latest", use LATEST channel
     if [ "${VERSION}" == "latest" ]; then
-        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${CHART_VERSION}"
+        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${REPO_VERSION}-c963500f9d985a1a42b67380bf7bb683cdace1d7"
+#        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${CHART_VERSION}"
     else
         fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER
     fi

--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -10,16 +10,35 @@ curl -sSf https://raw.githubusercontent.com/infinyon/fluvio/master/install.sh | 
 echo 'export PATH="$HOME/.fluvio/bin:$PATH"' >> $HOME/.bash_profile
 . $HOME/.bash_profile
 
-# Install Fluvio System Charts
-fluvio cluster start --setup --local --sys
+REPO_VERSION="$(curl -sSf https://raw.githubusercontent.com/infinyon/fluvio/master/VERSION)"
+CHART_VERSION="${REPO_VERSION}-${GITHUB_SHA}"
 
+#
+# Install Fluvio System Charts
+#
+
+# If VERSION is equal to exactly "latest", use LATEST channel
+if [ "${VERSION}" == "latest" ]; then
+    fluvio cluster start --setup --local --sys --chart-version="${CHART_VERSION}"
+else
+    fluvio cluster start --setup --local --sys
+fi
+
+#
 # Run Fluvio Cluster Pre-Install Check
+#
 
 fluvio cluster check
 
+# Install Local Fluvio Cluster
 if [ "$CLUSTER_TYPE" = "local" ]; then
-        # Install Local Fluvio Cluster
+
+    # If VERSION is equal to exactly "latest", use LATEST channel
+    if [ "${VERSION}" == "latest" ]; then
+        fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER --chart-version="${CHART_VERSION}"
+    else
         fluvio cluster start --rust-log $RUST_LOG --develop --local --spu $SPU_NUMBER
+    fi
 else
-        echo "Currently, only local cluster types are supported"
+    echo "Currently, only local cluster types are supported"
 fi


### PR DESCRIPTION
This basically sets the "composite action test" to be run only _after_ the `publish.yml` job finishes, and to run it twice:

- Once for `stable`
- Once for `latest`

Hopefully that will give us a good indication of how the end-to-end flow is working for both the active CLI and the staged-up-to-be-released CLI

See the workflow working here: https://github.com/nicholastmosher/fluvio/runs/3081131127?check_suite_focus=true