### PR TITLE
[Merged by Bors] - Add apply to stream dispatcher store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add windows build of cli and client. ([#1218](https://github.com/infinyon/fluvio/pull/1218))
 * Improve `#[derive(Encoder, Decoder)]` to work with data enums. ([#1232](https://github.com/infinyon/fluvio/pull/1232))
 * Fix Replication bug in K8 ([#1290](https://github.com/infinyon/fluvio/pull/1290))
+* Add apply method to `StoreContext`. ([#1289](https://github.com/infinyon/fluvio/pull/1289))
 
 ## Platform Version 0.8.5 - 2021-07-14
 * Add unstable Admin Watch API for topics, partitions, and SPUs ([#1136](https://github.com/infinyon/fluvio/pull/1136))

--- a/src/stream-dispatcher/Cargo.toml
+++ b/src/stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2018"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"

--- a/src/stream-dispatcher/src/store/mod.rs
+++ b/src/stream-dispatcher/src/store/mod.rs
@@ -99,6 +99,20 @@ mod context {
     where
         S: Spec + PartialEq,
     {
+        /// Wait for the termination of the apply action object, this is similar to ```kubectl apply```
+        pub async fn apply(
+            &self,
+            input: MetadataStoreObject<S, K8MetaItem>,
+        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+        where
+            S::IndexKey: Display,
+        {
+            let key: S::IndexKey = input.key_owned();
+            debug!("{}: applying: {}", S::LABEL, key);
+
+            self.wait_action(&key, WSAction::Apply(input)).await
+        }
+
         /// Wait for creation/update of spec.  There is no guarantee that this spec has been applied.
         /// Only that spec has been changed.
         ///


### PR DESCRIPTION
Currently we can create Kubernetes objects in a StoreContext with create_spec, but we cannot define in that function custom metadata for the object. For instance OwnerReference

Fixes #1294 