### PR TITLE
[Merged by Bors] - Updated examples for clarity

### DIFF
--- a/src/smartstream/examples/aggregate-average/src/lib.rs
+++ b/src/smartstream/examples/aggregate-average/src/lib.rs
@@ -28,7 +28,9 @@ pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData
         serde_json::from_slice(accumulator.as_ref()).unwrap_or_default();
 
     // Parse the new value as a 64-bit float
-    let value = std::str::from_utf8(current.value.as_ref())?.parse::<f64>()?;
+    let value = std::str::from_utf8(current.value.as_ref())?
+        .trim()
+        .parse::<f64>()?;
     average.add_value(value);
 
     let output = serde_json::to_vec_pretty(&average)?;

--- a/src/smartstream/examples/aggregate-average/src/lib.rs
+++ b/src/smartstream/examples/aggregate-average/src/lib.rs
@@ -24,8 +24,8 @@ impl IncrementalAverage {
 #[smartstream(aggregate)]
 pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData> {
     // Parse the average from JSON
-    let mut average = serde_json::from_slice(accumulator.as_ref())
-        .unwrap_or_else(|_| IncrementalAverage::default());
+    let mut average: IncrementalAverage =
+        serde_json::from_slice(accumulator.as_ref()).unwrap_or_default();
 
     // Parse the new value as a 64-bit float
     let value = std::str::from_utf8(current.value.as_ref())?.parse::<f64>()?;

--- a/src/smartstream/examples/aggregate-json/src/lib.rs
+++ b/src/smartstream/examples/aggregate-json/src/lib.rs
@@ -9,9 +9,9 @@ impl std::ops::Add for GithubStars {
     type Output = Self;
 
     fn add(mut self, next: Self) -> Self::Output {
-        for (key, new_stars) in next.0 {
+        for (repo, new_stars) in next.0 {
             self.0
-                .entry(key)
+                .entry(repo)
                 .and_modify(|stars| *stars += new_stars)
                 .or_insert(new_stars);
         }
@@ -22,11 +22,11 @@ impl std::ops::Add for GithubStars {
 #[smartstream(aggregate)]
 pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData> {
     // Parse accumulator
-    let accumulated_stars = serde_json::from_slice::<GithubStars>(accumulator.as_ref())
-        .unwrap_or_else(|_| GithubStars::default());
+    let accumulated_stars: GithubStars =
+        serde_json::from_slice(accumulator.as_ref()).unwrap_or_default();
 
     // Parse next record
-    let new_stars = serde_json::from_slice::<GithubStars>(current.value.as_ref())?;
+    let new_stars: GithubStars = serde_json::from_slice(current.value.as_ref())?;
 
     // Add stars and serialize
     let summed_stars = accumulated_stars + new_stars;

--- a/src/smartstream/examples/aggregate-sum/src/lib.rs
+++ b/src/smartstream/examples/aggregate-sum/src/lib.rs
@@ -7,8 +7,8 @@ pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData
     let current_string = std::str::from_utf8(current.value.as_ref())?;
 
     // Parse the strings into integers
-    let accumulator_int = accumulator_string.parse::<i32>().unwrap_or(0);
-    let current_int = current_string.parse::<i32>()?;
+    let accumulator_int = accumulator_string.trim().parse::<i32>().unwrap_or(0);
+    let current_int = current_string.trim().parse::<i32>()?;
 
     // Take the sum of the two integers and return it as a string
     let sum = accumulator_int + current_int;


### PR DESCRIPTION
While writing the blog I made a few updates to the examples to make them cleaner. I just wanted to add those updates to the main repo.

I also added `trim()` before parsing integers, which should close #1491 
