### PR TITLE
[Merged by Bors] - Add fluivo-run to Tier2 for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ env:
 
 jobs:
 
-
   # build binaries for linux musl which is primary OS for testing clusters
   build_primary_binaries:
     name: Build ${{ matrix.binary }} for ${{ matrix.rust-target }} on (${{ matrix.os }})
@@ -106,7 +105,6 @@ jobs:
           name: ${{ matrix.binary }}-${{ matrix.rust-target }}
           path: ${{ env.RUST_BIN_DIR }}/${{ matrix.binary }}
 
-
   # build other binaries which doesn't need test
   build_binaries:
     name: Build ${{ matrix.binary }} for ${{ matrix.rust-target }} on (${{ matrix.os }})
@@ -145,6 +143,10 @@ jobs:
             rust: stable
             rust-target: x86_64-apple-darwin
             binary: fluvio
+          - os: macos-latest
+            rust: stable
+            rust-target: x86_64-apple-darwin
+            binary: fluvio-run
           - os: macos-11
             rust: stable
             rust-target: aarch64-apple-darwin
@@ -190,6 +192,10 @@ jobs:
       - name: Build fluvio
         if: ${{ matrix.binary == 'fluvio.exe' }}
         run: make build-cli-minimal
+
+      - name: Build fluvio-run
+        if: ${{ matrix.binary == 'fluvio-run' }}
+        run: make build-cluster
 
       # Upload artifacts
       - name: Upload artifact - ${{ matrix.binary }}
@@ -240,7 +246,6 @@ jobs:
       - name: Integration test
         if: ${{ matrix.check == 'integration' }}
         run: make run-integration-test
-
 
   check_wasm:
     name: Build WASM crates (${{ matrix.wasm-crate }})
@@ -635,7 +640,6 @@ jobs:
           gh release upload -R infinyon/fluvio --clobber dev k8-util/helm/pkg_app/*.*
           gh release upload -R infinyon/fluvio --clobber dev k8-util/helm/pkg_sys/*.*
 
-
   publish_github_binaries:
     name: Publish to GitHub Releases dev (${{ matrix.artifact }}-${{ matrix.rust-target }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
@@ -654,6 +658,8 @@ jobs:
         artifact: [fluvio]
         include:
           - rust-target: x86_64-unknown-linux-musl
+            artifact: fluvio-run
+          - rust-target: x86_64-apple-darwin
             artifact: fluvio-run
 #          - rust-target: x86_64-pc-windows-msvc
 #            artifact: fluvio.exe

--- a/install.sh
+++ b/install.sh
@@ -67,9 +67,13 @@ assert_supported_cluster_target() {
             echo "x86_64-unknown-linux-musl"
             return 0
             ;;
+        x86_64-apple-darwin)
+            echo "x86_64-apple-darwin"
+            return 0
+            ;;
     esac
 
-    say "🥈 Target '${_target}' is not a Tier 1 platform target"
+    say "🥈 Target '${_target}' is not a Tier 1 or 2 platform target"
     say "⏭    Skipping installation of cluster executable fluvio-run"
     return 1
 }


### PR DESCRIPTION
This causes `fluvio-run` to be installed by `install.sh` on MacOS