### PR TITLE
[Merged by Bors] - Fix derive(Encoder) bug for enums with Unit and Data variants

### DIFF
--- a/src/protocol/fluvio-protocol-derive/src/ser.rs
+++ b/src/protocol/fluvio-protocol-derive/src/ser.rs
@@ -274,7 +274,15 @@ fn parse_enum_variants_size(
                 };
                 variant_expr.push(arm);
             }
-            _ => (),
+            FieldKind::Unit => {
+                let arm = quote! {
+                    #enum_ident::#id => {
+                        std::mem::size_of::<#int_type>()
+                    }
+                };
+
+                variant_expr.push(arm);
+            }
         }
     }
 

--- a/src/protocol/tests/enum.rs
+++ b/src/protocol/tests/enum.rs
@@ -73,6 +73,12 @@ impl Decoder for Mix {
 }
 
 #[derive(Encoder, Debug)]
+pub enum UnitAndDataEnum {
+    UnitVariant,
+    DataVariant(i16),
+}
+
+#[derive(Encoder, Debug)]
 pub enum VariantEnum {
     A(u16),
     C(String),


### PR DESCRIPTION
It turns out that Unit variant enums were not having their `write_size` implementation generated properly. This fixes it by generating write_size arms that report the tag size for Unit variants.

Since we have not yet published fluvio-protocol:0.6.0 I have not bumped the crate version.