### PR TITLE
[Merged by Bors] - Generalize stream dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-channel",
  "async-rwlock",
@@ -1942,7 +1942,6 @@ dependencies = [
  "flv-util",
  "futures-lite",
  "k8-metadata-client",
- "log",
  "once_cell",
  "serde",
  "serde_json",

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -50,7 +50,7 @@ fluvio-sc-schema = { version = "0.9.4", path = "../fluvio-sc-schema" }
 fluvio-stream-model = { version = "0.5.0", path = "../fluvio-stream-model" }
 fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { version = "0.11.0", features = ["k8", "serde"], path = "../fluvio-controlplane-metadata" }
-fluvio-stream-dispatcher = { version = "0.6.3", path = "../fluvio-stream-dispatcher" }
+fluvio-stream-dispatcher = { version = "0.6.5", path = "../fluvio-stream-dispatcher" }
 k8-client = { version = "5.1.5", optional = true }
 k8-metadata-client = { version = "3.0.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }

--- a/crates/fluvio-sc/src/controllers/partitions/controller.rs
+++ b/crates/fluvio-sc/src/controllers/partitions/controller.rs
@@ -130,3 +130,20 @@ impl PartitionController {
         }
     }
 }
+
+
+/* 
+#[cfg(test)]
+mod test {
+
+
+
+    #[fluvio_future::test(ignore)]
+
+    async fn test_election() {
+
+
+    }    
+
+}
+*/

--- a/crates/fluvio-sc/src/controllers/partitions/controller.rs
+++ b/crates/fluvio-sc/src/controllers/partitions/controller.rs
@@ -131,8 +131,7 @@ impl PartitionController {
     }
 }
 
-
-/* 
+/*
 #[cfg(test)]
 mod test {
 
@@ -143,7 +142,7 @@ mod test {
     async fn test_election() {
 
 
-    }    
+    }
 
 }
 */

--- a/crates/fluvio-sc/src/lib.rs
+++ b/crates/fluvio-sc/src/lib.rs
@@ -11,10 +11,6 @@ mod error;
 mod services;
 mod controllers;
 
-
-#[cfg(test)]
-mod fixture;
-
 pub use init::start_main_loop;
 
 const VERSION: &str = include_str!("../../../VERSION");

--- a/crates/fluvio-sc/src/lib.rs
+++ b/crates/fluvio-sc/src/lib.rs
@@ -11,6 +11,10 @@ mod error;
 mod services;
 mod controllers;
 
+
+#[cfg(test)]
+mod fixture;
+
 pub use init::start_main_loop;
 
 const VERSION: &str = include_str!("../../../VERSION");

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2018"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"
@@ -12,7 +12,6 @@ name = "fluvio_stream_dispatcher"
 path = "src/lib.rs"
 
 [dependencies]
-log = "0.4.8"
 tracing = "0.1.0"
 tracing-futures = "0.2.0"
 serde = { version = "1.0.103", features = ['derive'] }

--- a/crates/fluvio-stream-dispatcher/src/actions.rs
+++ b/crates/fluvio-stream-dispatcher/src/actions.rs
@@ -6,10 +6,10 @@ use crate::store::*;
 use crate::store::k8::K8MetaItem;
 
 #[derive(PartialEq, Clone)]
-pub enum WSAction<S,MetaContext = K8MetaItem>
+pub enum WSAction<S, MetaContext = K8MetaItem>
 where
     S: Spec + PartialEq,
-    MetaContext: MetadataItem
+    MetaContext: MetadataItem,
 {
     Apply(MetadataStoreObject<S, MetaContext>),
     UpdateSpec((S::IndexKey, S)),
@@ -18,11 +18,11 @@ where
     DeleteFinal(S::IndexKey),
 }
 
-impl<S,MetaContext> fmt::Display for WSAction<S,MetaContext>
+impl<S, MetaContext> fmt::Display for WSAction<S, MetaContext>
 where
     S: Spec + PartialEq,
     S::IndexKey: Display,
-    MetaContext: MetadataItem
+    MetaContext: MetadataItem,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -35,11 +35,11 @@ where
     }
 }
 
