### PR TITLE
[Merged by Bors] - Increasing crate versions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,13 +2032,11 @@ dependencies = [
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",
- "fork",
  "futures",
  "futures-lite",
  "hdrhistogram",
  "inventory",
  "md-5",
- "nix",
  "prettytable-rs",
  "rand 0.8.4",
  "serde",
@@ -2201,15 +2199,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fork"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c5b9b0bce249a456f83ac4404e8baad0d2ba81cf651949719a4f74eb7323bb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "form_urlencoded"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "log",
@@ -2032,11 +2032,13 @@ dependencies = [
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",
+ "fork",
  "futures",
  "futures-lite",
  "hdrhistogram",
  "inventory",
  "md-5",
+ "nix",
  "prettytable-rs",
  "rand 0.8.4",
  "serde",
@@ -2199,6 +2201,15 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fork"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c5b9b0bce249a456f83ac4404e8baad0d2ba81cf651949719a4f74eb7323bb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "form_urlencoded"

--- a/crates/fluvio-auth/Cargo.toml
+++ b/crates/fluvio-auth/Cargo.toml
@@ -23,7 +23,7 @@ tracing-futures = "0.2.4"
 x509-parser = "0.9.1"
 
 fluvio-controlplane-metadata = { version = "0.12.0", path = "../fluvio-controlplane-metadata" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
 fluvio-protocol = { path = "../fluvio-protocol",  version = "0.6" }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2018"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"
@@ -27,7 +27,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
 fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.5.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/crates/fluvio-controlplane/Cargo.toml
+++ b/crates/fluvio-controlplane/Cargo.toml
@@ -20,4 +20,4 @@ tracing = "0.1.19"
 fluvio-types = { path = "../fluvio-types", version = "0.2.0" }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.12.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/crates/fluvio-protocol-core/Cargo.toml
+++ b/crates/fluvio-protocol-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-core"
 edition = "2018"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "encoder and decoder for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"
@@ -25,4 +25,4 @@ static_assertions = "1.1.0"
 fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
 fluvio-controlplane-metadata = { version = "0.12.0", default-features = false, path = "../fluvio-controlplane-metadata" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -57,7 +57,7 @@ k8-metadata-client = { version = "3.0.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
 k8-types = { version = "0.2.7", features = ["app"] }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../fluvio-service", version = "0.0.0" }
 flv-tls-proxy = { version = "0.5.0" }
 

--- a/crates/fluvio-smartstream/Cargo.toml
+++ b/crates/fluvio-smartstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -18,5 +18,5 @@ crate-type = ['lib']
 
 [dependencies]
 eyre = { version = "0.6", default-features = false }
-fluvio-dataplane-protocol = { version = "0.6", path = "../fluvio-dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.7", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartstream-derive = { version = "0.1.1", path = "../fluvio-smartstream-derive", optional = true }

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
@@ -24,4 +24,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -53,7 +53,7 @@ fluvio-controlplane-metadata = { version = "0.12.0", path = "../fluvio-controlpl
 fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema", features = ["file"]}
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0", features = ["file"] }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
 fluvio-service = { path = "../fluvio-service", version = "0.0.0" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }
@@ -64,4 +64,4 @@ once_cell = "1.5.2"
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-future = { version = "0.3.1", features = ["fixture", "subscriber"] }
 derive_builder = { version = "0.10.0" }
-dataplane = { version = "0.6", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.7", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }

--- a/crates/fluvio-storage/Cargo.toml
+++ b/crates/fluvio-storage/Cargo.toml
@@ -36,11 +36,11 @@ thiserror = "1"
 fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
 fluvio-future = { version = "0.3.2", features = ["fs", "mmap","zero_copy"] }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["file"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0",features = ["file"] }
 fluvio-storage = { path = ".", features = ["fixture"]}
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = ["fixture"] }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -45,7 +45,7 @@ fluvio-types = { version = "0.2.1", features = ["events"], path = "../fluvio-typ
 fluvio-sc-schema = { version = "0.10.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.6.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "3.0.0"


### PR DESCRIPTION
The last release we mistakenly missed publishing a few crates bc we missed on increasing their version numbers.

`fluvio-protocol-codec` gets a patch bump to `0.3.3` from test changes. https://github.com/infinyon/fluvio/pull/1579
`fluvio-dataplane-protocol` gets a minor bump to `0.7.0` from public enum changes. https://github.com/infinyon/fluvio/pull/1595

Dependent crates were all patch bumped too (if we publish them).

---

This needs to be merged, and crates published before PR https://github.com/infinyon/fluvio/pull/1684 can pass 