### PR TITLE
[Merged by Bors] - Fix release flow to force update release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         continue-on-error: true
         run: |
           ${HOME}/.fluvio/bin/fluvio package bump dynamic "${{ env.VERSION }}"
-          ${HOME}/.fluvio/bin/fluvio package tag "fluvio:${{ env.VERSION }}" --tag=stable
+          ${HOME}/.fluvio/bin/fluvio package tag "fluvio:${{ env.VERSION }}" --tag=stable --force
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
I noticed that `install.sh` continued to install `0.9.0` for me despite the new `0.9.1` release. I realized that the `fluvio package tag` command in the release flow needs the `--force` flag in order to overwrite the current tag.