-impl<S,MetaContext> fmt::Debug for WSAction<S,MetaContext>
+impl<S, MetaContext> fmt::Debug for WSAction<S, MetaContext>
 where
     S: Spec + PartialEq,
     S::IndexKey: Display,
-    MetaContext: MetadataItem
+    MetaContext: MetadataItem,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/fluvio-stream-dispatcher/src/actions.rs
+++ b/crates/fluvio-stream-dispatcher/src/actions.rs
@@ -6,21 +6,23 @@ use crate::store::*;
 use crate::store::k8::K8MetaItem;
 
 #[derive(PartialEq, Clone)]
-pub enum WSAction<S>
+pub enum WSAction<S,MetaContext = K8MetaItem>
 where
     S: Spec + PartialEq,
+    MetaContext: MetadataItem
 {
-    Apply(MetadataStoreObject<S, K8MetaItem>),
+    Apply(MetadataStoreObject<S, MetaContext>),
     UpdateSpec((S::IndexKey, S)),
     UpdateStatus((S::IndexKey, S::Status)),
     Delete(S::IndexKey),
     DeleteFinal(S::IndexKey),
 }
 
-impl<S> fmt::Display for WSAction<S>
+impl<S,MetaContext> fmt::Display for WSAction<S,MetaContext>
 where
     S: Spec + PartialEq,
     S::IndexKey: Display,
+    MetaContext: MetadataItem
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -33,10 +35,11 @@ where
     }
 }
 
-impl<S> fmt::Debug for WSAction<S>
+impl<S,MetaContext> fmt::Debug for WSAction<S,MetaContext>
 where
     S: Spec + PartialEq,
     S::IndexKey: Display,
