### PR TITLE
[Merged by Bors] - Fix publish workflow missing backslash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
             echo "PACKAGE=$PACKAGE"
 
             ${HOME}/.fluvio/bin/fluvio package publish \
-              --package="${PACKAGE}"
+              --package="${PACKAGE}" \
               --version="${VERSION}+${{ github.sha }}" \
               --target="${TARGET}" \
               "${UNZIP_DIR}/${ARTIFACT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
 
             ${HOME}/.fluvio/bin/fluvio package publish \
               --force \
-              --package="${PACKAGE}"
+              --package="${PACKAGE}" \
               --version="${VERSION}" \
               --target="${TARGET}" \
               "${UNZIP_DIR}/${ARTIFACT}"


### PR DESCRIPTION
Forgot `\` in workflow file.