### PR TITLE
[Merged by Bors] - Update install.sh to use new tagging system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,7 @@ jobs:
         continue-on-error: true
         run: |
           ${HOME}/.fluvio/bin/fluvio package bump dynamic "${{ env.VERSION }}"
+          ${HOME}/.fluvio/bin/fluvio package tag "fluvio:${{ env.VERSION }}" --tag=stable
 
       - uses: actions/checkout@v2
 

--- a/makefiles/S3.toml
+++ b/makefiles/S3.toml
@@ -98,9 +98,13 @@ dependencies = ["install-fluvio-package"]
 script = """
 ${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
     bump dynamic $(cat VERSION)
-
 ${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
     bump latest $(cat VERSION)
+
+${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
+    tag "fluvio:$(cat VERSION)" --tag=stable --force
+${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
+    tag "fluvio:$(cat VERSION)" --tag=latest --force
 """
 
 # Bumps the `latest` version tag on packages.fluvio.io
@@ -109,9 +113,9 @@ ${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
 [tasks.bump-fluvio-latest]
 dependencies = ["install-fluvio-package"]
 script = """
-${HOME}/.fluvio/extensions/fluvio-package \
-    ${FLUVIO_PUBLISH_TEST} \
-    bump \
-    latest \
-    "$(cat VERSION)+$(git rev-parse HEAD)"
+${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
+    bump latest "$(cat VERSION)+$(git rev-parse HEAD)"
+
+${HOME}/.fluvio/extensions/fluvio-package ${FLUVIO_PUBLISH_TEST} \
+    tag "fluvio:$(cat VERSION)+$(git rev-parse HEAD)" --tag=latest --force
 """


### PR DESCRIPTION
Part of #1269 

This is a followup to infinyon/fluvio-packages#32 with the new tagging system that will allow us to use arbitrary targets in the package manager/install script

This install script may be used in the following ways and will work as expected:

```
$ ./install.sh # Installs stable fluvio
$ VERSION=stable ./install.sh # Installs stable fluvio
$ VERSION=latest ./install.sh # Installs latest fluvio
$ VERSION=0.8.4 ./install.sh # Installs fluvio v0.8.4
```

To test out this PR specifically, you can use the following commands:

```
$ curl -fsS https://raw.githubusercontent.com/nicholastmosher/fluvio/install-v2/install.sh | bash
$ curl -fsS https://raw.githubusercontent.com/nicholastmosher/fluvio/install-v2/install.sh | VERSION=stable bash
$ curl -fsS https://raw.githubusercontent.com/nicholastmosher/fluvio/install-v2/install.sh | VERSION=latest bash
$ curl -fsS https://raw.githubusercontent.com/nicholastmosher/fluvio/install-v2/install.sh | VERSION=0.8.4 bash
```