+    MetaContext: MetadataItem
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/fluvio-stream-dispatcher/src/store/mod.rs
+++ b/crates/fluvio-stream-dispatcher/src/store/mod.rs
@@ -9,7 +9,7 @@ mod context {
     use std::sync::Arc;
     use std::io::Error as IoError;
     use std::io::ErrorKind;
-    use std::fmt::{ Display ,Debug};
+    use std::fmt::{Display, Debug};
     use std::time::Duration;
 
     use fluvio_stream_model::core::MetadataItem;
@@ -28,9 +28,9 @@ mod context {
     use super::MetadataStoreObject;
     use super::{LocalStore, ChangeListener, MetadataChanges};
 
-    pub type K8ChangeListener<S,MetaContext = K8MetaItem> = ChangeListener<S, MetaContext>;
+    pub type K8ChangeListener<S, MetaContext = K8MetaItem> = ChangeListener<S, MetaContext>;
 
-    pub type StoreChanges<S,MetaContext = K8MetaItem> = MetadataChanges<S, MetaContext>;
+    pub type StoreChanges<S, MetaContext = K8MetaItem> = MetadataChanges<S, MetaContext>;
 
     static MAX_WAIT_TIME: Lazy<u64> = Lazy::new(|| {
         use std::env;
@@ -41,20 +41,20 @@ mod context {
     });
 
     #[derive(Debug, Clone)]
-    pub struct StoreContext<S,MetaContext = K8MetaItem>
+    pub struct StoreContext<S, MetaContext = K8MetaItem>
     where
         S: Spec,
-        MetaContext: MetadataItem + Debug
+        MetaContext: MetadataItem + Debug,
     {
         store: Arc<LocalStore<S, MetaContext>>,
-        sender: Sender<WSAction<S,MetaContext>>,
-        receiver: Receiver<WSAction<S,MetaContext>>,
+        sender: Sender<WSAction<S, MetaContext>>,
+        receiver: Receiver<WSAction<S, MetaContext>>,
     }
 
-    impl<S,MetaContext> StoreContext<S, MetaContext >
+    impl<S, MetaContext> StoreContext<S, MetaContext>
     where
         S: Spec,
-        MetaContext: MetadataItem
+        MetaContext: MetadataItem,
     {
         /// create new store context
         pub fn new() -> Self {
@@ -73,8 +73,8 @@ mod context {
 
         pub async fn send(
             &mut self,
-            actions: Vec<WSAction<S,MetaContext>>,
-        ) -> Result<(), SendError<WSAction<S,MetaContext>>> {
+            actions: Vec<WSAction<S, MetaContext>>,
+        ) -> Result<(), SendError<WSAction<S, MetaContext>>> {
             for action in actions.into_iter() {
                 self.sender.send(action).await?;
             }
@@ -82,7 +82,7 @@ mod context {
         }
 
         /// create new listener
-        pub fn change_listener(&self) -> K8ChangeListener<S,MetaContext> {
+        pub fn change_listener(&self) -> K8ChangeListener<S, MetaContext> {
             self.store.change_listener()
         }
 
@@ -90,25 +90,25 @@ mod context {
             &self.store
         }
 
-        pub fn receiver(&self) -> Receiver<WSAction<S,MetaContext>> {
+        pub fn receiver(&self) -> Receiver<WSAction<S, MetaContext>> {
             self.receiver.clone()
         }
     }
 
-    impl<S,MetaContext> Default for StoreContext<S,MetaContext>
+    impl<S, MetaContext> Default for StoreContext<S, MetaContext>
     where
         S: Spec,
-        MetaContext: MetadataItem
+        MetaContext: MetadataItem,
     {
         fn default() -> Self {
             Self::new()
         }
     }
 
-    impl<S,MetaContext> StoreContext<S, MetaContext >
+    impl<S, MetaContext> StoreContext<S, MetaContext>
     where
         S: Spec + PartialEq,
-        MetaContext: MetadataItem
+        MetaContext: MetadataItem,
     {
         /// Wait for the termination of the apply action object, this is similar to ```kubectl apply```
         pub async fn apply(
@@ -211,7 +211,7 @@ mod context {
         pub async fn wait_action(
             &self,
             key: &S::IndexKey,
-            action: WSAction<S,MetaContext>,
+            action: WSAction<S, MetaContext>,
         ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
@@ -228,7 +228,7 @@ mod context {
         pub async fn wait_action_with_timeout(
             &self,
             key: &S::IndexKey,
-            action: WSAction<S,MetaContext>,
+            action: WSAction<S, MetaContext>,
             timeout: Duration,
         ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
@@ -282,7 +282,7 @@ mod context {
         }
 
         /// send action
-        pub async fn send_action(&self, action: WSAction<S,MetaContext>) {
+        pub async fn send_action(&self, action: WSAction<S, MetaContext>) {
             if let Err(err) = self.sender.send(action).await {
                 error!("{}, error sending action to store: {}", S::LABEL, err);
             }

--- a/crates/fluvio-stream-dispatcher/src/store/mod.rs
+++ b/crates/fluvio-stream-dispatcher/src/store/mod.rs
@@ -9,9 +9,10 @@ mod context {
     use std::sync::Arc;
     use std::io::Error as IoError;
     use std::io::ErrorKind;
-    use std::fmt::Display;
+    use std::fmt::{ Display ,Debug};
     use std::time::Duration;
 
+    use fluvio_stream_model::core::MetadataItem;
     use tracing::error;
     use async_channel::{Sender, Receiver, bounded, SendError};
     use once_cell::sync::Lazy;
@@ -27,9 +28,9 @@ mod context {
     use super::MetadataStoreObject;
     use super::{LocalStore, ChangeListener, MetadataChanges};
 
-    pub type K8ChangeListener<S> = ChangeListener<S, K8MetaItem>;
+    pub type K8ChangeListener<S,MetaContext = K8MetaItem> = ChangeListener<S, MetaContext>;
 
-    pub type StoreChanges<S> = MetadataChanges<S, K8MetaItem>;
+    pub type StoreChanges<S,MetaContext = K8MetaItem> = MetadataChanges<S, MetaContext>;
 
     static MAX_WAIT_TIME: Lazy<u64> = Lazy::new(|| {
         use std::env;
@@ -40,18 +41,20 @@ mod context {
     });
 
     #[derive(Debug, Clone)]
-    pub struct StoreContext<S>
+    pub struct StoreContext<S,MetaContext = K8MetaItem>
     where
         S: Spec,
+        MetaContext: MetadataItem + Debug
     {
-        store: Arc<LocalStore<S, K8MetaItem>>,
-        sender: Sender<WSAction<S>>,
-        receiver: Receiver<WSAction<S>>,
+        store: Arc<LocalStore<S, MetaContext>>,
+        sender: Sender<WSAction<S,MetaContext>>,
+        receiver: Receiver<WSAction<S,MetaContext>>,
     }
 
-    impl<S> StoreContext<S>
+    impl<S,MetaContext> StoreContext<S, MetaContext >
     where
         S: Spec,
+        MetaContext: MetadataItem
     {
         /// create new store context
         pub fn new() -> Self {
@@ -59,7 +62,7 @@ mod context {
         }
 
         /// create new store context with store
-        pub fn new_with_store(store: Arc<LocalStore<S, K8MetaItem>>) -> Self {
+        pub fn new_with_store(store: Arc<LocalStore<S, MetaContext>>) -> Self {
             let (sender, receiver) = bounded(100);
             Self {
                 store,
@@ -70,8 +73,8 @@ mod context {
 
         pub async fn send(
             &mut self,
-            actions: Vec<WSAction<S>>,
-        ) -> Result<(), SendError<WSAction<S>>> {
+            actions: Vec<WSAction<S,MetaContext>>,
+        ) -> Result<(), SendError<WSAction<S,MetaContext>>> {
             for action in actions.into_iter() {
                 self.sender.send(action).await?;
             }
@@ -79,37 +82,39 @@ mod context {
         }
 
         /// create new listener
-        pub fn change_listener(&self) -> K8ChangeListener<S> {
+        pub fn change_listener(&self) -> K8ChangeListener<S,MetaContext> {
             self.store.change_listener()
         }
 
-        pub fn store(&self) -> &Arc<LocalStore<S, K8MetaItem>> {
+        pub fn store(&self) -> &Arc<LocalStore<S, MetaContext>> {
             &self.store
         }
 
-        pub fn receiver(&self) -> Receiver<WSAction<S>> {
+        pub fn receiver(&self) -> Receiver<WSAction<S,MetaContext>> {
             self.receiver.clone()
         }
     }
 
-    impl<S> Default for StoreContext<S>
+    impl<S,MetaContext> Default for StoreContext<S,MetaContext>
     where
         S: Spec,
+        MetaContext: MetadataItem
     {
         fn default() -> Self {
             Self::new()
         }
     }
 
-    impl<S> StoreContext<S>
+    impl<S,MetaContext> StoreContext<S, MetaContext >
     where
         S: Spec + PartialEq,
+        MetaContext: MetadataItem
     {
         /// Wait for the termination of the apply action object, this is similar to ```kubectl apply```
         pub async fn apply(
             &self,
-            input: MetadataStoreObject<S, K8MetaItem>,
-        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+            input: MetadataStoreObject<S, MetaContext>,
+        ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
         {
@@ -128,7 +133,7 @@ mod context {
             &self,
             key: S::IndexKey,
             spec: S,
-        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+        ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
         {
@@ -147,7 +152,7 @@ mod context {
             &self,
             key: S::IndexKey,
             status: S::Status,
-        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+        ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
         {
@@ -206,8 +211,8 @@ mod context {
         pub async fn wait_action(
             &self,
             key: &S::IndexKey,
-            action: WSAction<S>,
-        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+            action: WSAction<S,MetaContext>,
+        ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
         {
@@ -223,9 +228,9 @@ mod context {
         pub async fn wait_action_with_timeout(
             &self,
             key: &S::IndexKey,
-            action: WSAction<S>,
+            action: WSAction<S,MetaContext>,
             timeout: Duration,
-        ) -> Result<MetadataStoreObject<S, K8MetaItem>, IoError>
+        ) -> Result<MetadataStoreObject<S, MetaContext>, IoError>
         where
             S::IndexKey: Display,
         {
@@ -277,7 +282,7 @@ mod context {
         }
 
         /// send action
-        pub async fn send_action(&self, action: WSAction<S>) {
+        pub async fn send_action(&self, action: WSAction<S,MetaContext>) {
             if let Err(err) = self.sender.send(action).await {
                 error!("{}, error sending action to store: {}", S::LABEL, err);
             }


### PR DESCRIPTION
make stream dispatcher more generic instead of just working with `K8MetaItem`, this is need to make sc controllers more unit testable