### PR TITLE
Added spu local address logic

### DIFF
--- a/crates/fluvio-controlplane-metadata/src/spu/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/spu/spec.rs
@@ -12,8 +12,6 @@ use std::fmt;
 
 use flv_util::socket_helpers::EndPoint as SocketEndPoint;
 use flv_util::socket_helpers::EndPointEncryption;
-use fluvio_types::defaults::{SPU_PRIVATE_HOSTNAME, SPU_PRIVATE_PORT};
-use fluvio_types::defaults::SPU_PUBLIC_PORT;
 use fluvio_types::SpuId;
 use flv_util::socket_helpers::ServerAddress;
 
@@ -21,7 +19,7 @@ use dataplane::core::{Encoder, Decoder};
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::core::Version;
 
-#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -36,6 +34,9 @@ pub struct SpuSpec {
     pub private_endpoint: Endpoint,
     #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub rack: Option<String>,
+
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub public_endpoint_local: Option<Endpoint>,
 }
 
 impl fmt::Display for SpuSpec {
@@ -45,25 +46,6 @@ impl fmt::Display for SpuSpec {
             "id: {}, type: {}, public: {}",
             self.id, self.spu_type, self.public_endpoint
         )
-    }
-}
-
-impl Default for SpuSpec {
-    fn default() -> Self {
-        SpuSpec {
-            id: -1,
-            spu_type: SpuType::default(),
-            public_endpoint: IngressPort {
-                port: SPU_PUBLIC_PORT,
-                ..Default::default()
-            },
-            private_endpoint: Endpoint {
-                port: SPU_PRIVATE_PORT,
-                host: SPU_PRIVATE_HOSTNAME.to_string(),
-                encryption: EncryptionEnum::default(),
-            },
-            rack: None,
-        }
     }
 }
 
@@ -168,6 +150,7 @@ impl From<CustomSpuSpec> for SpuSpec {
             private_endpoint: spec.private_endpoint,
             rack: spec.rack,
             spu_type: SpuType::Custom,
+            public_endpoint_local: Default::default(),
         }
     }
 }

