### PR TITLE
[Merged by Bors] - CI: reliable and faster

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       SLEEP: 10
       TOPIC: foobar
+      FLV_SOCKET_WAIT: 600
     steps:
       - uses: actions/checkout@v2
       - name: Install Minikube for Github runner

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-cli-minimal: install_rustup_target
 build-cluster: install_rustup_target
 	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-build-test:	build-cluster build-cli
+build-test:	
 	cargo build --bin flv-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 install_rustup_target:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-cli-minimal: install_rustup_target
 build-cluster: install_rustup_target
 	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-build-test:	
+build-test:	install_rustup_target
 	cargo build --bin flv-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 install_rustup_target:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-cli-minimal: install_rustup_target
 build-cluster: install_rustup_target
 	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
-build-test:	install_rustup_target
+build-test:	install_rustup_target helm_pkg
 	cargo build --bin flv-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 install_rustup_target:

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,8 @@ test-rbac:
 ifeq (${CI},true)
 build-test-ci:
 else
-# When not in CI (i.e. development), build before testing
-build-test-ci: build-test
+# When not in CI (i.e. development), need build cli and cluster
+build-test-ci: build-test build-cli build-cluster
 endif
 
 


### PR DESCRIPTION
try to make cd-dev more reliable by increasing socket timeout
optimize build-test by removing explicit dependencies and move to test-setup