### PR TITLE
[Merged by Bors] - Add fluvio-test to dev releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,6 +728,8 @@ jobs:
             artifact: fluvio-run
           - rust-target: x86_64-pc-windows-gnu
             artifact: fluvio.exe
+          - rust-target: x86_64-unknown-linux-musl
+            artifact: fluvio-test
     permissions: write-all
     steps:
       - name: Login GH CLI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,9 @@ jobs:
           export VERSION="$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)"
 
           for ZIP_FILE in ./*.zip; do
+            # Don't publish `fluvio-test` artifact outside of github
+            [ "$ZIP_FILE" = "fluvio-test-x86_64-unknown-linux-musl.zip" ] && continue
+
             # Unzip all .zip files into directories with the same name (minus .zip)
             UNZIP_DIR="${ZIP_FILE//.zip/}"
             echo "Unzipping $ZIP_FILE into $UNZIP_DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,9 @@ jobs:
         if: ${{ steps.check_fluvio.outcome == 'failure' }}
         run: |
           for ZIP_FILE in ./*.zip; do
+            # Don't publish `fluvio-test` artifact outside of github
+            [ "$ZIP_FILE" = "fluvio-test-x86_64-unknown-linux-musl.zip" ] && continue
+
             # Unzip all .zip files into directories with the same name (minus .zip)
             UNZIP_DIR="${ZIP_FILE//.zip/}"
             echo "Unzipping $ZIP_FILE into $UNZIP_DIR"
@@ -305,17 +308,3 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  #validate_fluvio_release:
-  #  name: Validate Fluvio release 
-  #  needs: [bump_stable_fluvio]
-  #  runs-on: ubuntu-latest
-  #  env:
-  #    VERSION: ${{ needs.setup_job.outputs.VERSION }}
-  #    TARGET_SHA: ${{ needs.setup_job.outputs.GIT_SHA }}
-  #  steps:
-  #    - uses: actions/checkout@v2
-
-  #    - name: 
-  #      run: |
-  #        make VERSION=${{ env.VERSION }} GIT_COMMIT=${{ env.TARGET_SHA }} validate-release-stable


### PR DESCRIPTION
Also explicitly opt-out `fluvio-test` from fluvio package publish in the `Publish` and `Release` workflows.

`fluvio-test` is needed in the hourly test workflow for #1577, but we don't want to spend any time building because we already do all of that in `CI`. To avoid rebuilding, we should publish to the `dev` release.