### PR TITLE
Set owner_reference in input metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-channel",
  "async-rwlock",

--- a/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
+++ b/src/stream-dispatcher/src/dispatcher/k8_ws_service.rs
@@ -73,6 +73,7 @@ where
 
         input_metadata.labels = ctx.item().get_labels();
         input_metadata.annotations = ctx.item().annotations.clone();
+        input_metadata.owner_references = ctx.item().owner_references.clone();
 
         trace!("converted metadata: {:#?}", input_metadata);
         let new_k8 = InputK8Obj::new(k8_spec, input_metadata);


### PR DESCRIPTION
When using the new apply method, the owner_reference is being ignored. This fixes that.

Follow up of https://github.com/infinyon/fluvio/issues/1294