### PR TITLE
Move Arc inside StickyEvent, makes Future easier to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.8 - UNRELEASED
 * Add progress indicator to `fluvio cluster start` ([#1627](https://github.com/infinyon/fluvio/pull/1627))
 * Added `fluvio cluster diagnostics` to help debugging with support ([#1671](https://github.com/infinyon/fluvio/pull/1671))
+* Make `StickyEvent` easier to use with Future combinators ([#1652](https://github.com/infinyon/fluvio/pull/1652))
 
 ## Platform Version 0.9.7 - 2021-09-16
 * Improve progress message in `fluvio cluster start --local` ([#1586](https://github.com/infinyon/fluvio/pull/1586))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "event-listener",
  "fluvio-future",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,7 @@ version = "0.2.6"
 dependencies = [
  "event-listener",
  "fluvio-future",
+ "futures-util",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/fluvio-sc/src/services/public_api/public_server.rs
+++ b/crates/fluvio-sc/src/services/public_api/public_server.rs
@@ -72,7 +72,7 @@ where
         let mut api_stream = stream.api_stream::<AdminPublicRequest, AdminPublicApiKey>();
         let mut shared_sink = sink.as_shared();
 
-        let end_event = StickyEvent::shared();
+        let shutdown = StickyEvent::new();
 
         api_loop!(
             api_stream,
@@ -105,18 +105,16 @@ where
                 "list handler"
             ),
             AdminPublicRequest::WatchRequest(request) =>
-
                 super::watch::handle_watch_request(
                     request,
                     &service_context,
                     shared_sink.clone(),
-                    end_event.clone(),
+                    shutdown.clone(),
                 )
-
         );
 
         // we are done with this tcp stream, notify any controllers use this strep
-        end_event.notify();
+        shutdown.notify();
 
         Ok(())
     }

--- a/crates/fluvio-sc/src/services/public_api/watch.rs
+++ b/crates/fluvio-sc/src/services/public_api/watch.rs
@@ -56,7 +56,7 @@ pub fn handle_watch_request<AC>(
         ),
         WatchRequest::ManagedConnector(_) => WatchController::<ManagedConnectorSpec>::update(
             sink,
-            end_event,
+            shutdown,
             auth_ctx.global_ctx.managed_connectors().clone(),
             header,
         ),

--- a/crates/fluvio-service/src/server.rs
+++ b/crates/fluvio-service/src/server.rs
@@ -80,14 +80,14 @@ where
     A: Send + FluvioDecoder + Debug + 'static,
     S: FluvioService<Request = R, Context = C> + Send + Sync + Debug + 'static,
 {
-    pub fn run(self) -> Arc<StickyEvent> {
-        let shutdown = StickyEvent::shared();
+    pub fn run(self) -> StickyEvent {
+        let shutdown = StickyEvent::new();
         spawn(self.accept_incoming(shutdown.clone()));
         shutdown
     }
 
     #[instrument(skip(shutdown))]
-    async fn accept_incoming(self, shutdown: Arc<StickyEvent>) {
+    async fn accept_incoming(self, shutdown: StickyEvent) {
         debug!("Binding TcpListener");
         let listener = match TcpListener::bind(&self.addr).await {
             Ok(listener) => listener,
@@ -192,7 +192,7 @@ mod test {
         FluvioSocket::connect(&addr).await
     }
 
-    async fn test_client(addr: String, shutdown: Arc<StickyEvent>) {
+    async fn test_client(addr: String, shutdown: StickyEvent) {
         let mut socket = create_client(addr).await.expect("client");
 
         let request = EchoRequest::new("hello".to_owned());

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -65,7 +65,7 @@ impl FluvioService for PublicService {
 
         let mut shared_sink = sink.as_shared();
         let api_stream = stream.api_stream::<SpuServerRequest, SpuServerApiKey>();
-        let shutdown = StickyEvent::shared();
+        let shutdown = StickyEvent::new();
         let mut event_stream = api_stream.take_until(shutdown.listen_pinned());
 
         loop {

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "1"
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture", "subscriber"] }
 tokio = { version = "1.3.0", features = ["macros"] }
+futures-util = "0.3"

--- a/crates/fluvio-types/src/event.rs
+++ b/crates/fluvio-types/src/event.rs
@@ -280,19 +280,17 @@ mod test {
         let stream2 = stream::repeat(9);
         let _until2 = stream2.take_until(end.listen_pinned());
 
-        // In our real use-case, we need our stream to be `impl Stream + Send + Sync + 'static`
-        fn assert_stream<S: Stream + Send + Sync + 'static>(stream: S) -> S {
-            stream
-        }
-        // The stream needs to be able to be moved, as it will be stored in a struct
-        fn move_it<S>(it: S) -> S {
-            it
-        }
         let stream3 = stream::repeat(9);
         let until3 = stream3.take_until(end.listen_pinned());
-        let until3 = assert_stream(until3);
-        let pinned: Option<Pin<Box<dyn Stream<Item = i32> + Send + Sync>>> = Some(Box::pin(until3));
-        let _moved = move_it(pinned);
+        let pinned = Box::pin(until3);
+
+        struct DispatcherStateOrSomething {
+            _stream: Option<Pin<Box<dyn Stream<Item = i32>>>>,
+        }
+
+        let _stored = DispatcherStateOrSomething {
+            _stream: Some(pinned),
+        };
     }
 
     #[fluvio_future::test]

--- a/crates/fluvio-types/src/event.rs
+++ b/crates/fluvio-types/src/event.rs
@@ -75,6 +75,12 @@ impl StickyEvent {
     }
 }
 
+impl Default for StickyEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub mod offsets {
     use std::sync::atomic::{AtomicI64, Ordering};
     use std::sync::Arc;


### PR DESCRIPTION
This is a little bit of cleanup for `StickyEvent` that makes it much easier to use with Futures combinators.

Key changes:

- We now use `StickyEvent` instead of `Arc<StickyEvent>` everywhere, the Arc is now inside and StickyEvent is Clone
- The `listen` method now returns a Future bounded by `'static`, rather than one that is bounded by the `&self` lifetime
  - This is the key improvement that helps work with combinators