### PR TITLE
[Merged by Bors] - Test CLI backwards compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,7 +617,7 @@ jobs:
 
   k8_cli_backward_compat:
     name: Latest CLI vs Stable Cluster
-    needs: build_image
+    needs: build_binaries
     if: false
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,7 +616,7 @@ jobs:
           path: /tmp/k8_*.log
 
   k8_cli_backward_compat:
-    name: Latest CLI vs Stable Cluster on (${{ matrix.run }}) k8 (${{ matrix.k8 }})
+    name: Latest CLI vs Stable Cluster - k8 (${{ matrix.k8 }})
     needs: build_image
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,6 +615,51 @@ jobs:
           name: k8_${{ matrix.run }}_log
           path: /tmp/k8_*.log
 
+  k8_cli_backward_compat:
+    name: Latest CLI vs Stable Cluster on (${{ matrix.run }}) k8 (${{ matrix.k8 }})
+    needs: build_image
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        k8: [k3d,minikube]
+        cluster_version: [stable]
+        cli_version: [latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install K3d
+        if: ${{ matrix.k8 == 'k3d' }}
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          ./k8-util/cluster/reset-k3d.sh
+      - name: Install Minikube
+        if: ${{ matrix.k8 == 'minikube' }}
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: "v1.22.0"
+          kubernetes version: "v1.21.2"
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker
+
+      - name: Install stable CLI and start Fluvio cluster
+        run: |
+          curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+          ~/.fluvio/bin/fluvio cluster start
+
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v2
+        with:
+          name: fluvio-x86_64-unknown-linux-musl
+          path: .
+
+      - name: Print artifacts and mark executable
+        run: ls -la . && chmod +x ./fluvio && ./fluvio version
+
+      - name: Test ${{ matrix.cli_version }} CLI vs ${{ matrix.cluster_version }} cluster
+        run: |
+          make SKIP_SETUP=true CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test
+
   # Ensure all checks, tests are perform and all binaries are built
   # After this, we are committed for release
   docker_push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,7 @@ jobs:
 
       - name: Test ${{ matrix.cli_version }} CLI vs ${{ matrix.cluster_version }} cluster
         run: |
-          make SKIP_SETUP=true CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test
+          make SKIP_SETUP=true CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} FLUVIO_BIN=./fluvio cli-platform-cross-version-test
 
   # Ensure all checks, tests are perform and all binaries are built
   # After this, we are committed for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,32 +616,22 @@ jobs:
           path: /tmp/k8_*.log
 
   k8_cli_backward_compat:
-    name: Latest CLI vs Stable Cluster - k8 (${{ matrix.k8 }})
+    name: Latest CLI vs Stable Cluster
     needs: build_image
+    #if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        k8: [k3d,minikube]
         cluster_version: [stable]
         cli_version: [latest]
     steps:
       - uses: actions/checkout@v2
       - name: Install K3d
-        if: ${{ matrix.k8 == 'k3d' }}
         run: |
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           ./k8-util/cluster/reset-k3d.sh
-      - name: Install Minikube
-        if: ${{ matrix.k8 == 'minikube' }}
-        uses: manusa/actions-setup-minikube@v2.4.2
-        with:
-          minikube version: "v1.22.0"
-          kubernetes version: "v1.21.2"
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker
-
       - name: Install stable CLI and start Fluvio cluster
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,7 +618,7 @@ jobs:
   k8_cli_backward_compat:
     name: Latest CLI vs Stable Cluster
     needs: build_image
-    #if: false
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/cli-platform-cross-version-test.sh
+++ b/tests/cli-platform-cross-version-test.sh
@@ -5,7 +5,7 @@ set -e
 readonly CLI_VERSION=${1-stable}
 readonly CLUSTER_VERSION=${2-latest}
 readonly TEST_TOPIC=$CLI_VERSION-x-$CLUSTER_VERSION
-readonly FLUVIO_BIN=~/.fluvio/bin/fluvio
+readonly FLUVIO_BIN=${FLUVIO_BIN:-~/.fluvio/bin/fluvio}
 readonly PAYLOAD_SIZE=${PAYLOAD_SIZE:-100}
 readonly CI_SLEEP=${CI_SLEEP:-5}
 readonly CI=${CI:-}

--- a/tests/cli-platform-cross-version-test.sh
+++ b/tests/cli-platform-cross-version-test.sh
@@ -9,6 +9,8 @@ readonly FLUVIO_BIN=~/.fluvio/bin/fluvio
 readonly PAYLOAD_SIZE=${PAYLOAD_SIZE:-100}
 readonly CI_SLEEP=${CI_SLEEP:-5}
 readonly CI=${CI:-}
+readonly SKIP_SETUP=${SKIP_SETUP:-}
+readonly SKIP_CLEANUP=${SKIP_CLEANUP:-}
 
 # If we're in CI, we want to slow down execution
 # to give CPU some time to rest, so we don't time out
@@ -35,13 +37,13 @@ function setup_cli() {
 }
 
 function run_test() {
-    local RANDOM_DATA=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w${PAYLOAD_SIZE} | head -n1)
+    local TEST_DATA=$(shuf -zer -n${PAYLOAD_SIZE}  {A..Z} {a..z} {0..9} | tr -d '\0')
     ci_check;
 
-    $FLUVIO_BIN topic create $TEST_TOPIC
+    $FLUVIO_BIN topic create $TEST_TOPIC || true
     ci_check;
 
-    echo $RANDOM_DATA | $FLUVIO_BIN produce $TEST_TOPIC
+    echo $TEST_DATA | $FLUVIO_BIN produce $TEST_TOPIC
     ci_check;
 
     $FLUVIO_BIN consume $TEST_TOPIC -B -d
@@ -64,12 +66,25 @@ function main() {
         echo "[CI MODE] Skipping initial cleanup";
     fi
 
-    setup_cluster $CLUSTER_VERSION;
-    ci_check;
-    setup_cli $CLI_VERSION;
-    ci_check;
+    if [[ -z "$SKIP_SETUP" ]];
+    then
+        setup_cluster $CLUSTER_VERSION;
+        ci_check;
+        setup_cli $CLI_VERSION;
+        ci_check;
+    else
+        echo "Skipping setup"
+    fi
+
     run_test;
-    cleanup;
+
+    if [[ -z "$SKIP_CLEANUP" ]];
+    then
+        cleanup;
+    else
+        echo "Skipping cleanup"
+    fi
+
 }
 
 main;


### PR DESCRIPTION
Test the latest CLI against the current stable version of cluster in CI

Modified `cli-platform-cross-version-test` from CD_Dev so it can run in CI w/o setting up a cluster w/o setup, bc we do that outside the script.