### PR TITLE
[Merged by Bors] - Update `install.sh` with arm targets, add distinction for tiers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,16 +11,16 @@ readonly FLUVIO_TAG_STABLE="stable"
 readonly FLUVIO_PACKAGE="fluvio/fluvio"
 readonly FLUVIO_EXTENSIONS="${HOME}/.fluvio/extensions"
 
-# Ensure that this architecture is supported and matches the
+# Ensure that this target is supported and matches the
 # naming convention of known platform releases in the registry
 #
 # @param $1: The target triple of this architecture
 # @return: Status 0 if the architecture is supported, exit if not
-assert_supported_architecture() {
-    local _arch="$1"; shift
+assert_supported_client_target() {
+    local _target="$1"; shift
 
-    # Match against all supported architectures
-    case $_arch in
+    # Match against all supported targets
+    case $_target in
         x86_64-apple-darwin)
             echo "x86_64-apple-darwin"
             return 0
@@ -33,8 +33,19 @@ assert_supported_architecture() {
             echo "x86_64-unknown-linux-musl"
             return 0
             ;;
+        arm-unknown-linux-gnueabihf)
+            echo "arm-unknown-linux-gnueabihf"
+            return 0
+            ;;
+        armv7-unknown-linux-gnueabihf)
+            echo "armv7-unknown-linux-gnueabihf"
+            return 0
+            ;;
     esac
 
+    err "Target '${_target}' is not supported"
+    err "Consider filing an issue to add support for this platform using the link below! 👇"
+    err "  https://github.com/infinyon/fluvio/issues/new?title=Support+target+${_target}"
     return 1
 }
 
@@ -468,13 +479,7 @@ main() {
     # Some architectures may be folded into a single 'target' distribution
     # e.g. x86_64-unknown-linux-musl and x86_64-unknown-linux-gnu both download
     # the musl target release. The _target here is used in the URL to download
-    _target=$(assert_supported_architecture ${_arch})
-    _status=$?
-    if [ $_status -ne 0 ]; then
-        # If this architecture is not supported, return error
-        err "❌ Architecture ${_arch} is not supported."
-        abort_prompt_issue
-    fi
+    _target=$(assert_supported_client_target ${_arch})
 
     # If a VERSION env variable is set:
     if [ -n "${VERSION:-""}" ]; then

--- a/install.sh
+++ b/install.sh
@@ -544,7 +544,7 @@ main() {
     # verify_checksum "${_url}" "${_temp_file}" || return 1
 
     # After verification, install the file and make it executable
-    say "⬇️ Downloaded Fluvio, installing..."
+    say "⬇️  Downloaded Fluvio, installing..."
     ensure mkdir -p "${FLUVIO_BIN}"
     ensure mkdir -p "${FLUVIO_EXTENSIONS}"
     local _install_file="${FLUVIO_BIN}/fluvio"
@@ -557,13 +557,15 @@ main() {
     FLUVIO_BOOTSTRAP=true "${FLUVIO_BIN}/fluvio" install fluvio/fluvio-cloud
 
     set +e
-    _=$(assert_supported_cluster_target "${_target}")
+    _output=$(assert_supported_cluster_target "${_target}")
     _status=$?
     set -e
 
     if [ $_status -eq 0 ]; then
         say "☁️ Installing Fluvio Runner..."
         FLUVIO_BOOTSTRAP=true "${FLUVIO_BIN}/fluvio" install fluvio/fluvio-run
+    else
+        echo "${_output}"
     fi
 
     say "🎉 Install complete!"


### PR DESCRIPTION
Part of https://github.com/infinyon/fluvio/issues/1269

- Adds the following targets to "supported targets" for install.sh:
  - arm-unknown-linux-gnueabihf
  - armv7-unknown-linux-gnueabihf
- Adds a distinction between "client targets" and "platform targets" that aligns with Tier support
  - Tier 1 platforms get `fluvio-run`, others do not