### PR TITLE
Update RELEASE checklist

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@ Prior to releasing, the release manager should check the following:
 
 - [ ] Confirm that the sample code on the [fluvio.io] homepage is correct (Rust/Node/Python)
 - [ ] Review the "getting started" docs on fluvio.io/docs
+- [ ] If this is a Major Version Bump, be sure to coordinate with Fluvio Cloud release
 
 [fluvio.io]: https://fluvio.io
 
@@ -13,7 +14,6 @@ To actually perform the release, the core steps are:
 - Wait for workflow to complete successfully and apply `vX.Y.Z` tag to git
 - Publish any crates `fluvio` client depends on, followed by `fluvio` crate itself
 - Fast-forward `stable` branch to match `master` (may become automated)
-- Push new commit with updated `VERSION` and `CHANGELOG.md` files
 
 After performing the release, the release manager should do the following in order
 to prepare for the next release and announce the current release to the community:


### PR DESCRIPTION
During major version bumps, we should coordinate a Fluvio CLI update with a release of Fluvio Cloud in order to prevent the MINIMUM_PLATFORM_VERSION incompatibility notice to users. I have added this to the RELEASE checklist so we do not forget in the future.