### PR TITLE
[Merged by Bors] - Update cache keys to prevent conflicting saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
       - name: Install zig
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.os }}-${{ matrix.rust-target }}-${{ matrix.binary }}
 
       - name: Build fluvio
         if: ${{ matrix.binary == 'fluvio' }}
@@ -156,6 +158,8 @@ jobs:
       - name: Install Zig
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.rust-target }}-${{ matrix.check.name }}
 
       - name: ${{ matrix.check.name }}
         run: ${{ matrix.check.run }}


### PR DESCRIPTION
In our CI, our slowest job is "Unit/Doc test", and it appears that our rust-cache setup is failing to cache for that job:

![image](https://user-images.githubusercontent.com/4210949/126163475-1bd4d772-97de-48dd-8927-38eb49948164.png)

I believe this is because this job is part of a matrix and only the first job in that matrix is "reserving" the key to cache with. This PR should give each job in the matrix a unique key so that caching can work properly.