### PR TITLE
[Merged by Bors] - Make CI use public installer

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -126,28 +126,7 @@ jobs:
           minikube status
       - name: Setup for upgrade test
         run: |
-          gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
-
-      # Download artifacts
-      - name: Download artifact - fluvio
-        uses: actions/download-artifact@v2
-        with:
-          name: fluvio-x86_64-unknown-linux-musl
-          path: .
-      - name: Download Docker Image as Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: infinyon-fluvio
-          path: /tmp
-      - name: Load Fluvio Docker Image
-        run: |
-          ls -la /tmp
-          docker image load --input /tmp/infinyon-fluvio.tar
-          docker image ls -a
-
-      - name: Print artifacts and mark executable
-        run: ls -la . && chmod +x ./fluvio&& ./fluvio -h
 
       - name: Run upgrade test
         env:


### PR DESCRIPTION
I guess it isn't easy to share artifacts between workflows