### PR TITLE
[Merged by Bors] - Set crate version to 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-auth"
-version = "0.6.2"
+version = "0.0.0"
 dependencies = [
  "async-trait",
  "fluvio-controlplane-metadata",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane"
-version = "0.8.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",

--- a/crates/fluvio-auth/Cargo.toml
+++ b/crates/fluvio-auth/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "fluvio-auth"
-version = "0.6.2"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/infinyon/fluvio"
 description = "Authorization framework for Fluvio"
+publish = false
 
 
 [lib]

--- a/crates/fluvio-controlplane/Cargo.toml
+++ b/crates/fluvio-controlplane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-controlplane"
-version = "0.8.0"
+version = "0.0.0"
 edition = "2018"
 license = "Apache-2.0"
 description = "Fluvio control plane API"

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -48,7 +48,7 @@ fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "z
 fluvio-types = { version = "0.2.0", path = "../fluvio-types", features = ["events"] }
 fluvio-sc-schema = { version = "0.9.1", path = "../fluvio-sc-schema" }
 fluvio-stream-model = { version = "0.5.0", path = "../fluvio-stream-model" }
-fluvio-controlplane = { version = "0.8.0", path = "../fluvio-controlplane" }
+fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { version = "0.11.0", features = ["k8", "serde"], path = "../fluvio-controlplane-metadata" }
 fluvio-stream-dispatcher = { version = "0.6.3", path = "../fluvio-stream-dispatcher" }
 k8-client = { version = "5.1.5", optional = true }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
 
 # Fluvio dependencies
-fluvio-auth = { version = "0.6.1", path = "../fluvio-auth" }
+fluvio-auth = { version = "0.0.0", path = "../fluvio-auth" }
 fluvio-future = { version = "0.3.0", features = ["subscriber", "openssl_tls", "zero_copy"] }
 fluvio-types = { version = "0.2.0", path = "../fluvio-types", features = ["events"] }
 fluvio-sc-schema = { version = "0.9.1", path = "../fluvio-sc-schema" }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.5"
 # Fluvio dependencies
 fluvio-types = { version = "0.2.3", features = ["events"], path = "../fluvio-types" }
 fluvio-storage = { path = "../fluvio-storage" }
-fluvio-controlplane = { version = "0.8.0", path = "../fluvio-controlplane" }
+fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { version = "0.11.0", path = "../fluvio-controlplane-metadata" }
 fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema", features = ["file"]}
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }


### PR DESCRIPTION
Add `publish = false` to fluvio-auth too
We don't want to publish fluvio-auth or fluvio-controlplane
Resolves #1601