### PR TITLE
Restore last_stable_offset to prevent breaking changes

### DIFF
--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::admin::FluvioAdmin;
 pub use crate::fluvio::Fluvio;
 
 /// The minimum VERSION of the Fluvio Platform that this client is compatible with.
-const MINIMUM_PLATFORM_VERSION: &str = "0.9.0";
+const MINIMUM_PLATFORM_VERSION: &str = "0.8.0";
 
 /// Creates a producer that sends records to the named topic
 ///

--- a/src/dataplane-protocol/src/fetch/response.rs
+++ b/src/dataplane-protocol/src/fetch/response.rs
@@ -76,6 +76,10 @@ where
     /// The current high water mark.
     pub high_watermark: i64,
 
+    /// The last stable offset (or LSO) of the partition which is inherited from Kafka semamntics
+    #[deprecated(since = "0.4.0", note = "Please use high_watermark")]
+    pub last_stable_offset: i64,
+
     /// next offset to fetch in case of filter
     /// consumer should return that back to SPU, othewise SPU will re-turn same filter records
     #[fluvio(min_version = 11, ignorable)]
@@ -154,6 +158,7 @@ mod file {
     pub type FilePartitionResponse = FetchablePartitionResponse<FileRecordSet>;
 
     impl FileWrite for FilePartitionResponse {
+        #[allow(deprecated)]
         fn file_encode(
             &self,
             src: &mut BytesMut,
@@ -164,6 +169,7 @@ mod file {
             self.partition_index.encode(src, version)?;
             self.error_code.encode(src, version)?;
             self.high_watermark.encode(src, version)?;
+            self.last_stable_offset.encode(src, version)?;
             if version >= 11 {
                 self.next_filter_offset.encode(src, version)?;
             } else {

--- a/src/spu/src/replication/follower/sync.rs
+++ b/src/spu/src/replication/follower/sync.rs
@@ -169,5 +169,8 @@ impl SlicePartitionResponse for PeerFilePartitionResponse {
         self.error = error;
     }
 
+    /// ignore last stable offset
+    fn set_last_stable_offset(&mut self, _offset: i64) {}
+
     fn set_log_start_offset(&mut self, _offset: i64) {}
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -107,6 +107,8 @@ mod inner {
     pub trait SlicePartitionResponse {
         fn set_hw(&mut self, offset: i64);
 
+        fn set_last_stable_offset(&mut self, offset: i64);
+
         fn set_log_start_offset(&mut self, offset: i64);
 
         fn set_slice(&mut self, slice: AsyncFileSlice);
@@ -117,6 +119,11 @@ mod inner {
     impl SlicePartitionResponse for FilePartitionResponse {
         fn set_hw(&mut self, offset: i64) {
             self.high_watermark = offset;
+        }
+
+        #[allow(deprecated)]
+        fn set_last_stable_offset(&mut self, offset: i64) {
+            self.last_stable_offset = offset;
         }
 
         fn set_log_start_offset(&mut self, offset: i64) {

--- a/src/storage/src/replica.rs
+++ b/src/storage/src/replica.rs
@@ -284,6 +284,7 @@ impl FileReplica {
         );
 
         response.set_hw(hw);
+        response.set_last_stable_offset(hw);
         response.set_log_start_offset(self.get_log_start_offset());
 
         match self.find_segment(start_offset) {


### PR DESCRIPTION
This undoes the removal of `last_stable_offset` from `FetchablePartitionResponse` in an effort to remove breakages from the protocol change.