### PR TITLE
Remove dataplane reexport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ name = "fluvio-smartstream"
 version = "0.1.1"
 dependencies = [
  "fluvio-dataplane-protocol",
+ "fluvio-protocol",
  "fluvio-smartstream-derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ name = "fluvio-auth"
 version = "0.6.1"
 dependencies = [
  "async-trait",
+ "bytes",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
@@ -1488,6 +1489,7 @@ dependencies = [
 name = "fluvio-controlplane"
 version = "0.7.1"
 dependencies = [
+ "bytes",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-protocol",
@@ -1501,6 +1503,7 @@ name = "fluvio-controlplane-metadata"
 version = "0.9.2"
 dependencies = [
  "async-trait",
+ "bytes",
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-protocol",
@@ -1745,6 +1748,7 @@ dependencies = [
 name = "fluvio-sc-schema"
 version = "0.8.1"
 dependencies = [
+ "bytes",
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-protocol",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -23,7 +23,7 @@ tracing-futures = "0.2.4"
 x509-parser = "0.9.1"
 
 fluvio-controlplane-metadata = { version = "0.9.1", path = "../controlplane-metadata" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
 fluvio-protocol = { path = "../protocol",  version = "0.6" }
 fluvio-socket = { path = "../socket", version = "0.8.1" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.41"
+bytes = "1"
 serde = { version = "1.0.103", features = ['derive'] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"

--- a/src/auth/src/x509/request.rs
+++ b/src/auth/src/x509/request.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use dataplane::bytes::Buf;
 use dataplane::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
-use dataplane::derive::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 pub type AuthorizationScopes = Vec<String>;
 

--- a/src/auth/src/x509/request.rs
+++ b/src/auth/src/x509/request.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::assign_op_pattern)]
 
 use std::fmt::Debug;
+use bytes::Buf;
 
-use dataplane::bytes::Buf;
-use dataplane::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
 use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
 
 pub type AuthorizationScopes = Vec<String>;
 

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -44,7 +44,7 @@ fluvio-types = { version = "0.2.1", features = ["events"], path = "../types" }
 fluvio-sc-schema = { version = "0.8.1", path = "../sc-schema", default-features = false }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "1.0.2"

--- a/src/client/src/admin.rs
+++ b/src/client/src/admin.rs
@@ -3,8 +3,7 @@ use std::fmt::Display;
 
 use fluvio_future::net::DomainConnector;
 use tracing::{debug, instrument};
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_sc_schema::objects::{Metadata, AllCreatableSpec};
 use fluvio_sc_schema::AdminRequest;
 use fluvio_socket::FlvSocketError;

--- a/src/client/src/sockets.rs
+++ b/src/client/src/sockets.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 
 use tracing::{debug, trace, instrument};
 
-use dataplane::api::RequestMessage;
-use dataplane::api::Request;
+use fluvio_protocol::api::{Request, RequestMessage};
 use dataplane::versions::{ApiVersions, ApiVersionsRequest, ApiVersionsResponse};
 use fluvio_socket::FlvSocketError;
 use fluvio_socket::{FluvioSocket, SharedMultiplexerSocket};

--- a/src/client/src/spu.rs
+++ b/src/client/src/spu.rs
@@ -5,8 +5,7 @@ use tracing::{debug, trace, instrument};
 use async_lock::Mutex;
 
 use dataplane::ReplicaKey;
-use dataplane::api::Request;
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::{Request, RequestMessage};
 use fluvio_types::SpuId;
 use fluvio_socket::{MultiplexerSocket, SharedMultiplexerSocket, FlvSocketError, AsyncResponse};
 use crate::FluvioError;

--- a/src/client/src/sync/controller.rs
+++ b/src/client/src/sync/controller.rs
@@ -10,8 +10,7 @@ use tracing::{error, debug, instrument};
 use futures_util::stream::StreamExt;
 use event_listener::{Event, EventListener};
 
-use dataplane::core::Encoder;
-use dataplane::core::Decoder;
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_socket::AsyncResponse;
 use fluvio_sc_schema::objects::WatchRequest;
 use fluvio_sc_schema::objects::WatchResponse;

--- a/src/client/src/sync/store.rs
+++ b/src/client/src/sync/store.rs
@@ -58,7 +58,7 @@ impl MetadataStores {
 
     /// start watch for spu
     pub async fn start_watch_for_spu(&self) -> Result<(), FlvSocketError> {
-        use dataplane::api::RequestMessage;
+        use fluvio_protocol::api::RequestMessage;
         use fluvio_sc_schema::objects::WatchRequest;
 
         debug!("start watch for spu");
@@ -76,7 +76,7 @@ impl MetadataStores {
     }
 
     pub async fn start_watch_for_partition(&self) -> Result<(), FlvSocketError> {
-        use dataplane::api::RequestMessage;
+        use fluvio_protocol::api::RequestMessage;
         use fluvio_sc_schema::objects::WatchRequest;
 
         debug!("start watch for partition");
@@ -94,7 +94,7 @@ impl MetadataStores {
     }
 
     pub async fn start_watch_for_topic(&self) -> Result<(), FlvSocketError> {
-        use dataplane::api::RequestMessage;
+        use fluvio_protocol::api::RequestMessage;
         use fluvio_sc_schema::objects::WatchRequest;
 
         debug!("start watch for topic");

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -17,6 +17,7 @@ k8 = ["use_serde", "fluvio-stream-model/k8"]
 
 [dependencies]
 log = "0.4.8"
+bytes = "1"
 tracing = "0.1.19"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
 async-trait = "0.1.21"

--- a/src/controlplane-metadata/Cargo.toml
+++ b/src/controlplane-metadata/Cargo.toml
@@ -28,7 +28,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-stream-model = { path = "../stream-model", version = "0.5.0" }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/src/controlplane-metadata/src/message/msg_type.rs
+++ b/src/controlplane-metadata/src/message/msg_type.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 use crate::store::actions::*;
 use crate::core::*;

--- a/src/controlplane-metadata/src/message/replica_msg.rs
+++ b/src/controlplane-metadata/src/message/replica_msg.rs
@@ -12,7 +12,7 @@
 //!
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_types::SpuId;
 
 use crate::partition::*;

--- a/src/controlplane-metadata/src/partition/replica.rs
+++ b/src/controlplane-metadata/src/partition/replica.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_types::SpuId;
 use crate::partition::ReplicaKey;
 use crate::core::{MetadataItem};

--- a/src/controlplane-metadata/src/partition/spec.rs
+++ b/src/controlplane-metadata/src/partition/spec.rs
@@ -5,7 +5,7 @@
 //!
 //!
 use fluvio_types::SpuId;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 /// Spec for Partition
 /// Each partition has replicas spread among SPU

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::slice::Iter;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::Offset;
 use fluvio_types::SpuId;
 

--- a/src/controlplane-metadata/src/spg/spec.rs
+++ b/src/controlplane-metadata/src/spg/spec.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_types::defaults::{SPU_LOG_BASE_DIR, SPU_LOG_SIZE};
 
 #[derive(Encoder, Decoder, Default, Debug, PartialEq, Clone)]

--- a/src/controlplane-metadata/src/spg/status.rs
+++ b/src/controlplane-metadata/src/spg/status.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 #[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/spu/mod.rs
+++ b/src/controlplane-metadata/src/spu/mod.rs
@@ -12,11 +12,10 @@ mod k8;
 pub use k8::*;
 
 mod metadata {
+    use super::*;
 
     use crate::core::{Spec, Status};
     use crate::extended::{ObjectType, SpecExt};
-
-    use super::*;
 
     impl Spec for SpuSpec {
         const LABEL: &'static str = "SPU";
@@ -56,22 +55,17 @@ mod metadata {
 }
 
 mod custom_metadata {
+    use super::*;
 
+    use std::fmt;
     use std::io::Error;
     use std::io::ErrorKind;
-    use std::fmt;
-
+    use bytes::{Buf, BufMut};
     use tracing::trace;
-
-    use dataplane::core::Encoder;
-    use dataplane::core::Decoder;
-    use dataplane::core::Version;
-    use dataplane::bytes::{Buf, BufMut};
+    use fluvio_protocol::{Encoder, Decoder, Version};
 
     use crate::core::{Spec, Removable, Creatable};
     use crate::extended::{ObjectType, SpecExt};
-
-    use super::*;
 
     /// this is not real spec but is there to allow passing of parameters
     impl Spec for CustomSpuSpec {

--- a/src/controlplane-metadata/src/spu/spec.rs
+++ b/src/controlplane-metadata/src/spu/spec.rs
@@ -5,21 +5,20 @@
 //!
 //! Spu Spec metadata information cached locally.
 //!
+use std::fmt;
 use std::convert::TryFrom;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
-use std::fmt;
 
-use flv_util::socket_helpers::EndPoint as SocketEndPoint;
-use flv_util::socket_helpers::EndPointEncryption;
+use bytes::{Buf, BufMut};
+use fluvio_types::SpuId;
 use fluvio_types::defaults::{SPU_PRIVATE_HOSTNAME, SPU_PRIVATE_PORT};
 use fluvio_types::defaults::SPU_PUBLIC_PORT;
-use fluvio_types::SpuId;
+use flv_util::socket_helpers::EndPoint as SocketEndPoint;
+use flv_util::socket_helpers::EndPointEncryption;
 use flv_util::socket_helpers::ServerAddress;
 
-use fluvio_protocol::{Encoder, Decoder};
-use dataplane::bytes::{Buf, BufMut};
-use dataplane::core::Version;
+use fluvio_protocol::{Encoder, Decoder, Version};
 
 #[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/spu/spec.rs
+++ b/src/controlplane-metadata/src/spu/spec.rs
@@ -17,7 +17,7 @@ use fluvio_types::defaults::SPU_PUBLIC_PORT;
 use fluvio_types::SpuId;
 use flv_util::socket_helpers::ServerAddress;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::core::Version;
 

--- a/src/controlplane-metadata/src/spu/status.rs
+++ b/src/controlplane-metadata/src/spu/status.rs
@@ -7,7 +7,7 @@
 //!
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 #[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/controlplane-metadata/src/topic/spec.rs
+++ b/src/controlplane-metadata/src/topic/spec.rs
@@ -11,12 +11,10 @@ use std::io::{Error, ErrorKind};
 use std::collections::BTreeMap;
 
 use tracing::trace;
+use bytes::{Buf, BufMut};
 use fluvio_types::{ReplicaMap, SpuId};
 use fluvio_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAssignment};
-
-use dataplane::core::Version;
-use dataplane::bytes::{Buf, BufMut};
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder, Version};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/topic/spec.rs
+++ b/src/controlplane-metadata/src/topic/spec.rs
@@ -16,7 +16,7 @@ use fluvio_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAss
 
 use dataplane::core::Version;
 use dataplane::bytes::{Buf, BufMut};
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/src/controlplane-metadata/src/topic/status.rs
+++ b/src/controlplane-metadata/src/topic/status.rs
@@ -8,7 +8,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_types::{ReplicaMap, SpuId};
 
 // -----------------------------------

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 log = "0.4.8"
 tracing = "0.1.19"
+bytes = "1"
 
 # Fluvio dependencies
 fluvio-types = { path = "../types", version = "0.2.0" }

--- a/src/controlplane/Cargo.toml
+++ b/src/controlplane/Cargo.toml
@@ -20,4 +20,4 @@ bytes = "1"
 fluvio-types = { path = "../types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../controlplane-metadata", version = "0.9.1" }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/controlplane/src/lib.rs
+++ b/src/controlplane/src/lib.rs
@@ -13,6 +13,6 @@ pub use self::requests::register_spu::*;
 pub use self::requests::update_lrs::*;
 pub use self::requests::remove::*;
 
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::RequestMessage;
 
 pub type UpdateSpuRequestMessage = RequestMessage<UpdateSpuRequest>;

--- a/src/controlplane/src/requests/register_spu.rs
+++ b/src/controlplane/src/requests/register_spu.rs
@@ -12,10 +12,9 @@
 //!
 //! In subsequent releases, Register SPU will carry additional credentials for mTLS
 //!
-use dataplane::api::Request;
 use dataplane::ErrorCode;
-use fluvio_protocol::Decoder;
-use fluvio_protocol::Encoder;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use fluvio_types::SpuId;
 
 use crate::InternalScKey;

--- a/src/controlplane/src/requests/register_spu.rs
+++ b/src/controlplane/src/requests/register_spu.rs
@@ -14,8 +14,8 @@
 //!
 use dataplane::api::Request;
 use dataplane::ErrorCode;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
 use fluvio_types::SpuId;
 
 use crate::InternalScKey;

--- a/src/controlplane/src/requests/remove.rs
+++ b/src/controlplane/src/requests/remove.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use crate::InternalScKey;

--- a/src/controlplane/src/requests/remove.rs
+++ b/src/controlplane/src/requests/remove.rs
@@ -2,9 +2,8 @@
 
 use std::fmt;
 
-use dataplane::api::Request;
-use fluvio_protocol::Decoder;
-use fluvio_protocol::Encoder;
+use fluvio_protocol::api::Request;
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use crate::InternalScKey;

--- a/src/controlplane/src/requests/update_lrs.rs
+++ b/src/controlplane/src/requests/update_lrs.rs
@@ -3,9 +3,8 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use dataplane::api::Request;
-use fluvio_protocol::Decoder;
-use fluvio_protocol::Encoder;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use fluvio_controlplane_metadata::partition::ReplicaStatus;
 

--- a/src/controlplane/src/requests/update_lrs.rs
+++ b/src/controlplane/src/requests/update_lrs.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use fluvio_controlplane_metadata::partition::ReplicaStatus;
 

--- a/src/controlplane/src/requests/update_replica.rs
+++ b/src/controlplane/src/requests/update_replica.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::assign_op_pattern)]
 
-use fluvio_protocol::Decoder;
-use fluvio_protocol::Encoder;
-use dataplane::api::Request;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use fluvio_controlplane_metadata::message::ReplicaMsg;
 use fluvio_controlplane_metadata::partition::Replica;
 use crate::InternalSpuApi;

--- a/src/controlplane/src/requests/update_replica.rs
+++ b/src/controlplane/src/requests/update_replica.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
 use dataplane::api::Request;
 use fluvio_controlplane_metadata::message::ReplicaMsg;
 use fluvio_controlplane_metadata::partition::Replica;

--- a/src/controlplane/src/requests/update_spu.rs
+++ b/src/controlplane/src/requests/update_spu.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::api::Request;
-use fluvio_protocol::Decoder;
-use fluvio_protocol::Encoder;
+use fluvio_protocol::api::Request;
+use fluvio_protocol::{Encoder, Decoder};
 use fluvio_controlplane_metadata::spu::SpuSpec;
 use fluvio_controlplane_metadata::message::SpuMsg;
 

--- a/src/controlplane/src/requests/update_spu.rs
+++ b/src/controlplane/src/requests/update_spu.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::assign_op_pattern)]
 
 use dataplane::api::Request;
-use dataplane::derive::Decoder;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
 use fluvio_controlplane_metadata::spu::SpuSpec;
 use fluvio_controlplane_metadata::message::SpuMsg;
 

--- a/src/controlplane/src/sc_api.rs
+++ b/src/controlplane/src/sc_api.rs
@@ -1,14 +1,9 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
-use dataplane::api::api_decode;
-use dataplane::api::ApiMessage;
-use dataplane::api::RequestHeader;
-use dataplane::api::RequestMessage;
-use dataplane::bytes::Buf;
-use fluvio_protocol::Encoder;
-
-use fluvio_protocol::Decoder;
+use bytes::Buf;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::{api_decode, ApiMessage, RequestHeader, RequestMessage};
 
 use super::RegisterSpuRequest;
 use super::UpdateLrsRequest;

--- a/src/controlplane/src/sc_api.rs
+++ b/src/controlplane/src/sc_api.rs
@@ -6,9 +6,9 @@ use dataplane::api::ApiMessage;
 use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 use dataplane::bytes::Buf;
-use dataplane::derive::Encoder;
+use fluvio_protocol::Encoder;
 
-use dataplane::derive::Decoder;
+use fluvio_protocol::Decoder;
 
 use super::RegisterSpuRequest;
 use super::UpdateLrsRequest;

--- a/src/controlplane/src/spu_api.rs
+++ b/src/controlplane/src/spu_api.rs
@@ -6,8 +6,8 @@ use dataplane::api::ApiMessage;
 use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 use dataplane::bytes::Buf;
-use dataplane::derive::Encoder;
-use dataplane::derive::Decoder;
+use fluvio_protocol::Encoder;
+use fluvio_protocol::Decoder;
 
 use super::UpdateSpuRequest;
 use super::UpdateReplicaRequest;

--- a/src/controlplane/src/spu_api.rs
+++ b/src/controlplane/src/spu_api.rs
@@ -1,13 +1,9 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
-use dataplane::api::api_decode;
-use dataplane::api::ApiMessage;
-use dataplane::api::RequestHeader;
-use dataplane::api::RequestMessage;
-use dataplane::bytes::Buf;
-use fluvio_protocol::Encoder;
-use fluvio_protocol::Decoder;
+use bytes::Buf;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::{api_decode, ApiMessage, RequestHeader, RequestMessage};
 
 use super::UpdateSpuRequest;
 use super::UpdateReplicaRequest;

--- a/src/dataplane-protocol/Cargo.toml
+++ b/src/dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 
 use tracing::trace;
 
-use crate::core::bytes::Buf;
-use crate::core::bytes::BufMut;
+use bytes::Buf;
+use bytes::BufMut;
 
 use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::Version;
@@ -267,8 +267,7 @@ mod test {
     use std::io::Cursor;
     use std::io::Error as IoError;
 
-    use crate::core::Decoder;
-    use crate::core::Encoder;
+    use fluvio_protocol::{Encoder, Decoder};
     use crate::record::{Record, RecordData};
     use crate::batch::Batch;
     use super::BatchHeader;

--- a/src/dataplane-protocol/src/batch.rs
+++ b/src/dataplane-protocol/src/batch.rs
@@ -7,9 +7,8 @@ use tracing::trace;
 use crate::core::bytes::Buf;
 use crate::core::bytes::BufMut;
 
-use crate::core::Decoder;
-use crate::core::Encoder;
-use crate::core::Version;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Version;
 
 use crate::Offset;
 use crate::Size;

--- a/src/dataplane-protocol/src/common.rs
+++ b/src/dataplane-protocol/src/common.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use crate::derive::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 pub type Offset = i64;
 pub type Size = u32;

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -2,10 +2,10 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use crate::Isolation;
-use crate::api::Request;
 
 use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::derive::FluvioDefault;
+use fluvio_protocol::api::Request;
 
 use crate::record::RecordSet;
 

--- a/src/dataplane-protocol/src/fetch/request.rs
+++ b/src/dataplane-protocol/src/fetch/request.rs
@@ -4,9 +4,8 @@ use std::marker::PhantomData;
 use crate::Isolation;
 use crate::api::Request;
 
-use crate::core::Decoder;
-use crate::core::Encoder;
-use crate::derive::FluvioDefault;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::derive::FluvioDefault;
 
 use crate::record::RecordSet;
 

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -1,9 +1,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::core::Decoder;
-use crate::core::Encoder;
-use crate::derive::FluvioDefault;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::derive::FluvioDefault;
 
 use crate::record::RecordSet;
 use crate::ErrorCode;

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -139,6 +139,7 @@ pub use file::*;
 
 #[cfg(feature = "file")]
 mod file {
+    use super::*;
 
     use std::io::Error as IoError;
 
@@ -146,11 +147,8 @@ mod file {
     use bytes::BytesMut;
 
     use crate::record::FileRecordSet;
-    use crate::store::FileWrite;
-    use crate::store::StoreValue;
-    use crate::core::Version;
-
-    use super::*;
+    use fluvio_protocol::Version;
+    use fluvio_protocol::store::{FileWrite, StoreValue};
 
     pub type FileFetchResponse = FetchResponse<FileRecordSet>;
     pub type FileTopicResponse = FetchableTopicResponse<FileRecordSet>;

--- a/src/dataplane-protocol/src/lib.rs
+++ b/src/dataplane-protocol/src/lib.rs
@@ -15,11 +15,3 @@ pub mod fixture;
 
 pub use common::*;
 pub use error_code::*;
-
-pub use fluvio_protocol as core;
-pub use fluvio_protocol::api;
-pub use fluvio_protocol::bytes;
-pub use fluvio_protocol::derive;
-
-#[cfg(feature = "file")]
-pub use fluvio_protocol::store;

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::derive::FluvioDefault;
+use fluvio_protocol::api::Request;
 
-use crate::api::Request;
 use crate::record::RecordSet;
 
 use super::ProduceResponse;
@@ -78,17 +78,15 @@ pub use file::*;
 
 #[cfg(feature = "file")]
 mod file {
+    use super::*;
     use std::io::Error as IoError;
 
     use tracing::trace;
     use bytes::BytesMut;
 
-    use crate::core::Version;
     use crate::record::FileRecordSet;
-    use crate::store::FileWrite;
-    use crate::store::StoreValue;
-
-    use super::*;
+    use fluvio_protocol::Version;
+    use fluvio_protocol::store::{FileWrite, StoreValue};
 
     pub type FileProduceRequest = ProduceRequest<FileRecordSet>;
     pub type FileTopicRequest = TopicProduceData<FileRecordSet>;

--- a/src/dataplane-protocol/src/produce/request.rs
+++ b/src/dataplane-protocol/src/produce/request.rs
@@ -1,9 +1,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::core::Encoder;
-use crate::core::Decoder;
-use crate::derive::FluvioDefault;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::derive::FluvioDefault;
 
 use crate::api::Request;
 use crate::record::RecordSet;

--- a/src/dataplane-protocol/src/produce/response.rs
+++ b/src/dataplane-protocol/src/produce/response.rs
@@ -1,6 +1,5 @@
-use crate::core::Encoder;
-use crate::core::Decoder;
-use crate::derive::FluvioDefault;
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::derive::FluvioDefault;
 
 use crate::ErrorCode;
 

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -7,9 +7,7 @@ use std::io::ErrorKind;
 use content_inspector::{inspect, ContentType};
 use tracing::{trace, warn};
 use once_cell::sync::Lazy;
-
-use bytes::Buf;
-use bytes::BufMut;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use fluvio_protocol::{Encoder, Decoder, Version, DecoderVarInt, EncoderVarInt};
 
@@ -489,9 +487,7 @@ mod test {
     use std::io::Cursor;
     use std::io::Error as IoError;
 
-    use crate::core::Decoder;
-    use crate::core::Encoder;
-    use crate::record::Record;
+    use fluvio_protocol::{Encoder, Decoder};
 
     #[test]
     fn test_decode_encode_record() -> Result<(), IoError> {
@@ -618,7 +614,6 @@ mod test {
 
 #[cfg(feature = "file")]
 pub use file::*;
-use crate::bytes::{Bytes, BytesMut};
 
 #[cfg(feature = "file")]
 mod file {
@@ -628,16 +623,13 @@ mod file {
     use std::io::ErrorKind;
 
     use tracing::trace;
+    use bytes::Buf;
     use bytes::BufMut;
     use bytes::BytesMut;
 
     use fluvio_future::file_slice::AsyncFileSlice;
-    use crate::core::bytes::Buf;
-    use crate::core::Decoder;
-    use crate::core::Encoder;
-    use crate::core::Version;
-    use crate::store::FileWrite;
-    use crate::store::StoreValue;
+    use fluvio_protocol::{Encoder, Decoder, Version};
+    use fluvio_protocol::store::{FileWrite, StoreValue};
 
     #[derive(Default, Debug)]
     pub struct FileRecordSet(AsyncFileSlice);

--- a/src/dataplane-protocol/src/record.rs
+++ b/src/dataplane-protocol/src/record.rs
@@ -11,10 +11,7 @@ use once_cell::sync::Lazy;
 use bytes::Buf;
 use bytes::BufMut;
 
-use crate::core::{Encoder, Decoder};
-use crate::core::DecoderVarInt;
-use crate::core::EncoderVarInt;
-use crate::core::Version;
+use fluvio_protocol::{Encoder, Decoder, Version, DecoderVarInt, EncoderVarInt};
 
 use crate::batch::Batch;
 use crate::Offset;

--- a/src/dataplane-protocol/src/versions.rs
+++ b/src/dataplane-protocol/src/versions.rs
@@ -1,9 +1,9 @@
 use std::io::{Error as IoError, ErrorKind};
+use bytes::{BufMut, Buf};
+use fluvio_protocol::api::Request;
 use fluvio_protocol::{Encoder, Decoder, Version};
-use fluvio_protocol::bytes::{BufMut, Buf};
 
 use crate::ErrorCode;
-use crate::api::Request;
 
 pub const VERSIONS_API_KEY: u16 = 18;
 

--- a/src/dataplane-protocol/src/versions.rs
+++ b/src/dataplane-protocol/src/versions.rs
@@ -1,5 +1,5 @@
 use std::io::{Error as IoError, ErrorKind};
-use fluvio_protocol::{Encoder, Version, Decoder};
+use fluvio_protocol::{Encoder, Decoder, Version};
 use fluvio_protocol::bytes::{BufMut, Buf};
 
 use crate::ErrorCode;

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -26,4 +26,4 @@ static_assertions = "1.1.0"
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-controlplane-metadata = { version = "0.9.1", default-features = false, path = "../controlplane-metadata" }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -17,6 +17,7 @@ use_serde = ["fluvio-controlplane-metadata/use_serde", "serde"]
 [dependencies]
 log = "0.4.8"
 tracing = "0.1.19"
+bytes = "1"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
 thiserror = "1.0.20"
 static_assertions = "1.1.0"

--- a/src/sc-schema/src/apis.rs
+++ b/src/sc-schema/src/apis.rs
@@ -4,7 +4,7 @@
 //! Stores Api Keys supported by the SC.
 //!
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(

--- a/src/sc-schema/src/lib.rs
+++ b/src/sc-schema/src/lib.rs
@@ -31,7 +31,7 @@ pub enum ApiError {
 }
 
 mod admin {
-    use dataplane::api::Request;
+    use fluvio_protocol::api::Request;
 
     pub trait AdminRequest: Request {}
 }

--- a/src/sc-schema/src/objects/create.rs
+++ b/src/sc-schema/src/objects/create.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::Request;
+use fluvio_protocol::api::Request;
 
 use crate::Status;
 use crate::AdminPublicApiKey;
@@ -28,18 +28,18 @@ impl AdminRequest for CreateRequest {}
 
 #[allow(clippy::module_inception)]
 mod create {
+    use super::*;
 
     use std::io::Error;
     use std::io::ErrorKind;
 
+    use bytes::{Buf, BufMut};
     use tracing::trace;
 
-    use dataplane::core::Version;
-    use dataplane::bytes::{Buf, BufMut};
+    use fluvio_protocol::Version;
     use fluvio_controlplane_metadata::topic::TopicSpec;
     use fluvio_controlplane_metadata::spu::CustomSpuSpec;
     use fluvio_controlplane_metadata::spg::SpuGroupSpec;
-    use super::*;
 
     const TOPIC: u8 = 0;
     const CUSTOM_SPU: u8 = 1;

--- a/src/sc-schema/src/objects/create.rs
+++ b/src/sc-schema/src/objects/create.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use crate::Status;

--- a/src/sc-schema/src/objects/delete.rs
+++ b/src/sc-schema/src/objects/delete.rs
@@ -6,11 +6,11 @@
 use std::io::Error;
 use std::io::ErrorKind;
 
+use bytes::{Buf, BufMut};
 use tracing::trace;
 
-use dataplane::core::{Encoder, Decoder, Version};
-use dataplane::bytes::{Buf, BufMut};
-use dataplane::api::Request;
+use fluvio_protocol::{Encoder, Decoder, Version};
+use fluvio_protocol::api::Request;
 use fluvio_controlplane_metadata::topic::TopicSpec;
 use fluvio_controlplane_metadata::spu::CustomSpuSpec;
 use fluvio_controlplane_metadata::spu::CustomSpuKey;

--- a/src/sc-schema/src/objects/list.rs
+++ b/src/sc-schema/src/objects/list.rs
@@ -8,7 +8,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::Request;
+use fluvio_protocol::api::Request;
 
 use fluvio_controlplane_metadata::core::*;
 use fluvio_controlplane_metadata::topic::TopicSpec;
@@ -133,18 +133,15 @@ where
 
 // later this can be written using procedure macro
 mod encoding {
+    use super::*;
 
     use std::io::Error;
     use std::io::ErrorKind;
 
+    use bytes::{Buf, BufMut};
     use tracing::trace;
 
-    use dataplane::core::Encoder;
-    use dataplane::core::Decoder;
-    use dataplane::core::Version;
-    use dataplane::bytes::{Buf, BufMut};
-
-    use super::*;
+    use fluvio_protocol::{Encoder, Decoder, Version};
 
     impl ListRequest {
         /// type represent as string

--- a/src/sc-schema/src/objects/list.rs
+++ b/src/sc-schema/src/objects/list.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use fluvio_controlplane_metadata::core::*;

--- a/src/sc-schema/src/objects/watch.rs
+++ b/src/sc-schema/src/objects/watch.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::Request;
+use fluvio_protocol::api::Request;
 
 use fluvio_controlplane_metadata::core::*;
 use fluvio_controlplane_metadata::topic::TopicSpec;
@@ -99,18 +99,15 @@ where
 
 // later this can be written using procedure macro
 mod encoding {
+    use super::*;
 
     use std::io::Error;
     use std::io::ErrorKind;
 
+    use bytes::{Buf, BufMut};
     use tracing::trace;
 
-    use dataplane::core::Encoder;
-    use dataplane::core::Decoder;
-    use dataplane::core::Version;
-    use dataplane::bytes::{Buf, BufMut};
-
-    use super::*;
+    use fluvio_protocol::{Encoder, Decoder, Version};
 
     impl WatchRequest {
         /// type represent as string

--- a/src/sc-schema/src/objects/watch.rs
+++ b/src/sc-schema/src/objects/watch.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::Request;
 
 use fluvio_controlplane_metadata::core::*;

--- a/src/sc-schema/src/request.rs
+++ b/src/sc-schema/src/request.rs
@@ -7,15 +7,15 @@
 use std::convert::{TryInto};
 use std::io::Error as IoError;
 
+use bytes::Buf;
 use tracing::debug;
 
-use dataplane::bytes::Buf;
-use dataplane::api::{ApiMessage};
-use dataplane::api::RequestHeader;
-use dataplane::api::RequestMessage;
-
-use dataplane::api::api_decode;
 use fluvio_protocol::Encoder;
+use fluvio_protocol::api::ApiMessage;
+use fluvio_protocol::api::RequestHeader;
+use fluvio_protocol::api::RequestMessage;
+use fluvio_protocol::api::api_decode;
+
 use dataplane::versions::ApiVersionsRequest;
 
 use super::objects::*;

--- a/src/sc-schema/src/request.rs
+++ b/src/sc-schema/src/request.rs
@@ -15,7 +15,7 @@ use dataplane::api::RequestHeader;
 use dataplane::api::RequestMessage;
 
 use dataplane::api::api_decode;
-use dataplane::core::Encoder;
+use fluvio_protocol::Encoder;
 use dataplane::versions::ApiVersionsRequest;
 
 use super::objects::*;

--- a/src/sc-schema/src/response.rs
+++ b/src/sc-schema/src/response.rs
@@ -5,7 +5,7 @@
 //!
 //! Response sent to client. Sends entity name, error code and error message.
 //!
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::ErrorCode;
 
 use crate::ApiError;

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -55,7 +55,7 @@ k8-metadata-client = { version = "3.0.0" }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
 k8-types = { version = "0.2.5", features = ["app"] }
 fluvio-socket = { path = "../socket", version = "0.8.1" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 

--- a/src/sc/src/services/private_api/private_server.rs
+++ b/src/sc/src/services/private_api/private_server.rs
@@ -13,7 +13,7 @@ use async_channel::Sender;
 use futures_util::stream::Stream;
 
 use fluvio_types::SpuId;
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::RequestMessage;
 use fluvio_controlplane_metadata::spu::store::SpuLocalStorePolicy;
 use fluvio_service::{FlvService, wait_for_request};
 use fluvio_socket::{FluvioSocket, FlvSocketError, FluvioSink};

--- a/src/sc/src/services/public_api/api_version.rs
+++ b/src/sc/src/services/public_api/api_version.rs
@@ -1,7 +1,7 @@
 use std::io::Error;
 use tracing::{trace, instrument};
 
-use dataplane::api::{RequestMessage, ResponseMessage, Request};
+use fluvio_protocol::api::{RequestMessage, ResponseMessage, Request};
 use dataplane::versions::{ApiVersionKey, ApiVersionsRequest, ApiVersionsResponse, PlatformVersion};
 use fluvio_sc_schema::objects::*;
 use fluvio_sc_schema::AdminPublicApiKey;

--- a/src/sc/src/services/public_api/create.rs
+++ b/src/sc/src/services/public_api/create.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 
 use tracing::instrument;
 
-use dataplane::api::{RequestMessage, ResponseMessage};
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::Status;
 use fluvio_sc_schema::objects::{CreateRequest, AllCreatableSpec};
 use fluvio_auth::AuthContext;

--- a/src/sc/src/services/public_api/delete.rs
+++ b/src/sc/src/services/public_api/delete.rs
@@ -7,7 +7,7 @@
 use tracing::{trace, instrument};
 use std::io::Error;
 
-use dataplane::api::{RequestMessage, ResponseMessage};
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::Status;
 use fluvio_sc_schema::objects::{DeleteRequest};
 use fluvio_auth::{AuthContext};

--- a/src/sc/src/services/public_api/list.rs
+++ b/src/sc/src/services/public_api/list.rs
@@ -1,7 +1,7 @@
 use std::io::Error;
 use tracing::{debug, instrument};
 
-use dataplane::api::{RequestMessage, ResponseMessage};
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::objects::{ListRequest, ListResponse};
 use fluvio_auth::{AuthContext};
 

--- a/src/sc/src/services/public_api/watch.rs
+++ b/src/sc/src/services/public_api/watch.rs
@@ -5,8 +5,8 @@ use tracing::{debug, trace, error, instrument};
 
 use fluvio_types::event::SimpleEvent;
 use fluvio_socket::ExclusiveFlvSink;
-use dataplane::core::{Encoder, Decoder};
-use dataplane::api::{RequestMessage, RequestHeader, ResponseMessage};
+use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::{RequestMessage, RequestHeader, ResponseMessage};
 use fluvio_sc_schema::objects::{WatchRequest, WatchResponse, Metadata, MetadataUpdate};
 
 use fluvio_controlplane_metadata::core::Spec;

--- a/src/smartstream/Cargo.toml
+++ b/src/smartstream/Cargo.toml
@@ -17,5 +17,6 @@ derive = ["fluvio-smartstream-derive"]
 crate-type = ['lib']
 
 [dependencies]
+fluvio-protocol = { version = "0.6", path = "../protocol" }
 fluvio-dataplane-protocol = { version = "0.6", path = "../dataplane-protocol", default-features = false }
 fluvio-smartstream-derive = { version = "0.1.1", path = "./derive", optional = true }

--- a/src/smartstream/Cargo.toml
+++ b/src/smartstream/Cargo.toml
@@ -17,5 +17,5 @@ derive = ["fluvio-smartstream-derive"]
 crate-type = ['lib']
 
 [dependencies]
-fluvio-dataplane-protocol = { version = "0.5.2", path = "../dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.6", path = "../dataplane-protocol", default-features = false }
 fluvio-smartstream-derive = { version = "0.1.1", path = "./derive", optional = true }

--- a/src/smartstream/derive/src/generator.rs
+++ b/src/smartstream/derive/src/generator.rs
@@ -37,7 +37,7 @@ fn generate_decoding() -> TokenStream {
 
         let input_data = Vec::from_raw_parts(ptr, len, len);
         let mut records: Vec<fluvio_smartstream::dataplane::record::Record> = vec![];
-        if let Err(_err) = fluvio_smartstream::dataplane::core::Decoder::decode(&mut records, &mut std::io::Cursor::new(input_data), 0) {
+        if let Err(_err) = fluvio_smartstream::protocol::Decoder::decode(&mut records, &mut std::io::Cursor::new(input_data), 0) {
             return -1;
         };
     }
@@ -69,7 +69,7 @@ fn generate_map(func: &SmartStreamFn) -> TokenStream {
 fn generate_encoding() -> TokenStream {
     quote! {
         let mut out = vec![];
-        if let Err(_) = fluvio_smartstream::dataplane::core::Encoder::encode(&mut processed, &mut out, 0) {
+        if let Err(_) = fluvio_smartstream::protocol::Encoder::encode(&mut processed, &mut out, 0) {
             return -1;
         }
 

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -146,6 +146,7 @@ name = "fluvio-smartstream"
 version = "0.1.1"
 dependencies = [
  "fluvio-dataplane-protocol",
+ "fluvio-protocol",
  "fluvio-smartstream-derive",
 ]
 

--- a/src/smartstream/examples/Cargo.lock
+++ b/src/smartstream/examples/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/src/smartstream/src/lib.rs
+++ b/src/smartstream/src/lib.rs
@@ -1,3 +1,4 @@
+pub use fluvio_protocol as protocol;
 pub use fluvio_dataplane_protocol as dataplane;
 pub use dataplane::record::{Record, RecordData};
 

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -23,4 +23,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/src/spu-schema/src/client/api.rs
+++ b/src/spu-schema/src/client/api.rs
@@ -5,14 +5,9 @@ use tracing::trace;
 use std::convert::TryInto;
 use std::io::Error as IoError;
 
-use dataplane::bytes::Buf;
+use bytes::Buf;
 use fluvio_protocol::Encoder;
-
-use dataplane::api::RequestMessage;
-
-use dataplane::api::api_decode;
-use dataplane::api::RequestHeader;
-use dataplane::api::ApiMessage;
+use fluvio_protocol::api::{RequestMessage, RequestHeader, ApiMessage, api_decode};
 
 use super::SpuClientApiKey;
 use super::offset::ReplicaOffsetUpdateRequest;

--- a/src/spu-schema/src/client/api.rs
+++ b/src/spu-schema/src/client/api.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
-use dataplane::core::Encoder;
+use fluvio_protocol::Encoder;
 
 use dataplane::api::RequestMessage;
 

--- a/src/spu-schema/src/client/api_key.rs
+++ b/src/spu-schema/src/client/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 /// Api Key for Spu Client API (from server to client)
 #[repr(u16)]

--- a/src/spu-schema/src/client/offset.rs
+++ b/src/spu-schema/src/client/offset.rs
@@ -1,5 +1,5 @@
-use dataplane::api::Request;
 use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use dataplane::ReplicaKey;
 use dataplane::Offset;
 use dataplane::ErrorCode;

--- a/src/spu-schema/src/client/offset.rs
+++ b/src/spu-schema/src/client/offset.rs
@@ -1,5 +1,5 @@
 use dataplane::api::Request;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::ReplicaKey;
 use dataplane::Offset;
 use dataplane::ErrorCode;

--- a/src/spu-schema/src/server/api.rs
+++ b/src/spu-schema/src/server/api.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::io::Error as IoError;
 
 use dataplane::bytes::Buf;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::ApiMessage;
 use dataplane::api::api_decode;
 use dataplane::api::RequestHeader;

--- a/src/spu-schema/src/server/api.rs
+++ b/src/spu-schema/src/server/api.rs
@@ -5,15 +5,11 @@ use tracing::trace;
 use std::convert::TryInto;
 use std::io::Error as IoError;
 
-use dataplane::bytes::Buf;
+use bytes::Buf;
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::ApiMessage;
-use dataplane::api::api_decode;
-use dataplane::api::RequestHeader;
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::{ApiMessage, RequestHeader, RequestMessage, api_decode};
 
 use dataplane::produce::DefaultProduceRequest;
-
 use dataplane::fetch::FileFetchRequest;
 
 use crate::ApiVersionsRequest;

--- a/src/spu-schema/src/server/api_key.rs
+++ b/src/spu-schema/src/server/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::core::{Decoder, Encoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 // Make sure that the ApiVersion variant matches dataplane's API_VERSIONS_KEY
 static_assertions::const_assert_eq!(

--- a/src/spu-schema/src/server/fetch_offset.rs
+++ b/src/spu-schema/src/server/fetch_offset.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 use dataplane::api::Request;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::PartitionOffset;
 use dataplane::ReplicaKey;
 

--- a/src/spu-schema/src/server/fetch_offset.rs
+++ b/src/spu-schema/src/server/fetch_offset.rs
@@ -4,8 +4,8 @@
 //! API that allows CLI to fetch topic offsets.
 use std::fmt;
 
-use dataplane::api::Request;
 use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use dataplane::PartitionOffset;
 use dataplane::ReplicaKey;
 

--- a/src/spu-schema/src/server/stream_fetch.rs
+++ b/src/spu-schema/src/server/stream_fetch.rs
@@ -6,8 +6,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use dataplane::api::Request;
 use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
 use dataplane::Isolation;
@@ -68,10 +68,9 @@ mod file {
     use log::trace;
     use bytes::BytesMut;
 
-    use dataplane::core::Version;
-    use dataplane::store::StoreValue;
+    use fluvio_protocol::Version;
+    use fluvio_protocol::store::{FileWrite, StoreValue};
     use dataplane::record::FileRecordSet;
-    use dataplane::store::FileWrite;
 
     pub type FileStreamFetchRequest = StreamFetchRequest<FileRecordSet>;
 

--- a/src/spu-schema/src/server/stream_fetch.rs
+++ b/src/spu-schema/src/server/stream_fetch.rs
@@ -6,8 +6,8 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use dataplane::core::{Encoder, Decoder};
 use dataplane::api::Request;
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
 use dataplane::Isolation;

--- a/src/spu-schema/src/server/update_offset.rs
+++ b/src/spu-schema/src/server/update_offset.rs
@@ -2,8 +2,8 @@
 //! # Update Offsets
 //!
 
-use dataplane::api::Request;
 use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::api::Request;
 use dataplane::Offset;
 
 use crate::errors::ErrorCode;

--- a/src/spu-schema/src/server/update_offset.rs
+++ b/src/spu-schema/src/server/update_offset.rs
@@ -3,7 +3,7 @@
 //!
 
 use dataplane::api::Request;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::Offset;
 
 use crate::errors::ErrorCode;

--- a/src/spu/Cargo.toml
+++ b/src/spu/Cargo.toml
@@ -50,7 +50,7 @@ fluvio-controlplane-metadata = { version = "0.9.1", path = "../controlplane-meta
 fluvio-spu-schema = { version = "0.6.0", path = "../spu-schema", features = ["file"]}
 fluvio-protocol = { path = "../protocol", version = "0.6" }
 fluvio-socket = { path = "../socket", version = "0.8.1", features = ["file"] }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
 fluvio-service = { path = "../service", version = "0.6.0" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }
@@ -60,5 +60,5 @@ fluvio-future = { version = "0.3.1", features = ["subscriber", "openssl_tls", "z
 once_cell = "1.5.2"
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-future = { version = "0.3.1", features = ["fixture", "subscriber"] }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
 derive_builder = { version = "0.9.0" }

--- a/src/spu/src/control_plane/dispatcher.rs
+++ b/src/spu/src/control_plane/dispatcher.rs
@@ -18,7 +18,7 @@ use fluvio_controlplane::RegisterSpuRequest;
 use fluvio_controlplane::{UpdateSpuRequest, UpdateLrsRequest};
 use fluvio_controlplane::UpdateReplicaRequest;
 use fluvio_controlplane_metadata::partition::Replica;
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::RequestMessage;
 use fluvio_socket::{FluvioSocket, FlvSocketError, FluvioSink};
 use fluvio_storage::FileReplica;
 use flv_util::actions::Actions;

--- a/src/spu/src/core/store.rs
+++ b/src/spu/src/core/store.rs
@@ -12,7 +12,7 @@ use tracing::error;
 use tracing::instrument;
 
 use fluvio_controlplane_metadata::message::*;
-use dataplane::core::{Decoder, Encoder};
+use fluvio_protocol::{Decoder, Encoder};
 
 use flv_util::actions::Actions;
 use flv_util::SimpleConcurrentBTreeMap;

--- a/src/spu/src/replication/follower/api_key.rs
+++ b/src/spu/src/replication/follower/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 #[repr(u16)]
 #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]

--- a/src/spu/src/replication/follower/group.rs
+++ b/src/spu/src/replication/follower/group.rs
@@ -83,7 +83,8 @@ mod controller {
     use fluvio_socket::FluvioSocket;
     use fluvio_socket::FluvioSink;
     use fluvio_socket::FlvSocketError;
-    use dataplane::{ReplicaKey, api::RequestMessage};
+    use fluvio_protocol::api::RequestMessage;
+    use dataplane::ReplicaKey;
     use fluvio_types::{SpuId};
     use fluvio_storage::FileReplica;
     use fluvio_controlplane_metadata::spu::SpuSpec;

--- a/src/spu/src/replication/follower/peer_api.rs
+++ b/src/spu/src/replication/follower/peer_api.rs
@@ -1,12 +1,11 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
+use bytes::Buf;
 use tracing::trace;
 
-use dataplane::bytes::Buf;
 use fluvio_protocol::{Encoder, Decoder};
-
-use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
+use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::FollowerPeerApiEnum;
 use super::sync::DefaultSyncRequest;

--- a/src/spu/src/replication/follower/peer_api.rs
+++ b/src/spu/src/replication/follower/peer_api.rs
@@ -4,7 +4,8 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
+
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::FollowerPeerApiEnum;

--- a/src/spu/src/replication/follower/sync.rs
+++ b/src/spu/src/replication/follower/sync.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use bytes::BytesMut;
 use tracing::trace;
 
-use dataplane::core::{Encoder, Decoder, Version};
+use fluvio_protocol::{Decoder, Encoder, Version};
 use dataplane::record::{RecordSet, FileRecordSet};
 use dataplane::api::Request;
 use dataplane::ErrorCode;

--- a/src/spu/src/replication/follower/sync.rs
+++ b/src/spu/src/replication/follower/sync.rs
@@ -9,12 +9,11 @@ use std::marker::PhantomData;
 use bytes::BytesMut;
 use tracing::trace;
 
-use fluvio_protocol::{Decoder, Encoder, Version};
-use dataplane::record::{RecordSet, FileRecordSet};
-use dataplane::api::Request;
 use dataplane::ErrorCode;
-use dataplane::store::StoreValue;
-use dataplane::store::FileWrite;
+use dataplane::record::{RecordSet, FileRecordSet};
+use fluvio_protocol::{Decoder, Encoder, Version};
+use fluvio_protocol::api::Request;
+use fluvio_protocol::store::{StoreValue, FileWrite};
 use fluvio_storage::SlicePartitionResponse;
 use fluvio_future::file_slice::AsyncFileSlice;
 

--- a/src/spu/src/replication/leader/api_key.rs
+++ b/src/spu/src/replication/leader/api_key.rs
@@ -1,4 +1,4 @@
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 
 #[repr(u16)]
 #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]

--- a/src/spu/src/replication/leader/connection.rs
+++ b/src/spu/src/replication/leader/connection.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 
 use fluvio_storage::OffsetInfo;
 use fluvio_socket::{FluvioSink, FlvSocketError, FluvioStream};
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::RequestMessage;
 use fluvio_types::SpuId;
 
 use crate::{

--- a/src/spu/src/replication/leader/peer_api.rs
+++ b/src/spu/src/replication/leader/peer_api.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::LeaderPeerApiEnum;

--- a/src/spu/src/replication/leader/peer_api.rs
+++ b/src/spu/src/replication/leader/peer_api.rs
@@ -1,11 +1,11 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
+use bytes::Buf;
 use tracing::trace;
 
-use dataplane::bytes::Buf;
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
+use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::LeaderPeerApiEnum;
 use super::UpdateOffsetRequest;

--- a/src/spu/src/replication/leader/update_offsets.rs
+++ b/src/spu/src/replication/leader/update_offsets.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::api::Request;
 use dataplane::Offset;
 use fluvio_controlplane_metadata::partition::ReplicaKey;

--- a/src/spu/src/replication/leader/update_offsets.rs
+++ b/src/spu/src/replication/leader/update_offsets.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::assign_op_pattern)]
 
 use fluvio_protocol::{Encoder, Decoder};
-use dataplane::api::Request;
+use fluvio_protocol::api::Request;
 use dataplane::Offset;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 

--- a/src/spu/src/services/internal/api.rs
+++ b/src/spu/src/services/internal/api.rs
@@ -4,7 +4,8 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use dataplane::bytes::Buf;
-use dataplane::core::{Encoder, Decoder};
+use fluvio_protocol::{Encoder, Decoder};
+
 use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::fetch_stream_request::FetchStreamRequest;

--- a/src/spu/src/services/internal/api.rs
+++ b/src/spu/src/services/internal/api.rs
@@ -1,12 +1,11 @@
 use std::io::Error as IoError;
 use std::convert::TryInto;
 
+use bytes::Buf;
 use tracing::trace;
 
-use dataplane::bytes::Buf;
 use fluvio_protocol::{Encoder, Decoder};
-
-use dataplane::api::{RequestMessage, ApiMessage, RequestHeader};
+use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::fetch_stream_request::FetchStreamRequest;
 

--- a/src/spu/src/services/internal/fetch_stream_request.rs
+++ b/src/spu/src/services/internal/fetch_stream_request.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use dataplane::api::Request;
+use fluvio_protocol::api::Request;
 use fluvio_protocol::{Decoder, Encoder};
 use fluvio_types::SpuId;
 

--- a/src/spu/src/services/internal/fetch_stream_request.rs
+++ b/src/spu/src/services/internal/fetch_stream_request.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::assign_op_pattern)]
 
 use dataplane::api::Request;
-use dataplane::derive::{Decoder, Encoder};
+use fluvio_protocol::{Decoder, Encoder};
 use fluvio_types::SpuId;
 
 use super::SPUPeerApiEnum;

--- a/src/spu/src/services/public/api_versions.rs
+++ b/src/spu/src/services/public/api_versions.rs
@@ -1,10 +1,10 @@
 use std::io::Error;
 use tracing::{debug, instrument};
 
-use dataplane::api::{RequestMessage, ResponseMessage, Request};
 use dataplane::produce::DefaultProduceRequest;
 use dataplane::fetch::DefaultFetchRequest;
 use dataplane::versions::ApiVersionKey;
+use fluvio_protocol::api::{RequestMessage, ResponseMessage, Request};
 use fluvio_spu_schema::server::SpuServerApiKey;
 use fluvio_spu_schema::server::fetch_offset::FetchOffsetsRequest;
 use fluvio_spu_schema::server::stream_fetch::DefaultStreamFetchRequest;

--- a/src/spu/src/services/public/fetch_handler.rs
+++ b/src/spu/src/services/public/fetch_handler.rs
@@ -2,7 +2,8 @@ use tracing::{debug, trace, instrument};
 
 use fluvio_socket::ExclusiveFlvSink;
 use fluvio_socket::FlvSocketError;
-use dataplane::{ErrorCode, api::RequestMessage};
+use fluvio_protocol::api::RequestMessage;
+use dataplane::ErrorCode;
 use dataplane::fetch::{FileFetchResponse, FileFetchRequest, FilePartitionResponse, FileTopicResponse};
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 

--- a/src/spu/src/services/public/offset_request.rs
+++ b/src/spu/src/services/public/offset_request.rs
@@ -2,7 +2,7 @@ use std::io::Error as IoError;
 
 use tracing::{trace, instrument};
 
-use dataplane::api::{RequestMessage, ResponseMessage};
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_spu_schema::server::fetch_offset::FetchOffsetsRequest;
 use fluvio_spu_schema::server::fetch_offset::FetchOffsetTopicResponse;
 use fluvio_spu_schema::server::fetch_offset::FetchOffsetsResponse;

--- a/src/spu/src/services/public/produce_handler.rs
+++ b/src/spu/src/services/public/produce_handler.rs
@@ -8,8 +8,7 @@ use dataplane::ErrorCode;
 use dataplane::produce::{
     DefaultProduceRequest, ProduceResponse, TopicProduceResponse, PartitionProduceResponse,
 };
-use dataplane::api::RequestMessage;
-use dataplane::api::ResponseMessage;
+use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
 use crate::core::DefaultSharedGlobalContext;

--- a/src/spu/src/services/public/service_impl.rs
+++ b/src/spu/src/services/public/service_impl.rs
@@ -10,7 +10,8 @@ use fluvio_socket::FluvioSocket;
 use fluvio_socket::FlvSocketError;
 use fluvio_service::{call_service, FlvService};
 use fluvio_spu_schema::server::{SpuServerApiKey, SpuServerRequest};
-use dataplane::{ErrorCode, api::RequestMessage};
+use fluvio_protocol::api::RequestMessage;
+use dataplane::ErrorCode;
 
 use crate::core::DefaultSharedGlobalContext;
 use super::api_versions::handle_kf_lookup_version_request;
@@ -134,7 +135,7 @@ mod offset {
     use fluvio_spu_schema::server::update_offset::{
         OffsetUpdateStatus, UpdateOffsetsRequest, UpdateOffsetsResponse,
     };
-    use dataplane::api::ResponseMessage;
+    use fluvio_protocol::api::ResponseMessage;
 
     use super::{DefaultSharedGlobalContext, RequestMessage, ErrorCode};
 

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -9,12 +9,8 @@ use tokio::select;
 use fluvio_types::event::{SimpleEvent, offsets::OffsetPublisher};
 use fluvio_future::task::spawn;
 use fluvio_socket::{ExclusiveFlvSink, FlvSocketError};
-use dataplane::{
-    ErrorCode,
-    api::{RequestMessage, RequestHeader},
-    fetch::FetchablePartitionResponse,
-    record::RecordSet,
-};
+use fluvio_protocol::api::{RequestMessage, RequestHeader};
+use dataplane::{ErrorCode, fetch::FetchablePartitionResponse, record::RecordSet};
 use dataplane::{Offset, Isolation, ReplicaKey};
 use dataplane::fetch::FilePartitionResponse;
 use fluvio_spu_schema::server::stream_fetch::{

--- a/src/spu/src/smart_stream/filter.rs
+++ b/src/spu/src/smart_stream/filter.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, Error, anyhow};
 use tracing::debug;
 use wasmtime::{Caller, Extern, Func, Instance, Trap, TypedFunc, Store};
 
-use dataplane::core::{Decoder, Encoder};
+use fluvio_protocol::{Encoder, Decoder};
 use dataplane::batch::Batch;
 use dataplane::batch::MemoryRecords;
 use crate::smart_stream::{RecordsCallBack, RecordsMemory, SmartStreamModule, SmartStreamEngine};

--- a/src/spu/src/storage/mod.rs
+++ b/src/spu/src/storage/mod.rs
@@ -7,8 +7,8 @@ use async_rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use fluvio_controlplane_metadata::partition::{ReplicaKey};
 use dataplane::{Isolation, record::RecordSet};
-use dataplane::core::Encoder;
-use dataplane::{Offset};
+use fluvio_protocol::Encoder;
+use dataplane::Offset;
 use fluvio_storage::{ReplicaStorage, SlicePartitionResponse, StorageError, OffsetInfo};
 use fluvio_types::{event::offsets::OffsetChangeListener};
 use fluvio_types::event::offsets::OffsetPublisher;

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -35,11 +35,11 @@ derive_builder = "0.10.2"
 fluvio-types = { version = "0.2.0", path = "../types" }
 fluvio-future = { version = "0.3.2", features = ["fs", "mmap","zero_copy"] }
 fluvio-protocol = { path = "../protocol", version = "0.6" }
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-socket = { path = "../socket", version = "0.8.1",features = ["file"] }
 fluvio-storage = { path = ".", features = ["fixture"]}
-dataplane = { version = "0.5.1", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.6", path = "../dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }

--- a/src/storage/src/batch_header.rs
+++ b/src/storage/src/batch_header.rs
@@ -1,8 +1,7 @@
 use std::io::Error as IoError;
 
-use dataplane::core::{Version, Decoder, Encoder};
-use dataplane::bytes::Buf;
-use dataplane::bytes::BufMut;
+use bytes::{Buf, BufMut};
+use fluvio_protocol::{Version, Decoder, Encoder};
 use dataplane::batch::BatchRecords;
 
 use crate::batch::FileBatchStream;

--- a/src/storage/src/mut_records.rs
+++ b/src/storage/src/mut_records.rs
@@ -21,7 +21,7 @@ use fluvio_future::fs::BoundedFileOption;
 use fluvio_future::fs::BoundedFileSinkError;
 use dataplane::batch::Batch;
 use dataplane::{Offset, Size};
-use dataplane::core::Encoder;
+use fluvio_protocol::Encoder;
 
 use crate::util::generate_file_name;
 use crate::validator::validate;
@@ -372,7 +372,7 @@ mod tests {
     use fluvio_future::test_async;
     use flv_util::fixture::ensure_clean_file;
     use dataplane::batch::{Batch, MemoryRecords};
-    use dataplane::core::{Decoder, Encoder};
+    use fluvio_protocol::{Decoder, Encoder};
     use dataplane::fixture::create_batch;
     use dataplane::fixture::read_bytes_from_file;
 

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -396,7 +396,7 @@ mod tests {
     use fluvio_future::test_async;
     use dataplane::{Isolation, batch::Batch};
     use dataplane::{Offset, ErrorCode};
-    use dataplane::core::{Decoder, Encoder};
+    use fluvio_protocol::{Decoder, Encoder};
     use dataplane::fetch::FilePartitionResponse;
     use dataplane::record::RecordSet;
     use dataplane::batch::MemoryRecords;

--- a/src/storage/src/segment.rs
+++ b/src/storage/src/segment.rs
@@ -382,7 +382,7 @@ mod tests {
     use flv_util::fixture::ensure_new_dir;
     use dataplane::batch::{Batch, MemoryRecords};
     use dataplane::Size;
-    use dataplane::core::Decoder;
+    use fluvio_protocol::Decoder;
     use dataplane::fixture::create_batch_with_producer;
     use dataplane::fixture::create_batch;
     use dataplane::fixture::read_bytes_from_file;

--- a/src/storage/tests/replica_test.rs
+++ b/src/storage/tests/replica_test.rs
@@ -18,7 +18,7 @@ use dataplane::{
     },
     record::RecordSet,
 };
-use dataplane::api::RequestMessage;
+use fluvio_protocol::api::RequestMessage;
 use dataplane::record::Record;
 use dataplane::Offset;
 use dataplane::fixture::BatchProducer;


### PR DESCRIPTION
One of the things that confused me about the codebase for a really long time is the fact that `fluvio-dataplane-protocol` re-exports some items from `fluivo_protocol`, so all around the codebase I would see mixed instances of `use dataplane::derive::Encode` versus `use fluvio_protocol::Encode` and such, causing confusion about where these items actually lived and whether they were even the same.

I think that re-exports are useful at the top-level of a multi-crate project where third-party users are expected to use our code (i.e. the client crate), but I think that it makes more sense for internal code to directly import items from the original crate.

In this PR, I removed the re-exports of `fluvio_protocol` items from `fluvio-dataplane-protocol` and changed all of the `use dataplane` instances of these items to `use fluvio_protocol`. I wanted to do this now, since we are doing major bumps in preparation for `0.9.0` and this is a breaking change.