### PR TITLE
[Merged by Bors] - Check if CI run before initial cluster cleanup

### DIFF
--- a/tests/cli-platform-cross-version-test.sh
+++ b/tests/cli-platform-cross-version-test.sh
@@ -41,7 +41,13 @@ function cleanup() {
 }
 
 function main() {
-    cleanup;
+
+    # Run initial cleanup if we're not in CI.
+    if [[ -z "$CI" ]];
+    then
+        cleanup;
+    fi
+
     setup_cluster $CLUSTER_VERSION;
     setup_cli $CLI_VERSION;
     run_test;


### PR DESCRIPTION
Cross platform test incorrectly assumed the CLI was installed before starting test and was failing to clean up a non-existent cluster (`fluvio` not installed initially). That's only true in dev, not CI. 

CI should skip this step, and then install the CLI in its setup functions.