### PR TITLE
[Merged by Bors] - Do not error if update is not found for target

### DIFF
--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -60,10 +60,8 @@ impl InstallOpt {
         // After any "install" command, check if the CLI has an available update,
         // i.e. one that is not required, but present.
         let update_result = check_update_available(&agent, false).await;
-        if let Ok(maybe_latest) = update_result {
-            if let Some(latest_version) = maybe_latest {
-                prompt_available_update(&latest_version);
-            }
+        if let Ok(Some(latest_version)) = update_result {
+            prompt_available_update(&latest_version);
         }
         Ok(())
     }

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -59,11 +59,12 @@ impl InstallOpt {
 
         // After any "install" command, check if the CLI has an available update,
         // i.e. one that is not required, but present.
-        let maybe_latest = check_update_available(&agent, false).await?;
-        if let Some(latest_version) = maybe_latest {
-            prompt_available_update(&latest_version);
+        let update_result = check_update_available(&agent, false).await;
+        if let Ok(maybe_latest) = update_result {
+            if let Some(latest_version) = maybe_latest {
+                prompt_available_update(&latest_version);
+            }
         }
-
         Ok(())
     }
 


### PR DESCRIPTION
This fixes this installer bug when using `install.sh` from a target that does not have any releases published on stable

<img width="715" alt="image" src="https://user-images.githubusercontent.com/4210949/127544099-49064f3e-a5db-4263-91fa-758e3f3b5187.png">
