### PR TITLE
[Merged by Bors] - Module docs

### DIFF
--- a/src/smartstream/README.md
+++ b/src/smartstream/README.md
@@ -34,7 +34,7 @@ fluvio-smartstream = "0.2.0"
 For filtering, write your smartstream using `#[smartstream(filter)]` on your
 top-level function. Consider this the "main" function of your SmartStream.
 
-```rust
+```ignore
 use fluvio_smartstream::{smartstream, Record, Result};
 
 #[smartstream(filter)]
@@ -50,7 +50,7 @@ This filter will keep only records whose contents contain the letter `a`.
 
 Mapping functions use `#[smartstream(map)]`, and are also a top-level entrypoint.
 
-```rust
+```ignore
 use fluvio_smartstream::{smartstream, Record, RecordData, Result};
 
 #[smartstream(map)]
@@ -77,7 +77,7 @@ accumulator value will be passed to the next invocation of `aggregate` with
 the next record value. The resulting stream of values is the output accumulator
 from each step.
 
-```rust
+```ignore
 use fluvio_smartstream::{smartstream, Result, Record, RecordData};
 
 #[smartstream(aggregate)]

--- a/src/smartstream/src/lib.rs
+++ b/src/smartstream/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 pub use fluvio_dataplane_protocol as dataplane;
 pub use dataplane::record::{Record, RecordData};
 


### PR DESCRIPTION
Updated the README for `fluvio-smartstream` crate and also added `#![doc = include_str!("../README.md")]`, which is possibe since 1.54. I think we should start using README's for module docs more often now