### PR TITLE
[Merged by Bors] - Add exe suffic for windows targets

### DIFF
--- a/src/cli/src/install/plugins.rs
+++ b/src/cli/src/install/plugins.rs
@@ -98,7 +98,12 @@ impl InstallOpt {
 
         // Install the package to the ~/.fluvio/bin/ dir
         let fluvio_dir = fluvio_extensions_dir()?;
-        let package_path = fluvio_dir.join(id.name().as_str());
+        let package_filename = if target.to_string().contains("windows") {
+            format!("{}.exe", id.name().as_str())
+        } else {
+            id.name().to_string()
+        };
+        let package_path = fluvio_dir.join(&package_filename);
         install_bin(&package_path, &package_file)?;
 
         Ok(())

--- a/src/package-index/src/http.rs
+++ b/src/package-index/src/http.rs
@@ -65,10 +65,17 @@ impl HttpAgent {
         version: &semver::Version,
         target: &Target,
     ) -> Result<Request> {
+        let file_name = if target.to_string().contains("windows") {
+            format!("{}.exe", id.name())
+        } else {
+            id.name().to_string()
+        };
+
         let url = self.base_url.join(&format!(
-            "packages/{group}/{name}/{version}/{target}/{name}",
+            "packages/{group}/{name}/{version}/{target}/{file_name}",
             group = &id.group(),
             name = &id.name(),
+            file_name = file_name,
             version = version,
             target = target.as_str(),
         ))?;
@@ -82,10 +89,16 @@ impl HttpAgent {
         version: &semver::Version,
         target: &Target,
     ) -> Result<Request> {
+        let file_name = if target.to_string().contains("windows") {
+            format!("{}.exe", id.name())
+        } else {
+            id.name().to_string()
+        };
         let url = self.base_url.join(&format!(
-            "packages/{group}/{name}/{version}/{target}/{name}.sha256",
+            "packages/{group}/{name}/{version}/{target}/{file_name}.sha256",
             group = &id.group(),
             name = &id.name(),
+            file_name = file_name,
             version = version,
             target = target.as_str(),
         ))?;


### PR DESCRIPTION
Closes #1369.
Closes #1372.