### PR TITLE
[Merged by Bors] - Add 'arm-unknown-linux-gnueabihf' to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
             run: make build-cli
           - os: ubuntu-latest
             rust: stable
+            rust-target: arm-unknown-linux-gnueabihf
+            binary: fluvio
+            run: make build-cli
+          - os: ubuntu-latest
+            rust: stable
             rust-target: armv7-unknown-linux-gnueabihf
             binary: fluvio
             run: make build-cli
@@ -472,6 +477,7 @@ jobs:
         rust-target:
           - aarch64-unknown-linux-musl
           - armv7-unknown-linux-gnueabihf
+          - arm-unknown-linux-gnueabihf
           - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
         artifact: [fluvio]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,14 @@ jobs:
             rust: stable
             rust-target: aarch64-unknown-linux-musl
             binary: fluvio
-            run: make build-cli
           - os: ubuntu-latest
             rust: stable
             rust-target: arm-unknown-linux-gnueabihf
             binary: fluvio
-            run: make build-cli
           - os: ubuntu-latest
             rust: stable
             rust-target: armv7-unknown-linux-gnueabihf
             binary: fluvio
-            run: make build-cli
           - os: windows-latest
             rust: stable
             rust-target: x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-channel",
  "async-rwlock",

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install_tools_mac:
 	brew install helm
 
 build-cli: install_rustup_target
-ifeq ($(TARGET), armv7-unknown-linux-gnueabihf)
+ifneq (,$(findstring arm, $(TARGET))) # If TARGET contains the substring "arm"
 	cross build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 else
 	cargo build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
@@ -66,7 +66,6 @@ build-test:	build-cluster build-cli
 
 install_rustup_target:
 	./build-scripts/install_target.sh
-	
 
 #
 # List of smoke test steps.  This is used by CI

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DOCKER_IMAGE=$(DOCKER_REGISTRY)/fluvio
 TARGET_MUSL=x86_64-unknown-linux-musl
 TARGET?=
 BUILD_PROFILE=$(if $(RELEASE),release,debug)
+CARGO_BUILDER=$(if $(findstring arm,$(TARGET)),cross,cargo) # If TARGET contains the substring "arm"
 FLUVIO_BIN=$(if $(TARGET),./target/$(TARGET)/$(BUILD_PROFILE)/fluvio,./target/$(BUILD_PROFILE)/fluvio)
 RELEASE_FLAG=$(if $(RELEASE),--release,)
 TARGET_FLAG=$(if $(TARGET),--target $(TARGET),)
@@ -47,11 +48,7 @@ install_tools_mac:
 	brew install helm
 
 build-cli: install_rustup_target
-ifneq (,$(findstring arm, $(TARGET))) # If TARGET contains the substring "arm"
-	cross build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
-else
-	cargo build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
-endif
+	$(CARGO_BUILDER) build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 build-cli-minimal: install_rustup_target
 	# https://github.com/infinyon/fluvio/issues/1255

--- a/build-scripts/install_target.sh
+++ b/build-scripts/install_target.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-if [ "$TARGET" = "armv7-unknown-linux-gnueabihf" ]; then
-    cargo install cross
+if [ "$TARGET" = "armv7-unknown-linux-gnueabihf" ] || [ "$TARGET" = "arm-unknown-linux-gnueabihf" ]; then
+    # Install cross if not installed
+    [[ -x "$(command -v cross)" ]] && cargo install cross
 fi
 
 if [ -n "$TARGET" ]; then

--- a/build-scripts/install_target.sh
+++ b/build-scripts/install_target.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ "$TARGET" = "armv7-unknown-linux-gnueabihf" ] || [ "$TARGET" = "arm-unknown-linux-gnueabihf" ]; then
     # Install cross if not installed
-    [[ -x "$(command -v cross)" ]] && cargo install cross
+    [[ -x "$(command -v cross)" ]] || cargo install cross
 fi
 
 if [ -n "$TARGET" ]; then


### PR DESCRIPTION
Closes #1160 

This uses `cross` the same way that the armv7 build does