### PR TITLE
[Merged by Bors] - make SPU and SPG controller be dynamic based on ConfigMap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ k8-setup:
 # Kubernetes Tests
 
 smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
-smoke-test-k8: smoke-test build_k8_image
+smoke-test-k8: build_k8_image smoke-test 
 
 smoke-test-k8-tls: TEST_ARG_EXTRA=--tls $(EXTRA_ARG)
 smoke-test-k8-tls: build_k8_image smoke-test

--- a/src/cluster/src/cli/start/k8.rs
+++ b/src/cluster/src/cli/start/k8.rs
@@ -57,6 +57,10 @@ pub async fn process_k8(
         builder.image_tag(image_tag.trim());
     }
 
+    if let Some(service_type) = opt.service_type {
+        builder.service_type(service_type);
+    }
+
     let config = builder.build()?;
     let installer = ClusterInstaller::from_config(config)?;
     if opt.setup {

--- a/src/cluster/src/cli/start/mod.rs
+++ b/src/cluster/src/cli/start/mod.rs
@@ -127,6 +127,10 @@ pub struct StartOpt {
     /// Proxy address
     #[structopt(long)]
     pub proxy_addr: Option<String>,
+
+    /// Service Type
+    #[structopt(long)]
+    pub service_type: Option<String>,
 }
 
 impl StartOpt {

--- a/src/sc/src/k8/controllers/mod.rs
+++ b/src/sc/src/k8/controllers/mod.rs
@@ -17,6 +17,7 @@ mod k8_operator {
     use crate::k8::objects::spu_service::SpuServiceSpec;
     use crate::k8::objects::statefulset::StatefulsetSpec;
     use crate::k8::objects::spg_service::SpgServiceSpec;
+    use crate::k8::objects::spu_k8_config::ScK8Config;
     use crate::k8::controllers::spg_stateful::SpgStatefulSetController;
     use crate::k8::controllers::spu_service::SpuServiceController;
     use crate::k8::controllers::spu_controller::K8SpuController;
@@ -32,6 +33,7 @@ mod k8_operator {
         let spu_service_ctx: StoreContext<SpuServiceSpec> = StoreContext::new();
         let statefulset_ctx: StoreContext<StatefulsetSpec> = StoreContext::new();
         let spg_service_ctx: StoreContext<SpgServiceSpec> = StoreContext::new();
+        let config_ctx: StoreContext<ScK8Config> = StoreContext::new();
 
         info!("starting k8 cluster operators");
 
@@ -53,10 +55,16 @@ mod k8_operator {
             spg_service_ctx.clone(),
         );
 
+        K8ClusterStateDispatcher::<_, _>::start(
+            namespace.clone(),
+            k8_client.clone(),
+            config_ctx.clone(),
+        );
+
         whitelist!(config, "k8_spg", {
             SpgStatefulSetController::start(
-                k8_client.clone(),
                 namespace.clone(),
+                config_ctx.clone(),
                 global_ctx.spgs().clone(),
                 statefulset_ctx,
                 global_ctx.spus().clone(),
@@ -74,12 +82,7 @@ mod k8_operator {
         });
 
         whitelist!(config, "k8_spu_service", {
-            SpuServiceController::start(
-                k8_client,
-                namespace,
-                spu_service_ctx,
-                global_ctx.spgs().clone(),
-            );
+            SpuServiceController::start(config_ctx, spu_service_ctx, global_ctx.spgs().clone());
         });
     }
 }

--- a/src/sc/src/k8/controllers/mod.rs
+++ b/src/sc/src/k8/controllers/mod.rs
@@ -55,15 +55,11 @@ mod k8_operator {
             spg_service_ctx.clone(),
         );
 
-        K8ClusterStateDispatcher::<_, _>::start(
-            namespace.clone(),
-            k8_client.clone(),
-            config_ctx.clone(),
-        );
+        K8ClusterStateDispatcher::<_, _>::start(namespace.clone(), k8_client, config_ctx.clone());
 
         whitelist!(config, "k8_spg", {
             SpgStatefulSetController::start(
-                namespace.clone(),
+                namespace,
                 config_ctx.clone(),
                 global_ctx.spgs().clone(),
                 statefulset_ctx,

--- a/src/sc/src/k8/controllers/spu_service.rs
+++ b/src/sc/src/k8/controllers/spu_service.rs
@@ -1,12 +1,13 @@
 use std::{collections::HashMap, fmt, time::Duration};
 
-use fluvio_controlplane_metadata::store::MetadataStoreObject;
-use fluvio_stream_dispatcher::actions::WSAction;
-use k8_client::{ClientError, SharedK8Client};
 use tracing::{debug, trace, error, instrument};
 
 use fluvio_future::task::spawn;
 use fluvio_future::timer::sleep;
+use fluvio_controlplane_metadata::store::MetadataStoreObject;
+use fluvio_controlplane_metadata::store::k8::K8MetaItem;
+use fluvio_stream_dispatcher::actions::WSAction;
+use k8_client::{ClientError};
 
 use crate::stores::spg::{SpuGroupSpec};
 use crate::stores::{StoreContext, K8ChangeListener};
@@ -16,10 +17,9 @@ use crate::k8::objects::spu_service::SpuServiceSpec;
 
 /// Sync individual SPU services from SPU Group
 pub struct SpuServiceController {
-    client: SharedK8Client,
-    namespace: String,
     services: StoreContext<SpuServiceSpec>,
     groups: StoreContext<SpuGroupSpec>,
+    configs: StoreContext<ScK8Config>,
 }
 
 impl fmt::Display for SpuServiceController {
@@ -36,14 +36,12 @@ impl fmt::Debug for SpuServiceController {
 
 impl SpuServiceController {
     pub fn start(
-        client: SharedK8Client,
-        namespace: String,
+        configs: StoreContext<ScK8Config>,
         services: StoreContext<SpuServiceSpec>,
         groups: StoreContext<SpuGroupSpec>,
     ) {
         let controller = Self {
-            client,
-            namespace,
+            configs,
             services,
             groups,
         };
@@ -66,8 +64,10 @@ impl SpuServiceController {
         use tokio::select;
 
         let mut spg_listener = self.groups.change_listener();
+        let mut config_listener = self.configs.change_listener();
 
         self.sync_with_spg(&mut spg_listener).await?;
+        self.sync_with_config(&mut config_listener).await?;
 
         loop {
             trace!("waiting events");
@@ -78,8 +78,42 @@ impl SpuServiceController {
                     self.sync_with_spg(&mut spg_listener).await?;
                 },
 
+                _ = config_listener.listen() => {
+                    debug!("detected config changes");
+                    self.sync_with_config(&mut config_listener).await?;
+                }
+
             }
         }
+    }
+
+    async fn sync_with_config(
+        &mut self,
+        listener: &mut K8ChangeListener<ScK8Config>,
+    ) -> Result<(), ClientError> {
+        if !listener.has_change() {
+            trace!("no config change, skipping");
+            return Ok(());
+        }
+
+        let changes = listener.sync_changes().await;
+        let epoch = changes.epoch;
+        let (updates, deletes) = changes.parts();
+
+        debug!(
+            "received config changes updates: {},deletes: {},epoch: {}",
+            updates.len(),
+            deletes.len(),
+            epoch,
+        );
+
+        for config in updates.into_iter() {
+            // iterate over all spg
+            self.update_services(self.groups.store().clone_values().await, config.spec)
+                .await?;
+        }
+
+        Ok(())
     }
 
     async fn sync_with_spg(
@@ -87,7 +121,7 @@ impl SpuServiceController {
         listener: &mut K8ChangeListener<SpuGroupSpec>,
     ) -> Result<(), ClientError> {
         if !listener.has_change() {
-            trace!("no service change, skipping");
+            trace!("no spg changes, skipping");
             return Ok(());
         }
 
@@ -102,8 +136,22 @@ impl SpuServiceController {
             epoch,
         );
 
-        let spu_k8_config = ScK8Config::load(&self.client, &self.namespace).await?;
+        if let Some(config) = self.configs.store().value("fluvio").await {
+            self.update_services(updates, config.inner_owned().spec)
+                .await?;
+        } else {
+            error!("config map is not loaded, skipping");
+        }
 
+        Ok(())
+    }
+
+    /// update spu
+    async fn update_services(
+        &self,
+        updates: Vec<MetadataStoreObject<SpuGroupSpec, K8MetaItem>>,
+        config: ScK8Config,
+    ) -> Result<(), ClientError> {
         for group_item in updates.into_iter() {
             let spg_obj = SpuGroupObj::new(group_item);
 
@@ -113,7 +161,7 @@ impl SpuServiceController {
                 let spu_name = format!("{}-{}", spg_obj.key(), i);
                 debug!(%spu_name,"generating spu with name");
 
-                self.apply_spu_load_balancers(&spg_obj, &spu_name, &spu_k8_config)
+                self.apply_spu_load_balancers(&spg_obj, &spu_name, &config)
                     .await?;
             }
         }

--- a/src/sc/src/k8/objects/spu_k8_config.rs
+++ b/src/sc/src/k8/objects/spu_k8_config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use tracing::{debug, info};
 use serde::{Deserialize};
 
+
 use k8_client::{ClientError, SharedK8Client};
 use k8_metadata_client::MetadataClient;
 use k8_types::core::pod::{ResourceRequirements, PodSecurityContext};
@@ -10,10 +11,13 @@ use k8_types::core::config_map::ConfigMapSpec;
 use k8_types::InputObjectMeta;
 use k8_types::core::service::ServiceSpec;
 
+use crate::dispatcher::core::{Spec,Status};
+
+
 const CONFIG_MAP_NAME: &str = "spu-k8";
 
 // this is same struct as in helm config
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Deserialize, Debug, Clone, PartialEq,Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PodConfig {
     #[serde(default)]
@@ -22,7 +26,7 @@ pub struct PodConfig {
     pub storage_class: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug,PartialEq,Default,Clone)]
 pub struct ScK8Config {
     pub image: String,
     pub pod_security_context: Option<PodSecurityContext>,
@@ -101,3 +105,29 @@ impl ScK8Config {
         }
     }
 }
+
+
+/// Fluvio plaform K8 spec
+#[derive(Debug,  Default, Clone)]
+pub struct FluvioConfigSpec {
+    spec: ConfigMapSpec,
+    data: ScK8Config
+}
+
+impl PartialEq for FluvioConfigSpec {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Spec for FluvioConfigSpec {
+    const LABEL: &'static str = "FluvioConfig";
+    type IndexKey = String;
+    type Status = FluvioConfigStatus;
+    type Owner = Self;
+}
+
+#[derive(Deserialize, Debug, PartialEq, Default, Clone)]
+pub struct FluvioConfigStatus{}
+
+impl Status for FluvioConfigStatus {}

--- a/src/sc/src/k8/objects/spu_service.rs
+++ b/src/sc/src/k8/objects/spu_service.rs
@@ -9,8 +9,7 @@ use k8_types::{
 };
 use k8_types::core::service::LoadBalancerIngress;
 
-use crate::dispatcher::core::Spec;
-use crate::dispatcher::core::Status;
+use crate::dispatcher::core::{Spec,Status};
 use crate::stores::spg::SpuGroupSpec;
 
 /// Service associated with SPU

--- a/src/sc/src/k8/objects/spu_service.rs
+++ b/src/sc/src/k8/objects/spu_service.rs
@@ -9,7 +9,7 @@ use k8_types::{
 };
 use k8_types::core::service::LoadBalancerIngress;
 
-use crate::dispatcher::core::{Spec,Status};
+use crate::dispatcher::core::{Spec, Status};
 use crate::stores::spg::SpuGroupSpec;
 
 /// Service associated with SPU

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -189,12 +189,7 @@ where
                 Ok(ctx_item) => {
                     //   trace!("k8 revision: {}, meta revision: {}",ctx_item.revision(),ctx_item.inner().resource_version);
                     let owner = ctx_item.owner_owned();
-                    let ctx = MetadataContext::new(ctx_item, owner);
-
-                    let local_kv =
-                        MetadataStoreObject::new(key, local_spec, local_status).with_context(ctx);
-
-                    Ok(local_kv)
+                    Ok(MetadataStoreObject::new(key, local_spec, local_status).with_context(MetadataContext::new(ctx_item, owner)))
                 }
                 Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
                     ErrorKind::InvalidData,

--- a/src/stream-model/src/store/k8.rs
+++ b/src/stream-model/src/store/k8.rs
@@ -189,7 +189,8 @@ where
                 Ok(ctx_item) => {
                     //   trace!("k8 revision: {}, meta revision: {}",ctx_item.revision(),ctx_item.inner().resource_version);
                     let owner = ctx_item.owner_owned();
-                    Ok(MetadataStoreObject::new(key, local_spec, local_status).with_context(MetadataContext::new(ctx_item, owner)))
+                    Ok(MetadataStoreObject::new(key, local_spec, local_status)
+                        .with_context(MetadataContext::new(ctx_item, owner)))
                 }
                 Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
                     ErrorKind::InvalidData,

--- a/tests/fluvio-values.yaml
+++ b/tests/fluvio-values.yaml
@@ -1,3 +1,5 @@
 loadBalancer:
   serviceAnnotations:
     cloud.fluvio.io/hostname: xyz
+service:
+  type: ClusterIP

--- a/tests/fluvio-values.yaml
+++ b/tests/fluvio-values.yaml
@@ -1,0 +1,3 @@
+loadBalancer:
+  serviceAnnotations:
+    cloud.fluvio.io/hostname: xyz


### PR DESCRIPTION
Solves: #1412.  Make ConfigMap fully dynamic.   Update of SPG and SPU Service now uses ConfigMap store rather than loading directly from K8 as previously.  

This can be optimized further in the future