### PR TITLE
Update Cluster Install with proxy option and detail process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ helm_pkg:
 build-cli: install_rustup_target
 	$(CARGO_BUILDER) build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
+
 build-cli-minimal: install_rustup_target
 	# https://github.com/infinyon/fluvio/issues/1255
 	cargo build --bin fluvio $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG) --no-default-features --features consumer --manifest-path ./src/cli/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 DOCKER_TAG=$(VERSION)-$(GIT_COMMIT)
 DOCKER_REGISTRY=infinyon
 K8_CLUSTER?=$(shell ./k8-util/cluster/cluster-type.sh)
-DOCKER_IMAGE=$(DOCKER_REGISTRY)/fluvio
 TARGET_MUSL=x86_64-unknown-linux-musl
 TARGET?=
+IMAGE_VERSION?=					# If set, this indicates that the image is pre-built and should not be built
 BUILD_PROFILE=$(if $(RELEASE),release,debug)
 CARGO_BUILDER=$(if $(findstring arm,$(TARGET)),cross,cargo) # If TARGET contains the substring "arm"
 FLUVIO_BIN=$(if $(TARGET),./target/$(TARGET)/$(BUILD_PROFILE)/fluvio,./target/$(BUILD_PROFILE)/fluvio)
@@ -33,7 +33,7 @@ TEST_ENV_FLV_SPU_DELAY=
 TEST_ARG_SPU=--spu ${DEFAULT_SPU}
 TEST_ARG_LOG=--client-log ${CLIENT_LOG} --server-log ${SERVER_LOG}
 TEST_ARG_REPLICATION=-r ${REPL}
-TEST_ARG_DEVELOP=--develop
+TEST_ARG_DEVELOP=$(if $(IMAGE_VERSION),--image-version ${IMAGE_VERSION}, --develop)
 TEST_ARG_SKIP_CHECKS=
 TEST_ARG_EXTRA=
 TEST_ARG_CONSUMER_WAIT=
@@ -125,7 +125,7 @@ k8-setup:
 # Kubernetes Tests
 
 smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
-smoke-test-k8: build_k8_image smoke-test
+smoke-test-k8: smoke-test build_k8_image
 
 smoke-test-k8-tls: TEST_ARG_EXTRA=--tls $(EXTRA_ARG)
 smoke-test-k8-tls: build_k8_image smoke-test
@@ -229,6 +229,8 @@ run-client-doc-test: install_rustup_target
 
 # In CI mode, do not build k8 image
 ifeq (${CI},true)
+build_k8_image:
+else ifeq (${IMAGE_VERSION},true)
 build_k8_image:
 else
 # When not in CI (i.e. development), build image before testing

--- a/k8-util/cluster/reset-minikube.sh
+++ b/k8-util/cluster/reset-minikube.sh
@@ -5,5 +5,5 @@ set -e
 ARG1=${1:-docker}
 K8_VERSION=${2:-1.21.2}
 minikube delete
-minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION
+minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION --extra-config=apiserver.service-node-port-range=32760-32767 --ports=127.0.0.1:32760-32767:32760-32767
 # minikube start --extra-config=apiserver.v=10

--- a/k8-util/cluster/reset-minikube.sh
+++ b/k8-util/cluster/reset-minikube.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # delete and re-install minikube ready for fluvio
-# this defaults to docker and assume you have have sudo access
+# it uses docker as default driver
 set -e
 ARG1=${1:-docker}
 K8_VERSION=${2:-1.21.2}
 minikube delete
-minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION --extra-config=apiserver.service-node-port-range=32760-32767 --ports=127.0.0.1:32760-32767:32760-32767
+minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION --extra-config=apiserver.service-node-port-range=32700-32800 --ports=127.0.0.1:32700-32800:32700-32800
 # minikube start --extra-config=apiserver.v=10

--- a/src/client/src/fluvio.rs
+++ b/src/client/src/fluvio.rs
@@ -77,6 +77,7 @@ impl Fluvio {
         debug!("connected to cluster at: {}", inner_client.config().addr());
 
         let (socket, config, versions) = inner_client.split();
+        debug!(version = ?versions.platform_version(),"checking platform version");
         check_platform_compatible(versions.platform_version())?;
         let socket = MultiplexerSocket::shared(socket);
         let metadata = MetadataStores::start(socket.clone()).await?;
@@ -90,6 +91,7 @@ impl Fluvio {
             metadata,
         })
     }
+
 
     /// lazy get spu pool
     async fn spu_pool(&self) -> Result<Arc<SpuPool>, FluvioError> {

--- a/src/client/src/fluvio.rs
+++ b/src/client/src/fluvio.rs
@@ -92,7 +92,6 @@ impl Fluvio {
         })
     }
 
