### PR TITLE
[Merged by Bors] - Compare crates in repo w/ published crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -796,3 +796,25 @@ jobs:
     steps:
       - name: Done
         run: echo "Done!"
+
+  test_crate_versions:
+    name: Verify if crate versions need bump
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+      - name: Install cargo-download
+        run: cargo install cargo-download
+
+      - name: Check if crate versions need bump
+        run: ./release-scripts/test-crate-version.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         os: [ubuntu-latest]
         rust: [stable]
         rust-target: [x86_64-unknown-linux-gnu]
-        check: [fmt, clippy, doc, test, integration]
+        check: [fmt, clippy, doc, test, integration, crate_version]
     env:
       RUST_BACKTRACE: full
       RUSTV: ${{ matrix.rust }}
@@ -257,6 +257,11 @@ jobs:
       - name: Integration test
         if: ${{ matrix.check == 'integration' }}
         run: make run-integration-test
+      - name: Crate version check
+        if: ${{ matrix.check == 'crate_version' }}
+        run: |
+          cargo install cargo-download
+          ./release-scripts/test-crate-version.sh
 
   check_wasm:
     name: Build WASM crates (${{ matrix.wasm-crate }})
@@ -796,25 +801,3 @@ jobs:
     steps:
       - name: Done
         run: echo "Done!"
