### PR TITLE
[Merged by Bors] - Add CLI install to hourly test

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -28,6 +28,9 @@ jobs:
 
       - uses: nolar/setup-k3d-k3s@v1
 
+      - name: Install Fluvio CLI
+        run: curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+
       - name: Run longevity test
         run: make longevity-producer-test
 


### PR DESCRIPTION
The longevity tests assume the Fluvio CLI is installed