### PR TITLE
[Merged by Bors] - Fix plugin install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Publish docker image for aarch64 #1389 ([#1389](https://github.com/infinyon/fluvio/pull/1389))
 * Do not panic when trying to create topic with space in the name. ([#1448](https://github.com/infinyon/fluvio/pull/1448))
 * Deprecate consumer fetch API ([#957](https://github.com/infinyon/fluvio/issues/957))
+* Gracefully handle error when trying to install plugins or update. ([#1434](https://github.com/infinyon/fluvio/pull/1434))
 
 ## Platform Version 0.9.3 - 2021-08-19
 * Fix Replication timing. ([#1439](https://github.com/infinyon/fluvio/pull/1439))

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -8,6 +8,8 @@ use fluvio_sc_schema::ApiError;
 use fluvio_sc_schema::errors::ErrorCode;
 use fluvio_extension_common::output::OutputError;
 use crate::common::target::TargetError;
+use fluvio_index::{PackageId, Target};
+use semver::Version;
 
 pub type Result<T> = std::result::Result<T, CliError>;
 
@@ -41,6 +43,12 @@ pub enum CliError {
     WhichError(#[from] which::Error),
     #[error(transparent)]
     HttpError(#[from] HttpError),
+    #[error("Package {package} is not published at version {version} for target {target}")]
+    PackageNotFound {
+        package: PackageId,
+        version: Version,
+        target: Target,
+    },
 
     #[error(transparent)]
     TlsError(#[from] fluvio_future::openssl::TlsError),
@@ -54,7 +62,7 @@ pub enum CliError {
 #[derive(thiserror::Error, Debug)]
 #[error("Http Error: {}", inner)]
 pub struct HttpError {
-    inner: http_types::Error,
+    pub(crate) inner: http_types::Error,
 }
 
 impl From<http_types::Error> for CliError {

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -107,7 +107,7 @@ impl InstallOpt {
                 ));
                 return Ok(());
             }
-            Err(other) => return Err(other.into()),
+            Err(other) => return Err(other),
         };
         install_println("🔑 Downloaded and verified package file");
 

--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 
-use crate::CliError;
+use crate::Result;
 use crate::install::{
     fetch_latest_version, fetch_package_file, fluvio_extensions_dir, install_bin, install_println,
 };
@@ -24,7 +24,7 @@ pub struct InstallOpt {
 }
 
 impl InstallOpt {
-    pub async fn process(self) -> Result<(), CliError> {
+    pub async fn process(self) -> Result<()> {
         let agent = match &self.prefix {
             Some(prefix) => HttpAgent::with_prefix(prefix)?,
             None => HttpAgent::default(),
@@ -41,7 +41,7 @@ impl InstallOpt {
         let result = self.install_plugin(&agent).await;
         match result {
             Ok(_) => (),
-            Err(CliError::IndexError(fluvio_index::Error::MissingTarget(target))) => {
+            Err(crate::CliError::IndexError(fluvio_index::Error::MissingTarget(target))) => {
                 install_println(format!(
                     "❕ Package '{}' is not available for target {}, skipping",
                     self.package.name(),
@@ -66,7 +66,7 @@ impl InstallOpt {
         Ok(())
     }
 
-    async fn install_plugin(&self, agent: &HttpAgent) -> Result<(), CliError> {
+    async fn install_plugin(&self, agent: &HttpAgent) -> Result<()> {
         let target = fluvio_index::package_target()?;
 
         // If a version is given in the package ID, use it. Otherwise, use latest

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -103,7 +103,7 @@ impl UpdateOpt {
                 ));
                 return Ok(());
             }
-            Err(other) => return Err(other.into()),
+            Err(other) => return Err(other),
         };
         install_println("🔑 Downloaded and verified package file");
 

--- a/src/cli/src/install/update.rs
+++ b/src/cli/src/install/update.rs
@@ -4,7 +4,7 @@ use tracing::{debug, instrument};
 
 use semver::Version;
 use fluvio_index::{PackageId, HttpAgent};
-use crate::CliError;
+use crate::Result;
 use crate::install::{
     fetch_latest_version, fetch_package_file, install_bin, install_println, fluvio_extensions_dir,
 };
@@ -23,7 +23,7 @@ pub struct UpdateOpt {
 }
 
 impl UpdateOpt {
-    pub async fn process(self) -> Result<(), CliError> {
+    pub async fn process(self) -> Result<()> {
         let agent = HttpAgent::default();
         let plugin_meta = subcommand_metadata()?;
 
@@ -76,7 +76,7 @@ impl UpdateOpt {
     }
 
     #[instrument(skip(self, agent))]
-    async fn update_self(&self, agent: &HttpAgent) -> Result<(), CliError> {
+    async fn update_self(&self, agent: &HttpAgent) -> Result<()> {
         let target = fluvio_index::package_target()?;
         let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
         debug!(%target, %id, "Fluvio CLI updating self:");
@@ -106,12 +106,7 @@ impl UpdateOpt {
     }
 
     #[instrument(skip(self, agent))]
-    async fn update_plugin(
-        &self,
-        agent: &HttpAgent,
-        id: &PackageId,
-        path: &Path,
-    ) -> Result<(), CliError> {
+    async fn update_plugin(&self, agent: &HttpAgent, id: &PackageId, path: &Path) -> Result<()> {
         let target = fluvio_index::package_target()?;
         debug!(%target, %id, "Fluvio CLI updating plugin:");
 
@@ -140,7 +135,7 @@ impl UpdateOpt {
     skip(agent),
     fields(prefix = agent.base_url())
 )]
-pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> {
+pub async fn check_update_required(agent: &HttpAgent) -> Result<bool> {
     debug!("Checking for a required CLI update");
     let request = agent.request_index()?;
     let response = crate::http::execute(request).await?;
@@ -156,7 +151,7 @@ pub async fn check_update_required(agent: &HttpAgent) -> Result<bool, CliError> 
 pub async fn check_update_available(
     agent: &HttpAgent,
     prerelease: bool,
-) -> Result<Option<Version>, CliError> {
+) -> Result<Option<Version>> {
     let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Checking for an available (not required) CLI update:");
@@ -182,7 +177,7 @@ pub async fn check_update_available(
     skip(agent),
     fields(prefix = agent.base_url())
 )]
-pub async fn prompt_required_update(agent: &HttpAgent) -> Result<(), CliError> {
+pub async fn prompt_required_update(agent: &HttpAgent) -> Result<()> {
     let target = fluvio_index::package_target()?;
     let id: PackageId = FLUVIO_PACKAGE_ID.parse()?;
     debug!(%target, %id, "Fetching latest package version:");

--- a/src/package-index/src/package_id.rs
+++ b/src/package-index/src/package_id.rs
@@ -266,6 +266,26 @@ impl PackageId<WithVersion> {
     pub fn into_version(self) -> PackageVersion {
         self.version
     }
+
+    /// Convert to a `PackageId<WithVersion>` preserving the inner `Version`
+    pub fn into_maybe_versioned(self) -> PackageId<MaybeVersion> {
+        PackageId {
+            name: self.name,
+            group: self.group,
+            registry: self.registry,
+            version: Some(self.version),
+        }
+    }
+
+    /// Convert to a `PackageId<WithVersion>`, dropping the inner `Version`
+    pub fn into_unversioned(self) -> PackageId<MaybeVersion> {
+        PackageId {
+            name: self.name,
+            group: self.group,
+            registry: self.registry,
+            version: None,
+        }
+    }
 }
 
 impl PackageId<MaybeVersion> {


### PR DESCRIPTION
Adds a new error variant representing "this package isn't available" for a given package, version, and target. Also catches that error when running `fluvio install` in order to print a nice message to the user instead of crashing. Now, if somebody uses the installer from a platform that is not supported (or they try to specify a VERSION that does not exist), they'll get a message like the following in their installer output:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/4210949/129376758-cc9e0a5d-3667-4416-a33e-fb13f7e06aac.png">
