### PR TITLE
[Merged by Bors] - Change chart location for local installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.8 - UNRELEASED
 * Add progress indicator to `fluvio cluster start` ([#1627](https://github.com/infinyon/fluvio/pull/1627))
 * Added `fluvio cluster diagnostics` to help debugging with support ([#1671](https://github.com/infinyon/fluvio/pull/1671))
+* Fix installation of sys charts when running `fluvio cluster start --local --develop` ([#1647](https://github.com/infinyon/fluvio/issues/1647))
 
 ## Platform Version 0.9.7 - 2021-09-16
 * Improve progress message in `fluvio cluster start --local` ([#1586](https://github.com/infinyon/fluvio/pull/1586))

--- a/crates/fluvio-cluster/src/check/render.rs
+++ b/crates/fluvio-cluster/src/check/render.rs
@@ -204,7 +204,7 @@ impl ProgressRenderedText for CheckStatus {
                     None => "".to_string(),
                 };
                 let msg = format!("{}{}", e, cause);
-                format!("{:>6} {}", "❌".bold(), msg.red())
+                format!("{:>6} {}", "❌", msg.red())
             }
         };
 

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -23,14 +23,8 @@ pub async fn process_local(
         .render_checks(true)
         .spu_replicas(opt.spu);
 
-    match opt.k8_config.chart_location {
-        Some(chart_location) => {
-            builder.local_chart(chart_location);
-        }
-        None if opt.develop => {
-            builder.local_chart("./k8-util/helm/fluvio-sys");
-        }
-        _ => (),
+    if let Some(chart_location) = opt.k8_config.chart_location {
+        builder.local_chart(chart_location);
     }
 
     if let Some(rust_log) = opt.rust_log {

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -28,7 +28,7 @@ pub async fn process_local(
             builder.local_chart(chart_location);
         }
         None if opt.develop => {
-            builder.local_chart("./k8-util/helm");
+            builder.local_chart("./k8-util/helm/fluvio-sys");
         }
         _ => (),
     }


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio/issues/1647

Running `helm install fluvio-sys ./k8-util/helm/` fails with 
```
Error: validation: chart.metadata is required
```
`helm install fluvio-sys ./k8-util/helm/fluvio-sys` works
