### PR TITLE
[Merged by Bors] - feat: compress WASM binaries (SmartStream) (fixes #1140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Deprecate consumer fetch API ([#957](https://github.com/infinyon/fluvio/issues/957))
 * Gracefully handle error when trying to install plugins or update. ([#1434](https://github.com/infinyon/fluvio/pull/1434))
 * Fix timing issue in Multiplexor Socket ([#1484](https://github.com/infinyon/fluvio/pull/1484))
+* Compress WASM binaries. ([#1468](https://github.com/infinyon/fluvio/pull/1468))
 
 ## Platform Version 0.9.3 - 2021-08-19
 * Fix Replication timing. ([#1439](https://github.com/infinyon/fluvio/pull/1439))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -1859,6 +1859,7 @@ name = "fluvio-spu-schema"
 version = "0.8.0"
 dependencies = [
  "bytes",
+ "flate2",
  "fluvio-dataplane-protocol",
  "fluvio-protocol",
  "log",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -68,7 +68,7 @@ k8-config = { version = "1.3.0", optional = true}
 k8-client = { version = "5.0.0", optional = true}
 fluvio-cluster = { version = "0.0.0", path = "../cluster", default-features = false, features = ["cli"], optional = true }
 
-fluvio = { version = "0.9.0", path = "../client", default-features = false }
+fluvio = { version = "0.9.1", path = "../client", default-features = false }
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.5.0", path = "../package-index" }
 fluvio-extension-common = { version = "0.5.0", path = "../extension-common", features = ["target"]}
@@ -78,7 +78,7 @@ k8-types = { version = "0.2.0", features = ["core"]}
 # Optional Fluvio dependencies
 fluvio-types = { version = "0.2.0" , path = "../types", optional = true}
 fluvio-future = { version = "0.3.0", features = ["fs", "io", "subscriber", "native2_tls"], optional = true }
-fluvio-sc-schema = { version = "0.9.0", path = "../sc-schema", features = ["use_serde"], optional = true }
+fluvio-sc-schema = { version = "0.9.1", path = "../sc-schema", features = ["use_serde"], optional = true }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -47,13 +47,13 @@ include_dir = "0.6.1"
 tempdir = "0.3.7"
 
 # Fluvio dependencies
-fluvio = { version = "0.9.0", path = "../client", default-features = false }
+fluvio = { version = "0.9.1", path = "../client", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.3.0" }
 fluvio-command = { version = "0.2.0" }
 fluvio-extension-common = { version = "0.5.0", path = "../extension-common", optional = true }
 fluvio-controlplane-metadata = { version = "0.10.0", path = "../controlplane-metadata", features = ["k8"] }
-fluvio-sc-schema = { version = "0.9.0", path = "../sc-schema", default-features = false, optional = true  }
+fluvio-sc-schema = { version = "0.9.1", path = "../sc-schema", default-features = false, optional = true  }
 flv-util = "0.5.2"
 k8-config = { version = "1.3.0" }
 k8-client = { version = "5.0.0" }

--- a/src/extension-common/Cargo.toml
+++ b/src/extension-common/Cargo.toml
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "1.0.0", features = ["serde"] }
 
-fluvio = { version = "0.9.0", path = "../client",  optional = true }
+fluvio = { version = "0.9.1", path = "../client",  optional = true }
 fluvio-package-index = { version = "0.5", path = "../package-index" }

--- a/src/sc-schema/Cargo.toml
+++ b/src/sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"

--- a/src/sc/Cargo.toml
+++ b/src/sc/Cargo.toml
@@ -46,7 +46,7 @@ cfg-if = { version = "1.0.0" }
 fluvio-auth = { version = "0.6.1", path = "../auth" }
 fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "zero_copy"] }
 fluvio-types = { version = "0.2.0", path = "../types", features = ["events"] }
-fluvio-sc-schema = { version = "0.9.0", path = "../sc-schema" }
+fluvio-sc-schema = { version = "0.9.1", path = "../sc-schema" }
 fluvio-stream-model = { version = "0.5.0", path = "../stream-model" }
 fluvio-controlplane = { version = "0.8.0", path = "../controlplane" }
 fluvio-controlplane-metadata = { version = "0.10.1", features = ["k8", "serde"], path = "../controlplane-metadata" }

--- a/src/spu-schema/Cargo.toml
+++ b/src/spu-schema/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 file = ["dataplane/file"]
 
 [dependencies]
+flate2 = "1.0.20"
 log = "0.4.8"
 tracing = "0.1.19"
 bytes = "1.0.0"

--- a/src/spu/src/services/public/stream_fetch.rs
+++ b/src/spu/src/services/public/stream_fetch.rs
@@ -19,8 +19,7 @@ use dataplane::{
 use dataplane::{Offset, Isolation, ReplicaKey};
 use dataplane::fetch::FilePartitionResponse;
 use fluvio_spu_schema::server::stream_fetch::{
-    FileStreamFetchRequest, DefaultStreamFetchRequest, StreamFetchResponse, SmartStreamWasm,
-    SmartStreamKind,
+    FileStreamFetchRequest, DefaultStreamFetchRequest, StreamFetchResponse, SmartStreamKind,
 };
 use fluvio_types::event::offsets::OffsetChangeListener;
 
@@ -81,7 +80,7 @@ impl StreamFetchHandler {
             debug!("Has WASM payload: {}", msg.wasm_payload.is_some());
 
             let smartstream = if let Some(payload) = msg.wasm_payload {
-                let SmartStreamWasm::Raw(wasm) = &payload.wasm;
+                let wasm = &payload.wasm.get_raw()?;
                 let module = sm_engine.create_module_from_binary(wasm).map_err(|err| {
                     SocketError::Io(IoError::new(
                         ErrorKind::Other,
@@ -618,7 +617,7 @@ mod test {
     };
     use dataplane::fixture::{create_batch, TEST_RECORD};
     use fluvio_spu_schema::server::update_offset::{UpdateOffsetsRequest, OffsetUpdate};
-
+    use fluvio_spu_schema::server::stream_fetch::SmartStreamWasm;
     use crate::core::GlobalContext;
     use crate::config::SpuConfig;
     use crate::replication::leader::LeaderReplicaState;


### PR DESCRIPTION
- added Gzip variant to `SmartStreamWasm` and conversion methods
- bumped the default protocol API version
- compression/decompression using the `flate2` crate
with the default pure Rust backend