-
-  test_crate_versions:
-    name: Verify if crate versions need bump
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        rust: [stable]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-      - name: Install cargo-download
-        run: cargo install cargo-download
-
-      - name: Check if crate versions need bump
-        run: ./release-scripts/test-crate-version.sh

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+set -u
+
+PUBLISH_CRATES=(
+    fluvio-protocol-core
+    fluvio-smartstream-derive
+    fluvio-types
+    fluvio-protocol-derive
+    fluvio-protocol-codec
+    fluvio-protocol
+    fluvio-dataplane-protocol
+    fluvio-socket
+    fluvio-stream-model
+    fluvio-controlplane-metadata
+    fluvio-spu-schema
+    fluvio-sc-schema
+    fluvio-smartstream
+    #fluvio
+    fluvio-stream-dispatcher
+    fluvio-package-index
+    fluvio-extension-common
+)
+
+ALL_CRATE_CHECK_PASS=true
+CHECK_CRATES=()
+readonly VERBOSE=${VERBOSE:-false}
+
+# Check if we have cargo-download in path
+# Attempt to download it
+function cargo_download_check() {
+    :
+}
+
+function download_crate() {
+    CRATE_NAME=$1
+    mkdir -p ./crates_io/$CRATE_NAME
+
+    if [[ $VERBOSE == true ]];
+    then
+        cargo download -x  $CRATE_NAME -o ./crates_io/$CRATE_NAME --verbose
+    else
+        cargo download -x  $CRATE_NAME -o ./crates_io/$CRATE_NAME --quiet
+    fi
+    
+}
+
+
+function compare_crates_src() {
+    CRATE_NAME=$1
+
+    if [[ $VERBOSE == true ]];
+    then
+        diff -bur ./crates/$CRATE_NAME/src ./crates_io/$CRATE_NAME/src;
+    else
+        diff -burq ./crates/$CRATE_NAME/src ./crates_io/$CRATE_NAME/src;
+    fi
+    
+}
+
+function compare_crates_version() {
+    CRATE_NAME=$1
+
+    CRATESIO_VERSION=$(cat ./crates_io/$CRATE_NAME/Cargo.toml | grep -e "^version" | head -1)
+    REPO_VERSION=$(cat ./crates/$CRATE_NAME/Cargo.toml | grep -e "^version" | head -1)
+
+    if [[ $CRATESIO_VERSION == $REPO_VERSION ]];
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# ✅ If src matches and version matches (This is the most common success case)
+# ✅ If src does not match and version does not match
+# ❌ If src matches and version does not match (This is highly unlikely)
+# ❌ If src does not match and version does match (This is the most common fail case)
+function does_repo_crate_version_need_bump() {
+    SRC_MATCH=$1
+    VERSION_MATCH=$2
+    CRATE_NAME=$3
+
+    if [[ "$SRC_MATCH" == true && "$VERSION_MATCH" == true ]];
+    then
+        echo "✅ Crate has not changed"
+    fi
+
+    if [[ "$SRC_MATCH" == false && "$VERSION_MATCH" == false ]];
+    then
+        echo "✅ Crate has already been bumped"
+    fi
+
+    if [[ "$SRC_MATCH" == false && "$VERSION_MATCH" == true ]];
+    then
+        echo "❌ Code has changed but version needs to be bumped"
+        CHECK_CRATES+=("$CRATE_NAME")
+        ALL_CRATE_CHECK_PASS=false
+    fi
+
+    if [[ "$SRC_MATCH" == true && "$VERSION_MATCH" == false ]];
+    then
+        echo "❌ Code has NOT changed, but versions don't match. Something is weird."
+        CHECK_CRATES+=("$CRATE_NAME")
+        ALL_CRATE_CHECK_PASS=false
+    fi
+
+
+}
+
+function main() {
+
+    if [[ $VERBOSE != false ]];
+    then
+        echo "VERBOSE MODE ON"
+        set -x
+    fi
+    
+    cargo_download_check;
+
+    rm -rf ./crates_io
+    mkdir -p ./crates_io;
+
+    for crate in "${PUBLISH_CRATES[@]}" ; do
+        echo "Checking: $crate"
+
+        SRC_MATCH=false        
+        VERSION_MATCH=false
+
+        download_crate $crate;
+
+
+        compare_crates_src $crate;
+        if [[ "$?" == 0 ]];
+        then
+            #echo "Crate src match"
+            SRC_MATCH=true
+        #else
+        #    #echo "Crate src DOES NOT match"
+        fi 
+        
+        compare_crates_version $crate;
+        if [[ "$?" == 0 ]];
+        then
+            #echo "Crate version match"
+            VERSION_MATCH=true
+        #else
+        #    #echo "Crate version DOES NOT match"
+        fi 
+
+        does_repo_crate_version_need_bump $SRC_MATCH $VERSION_MATCH $crate;
+    done
+
+    echo
+    echo "Results:"
+    if [[ $ALL_CRATE_CHECK_PASS == true ]];
+    then
+        echo "✅ All crates appear to be ready for publishing"
+        return 0
+    else
+        echo "❌ The following crates require attention:"
+        printf '* %s\n' "${CHECK_CRATES[@]}"
+        return 1
+    fi
+}
+
+main;

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -56,48 +56,47 @@ function download_crate() {
 function compare_crates_src() {
     CRATE_NAME=$1
 
-    if [[ $CRATE_NAME == "fluvio" ]];
+#    if [[ $CRATE_NAME == "fluvio" ]];
+#    then
+#        compare_fluvio_src;
+#    else
+#
+    if [[ $VERBOSE == true ]];
     then
-        compare_fluvio_src;
+        diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
     else
-
-        if [[ $VERBOSE == true ]];
-        then
-            diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
-        else
-            # Don't print the diff
-            diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
-        fi
+        # Don't print the diff
+        diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
     fi
+#    fi
     
 }
 
-# The fluvio crate needs to be handled differently than the rest
-# NOTICE:
-# We are unable to verify changes to the producer subcrate,
-# as a consequence to code optimizations made by crates.io
-function compare_fluvio_src() {
-    TMP=$(mktemp)
-    EXPECTED_OUT="Only in ./crates/fluvio/src: producer\nOnly in ./crates_io/fluvio/src: producer.rs"
-
-    if [[ $VERBOSE == true ]];
-    then
-        diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
-    else
-        # Don't print the diff
-        diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
-    fi
-
-    if [[ "$(echo -e "$EXPECTED_OUT")" == "$(cat "$TMP")" ]];
-    then
-        rm "$TMP"
-        return 0
-    else
-        rm "$TMP"
-        return 1
-    fi
-
-}
+## The fluvio crate needs to be handled differently than the rest
+## NOTICE:
+## We are unable to verify changes to the producer subcrate,
+## as a consequence to code optimizations made by crates.io
+#function compare_fluvio_src() {
+#    TMP=$(mktemp)
+#    EXPECTED_OUT="Only in ./crates/fluvio/src: producer\nOnly in ./crates_io/fluvio/src: producer.rs"
+#
+#    if [[ $VERBOSE == true ]];
+#    then
+#        diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
+#    else
+#        # Don't print the diff
+#        diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
+#    fi
+#
+#    if [[ "$(echo -e "$EXPECTED_OUT")" == "$(cat "$TMP")" ]];
+#    then
+#        rm "$TMP"
+#        return 0
+#    else
+#        rm "$TMP"
+#        return 1
+#    fi
+#}
 
 function compare_crates_version() {
     CRATE_NAME=$1

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -u
+set -eu
 
 PUBLISH_CRATES=(
     fluvio-protocol-core
@@ -27,20 +27,27 @@ CHECK_CRATES=()
 readonly VERBOSE=${VERBOSE:-false}
 
 # Check if we have cargo-download in path
-# Attempt to download it
+# If not, attempt to download it
 function cargo_download_check() {
-    :
+    if which cargo-download;
+    then
+        echo "🔧 cargo-download found"
+    else
+        echo "cargo-download not found"
+        echo "Attempting to download"
+        cargo install cargo-download
+    fi
 }
 
 function download_crate() {
     CRATE_NAME=$1
-    mkdir -p ./crates_io/$CRATE_NAME
+    mkdir -p ./crates_io/"$CRATE_NAME"
 
     if [[ $VERBOSE == true ]];
     then
-        cargo download -x  $CRATE_NAME -o ./crates_io/$CRATE_NAME --verbose
+        cargo download -x "$CRATE_NAME" -o ./crates_io/"$CRATE_NAME" --verbose
     else
-        cargo download -x  $CRATE_NAME -o ./crates_io/$CRATE_NAME --quiet
+        cargo download -x "$CRATE_NAME" -o ./crates_io/"$CRATE_NAME" --quiet
     fi
     
 }
@@ -51,9 +58,10 @@ function compare_crates_src() {
 
     if [[ $VERBOSE == true ]];
     then
-        diff -bur ./crates/$CRATE_NAME/src ./crates_io/$CRATE_NAME/src;
+        diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
     else
-        diff -burq ./crates/$CRATE_NAME/src ./crates_io/$CRATE_NAME/src;
+        # Don't print the diff
+        diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
     fi
     
 }
@@ -61,10 +69,10 @@ function compare_crates_src() {
 function compare_crates_version() {
     CRATE_NAME=$1
 
-    CRATESIO_VERSION=$(cat ./crates_io/$CRATE_NAME/Cargo.toml | grep -e "^version" | head -1)
-    REPO_VERSION=$(cat ./crates/$CRATE_NAME/Cargo.toml | grep -e "^version" | head -1)
+    CRATESIO_VERSION=$(grep -e "^version" ./crates_io/"$CRATE_NAME"/Cargo.toml | head -1)
+    REPO_VERSION=$(grep -e "^version" ./crates/"$CRATE_NAME"/Cargo.toml | head -1)
 
-    if [[ $CRATESIO_VERSION == $REPO_VERSION ]];
+    if [[ "$CRATESIO_VERSION" == "$REPO_VERSION" ]];
     then
         return 0
     else
@@ -76,36 +84,41 @@ function compare_crates_version() {
 # ✅ If src does not match and version does not match
 # ❌ If src matches and version does not match (This is highly unlikely)
 # ❌ If src does not match and version does match (This is the most common fail case)
-function does_repo_crate_version_need_bump() {
+function check_crate() {
     SRC_MATCH=$1
     VERSION_MATCH=$2
     CRATE_NAME=$3
 
+    # No changes between repo and crates.io
     if [[ "$SRC_MATCH" == true && "$VERSION_MATCH" == true ]];
     then
-        echo "✅ Crate has not changed"
+        echo "🟢 Repo code does not differ from crates.io"
     fi
 
+    # Code changes found, but versions don't match
+    # It's assumed that the repo is bumped appropriately
     if [[ "$SRC_MATCH" == false && "$VERSION_MATCH" == false ]];
     then
-        echo "✅ Crate has already been bumped"
+        echo "🟢 Repo code differs, but version has been updated too"
     fi
 
+    # Code changes found, however versions match
+    # It's assumed that the repo has increased version number
     if [[ "$SRC_MATCH" == false && "$VERSION_MATCH" == true ]];
     then
-        echo "❌ Code has changed but version needs to be bumped"
+        echo "⛔ Code has changed but version needs to be bumped"
         CHECK_CRATES+=("$CRATE_NAME")
         ALL_CRATE_CHECK_PASS=false
     fi
 
+    # No code changes found, but the versions are different
+    # This is unneeded change w/o code modifications
     if [[ "$SRC_MATCH" == true && "$VERSION_MATCH" == false ]];
     then
-        echo "❌ Code has NOT changed, but versions don't match. Something is weird."
+        echo "🔴 Code has NOT changed, but versions don't match. Something is weird."
         CHECK_CRATES+=("$CRATE_NAME")
         ALL_CRATE_CHECK_PASS=false
     fi
-
-
 }
 
 function main() {
@@ -127,28 +140,20 @@ function main() {
         SRC_MATCH=false        
         VERSION_MATCH=false
 
-        download_crate $crate;
+        download_crate "$crate";
 
-
-        compare_crates_src $crate;
-        if [[ "$?" == 0 ]];
+        if compare_crates_src "$crate";
         then
-            #echo "Crate src match"
             SRC_MATCH=true
-        #else
-        #    #echo "Crate src DOES NOT match"
         fi 
         
-        compare_crates_version $crate;
-        if [[ "$?" == 0 ]];
+        
+        if compare_crates_version "$crate";
         then
-            #echo "Crate version match"
             VERSION_MATCH=true
-        #else
-        #    #echo "Crate version DOES NOT match"
         fi 
 
-        does_repo_crate_version_need_bump $SRC_MATCH $VERSION_MATCH $crate;
+        check_crate "$SRC_MATCH" "$VERSION_MATCH" "$crate";
     done
 
     echo

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -56,11 +56,6 @@ function download_crate() {
 function compare_crates_src() {
     CRATE_NAME=$1
 
-#    if [[ $CRATE_NAME == "fluvio" ]];
-#    then
-#        compare_fluvio_src;
-#    else
-#
     if [[ $VERBOSE == true ]];
     then
         diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
@@ -68,35 +63,8 @@ function compare_crates_src() {
         # Don't print the diff
         diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src;
     fi
-#    fi
     
 }
-
-## The fluvio crate needs to be handled differently than the rest
-## NOTICE:
-## We are unable to verify changes to the producer subcrate,
-## as a consequence to code optimizations made by crates.io
-#function compare_fluvio_src() {
-#    TMP=$(mktemp)
-#    EXPECTED_OUT="Only in ./crates/fluvio/src: producer\nOnly in ./crates_io/fluvio/src: producer.rs"
-#
-#    if [[ $VERBOSE == true ]];
-#    then
-#        diff -bur ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
-#    else
-#        # Don't print the diff
-#        diff -burq ./crates/"$CRATE_NAME"/src ./crates_io/"$CRATE_NAME"/src | tee "$TMP";
-#    fi
-#
-#    if [[ "$(echo -e "$EXPECTED_OUT")" == "$(cat "$TMP")" ]];
-#    then
-#        rm "$TMP"
-#        return 0
-#    else
-#        rm "$TMP"
-#        return 1
-#    fi
-#}
 
 function compare_crates_version() {
     CRATE_NAME=$1


### PR DESCRIPTION
Catch if we forget to version bump a crate

Fixes #1496

Not yet handling changes only to a crate's `Cargo.toml` due to crates.io re-formatting the original Cargo.toml. This is an edge case.

This test probably belongs in `CD_Dev` but keeping it in `CI` for now.