### PR TITLE
[Merged by Bors] - Re-enable new build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,23 @@ jobs:
     strategy:
       matrix:
         rust-target:
-#          - aarch64-unknown-linux-musl
-#          - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
         rust: [stable]
         binary: [fluvio]
         include:
-#          - os: ubuntu-latest
-#            rust: stable
-#            rust-target: aarch64-unknown-linux-musl
-#            binary: fluvio
-#            run: make build-cli
-#          - os: ubuntu-latest
-#            rust: stable
-#            rust-target: armv7-unknown-linux-gnueabihf
-#            binary: fluvio
-#            run: make build-cli
+          - os: ubuntu-latest
+            rust: stable
+            rust-target: aarch64-unknown-linux-musl
+            binary: fluvio
+            run: make build-cli
+          - os: ubuntu-latest
+            rust: stable
+            rust-target: armv7-unknown-linux-gnueabihf
+            binary: fluvio
+            run: make build-cli
           - os: macos-latest
             rust: stable
             rust-target: x86_64-apple-darwin
@@ -429,8 +429,8 @@ jobs:
     strategy:
       matrix:
         rust-target:
-#          - aarch64-unknown-linux-musl
-#          - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
         artifact: [fluvio]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,7 @@ jobs:
 
       - name: Build fluvio
         if: ${{ matrix.binary == 'fluvio' }}
-        run: |
-          make build-cli
-          ${{ env.RUST_BIN_DIR }}/fluvio version
+        run: make build-cli
 
       - name: Build fluvio-run
         if: ${{ matrix.binary == 'fluvio-run' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.8.6"
+version = "0.8.5"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.8.6"
+version = "0.8.5"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]


### PR DESCRIPTION
Now that `0.8.5` is published with the #1234 fix, we can re-enable publishing extra targets.