### PR TITLE
Fix typo 'lsr' to 'lrs'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3923,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -4591,9 +4591,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4601,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4616,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4628,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4638,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4651,15 +4651,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
+checksum = "ce783b6c3854292723f498b7bfcf65a782a320b6f1cb3012d08dfbc603fa62f5"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -4671,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
+checksum = "3859815cf8435b92f3a34381bef950daffc1403bbb77ef99e35422a7b0abb194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4911,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/k8-util/helm/fluvio-sys/templates/crd_partition.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_partition.yaml
@@ -55,7 +55,7 @@ spec:
         type: integer
         format: int32
         description: Live Replicas
-        jsonPath: .status.lsr
+        jsonPath: .status.lrs
       - name: HW
         type: integer
         format: int64

--- a/src/cli/src/consumer/partition/list.rs
+++ b/src/cli/src/consumer/partition/list.rs
@@ -131,7 +131,7 @@ mod display {
                         l -> format!("{:?}",status.resolution),
                         l -> status.leader.hw.to_string(),
                         l -> status.leader.leo.to_string(),
-                        l -> status.lsr.to_string(),
+                        l -> status.lrs.to_string(),
                         l -> format!("{:?}",status.replicas)
                     ]
                 })

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -29,9 +29,7 @@ use super::ElectionScoring;
 pub struct PartitionStatus {
     pub resolution: PartitionResolution,
     pub leader: ReplicaStatus,
-    // TODO: Next time we make a breaking protocol change, rename this to `lrs`
-    // TODO: There is no such thing as `lsr`, it is a typo
-    pub lsr: u32,
+    pub lrs: u32,
     pub replicas: Vec<ReplicaStatus>,
     pub is_being_deleted: bool,
 }
@@ -85,9 +83,8 @@ impl PartitionStatus {
         self.resolution != PartitionResolution::Online
     }
 
-    // TODO: At next breaking change, deprecate this and replace with `fn lrs` to fix typo
-    pub fn lsr(&self) -> u32 {
-        self.lsr
+    pub fn lrs(&self) -> u32 {
+        self.lrs
     }
 
     pub fn replica_iter(&self) -> Iter<ReplicaStatus> {
@@ -176,7 +173,7 @@ impl PartitionStatus {
     /// recalculate lrs which is count of follower whose leo is same as leader
     fn update_lrs(&mut self) {
         let leader_leo = self.leader.leo;
-        self.lsr = self
+        self.lrs = self
             .replicas
             .iter()
             .filter(|re| re.leo != -1 && leader_leo == re.leo)

--- a/src/controlplane-metadata/src/partition/status.rs
+++ b/src/controlplane-metadata/src/partition/status.rs
@@ -29,6 +29,7 @@ use super::ElectionScoring;
 pub struct PartitionStatus {
     pub resolution: PartitionResolution,
     pub leader: ReplicaStatus,
+    #[cfg_attr(feature = "use_serde", serde(alias = "lsr"))]
     pub lrs: u32,
     pub replicas: Vec<ReplicaStatus>,
     pub is_being_deleted: bool,


### PR DESCRIPTION
Closes #1296 in preparation for the `0.9.0` release. This includes renaming a CRD status field name, is there anything special we need to do to mark that breaking change? It is only a print column name if that matters.