### PR TITLE
[Merged by Bors] - Fix typo in CD workflow

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -160,4 +160,4 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           command: |
-            run: make CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test
+            make CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test


### PR DESCRIPTION
the "run:" prefix from previous version before using retry action