### PR TITLE
[Merged by Bors] - Disable publishing fluvio.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,8 +669,8 @@ jobs:
         include:
           - rust-target: x86_64-unknown-linux-musl
             artifact: fluvio-run
-          - rust-target: x86_64-pc-windows-msvc
-            artifact: fluvio.exe
+#          - rust-target: x86_64-pc-windows-msvc
+#            artifact: fluvio.exe
     permissions: write-all
     steps:
       - name: Login GH CLI


### PR DESCRIPTION
Until we find a solution to the publishing problem, let's unblock the other build targets.