### PR TITLE
[Merged by Bors] - Slow down test for github runner env

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -142,10 +142,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cli-platform-cross-version-test:
-    name: CLI x Platform version test 
+    name: CLI (${{ matrix.cli_version }}) x Platform (${{ matrix.cluster_version }}) version test 
     #if: false
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         cluster_version: [stable, latest]
@@ -154,4 +155,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: nolar/setup-k3d-k3s@v1
       - name: CLI ${{ matrix.cli_version }} x Cluster ${{ matrix.cluster_version }}
-        run: make CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: |
+            run: make CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test

--- a/tests/cli-platform-cross-version-test.sh
+++ b/tests/cli-platform-cross-version-test.sh
@@ -7,6 +7,19 @@ readonly CLUSTER_VERSION=${2-latest}
 readonly TEST_TOPIC=$CLI_VERSION-x-$CLUSTER_VERSION
 readonly FLUVIO_BIN=~/.fluvio/bin/fluvio
 readonly PAYLOAD_SIZE=${PAYLOAD_SIZE:-100}
+readonly CI_SLEEP=${CI_SLEEP:-5}
+readonly CI=${CI:-}
+
+# If we're in CI, we want to slow down execution
+# to give CPU some time to rest, so we don't time out
+function ci_check() {
+    if [[ ! -z "$CI" ]];
+    then
+        echo "[CI MODE] Pausing for ${CI_SLEEP} second(s)";
+        w | head -1
+        sleep ${CI_SLEEP};
+    fi
+}
 
 function setup_cluster() {
     echo "Installing cluster @ VERSION: $CLUSTER_VERSION"
@@ -28,10 +41,16 @@ function setup_cli() {
 
 function run_test() {
     local RANDOM_DATA=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w${PAYLOAD_SIZE} | head -n1)
+    ci_check;
 
     $FLUVIO_BIN topic create $TEST_TOPIC
+    ci_check;
+
     echo $RANDOM_DATA | $FLUVIO_BIN produce $TEST_TOPIC
+    ci_check;
+
     $FLUVIO_BIN consume $TEST_TOPIC -B -d
+    ci_check;
     # TODO: Verify the test output matches
 }
 
@@ -46,10 +65,14 @@ function main() {
     if [[ -z "$CI" ]];
     then
         cleanup;
+    else
+        echo "[CI MODE] Skipping initial cleanup";
     fi
 
     setup_cluster $CLUSTER_VERSION;
+    ci_check;
     setup_cli $CLI_VERSION;
+    ci_check;
     run_test;
     cleanup;
 }


### PR DESCRIPTION
The test locks up before doing anything useful bc of cpu.
Copying what we do for the upgrade test.

Adding retry, just in case of env-related failure