### PR TITLE
[Merged by Bors] - disable k8 if build image_version is supplied

### DIFF
--- a/k8-util/cluster/reset-minikube.sh
+++ b/k8-util/cluster/reset-minikube.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # delete and re-install minikube ready for fluvio
-# this defaults to docker and assume you have have sudo access
+# it uses docker as default driver
 set -e
+set -x
 ARG1=${1:-docker}
 K8_VERSION=${2:-1.21.2}
+
+if [ "$(uname)" == "Darwin" ]; then
+EXTRA_CONFIG=--extra-config=apiserver.service-node-port-range=32700-32800 --ports=127.0.0.1:32700-32800:32700-32800
+fi
+
+
 minikube delete
-minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION
+minikube start --driver $ARG1 --kubernetes-version=$K8_VERSION $EXTRA_CONFIG
 # minikube start --extra-config=apiserver.v=10

--- a/src/cluster/src/start/k8.rs
+++ b/src/cluster/src/start/k8.rs
@@ -316,6 +316,10 @@ pub struct ClusterConfig {
     /// ```
     #[builder(default = "false")]
     render_checks: bool,
+
+    /// Use proxy address for communicating with kubernetes cluster
+    #[builder(setter(into), default)]
+    proxy_addr: Option<String>,
 }
 
 impl ClusterConfig {

--- a/tests/runner/src/utils/test_meta/environment.rs
+++ b/tests/runner/src/utils/test_meta/environment.rs
@@ -176,6 +176,14 @@ pub struct EnvironmentSetup {
     /// In seconds, the maximum time a test will run before considered a fail (default: 1 hour)
     #[structopt(long, parse(try_from_str = parse_timeout_seconds), default_value = "3600")]
     pub timeout: Duration,
+
+    /// K8: use specific image version
+    #[structopt(long)]
+    pub image_version: Option<String>,
+
+    /// K8: use sc address
+    #[structopt(long)]
+    pub proxy_addr: Option<String>,
 }
 
 #[allow(clippy::unnecessary_wraps)]


### PR DESCRIPTION
This is for #1363.

Disable building image if image version is supplied.  This is useful in the Mac where building image might not work.  In this case, we use image supplied built using Linux.

Also, by default use proxy for accessing Minikube cluster since Docker for Mac doesn't map ports from Minikube to host automatically. 