### PR TITLE
[Merged by Bors] - Update ConsumerConfig to use derive_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "base64",
  "bytes",
  "cfg-if 1.0.0",
+ "derive_builder 0.10.2",
  "dirs 3.0.2",
  "event-listener",
  "fluvio-dataplane-protocol",

--- a/src/cli/src/consumer/consume/mod.rs
+++ b/src/cli/src/consumer/consume/mod.rs
@@ -107,20 +107,18 @@ impl ConsumeOpt {
         self.init_ctrlc()?;
         let offset = self.calculate_offset()?;
 
-        let mut consume_config = {
-            let mut config = ConsumerConfig::default();
-            if let Some(max_bytes) = self.max_bytes {
-                config = config.with_max_bytes(max_bytes);
-            }
-            config
-        };
+        let mut builder = ConsumerConfig::builder();
+        if let Some(max_bytes) = self.max_bytes {
+            builder.max_bytes(max_bytes);
+        }
 
         if let Some(filter_path) = &self.smart_stream {
             let buffer = std::fs::read(filter_path)?;
             debug!(len = buffer.len(), "read filter bytes");
-            consume_config = consume_config.with_wasm_filter(buffer);
+            builder.wasm_filter(buffer);
         }
 
+        let consume_config = builder.build()?;
         if self.disable_continuous {
             self.consume_records_batch(&consumer, offset, consume_config)
                 .await?;

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -37,6 +37,7 @@ semver = "1.0.0"
 pin-project-lite = "0.2"
 siphasher = "0.3.5"
 cfg-if = "1.0.0"
+derive_builder = "0.10"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.5", features = ["task", "openssl_tls", "task_unstable"] }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -22,6 +22,7 @@ use fluvio_types::event::offsets::OffsetPublisher;
 use crate::FluvioError;
 use crate::offset::Offset;
 use crate::spu::SpuPool;
+use derive_builder::Builder;
 
 /// An interface for consuming events from a particular partition
 ///
@@ -109,9 +110,8 @@ impl PartitionConsumer {
         &self,
         offset: Offset,
     ) -> Result<FetchablePartitionResponse<RecordSet>, FluvioError> {
-        let records = self
-            .fetch_with_config(offset, ConsumerConfig::default())
-            .await?;
+        let config = ConsumerConfig::builder().build()?;
+        let records = self.fetch_with_config(offset, config).await?;
         Ok(records)
     }
 
@@ -133,8 +133,9 @@ impl PartitionConsumer {
     /// # use fluvio::{PartitionConsumer, FluvioError, Offset, ConsumerConfig};
     /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
     /// // Use custom fetching configurations
-    /// let fetch_config = ConsumerConfig::default()
-    ///     .with_max_bytes(1000);
+    /// let fetch_config = ConsumerConfig::builder()
+    ///     .max_bytes(1000)
+    ///     .build()?;
     ///
     /// let response = consumer.fetch_with_config(Offset::beginning(), fetch_config).await?;
     /// for batch in response.records.batches {
@@ -247,9 +248,8 @@ impl PartitionConsumer {
         &self,
         offset: Offset,
     ) -> Result<impl Stream<Item = Result<Record, FluvioError>>, FluvioError> {
-        let stream = self
-            .stream_with_config(offset, ConsumerConfig::default())
-            .await?;
+        let config = ConsumerConfig::builder().build()?;
+        let stream = self.stream_with_config(offset, config).await?;
 
         Ok(stream)
     }
@@ -277,8 +277,9 @@ impl PartitionConsumer {
     /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
     /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
-    /// let fetch_config = ConsumerConfig::default()
-    ///     .with_max_bytes(1000);
+    /// let fetch_config = ConsumerConfig::builder()
+    ///     .max_bytes(1000)
+    ///     .build()?;
     /// let mut stream = consumer.stream_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Some(Ok(record)) = stream.next().await {
     ///     let key: Option<String> = record.key().map(|key| String::from_utf8_lossy(key).to_string());
@@ -329,8 +330,9 @@ impl PartitionConsumer {
     /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
     /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
-    /// let fetch_config = ConsumerConfig::default()
-    ///     .with_max_bytes(1000);
+    /// let fetch_config = ConsumerConfig::builder()
+    ///     .max_bytes(1000)
+    ///     .build()?;
     /// let mut stream = consumer.stream_batches_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Some(Ok(batch)) = stream.next().await {
     ///     for record in batch.records() {
@@ -410,9 +412,9 @@ impl PartitionConsumer {
             .lookup_version(DefaultStreamFetchRequest::API_KEY)
             .unwrap_or((WASM_MODULE_API - 1) as i16);
 
-        if !config.wasm_module.is_empty() {
+        if let Some(wasm) = config.wasm_module {
             if stream_fetch_version >= WASM_MODULE_API as i16 {
-                stream_request.wasm_module = config.wasm_module;
+                stream_request.wasm_module = wasm;
             } else {
                 return Err(FluvioError::Other("SPU does not support WASM".to_owned()));
             }
@@ -565,33 +567,34 @@ static MAX_FETCH_BYTES: Lazy<i32> = Lazy::new(|| {
 });
 
 /// Configures the behavior of consumer fetching and streaming
-#[derive(Debug)]
+#[derive(Debug, Builder)]
+#[builder(build_fn(private, name = "build_impl"))]
 pub struct ConsumerConfig {
+    #[builder(default = "*MAX_FETCH_BYTES")]
     pub(crate) max_bytes: i32,
+    #[builder(default)]
     pub(crate) isolation: Isolation,
-    wasm_module: Vec<u8>,
-}
-
-impl Default for ConsumerConfig {
-    fn default() -> Self {
-        Self {
-            max_bytes: *MAX_FETCH_BYTES,
-            isolation: Isolation::default(),
-            wasm_module: vec![],
-        }
-    }
+    #[builder(private, setter(into, strip_option))]
+    pub(crate) wasm_module: Option<Vec<u8>>,
 }
 
 impl ConsumerConfig {
-    /// Maximum number of bytes to be fetched at a time.
-    pub fn with_max_bytes(mut self, max_bytes: i32) -> Self {
-        self.max_bytes = max_bytes;
-        self
+    pub fn builder() -> ConsumerConfigBuilder {
+        ConsumerConfigBuilder::default()
+    }
+}
+
+impl ConsumerConfigBuilder {
+    pub fn build(&self) -> Result<ConsumerConfig, FluvioError> {
+        let config = self.build_impl().map_err(|e| {
+            FluvioError::ConsumerConfigError(format!("Missing required config option: {}", e))
+        })?;
+        Ok(config)
     }
 
-    /// set wasm filter
-    pub fn with_wasm_filter(mut self, bytes: Vec<u8>) -> Self {
-        self.wasm_module = bytes;
+    /// Adds a SmartStream filter to this ConsumerConfig
+    pub fn wasm_filter<T: Into<Vec<u8>>>(&mut self, filter: T) -> &mut Self {
+        self.wasm_module(filter.into());
         self
     }
 }

--- a/src/client/src/consumer.rs
+++ b/src/client/src/consumer.rs
@@ -574,7 +574,7 @@ pub struct ConsumerConfig {
     pub(crate) max_bytes: i32,
     #[builder(default)]
     pub(crate) isolation: Isolation,
-    #[builder(private, setter(into, strip_option))]
+    #[builder(private, default, setter(into, strip_option))]
     pub(crate) wasm_module: Option<Vec<u8>>,
 }
 
@@ -632,5 +632,15 @@ impl Record {
 impl AsRef<[u8]> for Record {
     fn as_ref(&self) -> &[u8] {
         self.value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_consumer_config_default() {
+        let _config = ConsumerConfig::builder().build().unwrap();
     }
 }

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -30,6 +30,8 @@ pub enum FluvioError {
         cluster_version: Version,
         client_minimum_version: Version,
     },
+    #[error("Consumer config error: {0}")]
+    ConsumerConfigError(String),
     #[error("Unknown error: {0}")]
     Other(String),
 }


### PR DESCRIPTION
Closes #1271 as one of the breaking changes to be included in `0.9.0`