### PR TITLE
[Merged by Bors] - Add matrix vars for CD_Dev installer_check

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -153,6 +153,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         version: [latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fix the error in CD_Dev due to missing var `os`