### PR TITLE
[Merged by Bors] - Create SmartStreamBase to manage wasmtime/memory

### DIFF
--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",

--- a/crates/fluvio-spu/src/smartstream/aggregate.rs
+++ b/crates/fluvio-spu/src/smartstream/aggregate.rs
@@ -9,7 +9,7 @@ use wasmtime::TypedFunc;
 use dataplane::core::Encoder;
 use dataplane::batch::Batch;
 use dataplane::batch::MemoryRecords;
-use crate::smartstream::{SmartStreamEngine, SmartStreamModule, SmartStreamBase};
+use crate::smartstream::{SmartStreamEngine, SmartStreamModule, SmartStreamContext};
 use crate::smartstream::file_batch::FileBatchIterator;
 use dataplane::smartstream::{
     SmartStreamRuntimeError, SmartStreamAggregateInput, SmartStreamInput, SmartStreamOutput,
@@ -20,7 +20,7 @@ const AGGREGATE_FN_NAME: &str = "aggregate";
 type AggregateFn = TypedFunc<(i32, i32), i32>;
 
 pub struct SmartStreamAggregate {
-    base: SmartStreamBase,
+    base: SmartStreamContext,
     aggregate_fn: AggregateFn,
     accumulator: Vec<u8>,
 }
@@ -31,7 +31,7 @@ impl SmartStreamAggregate {
         module: &SmartStreamModule,
         accumulator: Vec<u8>,
     ) -> Result<Self> {
-        let mut base = SmartStreamBase::new(engine, module)?;
+        let mut base = SmartStreamContext::new(engine, module)?;
         let aggregate_fn: AggregateFn = base
             .instance
             .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)?;

--- a/crates/fluvio-spu/src/smartstream/filter.rs
+++ b/crates/fluvio-spu/src/smartstream/filter.rs
@@ -12,20 +12,20 @@ use dataplane::smartstream::{
     SmartStreamInput, SmartStreamOutput, SmartStreamRuntimeError, SmartStreamInternalError,
 };
 use fluvio_protocol::Encoder;
-use crate::smartstream::{SmartStreamModule, SmartStreamEngine, SmartStreamBase};
+use crate::smartstream::{SmartStreamModule, SmartStreamEngine, SmartStreamContext};
 use crate::smartstream::file_batch::FileBatchIterator;
 
 const FILTER_FN_NAME: &str = "filter";
 type FilterFn = TypedFunc<(i32, i32), i32>;
 
 pub struct SmartStreamFilter {
-    base: SmartStreamBase,
+    base: SmartStreamContext,
     filter_fn: FilterFn,
 }
 
 impl SmartStreamFilter {
     pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
-        let mut base = SmartStreamBase::new(engine, module)?;
+        let mut base = SmartStreamContext::new(engine, module)?;
         let filter_fn: FilterFn = base
             .instance
             .get_typed_func(&mut base.store, FILTER_FN_NAME)?;

--- a/crates/fluvio-spu/src/smartstream/filter.rs
+++ b/crates/fluvio-spu/src/smartstream/filter.rs
@@ -1,62 +1,36 @@
-use std::sync::Arc;
 use std::time::Instant;
-use std::io::Cursor;
 use std::convert::TryFrom;
 
 use anyhow::{Result, Error};
 
 use tracing::debug;
-use wasmtime::{Caller, Extern, Func, Instance, Trap, TypedFunc, Store};
+use wasmtime::TypedFunc;
 
 use dataplane::batch::Batch;
 use dataplane::batch::MemoryRecords;
 use dataplane::smartstream::{
     SmartStreamInput, SmartStreamOutput, SmartStreamRuntimeError, SmartStreamInternalError,
 };
-use fluvio_protocol::{Encoder, Decoder};
-use crate::smartstream::{RecordsCallBack, RecordsMemory, SmartStreamModule, SmartStreamEngine};
+use fluvio_protocol::Encoder;
+use crate::smartstream::{SmartStreamModule, SmartStreamEngine, SmartStreamBase};
 use crate::smartstream::file_batch::FileBatchIterator;
 
 const FILTER_FN_NAME: &str = "filter";
 type FilterFn = TypedFunc<(i32, i32), i32>;
 
 pub struct SmartStreamFilter {
-    store: Store<()>,
-    instance: Instance,
+    base: SmartStreamBase,
     filter_fn: FilterFn,
-    records_cb: Arc<RecordsCallBack>,
 }
 
 impl SmartStreamFilter {
     pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
-        let mut store = Store::new(&engine.0, ());
-        let cb = Arc::new(RecordsCallBack::new());
-        let callback = cb.clone();
+        let mut base = SmartStreamBase::new(engine, module)?;
+        let filter_fn: FilterFn = base
+            .instance
+            .get_typed_func(&mut base.store, FILTER_FN_NAME)?;
 
-        let copy_records = Func::wrap(
-            &mut store,
-            move |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
-                debug!(len, "callback from wasm filter");
-                let memory = match caller.get_export("memory") {
-                    Some(Extern::Memory(mem)) => mem,
-                    _ => return Err(Trap::new("failed to find host memory")),
-                };
-
-                let records = RecordsMemory { ptr, len, memory };
-                cb.set(records);
-                Ok(())
-            },
-        );
-
-        let instance = Instance::new(&mut store, &module.0, &[copy_records.into()])?;
-        let filter_fn: FilterFn = instance.get_typed_func(&mut store, FILTER_FN_NAME)?;
-
-        Ok(Self {
-            store,
-            instance,
-            filter_fn,
-            records_cb: callback,
-        })
+        Ok(Self { base, filter_fn })
     }
 
     /// filter batches with maximum bytes to be send back consumer
@@ -96,23 +70,12 @@ impl SmartStreamFilter {
 
             let now = Instant::now();
 
-            let mut input_data = Vec::new();
-            let smartstream_input = SmartStreamInput {
+            let input = SmartStreamInput {
                 base_offset: file_batch.batch.base_offset,
                 record_data: file_batch.records.clone(),
             };
-            fluvio_protocol::Encoder::encode(&smartstream_input, &mut input_data, 0)?;
-
-            self.records_cb.clear();
-            let array_ptr = super::memory::copy_memory_to_instance(
-                &mut self.store,
-                &self.instance,
-                &input_data,
-            )?;
-
-            let filter_output = self
-                .filter_fn
-                .call(&mut self.store, (array_ptr as i32, input_data.len() as i32))?;
+            let slice = self.base.write_input(&input)?;
+            let filter_output = self.filter_fn.call(&mut self.base.store, slice)?;
 
             debug!(filter_output,filter_execution_time = %now.elapsed().as_millis());
 
@@ -122,17 +85,7 @@ impl SmartStreamFilter {
                 return Err(internal_error.into());
             }
 
-            let bytes = self
-                .records_cb
-                .get()
-                .and_then(|m| m.copy_memory_from(&mut self.store).ok())
-                .unwrap_or_default();
-            debug!(out_filter_bytes = bytes.len());
-
-            // this is inefficient for now
-            let mut output = SmartStreamOutput::default();
-            output.decode(&mut Cursor::new(bytes), 0)?;
-
+            let output: SmartStreamOutput = self.base.read_output()?;
             let maybe_error = output.error;
             let mut records = output.successes;
 

--- a/crates/fluvio-spu/src/smartstream/map.rs
+++ b/crates/fluvio-spu/src/smartstream/map.rs
@@ -12,20 +12,20 @@ use dataplane::batch::MemoryRecords;
 use dataplane::smartstream::{
     SmartStreamInput, SmartStreamOutput, SmartStreamRuntimeError, SmartStreamInternalError,
 };
-use crate::smartstream::{SmartStreamEngine, SmartStreamModule, SmartStreamBase};
+use crate::smartstream::{SmartStreamEngine, SmartStreamModule, SmartStreamContext};
 use crate::smartstream::file_batch::FileBatchIterator;
 
 const MAP_FN_NAME: &str = "map";
 type MapFn = TypedFunc<(i32, i32), i32>;
 
 pub struct SmartStreamMap {
-    base: SmartStreamBase,
+    base: SmartStreamContext,
     map_fn: MapFn,
 }
 
 impl SmartStreamMap {
     pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
-        let mut base = SmartStreamBase::new(engine, module)?;
+        let mut base = SmartStreamContext::new(engine, module)?;
         let map_fn: MapFn = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)?;
 
         Ok(Self { base, map_fn })

--- a/crates/fluvio-spu/src/smartstream/map.rs
+++ b/crates/fluvio-spu/src/smartstream/map.rs
@@ -1,63 +1,34 @@
-use std::sync::Arc;
 use std::time::Instant;
-use std::io::Cursor;
 use std::convert::TryFrom;
 
 use anyhow::{Result, Error};
 
 use tracing::debug;
-use wasmtime::{Caller, Extern, Func, Instance, Trap, TypedFunc, Store};
+use wasmtime::TypedFunc;
 
-use dataplane::core::{Decoder, Encoder};
+use dataplane::core::Encoder;
 use dataplane::batch::Batch;
 use dataplane::batch::MemoryRecords;
 use dataplane::smartstream::{
     SmartStreamInput, SmartStreamOutput, SmartStreamRuntimeError, SmartStreamInternalError,
 };
-use crate::smartstream::{RecordsCallBack, RecordsMemory, SmartStreamEngine, SmartStreamModule};
+use crate::smartstream::{SmartStreamEngine, SmartStreamModule, SmartStreamBase};
 use crate::smartstream::file_batch::FileBatchIterator;
 
 const MAP_FN_NAME: &str = "map";
 type MapFn = TypedFunc<(i32, i32), i32>;
 
 pub struct SmartStreamMap {
-    store: Store<()>,
-    instance: Instance,
+    base: SmartStreamBase,
     map_fn: MapFn,
-    records_cb: Arc<RecordsCallBack>,
 }
 
 impl SmartStreamMap {
     pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
-        let mut store = Store::new(&engine.0, ());
-        let cb = Arc::new(RecordsCallBack::new());
-        let records_cb = cb.clone();
-        let copy_records = Func::wrap(
-            &mut store,
-            move |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
-                debug!(len, "callback from wasm map");
-                let memory = match caller.get_export("memory") {
-                    Some(Extern::Memory(mem)) => mem,
-                    _ => return Err(Trap::new("failed to find host memory")),
-                };
+        let mut base = SmartStreamBase::new(engine, module)?;
+        let map_fn: MapFn = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)?;
 
-                let records = RecordsMemory { ptr, len, memory };
-
-                cb.set(records);
-
-                Ok(())
-            },
-        );
-
-        let instance = Instance::new(&mut store, &module.0, &[copy_records.into()])?;
-        let map_fn: MapFn = instance.get_typed_func(&mut store, MAP_FN_NAME)?;
-
-        Ok(Self {
-            store,
-            instance,
-            map_fn,
-            records_cb,
-        })
+        Ok(Self { base, map_fn })
     }
 
     /// map batches with maximum bytes to be send back consumer
@@ -97,23 +68,12 @@ impl SmartStreamMap {
 
             let now = Instant::now();
 
-            let mut input_data = Vec::new();
-            let smartstream_input = SmartStreamInput {
+            let input = SmartStreamInput {
                 base_offset: file_batch.batch.base_offset,
                 record_data: file_batch.records.clone(),
             };
-            smartstream_input.encode(&mut input_data, 0)?;
-
-            self.records_cb.clear();
-            let array_ptr = super::memory::copy_memory_to_instance(
-                &mut self.store,
-                &self.instance,
-                &input_data,
-            )?;
-
-            let map_output = self
-                .map_fn
-                .call(&mut self.store, (array_ptr as i32, input_data.len() as i32))?;
+            let slice = self.base.write_input(&input)?;
+            let map_output = self.map_fn.call(&mut self.base.store, slice)?;
 
             debug!(map_output, map_execution_time = %now.elapsed().as_millis());
 
@@ -123,17 +83,7 @@ impl SmartStreamMap {
                 return Err(internal_error.into());
             }
 
-            let bytes = self
-                .records_cb
-                .get()
-                .and_then(|m| m.copy_memory_from(&mut self.store).ok())
-                .unwrap_or_default();
-            debug!(out_map_bytes = bytes.len());
-
-            // this is inefficient for now
-            let mut output = SmartStreamOutput::default();
-            output.decode(&mut Cursor::new(bytes), 0)?;
-
+            let output: SmartStreamOutput = self.base.read_output()?;
             let maybe_error = output.error;
             let mut records = output.successes;
 

--- a/crates/fluvio-spu/src/smartstream/mod.rs
+++ b/crates/fluvio-spu/src/smartstream/mod.rs
@@ -48,13 +48,13 @@ impl SmartStreamModule {
     }
 }
 
-pub struct SmartStreamBase {
+pub struct SmartStreamContext {
     store: Store<()>,
     instance: Instance,
     records_cb: Arc<RecordsCallBack>,
 }
 
-impl SmartStreamBase {
+impl SmartStreamContext {
     pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
         let mut store = Store::new(&engine.0, ());
         let cb = Arc::new(RecordsCallBack::new());

--- a/crates/fluvio-spu/src/smartstream/mod.rs
+++ b/crates/fluvio-spu/src/smartstream/mod.rs
@@ -1,15 +1,19 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use tracing::debug;
 use anyhow::Result;
-use wasmtime::{Memory, Store, Engine, Module};
+use wasmtime::{Memory, Store, Engine, Module, Func, Caller, Extern, Trap, Instance};
 use crate::smartstream::filter::SmartStreamFilter;
 use crate::smartstream::map::SmartStreamMap;
 use crate::smartstream::aggregate::SmartStreamAggregate;
+use dataplane::core::{Encoder, Decoder};
 
 mod memory;
 pub mod filter;
 pub mod map;
 pub mod aggregate;
 pub mod file_batch;
+
+pub type WasmSlice = (i32, i32);
 
 #[derive(Default)]
 pub struct SmartStreamEngine(pub(crate) Engine);
@@ -41,6 +45,62 @@ impl SmartStreamModule {
     ) -> Result<SmartStreamAggregate> {
         let aggregate = SmartStreamAggregate::new(engine, self, accumulator)?;
         Ok(aggregate)
+    }
+}
+
+pub struct SmartStreamBase {
+    store: Store<()>,
+    instance: Instance,
+    records_cb: Arc<RecordsCallBack>,
+}
+
+impl SmartStreamBase {
+    pub fn new(engine: &SmartStreamEngine, module: &SmartStreamModule) -> Result<Self> {
+        let mut store = Store::new(&engine.0, ());
+        let cb = Arc::new(RecordsCallBack::new());
+        let records_cb = cb.clone();
+        let copy_records = Func::wrap(
+            &mut store,
+            move |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
+                debug!(len, "callback from wasm filter");
+                let memory = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return Err(Trap::new("failed to find host memory")),
+                };
+
+                let records = RecordsMemory { ptr, len, memory };
+                cb.set(records);
+                Ok(())
+            },
+        );
+
+        let instance = Instance::new(&mut store, &module.0, &[copy_records.into()])?;
+        Ok(Self {
+            store,
+            instance,
+            records_cb,
+        })
+    }
+
+    pub fn write_input<E: Encoder>(&mut self, input: &E) -> Result<WasmSlice> {
+        self.records_cb.clear();
+        let mut input_data = Vec::new();
+        input.encode(&mut input_data, 0)?;
+        let array_ptr =
+            self::memory::copy_memory_to_instance(&mut self.store, &self.instance, &input_data)?;
+        let length = input_data.len();
+        Ok((array_ptr as i32, length as i32))
+    }
+
+    pub fn read_output<D: Decoder + Default>(&mut self) -> Result<D> {
+        let bytes = self
+            .records_cb
+            .get()
+            .and_then(|m| m.copy_memory_from(&mut self.store).ok())
+            .unwrap_or_default();
+        let mut output = D::default();
+        output.decode(&mut std::io::Cursor::new(bytes), 0)?;
+        Ok(output)
     }
 }
 


### PR DESCRIPTION
This pulls a lot of the `wasmtime` code related to reading and writing memory into a common type called `SmartStreamBase`. Each concrete smartstream wraps this as well as their own typed wasm function and potentially any state (e.g. the aggregate accumulator).

This is part 1 of the smartstreams refactor in preparation for #1335 