--- a/crates/fluvio-sc/src/k8/objects/spg_group.rs
+++ b/crates/fluvio-sc/src/k8/objects/spg_group.rs
@@ -106,20 +106,21 @@ impl SpuGroupObj {
 
         let spu_private_ep = SpuEndpointTemplate::default_private();
 
+        let spu_public_ep = SpuEndpointTemplate::default_public();
         let public_endpoint = if let Some(ingress) = services.get(&spu_name) {
             debug!(%ingress);
             ingress.clone()
         } else {
-            let spu_public_ep = SpuEndpointTemplate::default_public();
             IngressPort {
                 port: spu_public_ep.port,
-                encryption: spu_public_ep.encryption,
+                encryption: spu_public_ep.encryption.clone(),
                 ingress: vec![],
             }
         };
 
         let full_group_name = format!("fluvio-spg-{}", self.key());
         let full_spu_name = format!("fluvio-spg-{}", spu_name);
+
         let spu_spec = SpuSpec {
             id: spu_id,
             spu_type: SpuType::Managed,
@@ -130,6 +131,11 @@ impl SpuGroupObj {
                 encryption: spu_private_ep.encryption,
             },
             rack: None,
+            public_endpoint_local: Some(Endpoint {
+                host: format!("{}.{}", full_spu_name, full_group_name),
+                port: spu_public_ep.port,
+                encryption: spu_public_ep.encryption,
+            }),
         };
 
         /*

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -109,7 +109,7 @@ impl FluvioAdmin {
     #[instrument(skip(config))]
     pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
         let connector = DomainConnector::try_from(config.tls.clone())?;
-        let config = ClientConfig::new(&config.endpoint, connector);
+        let config = ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);
         let inner_client = config.connect().await?;
         debug!("connected to cluster at: {}", inner_client.config().addr());
 

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -16,6 +16,10 @@ pub struct FluvioConfig {
     // We don't want to have a "" address.
     #[serde(alias = "addr")]
     pub endpoint: String,
+
+    #[serde(default)]
+    pub use_spu_local_address: bool,
+
     /// The TLS policy to use when connecting to the cluster
     // If no TLS field is present in config file,
     // use the default of NoTls
@@ -28,6 +32,7 @@ impl FluvioConfig {
     pub fn new<S: Into<String>>(addr: S) -> Self {
         Self {
             endpoint: addr.into(),
+            use_spu_local_address: false,
             tls: TlsPolicy::Disabled,
         }
     }

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -73,7 +73,7 @@ impl Fluvio {
         connector: DomainConnector,
         config: &FluvioConfig,
     ) -> Result<Self, FluvioError> {
-        let config = ClientConfig::new(&config.endpoint, connector);
+        let config = ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);
         let inner_client = config.connect().await?;
         debug!("connected to cluster");
 

--- a/crates/fluvio/src/sockets.rs
+++ b/crates/fluvio/src/sockets.rs
@@ -76,6 +76,7 @@ pub struct ClientConfig {
     addr: String,
     client_id: String,
     connector: DomainConnector,
+    pub(crate) use_spu_local_address: bool,
 }
 
 impl fmt::Display for ClientConfig {
@@ -91,16 +92,17 @@ impl From<String> for ClientConfig {
 }
 
 impl ClientConfig {
-    pub fn new<S: Into<String>>(addr: S, connector: DomainConnector) -> Self {
+    pub fn new<S: Into<String>>(addr: S, connector: DomainConnector, use_spu_local_address: bool) -> Self {
         Self {
             addr: addr.into(),
             client_id: "fluvio".to_owned(),
             connector,
+            use_spu_local_address,
         }
     }
 
     pub fn with_addr(addr: String) -> Self {
-        Self::new(addr, Box::new(DefaultDomainConnector::default()))
+        Self::new(addr, Box::new(DefaultDomainConnector::default()), false)
     }
 
     pub fn addr(&self) -> &str {
@@ -141,6 +143,7 @@ impl ClientConfig {
             addr: self.addr.clone(),
             client_id: self.client_id.clone(),
             connector,
+            use_spu_local_address: self.use_spu_local_address,
         }
     }
 }

--- a/crates/fluvio/src/spu.rs
+++ b/crates/fluvio/src/spu.rs
@@ -78,7 +78,17 @@ impl SpuPool {
 
         debug!("connecting to spu: {}", spu.spec);
         let mut client_config = self.config.with_prefix_sni_domain(spu.key());
-        let spu_addr = spu.spec.public_endpoint.addr();
+
+        let spu_addr = if self.config.use_spu_local_address && spu.spec.public_endpoint_local.is_some() {
+            let public_endpoint_local = spu.spec.public_endpoint_local.unwrap();
+			let host = public_endpoint_local.host;
+            let port = public_endpoint_local.port;
+            format!("{}:{}", host, port)
+        } else {
+            spu.spec.public_endpoint.addr()
+        };
+
+
         debug!("spu addr: {}", spu_addr);
         client_config.set_addr(spu_addr);
         let versioned_socket = client_config.connect().await?;

--- a/k8-util/helm/fluvio-sys/templates/crd_spu.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_spu.yaml
@@ -33,7 +33,7 @@ spec:
                   type: string
                   enum:
                     - Custom
-                    - Managed              
+                    - Managed
                 rack:
                   type: string
                 publicEndpoint:
@@ -75,6 +75,21 @@ spec:
                       enum:
                         - PLAINTEXT
                         - SSL
+                publicEndpointLocal:
+                  required: ["host"]
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                    port:
+                      minimum: 1
+                      maximum: 65535
+                      type: integer
+                    encryption:
+                      type: string
+                      enum:
+                        - PLAINTEXT
+                        - SSL
       additionalPrinterColumns:
       - name: ID
         type: integer
@@ -98,4 +113,4 @@ spec:
         type: integer
         description: Spu Type
         jsonPath: .spec.privateEndpoint.port
-    
+


### PR DESCRIPTION
Closes #1537.
Closes  #1546.

Tried to make this a non-breaking change. Looks like with the optional type for `public_endpoint_local`, it works as expected.

Testing this was a bit of a pain, we ended up spinning up a new pod in the k8s cluster and running the fluvio client with `use_spu_local_address = true` in the config to verify that it was using the correct endpoint.