### PR TITLE
[Merged by Bors] - Add cd_release matrix var

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         version: [none, stable, semver]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
cd_release job `installer_check` missing `os` var for `runs-on`
example: https://github.com/infinyon/fluvio/actions/runs/1172072772
