### PR TITLE
[Merged by Bors] - Add upgrade test to CI workflow

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -137,7 +137,7 @@ jobs:
           max_attempts: 3
           command: |
             export PATH=~/.fluvio/bin:$PATH
-            make upgrade-test
+            USE_LATEST=true make upgrade-test
 
       - name: Clean minikube
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           command: |
+            export PATH=~/.fluvio/bin:$PATH
             make FLUVIO_BIN=./fluvio upgrade-test 
 
       - name: Save logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,10 @@ jobs:
       - name: Print artifacts and mark executable
         run: ls -la . && chmod +x ./fluvio && ./fluvio version
 
+      - name: Setup for upgrade test
+        run: |
+          curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+
       - name: Run upgrade test with CI artifacts
         env:
           TEST_DATA_BYTES: 10000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,7 @@ jobs:
 
   k8_upgrade_test:
     name: Upgrade cluster test
+    if: false # Disable job for CI
     needs: build_image
     runs-on: ${{ matrix.os }}
     strategy:
@@ -509,6 +510,7 @@ jobs:
       - check_windows
       - local_cluster_test
       - k8_cluster_test
+      #- k8_upgrade_test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,9 +375,96 @@ jobs:
           make FLUVIO_BIN=./fluvio RELEASE=true TARGET=x86_64-unknown-linux-musl k8-setup
 
       - name: Run smoke-test-k8-tls-root
-        timeout-minutes: 5
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: |
+            make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
+
+      - name: Save logs
+        if: failure()
         run: |
-          make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
+          echo "minikube profile list"
+          minikube profile list
+          echo "helm list"
+          helm list
+          echo "get statefulset"
+          kubectl get statefulset
+          echo "kubectl get pvc"
+          kubectl get pvc
+          echo "kubectl get pods"
+          kubectl get pods
+          echo "kubectl get svc"
+          kubectl get svc
+          echo "kubectl get spu"
+          kubectl get spu
+          echo "kubectl get spg"
+          kubectl get spg
+          kubectl logs -l app=fluvio-sc > /tmp/flv_sc.log
+      - name: Upload logs
+        timeout-minutes: 5
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: fluvio-k8-logs
+          path: /tmp/flv_sc.log
+
+  k8_upgrade_test:
+    name: Upgrade cluster test
+    needs: build_image
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+    env:
+      FLV_SOCKET_WAIT: 600
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Minikube for Github runner
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: "v1.22.0"
+          kubernetes version: "v1.21.2"
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+      - name: Test minikube
+        run: |
+          helm version
+          minikube profile list
+          minikube status
+      # Download artifacts
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v2
+        with:
+          name: fluvio-x86_64-unknown-linux-musl
+          path: .
+      - name: Download Docker Image as Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: infinyon-fluvio
+          path: /tmp
+      - name: Load Fluvio Docker Image
+        run: |
+          ls -la /tmp
+          eval $(minikube -p minikube docker-env)
+          docker image load --input /tmp/infinyon-fluvio.tar
+          docker image ls -a
+
+      - name: Print artifacts and mark executable
+        run: ls -la . && chmod +x ./fluvio && ./fluvio version
+
+      - name: Run upgrade test with CI artifacts
+        env:
+          TEST_DATA_BYTES: 10000
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: |
+            make FLUVIO_BIN=./fluvio upgrade-test 
+
       - name: Save logs
         if: failure()
         run: |

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -25,7 +25,7 @@ readonly CI=${CI:-}
 readonly STABLE_TOPIC=${STABLE_TOPIC:-stable}
 readonly PRERELEASE_TOPIC=${PRERELEASE_TOPIC:-prerelease}
 readonly USE_LATEST=${USE_LATEST:-}
-readonly FLUVIO_BIN=$(readlink -f ${FLUVIO_BIN:-"$(pwd)/fluvio"})
+readonly FLUVIO_BIN=$(readlink -f ${FLUVIO_BIN:-"$(which fluvio)"})
 
 # Change to this script's directory 
 pushd "$(dirname "$(readlink -f "$0")")" > /dev/null
@@ -35,7 +35,7 @@ function cleanup() {
     rm -f --verbose ./*.txt.tmp;
     rm -f --verbose ./*.checksum;
     echo Delete cluster if possible
-    fluvio cluster delete || true
+    $FLUVIO_BIN cluster delete || true
 }
 
 # If we're in CI, we want to slow down execution

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -103,32 +103,21 @@ function validate_upgrade_cluster_to_prerelease() {
 
     # Change dir to get access to Helm charts
     pushd ..
-    if [[ ! -z "$CI" ]];
+    if [[ ! -z "$USE_LATEST" ]];
     then
-        echo "[CI MODE] Download the latest published dev CLI"
+        echo "Download the latest published dev CLI"
         TARGET_VERSION=$(curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash | grep "Downloading Fluvio" | awk '{print $5}' | sed 's/[+]/-/')
-        echo "[CI MODE] Installed CLI version ${TARGET_VERSION}"
+        echo "Installed CLI version ${TARGET_VERSION}"
         FLUVIO_BIN_ABS_PATH=${HOME}/.fluvio/bin/fluvio
-        echo "[CI MODE] Upgrading cluster to ${TARGET_VERSION}"
+        echo "Upgrading cluster to ${TARGET_VERSION}"
         $FLUVIO_BIN_ABS_PATH cluster upgrade --chart-version=${TARGET_VERSION} --develop
         sleep 20
+    else
+        echo "Test local image v${PRERELEASE}"
+        # This should use the binary that the Makefile set
 
-    else 
-
-        if [[ ! -z "$USE_LATEST" ]];
-        then
-            echo "Download the latest published dev CLI"
-            TARGET_VERSION=$(curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash | grep "Downloading Fluvio" | awk '{print $5}' | sed 's/[+]/-/')
-            echo "Installed CLI version ${TARGET_VERSION}"
-            FLUVIO_BIN_ABS_PATH=${HOME}/.fluvio/bin/fluvio
-            echo "Upgrading cluster to ${TARGET_VERSION}"
-            $FLUVIO_BIN_ABS_PATH cluster upgrade --chart-version=${TARGET_VERSION} --develop
-            sleep 20
-        else
-            echo "Test local development image v${PRERELEASE}"
-            # This should use the binary that the Makefile set
-            $FLUVIO_BIN_ABS_PATH cluster upgrade --chart-version=${TARGET_VERSION} --develop
-        fi
+        echo "Using Fluvio binary located @ ${FLUVIO_BIN_ABS_PATH}"
+        $FLUVIO_BIN_ABS_PATH cluster upgrade --chart-version=${TARGET_VERSION} --develop
     fi
     popd
 


### PR DESCRIPTION
Still testing, so there's heavy duplication in CI jobs

The CI job should test in DEBUG mode with the CI artifacts. The CD_Dev job should use the public artifacts

Minor fix, the smoke test is wrapped in `nick-invision/retry@v2` to retry the job if it fails, max 3 attempts. Just to save time rerunning all jobs for CI environmental issues.

Resolves #1262 