### PR TITLE
[Merged by Bors] - Fluvio install fix for windows

### DIFF
--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -67,7 +67,6 @@ async fn fetch_latest_version<T>(
     prerelease: bool,
 ) -> Result<Version, CliError> {
     let request = agent.request_package(id)?;
-    println!("GETTING REQUEST FROM {:?}", request.url());
     debug!(
         url = %request.url(),
         "Requesting package manifest:",

--- a/src/cli/src/install/mod.rs
+++ b/src/cli/src/install/mod.rs
@@ -67,6 +67,7 @@ async fn fetch_latest_version<T>(
     prerelease: bool,
 ) -> Result<Version, CliError> {
     let request = agent.request_package(id)?;
+    println!("GETTING REQUEST FROM {:?}", request.url());
     debug!(
         url = %request.url(),
         "Requesting package manifest:",
@@ -178,7 +179,7 @@ fn make_executable(file: &mut File) -> Result<(), IoError> {
 
 #[cfg(not(unix))]
 fn make_executable(_file: &mut File) -> Result<(), IoError> {
-    unimplemented!();
+    Ok(())
 }
 
 pub fn install_println<S: AsRef<str>>(string: S) {


### PR DESCRIPTION
Closes #1371 and #1372.

Testing this is a little hard as we don't have any fluvio packages built for windows. However, the initial call to `fluvio` on windows creates a directory of `C:\Users\User\.fluvio\extensions` where `User` is the username of the user.