-
     /// lazy get spu pool
     async fn spu_pool(&self) -> Result<Arc<SpuPool>, FluvioError> {
         self.spu_pool

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -33,6 +33,7 @@ pub async fn process_k8(
         .chart_values(opt.k8_config.chart_values)
         .render_checks(true)
         .upgrade(upgrade)
+        .proxy_addr(opt.proxy_addr)
         .with_if(skip_sys, |b| b.install_sys(false))
         .with_if(opt.skip_checks, |b| b.skip_checks(true));
 

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use fluvio::config::TlsPolicy;
 use semver::Version;
 
-use crate::{ClusterInstaller, K8InstallError, StartStatus, ClusterConfig,ClusterError};
+use crate::{ClusterInstaller, K8InstallError, StartStatus, ClusterConfig, ClusterError};
 use crate::cli::ClusterCliError;
 use crate::cli::start::StartOpt;
 use crate::check::render::{
@@ -62,9 +62,9 @@ pub async fn process_k8(
     if opt.setup {
         setup_k8(&installer).await?;
     } else {
-        let k8_install: Result<_,ClusterError> = start_k8(&installer).await.map_err(|err| err.into());
+        let k8_install: Result<_, ClusterError> =
+            start_k8(&installer).await.map_err(|err| err.into());
         k8_install?
-        
     }
 
     Ok(())

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use fluvio::config::TlsPolicy;
 use semver::Version;
 
-use crate::{ClusterInstaller, ClusterError, K8InstallError, StartStatus, ClusterConfig};
+use crate::{ClusterInstaller, K8InstallError, StartStatus, ClusterConfig,ClusterError};
 use crate::cli::ClusterCliError;
 use crate::cli::start::StartOpt;
 use crate::check::render::{
@@ -62,13 +62,15 @@ pub async fn process_k8(
     if opt.setup {
         setup_k8(&installer).await?;
     } else {
-        start_k8(&installer).await?;
+        let k8_install: Result<_,ClusterError> = start_k8(&installer).await.map_err(|err| err.into());
+        k8_install?
+        
     }
 
     Ok(())
 }
 
-pub async fn start_k8(installer: &ClusterInstaller) -> Result<(), ClusterCliError> {
+pub async fn start_k8(installer: &ClusterInstaller) -> Result<(), K8InstallError> {
     match installer.install_fluvio().await {
         // Successfully performed startup without pre-checks
         Ok(StartStatus { checks: None, .. }) => {
@@ -83,7 +85,7 @@ pub async fn start_k8(installer: &ClusterInstaller) -> Result<(), ClusterCliErro
             println!("Successfully installed Fluvio!");
         }
         // Aborted startup because pre-checks failed
-        Err(ClusterError::InstallK8(K8InstallError::FailedPrecheck(check_statuses))) => {
+        Err(K8InstallError::FailedPrecheck(check_statuses)) => {
             render_statuses_next_steps(&check_statuses);
         }
         // Another type of error occurred during checking or startup

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -123,6 +123,10 @@ pub struct StartOpt {
     /// Tries to setup necessary environment for cluster startup
     #[structopt(long)]
     pub setup: bool,
+
+    /// Proxy address
+    #[structopt(long)]
+    pub proxy_addr: Option<String>,
 }
 
 impl StartOpt {

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -141,7 +141,7 @@ impl StartOpt {
         use crate::cli::start::k8::process_k8;
 
         if self.sys {
-            process_sys(self, upgrade)?;
+            process_sys(self, platform_version)?;
         } else if self.local {
             process_local(self, platform_version).await?;
         } else {

--- a/src/cluster/src/cli/start/sys.rs
+++ b/src/cluster/src/cli/start/sys.rs
@@ -4,27 +4,14 @@ use crate::cli::start::StartOpt;
 use crate::cli::ClusterCliError;
 use crate::charts::{ChartConfig, ChartInstallError, ChartInstaller};
 use crate::ClusterError;
-use crate::sys::SysConfig;
+use crate::sys::{SysConfig,SysInstallError};
 
-pub fn process_sys(opt: StartOpt,platform_version: Version) -> Result<(), ClusterCliError> {
-    install_sys_impl(opt, platform_version).map_err(ClusterError::InstallSys)?;
-    Ok(())
-}
-
-fn install_sys_impl(opt: StartOpt, platform_version: Version) -> Result<(), ChartInstallError> {
-
-    /* 
+pub fn process_sys(opt: StartOpt,platform_version: Version) -> Result<(), SysInstallError> {
+    
     let config = SysConfig::builder(platform_version)
         .namespace(&opt.k8_config.namespace)
-        .with(|builder| match &opt.k8_config.chart_location {
-            // If a chart location is given, use it
-            Some(chart_location) => builder.local_chart(chart_location),
-            // If we're in develop mode (but no explicit chart location), use local path
-            None if opt.develop => builder.local_chart("./k8-util/helm"),
-            _ => builder,
-        })
         .build()?;
-    */
+    
     /* 
     if upgrade {
         println!("upgrading sys chart");

--- a/src/cluster/src/cli/start/sys.rs
+++ b/src/cluster/src/cli/start/sys.rs
@@ -9,7 +9,11 @@ pub fn process_sys(opt: StartOpt, upgrade: bool) -> Result<(), ClusterCliError> 
 }
 
 fn install_sys_impl(opt: StartOpt, upgrade: bool) -> Result<(), ChartInstallError> {
-    println!("installing sys chart");
+    if upgrade {
+        println!("upgrading sys chart");
+    } else {
+        println!("installing sys chart");
+    }
 
     let config = ChartConfig::sys_builder()
         .namespace(&opt.k8_config.namespace)

--- a/src/cluster/src/cli/start/sys.rs
+++ b/src/cluster/src/cli/start/sys.rs
@@ -1,14 +1,31 @@
+use semver::Version;
+
 use crate::cli::start::StartOpt;
 use crate::cli::ClusterCliError;
 use crate::charts::{ChartConfig, ChartInstallError, ChartInstaller};
 use crate::ClusterError;
+use crate::sys::SysConfig;
 
-pub fn process_sys(opt: StartOpt, upgrade: bool) -> Result<(), ClusterCliError> {
-    install_sys_impl(opt, upgrade).map_err(ClusterError::InstallSys)?;
+pub fn process_sys(opt: StartOpt,platform_version: Version) -> Result<(), ClusterCliError> {
+    install_sys_impl(opt, platform_version).map_err(ClusterError::InstallSys)?;
     Ok(())
 }
 
-fn install_sys_impl(opt: StartOpt, upgrade: bool) -> Result<(), ChartInstallError> {
+fn install_sys_impl(opt: StartOpt, platform_version: Version) -> Result<(), ChartInstallError> {
+
+    /* 
+    let config = SysConfig::builder(platform_version)
+        .namespace(&opt.k8_config.namespace)
+        .with(|builder| match &opt.k8_config.chart_location {
+            // If a chart location is given, use it
+            Some(chart_location) => builder.local_chart(chart_location),
+            // If we're in develop mode (but no explicit chart location), use local path
+            None if opt.develop => builder.local_chart("./k8-util/helm"),
+            _ => builder,
+        })
+        .build()?;
+    */
+    /* 
     if upgrade {
         println!("upgrading sys chart");
     } else {
@@ -26,6 +43,7 @@ fn install_sys_impl(opt: StartOpt, upgrade: bool) -> Result<(), ChartInstallErro
         .build()?;
     let installer = ChartInstaller::from_config(config)?;
     installer.process(upgrade)?;
+    */
 
     Ok(())
 }

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -9,6 +9,7 @@ use fluvio_command::CommandError;
 use crate::check::{CheckResults, CheckStatuses};
 use crate::charts::ChartInstallError;
 
+
 /// The types of errors that can occur during cluster management
 #[derive(thiserror::Error, Debug)]
 pub enum ClusterError {

--- a/src/cluster/src/error.rs
+++ b/src/cluster/src/error.rs
@@ -9,7 +9,6 @@ use fluvio_command::CommandError;
 use crate::check::{CheckResults, CheckStatuses};
 use crate::charts::ChartInstallError;
 
-
 /// The types of errors that can occur during cluster management
 #[derive(thiserror::Error, Debug)]
 pub enum ClusterError {

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -38,8 +38,8 @@ pub mod cli;
 
 use fluvio_helm as helm;
 
-pub use start::k8::{ClusterInstaller, ClusterConfig, ClusterConfigBuilder};
-pub use start::local::{LocalInstaller, LocalConfig, LocalConfigBuilder};
+pub use start::k8::{ClusterInstaller, ClusterConfig,};
+pub use start::local::{LocalInstaller, LocalConfig};
 pub use error::{ClusterError, K8InstallError, LocalInstallError, UninstallError};
 pub use helm::HelmError;
 pub use check::{ClusterChecker, CheckStatus, CheckStatuses, CheckResult, CheckResults};

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -27,6 +27,7 @@
 
 /// charts
 pub mod charts;
+pub mod sys;
 mod check;
 mod start;
 mod delete;

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -38,7 +38,7 @@ pub mod cli;
 
 use fluvio_helm as helm;
 
-pub use start::k8::{ClusterInstaller, ClusterConfig,};
+pub use start::k8::{ClusterInstaller, ClusterConfig};
 pub use start::local::{LocalInstaller, LocalConfig};
 pub use error::{ClusterError, K8InstallError, LocalInstallError, UninstallError};
 pub use helm::HelmError;

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -761,6 +761,7 @@ impl ClusterInstaller {
             chart_values.push(np_conf_path.to_path_buf());
 
             let external_addr = if let Some(addr) = &self.config.proxy_addr {
+                debug!(?addr, "use proxying");
                 addr.to_owned()
             } else {
                 debug!("Using NodePort service type");
@@ -796,6 +797,8 @@ impl ClusterInstaller {
 
             let mut helm_lb_config = BTreeMap::new();
             helm_lb_config.insert("loadBalancer", service_annotation);
+
+            debug!(?helm_lb_config, "helm_lb_config");
 
             serde_yaml::to_writer(&np_addr_fd, &helm_lb_config)
                 .map_err(|err| K8InstallError::Other(err.to_string()))?;
@@ -928,6 +931,7 @@ impl ClusterInstaller {
                                             let node_port = node_port.ok_or_else(|| K8InstallError::Other("Expecting a NodePort port".into()))?;
 
                                             let host_addr = if let Some(addr) = &self.config.proxy_addr {
+                                                debug!(?addr,"using proxy");
                                                 addr.to_owned()
                                             } else {
 

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -715,11 +715,6 @@ impl ClusterInstaller {
         // Create a managed SPU cluster
         self.create_managed_spu_group(&fluvio).await?;
 
-        // Wait for the SPU cluster to spin up
-        if !self.config.skip_spu_liveness_check {
-            self.wait_for_spu(namespace).await?;
-        }
-
         Ok(StartStatus {
             address,
             port,
@@ -730,7 +725,6 @@ impl ClusterInstaller {
     /// Install Fluvio Core chart on the configured cluster
     #[instrument(skip(self))]
     async fn install_app(&self) -> Result<(), K8InstallError> {
-        println!("Installing Fluvio app");
         debug!(
             "Installing fluvio with the following configuration: {:#?}",
             &self.config
@@ -1172,6 +1166,12 @@ impl ClusterInstaller {
         };
 
         admin.create(name, false, spu_spec).await?;
+
+        // Wait for the SPU cluster to spin up
+        if !self.config.skip_spu_liveness_check {
+            self.wait_for_spu(&self.config.namespace).await?;
+        }
+
         Ok(())
     }
 }

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -825,7 +825,11 @@ impl ClusterInstaller {
 
         debug!("Using helm install settings: {:#?}", &install_settings);
 
-        println!("installing fluvio chart");
+        if self.config.upgrade {
+            println!("Upgrading fluvio chart");
+        } else {
+            println!("installing fluvio chart");
+        }
 
         let mut config = ChartConfig::app_builder()
             .namespace(&self.config.namespace)

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use std::env;
 
 use derive_builder::Builder;
-use tracing::{info, warn, debug, error, instrument};
+use tracing::{info, warn, debug, instrument};
 use once_cell::sync::Lazy;
 use tempfile::NamedTempFile;
 use semver::Version;
@@ -18,7 +18,6 @@ use fluvio::metadata::spg::SpuGroupSpec;
 use fluvio::metadata::spu::SpuSpec;
 use fluvio::config::{TlsPolicy, TlsConfig, TlsPaths, ConfigFile, Profile};
 use fluvio_future::timer::sleep;
-use fluvio_future::net::{TcpStream};
 use k8_client::K8Client;
 use k8_config::K8Config;
 use k8_client::meta_client::MetadataClient;
@@ -50,7 +49,7 @@ static MAX_SC_NETWORK_LOOP: Lazy<u16> = Lazy::new(|| {
     let var_value = env::var("FLV_CLUSTER_MAX_SC_NETWORK_LOOP").unwrap_or_default();
     var_value.parse().unwrap_or(60)
 });
-const NETWORK_SLEEP_MS: u64 = 2000;
+
 /// maximum tiime for VERSION CHECK
 static MAX_SC_VERSION_LOOP: Lazy<u8> = Lazy::new(|| {
     let var_value = env::var("FLV_CLUSTER_MAX_SC_VERSION_LOOP").unwrap_or_default();
@@ -643,7 +642,10 @@ impl ClusterInstaller {
         skip(self),
         fields(namespace = &*self.config.namespace),
     )]
-    pub async fn install_fluvio(&self) -> Result<StartStatus, ClusterError> {
+    pub async fn install_fluvio(&self) -> Result<StartStatus, K8InstallError> {
+        println!("starting installing");
+
+        let mut installed = false;
         let checks = match self.config.skip_checks {
             true => None,
             // Check if env is ready for install and tries to fix anything it can
@@ -661,14 +663,8 @@ impl ClusterInstaller {
                     match status {
                         // If Fluvio is already installed, return the SC's address
                         CheckStatus::Fail(CheckFailed::AlreadyInstalled) => {
-                            debug!("Fluvio is already installed. Getting SC address");
-                            let (address, port) =
-                                self.wait_for_sc_service(&self.config.namespace).await?;
-                            return Ok(StartStatus {
-                                address,
-                                port,
-                                checks: Some(statuses),
-                            });
+                            debug!("Fluvio is already installed");
+                            installed = true;
                         }
                         CheckStatus::Fail(_) => any_failed = true,
                         _ => (),
@@ -683,36 +679,43 @@ impl ClusterInstaller {
             }
         };
 
-        self.install_app().await?;
+        if !installed {
+            self.install_app().await?;
+        }
+
         let namespace = &self.config.namespace;
-        let (address, port) = self
-            .wait_for_sc_service(namespace)
+
+        let (address, port) = self.discover_sc_address(namespace)
             .await
-            .map_err(|_| K8InstallError::UnableToDetectService)?;
-        println!("Fluvio SC is up at: {}", address);
+            .map_err(|_| K8InstallError::SCServiceTimeout)?;
+           
+        println!("found SC service addr: {}:{}", address, port);
+        let cluster_config = FluvioConfig::new(address.clone()).with_tls(self.config.client_tls_policy.clone());
+        let fluvio = connect_to_sc(&cluster_config).await?;
+
+        let platform_version = fluvio.platform_version();
+        println!("Connect to SC with platform version: {}",&platform_version);
+
+        // check if platform is not compatible with  cluster installer
+        if !versions_compatible(
+            platform_version.clone(),
+            self.config.platform_version.clone(),
+        ){
+            return Err(K8InstallError::FailedPlatformVersion(
+                self.config.platform_version.to_string(),
+            ));
+        }
 
         if self.config.save_profile {
             self.update_profile(address.clone())?;
         }
 
-        let cluster =
-            FluvioConfig::new(address.clone()).with_tls(self.config.client_tls_policy.clone());
 
-        if self.config.spu_replicas > 0 && !self.config.upgrade {
-            debug!("waiting for SC to spin up before attemp to spin up spu");
-            // Wait a little bit for the SC to spin up
-            sleep(Duration::from_millis(2000)).await;
+        // Create a managed SPU cluster
+        self.create_managed_spu_group(&fluvio).await?;
+       
 
-            // Create a managed SPU cluster
-            self.create_managed_spu_group(&cluster).await?;
-        }
-
-        // When upgrading, wait for platform version to match new version
-        println!(
-            "Waiting up to {} seconds for Fluvio cluster version check...",
-            *MAX_SC_VERSION_LOOP * 2
-        );
-        self.wait_for_fluvio_version(&cluster).await?;
+        
 
         // Wait for the SPU cluster to spin up
         if !self.config.skip_spu_liveness_check {
@@ -729,6 +732,8 @@ impl ClusterInstaller {
     /// Install Fluvio Core chart on the configured cluster
     #[instrument(skip(self))]
     async fn install_app(&self) -> Result<(), K8InstallError> {
+
+        println!("Installing Fluvio app");
         debug!(
             "Installing fluvio with the following configuration: {:#?}",
             &self.config
@@ -854,7 +859,7 @@ impl ClusterInstaller {
 
     /// Looks up the external address of a Fluvio SC instance in the given namespace
     #[instrument(skip(self, ns))]
-    async fn discover_sc_address(&self, ns: &str) -> Result<Option<(String, u16)>, K8InstallError> {
+    async fn discover_sc_address(&self, ns: &str) -> Result<(String, u16), K8InstallError> {
         use tokio::select;
         use futures_lite::stream::StreamExt;
 
@@ -870,7 +875,7 @@ impl ClusterInstaller {
             select! {
                 _ = &mut timer => {
                     debug!(timer = *MAX_SC_SERVICE_WAIT,"timer expired");
-                    return Ok(None)
+                    return Err(K8InstallError::SCServiceTimeout)
                 },
                 service_next = service_stream.next() => {
                     if let Some(service_watches) = service_next {
@@ -908,14 +913,14 @@ impl ClusterInstaller {
 
 
                                     if self.config.use_cluster_ip  {
-                                        return Ok(Some((format!("{}:{}",service.spec.cluster_ip,target_port),target_port)))
+                                        return Ok((service.spec.cluster_ip,target_port))
                                     };
 
                                     let k8_load_balancer_type = service.spec.r#type.ok_or_else(|| K8InstallError::Other("Load Balancer Type".into()))?;
 
                                     match k8_load_balancer_type {
                                         LoadBalancerType::ClusterIP => {
-                                            return Ok(Some((format!("{}:{}",service.spec.cluster_ip,target_port),target_port)))
+                                            return Ok((service.spec.cluster_ip,target_port))
                                         },
                                         LoadBalancerType::NodePort => {
                                             let node_port = node_port.ok_or_else(|| K8InstallError::Other("Expecting a NodePort port".into()))?;
@@ -939,7 +944,7 @@ impl ClusterInstaller {
                                                 external_addr.address
                                             };
 
-                                            return Ok(Some((format!("{}:{}",host_addr,node_port),node_port)))
+                                            return Ok((host_addr,node_port))
                                         },
                                         LoadBalancerType::LoadBalancer => {
                                             let ingress_addr = service
@@ -952,7 +957,7 @@ impl ClusterInstaller {
 
                                             if let Some(sock_addr) = ingress_addr.map(|addr| {format!("{}:{}", addr, target_port)}) {
                                                     debug!(%sock_addr,"found lb address");
-                                                    return Ok(Some((sock_addr,target_port)))
+                                                    return Ok((sock_addr,target_port))
                                             }
                                         },
                                         LoadBalancerType::ExternalName => {
@@ -966,86 +971,15 @@ impl ClusterInstaller {
                         }
                     } else {
                         debug!("service stream ended");
-                        return Ok(None)
+                        return Err(K8InstallError::SCServiceTimeout)
                     }
                 }
             }
         }
     }
 
-    /// Wait until the platform version of the cluster matches the chart version here
-    #[instrument(skip(self))]
-    async fn wait_for_fluvio_version(&self, config: &FluvioConfig) -> Result<(), K8InstallError> {
-        for attempt in 0..*MAX_SC_VERSION_LOOP {
-            let fluvio = match Fluvio::connect_with_config(config).await {
-                Ok(fluvio) => fluvio,
-                Err(_) => {
-                    sleep(Duration::from_millis(2_000)).await;
-                    continue;
-                }
-            };
-
-            // The major.minor.patch versions should match after upgrade
-            let platform_version = fluvio.platform_version();
-            let compatible = versions_compatible(
-                platform_version.clone(),
-                self.config.platform_version.clone(),
-            );
-
-            if compatible {
-                // Success
-                break;
-            }
-            debug!(
-                platform = %platform_version,
-                platform_version = %self.config.platform_version,
-                "Existing platform version is different than platform version",
-            );
-            if attempt >= *MAX_SC_VERSION_LOOP - 1 {
-                return Err(K8InstallError::FailedPlatformVersion(
-                    self.config.platform_version.to_string(),
-                ));
-            }
-            sleep(Duration::from_millis(2_000)).await;
-        }
-
-        Ok(())
-    }
-
-    /// Wait until the Fluvio SC public service appears in Kubernetes
-    /// return address and port
-    #[instrument(skip(self, ns))]
-    async fn wait_for_sc_service(&self, ns: &str) -> Result<(String, u16), K8InstallError> {
-        println!("waiting for SC service");
-        if let Some((sock_addr, port)) = self.discover_sc_address(ns).await? {
-            println!("found SC service addr: {:#?}", sock_addr);
-            self.wait_for_sc_port_check(&sock_addr).await?;
-            Ok((sock_addr, port))
-        } else {
-            Err(K8InstallError::SCServiceTimeout)
-        }
-    }
-
-    /// Wait until the Fluvio SC public service appears in Kubernetes
-    async fn wait_for_sc_port_check(&self, sock_addr_str: &str) -> Result<(), K8InstallError> {
-        println!("trying to connect sc port {} at ..", sock_addr_str);
-        for i in 0..*MAX_SC_NETWORK_LOOP {
-            // let sock_addr = self.wait_for_sc_dns(sock_addr_str).await?;
-            // println!("got SC address: {:#?}",sock_addr);
-            if TcpStream::connect(&sock_addr_str).await.is_ok() {
-                info!(sock_addr = %sock_addr_str, "finished SC port check");
-                return Ok(());
-            }
-            info!(
-                attempt = i,
-                "sc port closed, sleeping for {} ms", NETWORK_SLEEP_MS
-            );
-            sleep(Duration::from_millis(NETWORK_SLEEP_MS)).await;
-        }
-        error!(sock_addr = %sock_addr_str, "timeout for SC port check");
-        Err(K8InstallError::SCPortCheckTimeout)
-    }
-
+    
+    
     /// Wait until all SPUs are ready and have ingress
     #[instrument(skip(self, ns))]
     async fn wait_for_spu(&self, ns: &str) -> Result<bool, K8InstallError> {
@@ -1158,7 +1092,7 @@ impl ClusterInstaller {
 
     /// Updates the Fluvio configuration with the newly installed cluster info.
     fn update_profile(&self, external_addr: String) -> Result<(), K8InstallError> {
-        debug!("updating profile for: {}", external_addr);
+        println!("updating profile");
         let mut config_file = ConfigFile::load_default_or_new()?;
         let config = config_file.mut_config();
 
@@ -1213,14 +1147,23 @@ impl ClusterInstaller {
 
     /// Provisions a SPU group for the given cluster according to internal config
     #[instrument(
-    skip(self, cluster),
-    fields(cluster_endpoint = & * cluster.endpoint)
+    skip(self, fluvio),
     )]
-    async fn create_managed_spu_group(&self, cluster: &FluvioConfig) -> Result<(), K8InstallError> {
-        println!("Trying to create managed {} spus", self.config.spu_replicas);
+    async fn create_managed_spu_group(&self, fluvio: &Fluvio) -> Result<(), K8InstallError> {
+       
+        
         let name = self.config.group_name.clone();
-        let fluvio = Fluvio::connect_with_config(cluster).await?;
         let admin = fluvio.admin().await;
+
+        println!("checking if spu groups exists");
+        let lists = admin.list::<SpuGroupSpec, _>(vec![]).await?;
+
+        if !lists.is_empty() {
+            println!("spu group: {} exists, skipping",lists[0].name);
+            return Ok(())
+        }
+
+        println!("Trying to create managed {} spus", self.config.spu_replicas);
 
         let spu_spec = SpuGroupSpec {
             replicas: self.config.spu_replicas,
@@ -1236,6 +1179,38 @@ impl ClusterInstaller {
 fn versions_compatible(a: Version, b: Version) -> bool {
     Version::new(a.major, a.minor, a.patch) == Version::new(b.major, b.minor, b.patch)
 }
+
+/// Check if the SC service is up and running
+async fn connect_to_sc(config: &FluvioConfig) -> Result<Fluvio, K8InstallError> {
+
+    async fn try_connect_sc(fluvio_config: &FluvioConfig) -> Option<Fluvio>  {
+        match Fluvio::connect_with_config(fluvio_config).await {
+            Ok(fluvio) => Some(fluvio),
+            Err(err) => {
+                debug!("couldn't connect: {:#?}",err);
+                return None
+            }
+        }
+    }
+
+    for attempt in 0..*MAX_SC_VERSION_LOOP {
+
+        if let Some(fluvio) = try_connect_sc(config).await {
+            return Ok(fluvio)
+        } else {
+            if attempt < *MAX_SC_VERSION_LOOP - 1 {
+                sleep(Duration::from_secs(1)).await;
+            }        
+            
+        }
+       
+    }
+
+    Err(K8InstallError::SCServiceTimeout)
+
+    
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -318,8 +318,7 @@ pub struct ClusterConfig {
 
     /// Use specified SC address
     #[builder(setter(into, strip_option), default)]
-    sc_addr: Option<String>
-    
+    sc_addr: Option<String>,
 }
 
 impl ClusterConfig {
@@ -922,7 +921,7 @@ impl ClusterInstaller {
                                             let node_port = node_port.ok_or_else(|| K8InstallError::Other("Expecting a NodePort port".into()))?;
 
                                             let host_addr = if let Some(addr) = &self.config.sc_addr {
-                                                addr.to_owned() 
+                                                addr.to_owned()
                                             } else {
 
                                                 debug!("k8 node query");
@@ -1019,7 +1018,7 @@ impl ClusterInstaller {
     async fn wait_for_sc_service(&self, ns: &str) -> Result<(String, u16), K8InstallError> {
         println!("waiting for SC service");
         if let Some((sock_addr, port)) = self.discover_sc_address(ns).await? {
-            println!("found SC service addr: {:#?}",sock_addr);
+            println!("found SC service addr: {:#?}", sock_addr);
             self.wait_for_sc_port_check(&sock_addr).await?;
             Ok((sock_addr, port))
         } else {
@@ -1029,10 +1028,10 @@ impl ClusterInstaller {
 
     /// Wait until the Fluvio SC public service appears in Kubernetes
     async fn wait_for_sc_port_check(&self, sock_addr_str: &str) -> Result<(), K8InstallError> {
-        println!("trying to connect sc port {} at ..",sock_addr_str);
+        println!("trying to connect sc port {} at ..", sock_addr_str);
         for i in 0..*MAX_SC_NETWORK_LOOP {
-           // let sock_addr = self.wait_for_sc_dns(sock_addr_str).await?;
-           // println!("got SC address: {:#?}",sock_addr);
+            // let sock_addr = self.wait_for_sc_dns(sock_addr_str).await?;
+            // println!("got SC address: {:#?}",sock_addr);
             if TcpStream::connect(&sock_addr_str).await.is_ok() {
                 info!(sock_addr = %sock_addr_str, "finished SC port check");
                 return Ok(());
@@ -1046,8 +1045,6 @@ impl ClusterInstaller {
         error!(sock_addr = %sock_addr_str, "timeout for SC port check");
         Err(K8InstallError::SCPortCheckTimeout)
     }
-
-    
 
     /// Wait until all SPUs are ready and have ingress
     #[instrument(skip(self, ns))]

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -25,7 +25,6 @@ use k8_types::core::service::{LoadBalancerType, ServiceSpec, TargetPort};
 use k8_types::core::node::{NodeSpec, NodeAddress};
 use fluvio_command::CommandExt;
 
-use crate::helm::{HelmClient};
 use crate::check::{CheckFailed, CheckResults, AlreadyInstalled, SysChartCheck};
 use crate::error::K8InstallError;
 use crate::{ClusterError, StartStatus, DEFAULT_NAMESPACE, CheckStatus, ClusterChecker, CheckStatuses};
@@ -572,8 +571,6 @@ pub struct ClusterInstaller {
     config: ClusterConfig,
     /// Shared Kubernetes client for install
     kube_client: K8Client,
-    /// Helm client for performing installs
-    helm_client: HelmClient,
 }
 
 impl ClusterInstaller {
@@ -592,7 +589,6 @@ impl ClusterInstaller {
         Ok(Self {
             config,
             kube_client: K8Client::default().map_err(K8InstallError::K8ClientError)?,
-            helm_client: HelmClient::new().map_err(K8InstallError::HelmError)?,
         })
     }
 

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -317,8 +317,8 @@ pub struct ClusterConfig {
     render_checks: bool,
 
     /// Use specified SC address
-    #[builder(setter(into, strip_option), default)]
-    sc_addr: Option<String>,
+    #[builder(setter(into), default)]
+    proxy_addr: Option<String>,
 }
 
 impl ClusterConfig {
@@ -920,7 +920,7 @@ impl ClusterInstaller {
                                         LoadBalancerType::NodePort => {
                                             let node_port = node_port.ok_or_else(|| K8InstallError::Other("Expecting a NodePort port".into()))?;
 
-                                            let host_addr = if let Some(addr) = &self.config.sc_addr {
+                                            let host_addr = if let Some(addr) = &self.config.proxy_addr {
                                                 addr.to_owned()
                                             } else {
 

--- a/src/cluster/src/sys/error.rs
+++ b/src/cluster/src/sys/error.rs
@@ -1,4 +1,4 @@
-use fluvio_helm::HelmError;
+use semver::Error as VersionError;
 
 use crate::charts::ChartInstallError;
 
@@ -11,4 +11,8 @@ pub enum SysInstallError {
     /// An error occurred while trying to install Fluvio system charts
     #[error("Chart Installation Error")]
     ChartError(#[from] ChartInstallError),
+    #[error("Version Error")]
+    VersionError(#[from] VersionError),
+    #[error("Other System Error {0}")]
+    Other(String),
 }

--- a/src/cluster/src/sys/error.rs
+++ b/src/cluster/src/sys/error.rs
@@ -1,0 +1,14 @@
+use fluvio_helm::HelmError;
+
+use crate::charts::ChartInstallError;
+
+/// Errors that may occur while trying to install Fluvio System Components
+#[derive(thiserror::Error, Debug)]
+pub enum SysInstallError {
+    /// Attempted to construct a Config object without all required fields
+    #[error("Missing required config option {0}")]
+    MissingRequiredConfig(String),
+    /// An error occurred while trying to install Fluvio system charts
+    #[error("Chart Installation Error")]
+    ChartError(#[from] ChartInstallError),
+}

--- a/src/cluster/src/sys/installer.rs
+++ b/src/cluster/src/sys/installer.rs
@@ -96,12 +96,14 @@ impl SysInstaller {
     fn run(&self) -> Result<(), SysInstallError> {
         println!("Start Sys Configuration");
 
-        let mut config = ChartConfig::sys_builder()
+        let config = ChartConfig::sys_builder()
             .namespace(&self.config.namespace)
             .version(self.config.chart_version.clone())
             .build()?;
 
         let installer = ChartInstaller::from_config(config)?;
+
+        
 
         info!("Fluvio sys chart has been installed");
         Ok(())

--- a/src/cluster/src/sys/installer.rs
+++ b/src/cluster/src/sys/installer.rs
@@ -1,0 +1,128 @@
+use std::path::{Path, PathBuf};
+
+use tracing::{info, debug, instrument};
+use derive_builder::Builder;
+use semver::Version;
+
+use crate::charts::{ChartConfig, ChartInstaller};
+use crate::UserChartLocation;
+use crate::DEFAULT_NAMESPACE;
+
+use super::SysInstallError;
+
+/// Configuration options for installing Fluvio system charts
+#[derive(Builder, Debug, Clone)]
+#[builder(build_fn(private, name = "build_impl"))]
+pub struct SysConfig {
+    /// Platform version
+    #[builder(setter(into))]
+    platform_version: Version,
+
+    /// Sets the Kubernetes namespace to install Syste Chart.
+    #[builder(setter(into), default = "DEFAULT_NAMESPACE.to_string()")]
+    namespace: String,
+
+    /// if true, don't perform install
+    #[builder(default = "false")]
+    dry_run: bool,
+
+    /// Sets a specific version of the Fluvio helm chart to install.
+    #[builder(setter(into), default)]
+    chart_version: Option<Version>,
+    /// The location to search for the Helm charts to install
+    #[builder(setter(into, strip_option), default)]
+    chart_location: Option<UserChartLocation>,
+}
+
+impl SysConfig {
+    /// Creates a default [`SysConfigBuilder`].
+    ///
+    /// The required argument `chart_version` must be provdied when
+    /// constructing the builder.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use fluvio_cluster::SysConfig;
+    /// use semver::Version;
+    /// let builder = SysConfig::builder(Version::parse("0.7.0-alpha.1").unwrap());
+    /// ```
+    pub fn builder(platform_version: Version) -> SysConfigBuilder {
+        let mut builder = SysConfigBuilder::default();
+        builder.platform_version(platform_version);
+        builder
+    }
+}
+
+impl SysConfigBuilder {
+    /// Validates all builder options and constructs a `SysConfig`
+    pub fn build(&self) -> Result<SysConfig, SysInstallError> {
+        let config = self
+            .build_impl()
+            .map_err(|err| SysInstallError::MissingRequiredConfig(err.to_string()))?;
+        Ok(config)
+    }
+
+    /// The local chart location to install sys charts from
+    pub fn local_chart<S: Into<PathBuf>>(&mut self, local_chart_location: S) -> &mut Self {
+        let user_chart_location = UserChartLocation::Local(local_chart_location.into());
+        debug!(?user_chart_location, "setting local chart");
+        self.chart_location(user_chart_location);
+        self
+    }
+
+    /// set remote chart
+    pub fn remote_chart<S: Into<String>>(&mut self, remote_chart_location: S) -> &mut Self {
+        self.chart_location(UserChartLocation::Remote(remote_chart_location.into()));
+        self
+    }
+}
+
+/// Installs or upgrades the Fluvio system components
+
+#[derive(Debug)]
+pub struct SysInstaller {
+    config: SysConfig,
+}
+
+impl SysInstaller {
+    /// Create a new `SysInstaller` using the given config
+    pub fn from_config(config: SysConfig) -> Result<Self, SysInstallError> {
+        Ok(Self { config })
+    }
+
+    /// run installation
+    #[instrument(skip(self))]
+    fn run(&self) -> Result<(), SysInstallError> {
+        println!("Start Sys Configuration");
+
+        let mut config = ChartConfig::sys_builder()
+            .namespace(&self.config.namespace)
+            .version(self.config.chart_version.clone())
+            .build()?;
+
+        let installer = ChartInstaller::from_config(config)?;
+
+        info!("Fluvio sys chart has been installed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /*
+    #[test]
+    fn test_build_config() {
+        let config: SysConfig =
+            SysConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
+                .build()
+                .expect("should build config with required options");
+        assert_eq!(
+            config.chart_version,
+            semver::Version::parse("0.7.0-alpha.1").unwrap()
+        );
+    }
+    */
+}

--- a/src/cluster/src/sys/mod.rs
+++ b/src/cluster/src/sys/mod.rs
@@ -1,0 +1,5 @@
+mod installer;
+mod error;
+
+pub use installer::*;
+pub use error::*;

--- a/tests/runner/src/utils/setup/environment/k8.rs
+++ b/tests/runner/src/utils/setup/environment/k8.rs
@@ -35,9 +35,7 @@ impl TestEnvironmentDriver for K8EnvironmentDriver {
             }
         }
 
-        if let Some(addr) = &self.option.sc_addr {
-            builder.sc_addr(addr);
-        }
+        builder.proxy_addr(self.option.proxy_addr.clone());        
 
         builder
             .spu_replicas(self.option.spu())

--- a/tests/runner/src/utils/setup/environment/k8.rs
+++ b/tests/runner/src/utils/setup/environment/k8.rs
@@ -28,7 +28,17 @@ impl TestEnvironmentDriver for K8EnvironmentDriver {
         let mut builder = ClusterConfig::builder(version);
         if self.option.develop_mode() {
             builder.development().expect("should test in develop mode");
+        } else {
+            // check if image version is specified
+            if let Some(image) = &self.option.image_version {
+                builder.image_tag(image);
+            }
         }
+
+        if let Some(addr) = &self.option.sc_addr {
+            builder.sc_addr(addr);
+        }
+
         builder
             .spu_replicas(self.option.spu())
             .skip_checks(self.option.skip_checks())

--- a/tests/runner/src/utils/setup/environment/k8.rs
+++ b/tests/runner/src/utils/setup/environment/k8.rs
@@ -35,7 +35,7 @@ impl TestEnvironmentDriver for K8EnvironmentDriver {
             }
         }
 
-        builder.proxy_addr(self.option.proxy_addr.clone());        
+        builder.proxy_addr(self.option.proxy_addr.clone());
 
         builder
             .spu_replicas(self.option.spu())

--- a/tests/runner/src/utils/test_meta/environment.rs
+++ b/tests/runner/src/utils/test_meta/environment.rs
@@ -183,8 +183,7 @@ pub struct EnvironmentSetup {
 
     /// K8: use sc address
     #[structopt(long)]
-    pub sc_addr: Option<String>
-
+    pub sc_addr: Option<String>,
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/tests/runner/src/utils/test_meta/environment.rs
+++ b/tests/runner/src/utils/test_meta/environment.rs
@@ -176,6 +176,15 @@ pub struct EnvironmentSetup {
     /// In seconds, the maximum time a test will run before considered a fail (default: 1 hour)
     #[structopt(long, parse(try_from_str = parse_timeout_seconds), default_value = "3600")]
     pub timeout: Duration,
+
+    /// K8: use specific image version
+    #[structopt(long)]
+    pub image_version: Option<String>,
+
+    /// K8: use sc address
+    #[structopt(long)]
+    pub sc_addr: Option<String>
+
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/tests/runner/src/utils/test_meta/environment.rs
+++ b/tests/runner/src/utils/test_meta/environment.rs
@@ -183,7 +183,7 @@ pub struct EnvironmentSetup {
 
     /// K8: use sc address
     #[structopt(long)]
-    pub sc_addr: Option<String>,
+    pub proxy_addr: Option<String>,
 }
 
 #[allow(clippy::unnecessary_wraps)]


### PR DESCRIPTION
This PR updates the current issue with Cluster Installer:
* Provide relevant information during each installation steps.
* Add Proxy mode to access k3 cluster that doesn't expose direct ports from host