### PR TITLE
[Merged by Bors] - Add tag resolution to package-index

### DIFF
--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -83,7 +83,7 @@ impl InstallOpt {
                 let id = &self.package;
                 install_println(format!("🎣 Fetching latest version for package: {}...", id));
                 let version = fetch_latest_version(agent, id, &target, self.develop).await?;
-                let id = id.clone().into_versioned(version);
+                let id = id.clone().into_versioned(version.into());
                 install_println(format!(
                     "⏳ Downloading package with latest version: {}...",
                     id

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -84,7 +84,7 @@ impl UpdateOpt {
         // Find the latest version of this package
         install_println("🎣 Fetching latest version for fluvio...");
         let latest_version = fetch_latest_version(agent, &id, &target, self.develop).await?;
-        let id = id.into_versioned(latest_version);
+        let id = id.into_versioned(latest_version.into());
 
         // Download the package file from the package registry
         install_println(format!(
@@ -122,7 +122,7 @@ impl UpdateOpt {
             id.pretty(),
             version
         );
-        let id = id.clone().into_versioned(version);
+        let id = id.clone().into_versioned(version.into());
         let package_file = fetch_package_file(agent, &id, &target).await?;
         println!("🔑 Downloaded and verified package file");
 

--- a/src/package-index/src/error.rs
+++ b/src/package-index/src/error.rs
@@ -39,10 +39,18 @@ pub enum Error {
     InvalidPackageName(String),
     #[error("Invalid group name: {0}")]
     InvalidGroupName(String),
+    #[error("Invalid tag name: {0}")]
+    InvalidTagName(String),
+    #[error("Tag '{0}' does not exist")]
+    TagDoesNotExist(String),
+    #[error("Failed to parse PackageVersion from '{0}', must be valid Semver or Tag name")]
+    InvalidPackageVersion(String),
     #[error("Version number is required here")]
     MissingVersion,
     #[error("Failed to parse registry segment of PackageId")]
     FailedToParseRegistry(url::ParseError),
+    #[error("An unknown error occurred: {0}")]
+    Other(String),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/package-index/src/lib.rs
+++ b/src/package-index/src/lib.rs
@@ -10,15 +10,19 @@
 
 use serde::{Serialize, Deserialize};
 
+mod tags;
 mod http;
 mod error;
 mod target;
+mod version;
 mod package;
 mod package_id;
 
+pub use tags::TagName;
 pub use http::HttpAgent;
 pub use error::{Error, Result};
 pub use target::{Target, package_target};
+pub use version::PackageVersion;
 pub use package::{Package, PackageKind, Release};
 pub use package_id::{PackageId, GroupName, PackageName, Registry, WithVersion, MaybeVersion};
 use semver::Version;

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -257,20 +257,6 @@ impl<T> PackageId<T> {
 }
 
 impl PackageId<WithVersion> {
-    /// Create a new, versioned PackageId.
-    pub(crate) fn new_versioned(
-        name: PackageName,
-        group: GroupName,
-        version: PackageVersion,
-    ) -> Self {
-        Self {
-            registry: None,
-            group: Some(group),
-            name,
-            version,
-        }
-    }
-
     /// A PackageId<WithVersion> indisputably has a version, no Option required.
     pub fn version(&self) -> &PackageVersion {
         &self.version
@@ -556,31 +542,10 @@ mod tests {
     }
 
     #[test]
-    fn test_package_id_idempotent() {
-        let package_id = PackageId::new_versioned(
-            "project-x-secret-sauce".parse().unwrap(),
-            "infinyon.super.secret.division".parse().unwrap(),
-            "100.0.0-special-edition".parse::<PackageVersion>().unwrap(),
-        );
-
-        let package_id_string = package_id.to_string();
-        assert_eq!(
-            package_id_string,
-            "infinyon.super.secret.division/\
-            project-x-secret-sauce:100.0.0-special-edition"
-        );
-
-        let parsed_package_id: PackageId<WithVersion> = package_id_string.parse().unwrap();
-        assert_eq!(package_id, parsed_package_id);
-    }
-
-    #[test]
     fn test_package_id_display() {
-        let package_id_with_version = PackageId::new_versioned(
-            "fluvio".parse().unwrap(),
-            "fluvio".parse().unwrap(),
-            "1.2.3-alpha".parse::<PackageVersion>().unwrap(),
-        );
+        let package_id_with_version = "fluvio/fluvio:1.2.3-alpha"
+            .parse::<PackageId<WithVersion>>()
+            .unwrap();
         assert_eq!(
             "fluvio/fluvio:1.2.3-alpha",
             format!("{}", package_id_with_version)
@@ -640,12 +605,9 @@ mod tests {
 
     #[test]
     fn test_serialize_package_id_versioned() {
-        let package_id_with_version = PackageId::new_versioned(
-            "fluvio".parse().unwrap(),
-            "fluvio".parse().unwrap(),
-            "1.2.3".parse::<PackageVersion>().unwrap(),
-        );
-
+        let package_id_with_version = "fluvio/fluvio:1.2.3"
+            .parse::<PackageId<WithVersion>>()
+            .unwrap();
         let json = serde_json::to_string(&package_id_with_version).unwrap();
         assert_eq!(json, r#""fluvio/fluvio:1.2.3""#);
     }

--- a/src/package-index/src/tags.rs
+++ b/src/package-index/src/tags.rs
@@ -23,7 +23,7 @@ impl std::str::FromStr for TagName {
                 s
             )));
         }
-        if s.contains("/") {
+        if s.contains('/') {
             return Err(Error::InvalidTagName(format!(
                 "tag name may not contain '/', got '{}'",
                 s

--- a/src/package-index/src/tags.rs
+++ b/src/package-index/src/tags.rs
@@ -1,0 +1,41 @@
+use std::fmt;
+use crate::Error;
+
+/// Represents names that may be used for Tags
+///
+/// This includes any ascii string that does not contain a `/`
+#[derive(Debug, Clone, PartialEq)]
+pub struct TagName(String);
+
+impl AsRef<str> for TagName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for TagName {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.is_ascii() {
+            return Err(Error::InvalidTagName(format!(
+                "tag name must be ascii, got '{}'",
+                s
+            )));
+        }
+        if s.contains("/") {
+            return Err(Error::InvalidTagName(format!(
+                "tag name may not contain '/', got '{}'",
+                s
+            )));
+        }
+
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl fmt::Display for TagName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/src/package-index/src/version.rs
+++ b/src/package-index/src/version.rs
@@ -1,0 +1,91 @@
+use semver::Version;
+use crate::{TagName, Error};
+use std::fmt;
+
+/// A type representing a package version in a PackageId.
+///
+/// In a PackageId string like `fluvio/fluvio:1.2.3`, this
+/// is the `1.2.3`.
+///
+/// A `PackageVersion` may be either a direct semver, or it may be
+/// the name of a tag which can later be resolved to a semver by
+/// looking up the tag in the package registry.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum PackageVersion {
+    Semver(Version),
+    Tag(TagName),
+}
+
+impl std::str::FromStr for PackageVersion {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // First, try to parse as semver::Version
+        if let Ok(version) = Version::parse(s) {
+            tracing::debug!("Parsed PackageVersion::Semver from '{}'", s);
+            return Ok(Self::Semver(version));
+        }
+
+        // Try to parse as TagName
+        if let Ok(tagname) = s.parse::<TagName>() {
+            tracing::debug!("Parsed PackageVersion::Tag from '{}'", s);
+            return Ok(Self::Tag(tagname));
+        };
+
+        return Err(Error::InvalidPackageVersion(s.to_string()));
+    }
+}
+
+impl From<Version> for PackageVersion {
+    fn from(version: Version) -> Self {
+        Self::Semver(version)
+    }
+}
+
+impl From<TagName> for PackageVersion {
+    fn from(tag: TagName) -> Self {
+        Self::Tag(tag)
+    }
+}
+
+impl fmt::Display for PackageVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Semver(sv) => sv.fmt(f),
+            Self::Tag(tag) => tag.fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_package_version_semver() {
+        let package_version = "1.2.3-alpha.1".parse::<PackageVersion>().unwrap();
+        match &package_version {
+            PackageVersion::Semver(sv) => {
+                assert_eq!(sv.major, 1);
+                assert_eq!(sv.minor, 2);
+                assert_eq!(sv.patch, 3);
+                assert_eq!(sv.pre.as_str(), "alpha.1");
+                assert_eq!(format!("{}", package_version), "1.2.3-alpha.1");
+            }
+            _ => panic!("should have parsed as semver"),
+        }
+    }
+
+    #[test]
+    fn test_package_version_tag() {
+        let package_version = "stable".parse::<PackageVersion>().unwrap();
+        match &package_version {
+            PackageVersion::Tag(tag) => {
+                assert_eq!(tag.as_ref(), "stable");
+                assert_eq!(format!("{}", package_version), "stable");
+            }
+            _ => panic!("should have parsed as tag"),
+        }
+    }
+}

--- a/src/package-index/src/version.rs
+++ b/src/package-index/src/version.rs
@@ -33,7 +33,7 @@ impl std::str::FromStr for PackageVersion {
             return Ok(Self::Tag(tagname));
         };
 
-        return Err(Error::InvalidPackageVersion(s.to_string()));
+        Err(Error::InvalidPackageVersion(s.to_string()))
     }
 }
 


### PR DESCRIPTION
This allows the Fluvio CLI to install packages whose version references a tag in addition to a specific version

Whereas before we could only use exact versions such as

```
fluvio install fluvio:0.8.4
```

We can now use tag names in the position after `:`

```
fluvio install fluvio:stable
fluvio install fluvio:latest
```