### PR TITLE
[Merged by Bors] - Add reminder to publish `fluvio-smartstream` crate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,8 @@ Other dependent repos:
 First Lock master branch (TBD)
 
 - [ ] Publish all public crates.
+  - [ ] `fluvio` and any dependencies
+  - [ ] `fluvio-smartstream`
 - [ ] Update `CHANGELOG.md` with release date.
 - [ ] Run the `release.yml` workflow on GitHub Actions.
 - [ ] Wait for workflow to complete successfully and apply `vX.Y.Z` tag to git.


### PR DESCRIPTION
We forgot to publish the `fluvio-smartstream` crate in this past release, I thought I updated this in the RELEASE checklist but I don't think it made it in.