### PR TITLE
[Merged by Bors] - Fluvio test remove locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,6 @@ dependencies = [
 name = "fluvio-test"
 version = "0.0.0"
 dependencies = [
- "async-lock",
  "async-trait",
  "bencher",
  "bytes",
@@ -2034,7 +2033,6 @@ dependencies = [
  "fluvio-types",
  "futures",
  "futures-lite",
- "hdrhistogram",
  "inventory",
  "md-5",
  "prettytable-rs",
@@ -2079,7 +2077,6 @@ dependencies = [
 name = "fluvio-test-util"
 version = "0.0.0"
 dependencies = [
- "async-lock",
  "async-trait",
  "bytes",
  "dyn-clone",

--- a/crates/fluvio-test-derive/src/lib.rs
+++ b/crates/fluvio-test-derive/src/lib.rs
@@ -78,7 +78,7 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
             serde_json::from_str(#fn_test_reqs_str).expect("Could not deserialize test reqs")
         }
 
-        pub fn #out_fn_iden(mut test_driver: Arc<RwLock<TestDriver>>, mut test_case: TestCase) -> Result<TestResult, TestResult> {
+        pub fn #out_fn_iden(mut test_driver: Arc<TestDriver>, mut test_case: TestCase) -> Result<TestResult, TestResult> {
             //println!("Inside the function");
             let future = async move {
                 //println!("Inside the async wrapper function");
@@ -97,27 +97,24 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         #[allow(clippy::unnecessary_operation)]
-        pub async fn ext_test_fn(mut test_driver: Arc<RwLock<TestDriver>>, test_case: TestCase) -> TestResult {
+        pub async fn ext_test_fn(mut test_driver: Arc<TestDriver>, test_case: TestCase) -> TestResult {
             use fluvio_test_util::test_meta::environment::EnvDetail;
             #test_body;
 
-
-            let lock = test_driver.read().await;
-
             TestResult {
-                topic_num: lock.topic_num as u64,
-                producer_num: lock.producer_num as u64,
-                consumer_num: lock.consumer_num as u64,
-                producer_bytes: lock.producer_bytes as u64,
-                consumer_bytes: lock.consumer_bytes as u64,
-                topic_create_latency_histogram: lock.topic_create_latency_histogram.clone(),
-                producer_latency_histogram: lock.producer_latency_histogram.clone(),
-                consumer_latency_histogram: lock.consumer_latency_histogram.clone(),
+                //topic_num: lock.topic_num as u64,
+                //producer_num: lock.producer_num as u64,
+                //consumer_num: lock.consumer_num as u64,
+                //producer_bytes: lock.producer_bytes as u64,
+                //consumer_bytes: lock.consumer_bytes as u64,
+                //topic_create_latency_histogram: lock.topic_create_latency_histogram.clone(),
+                //producer_latency_histogram: lock.producer_latency_histogram.clone(),
+                //consumer_latency_histogram: lock.consumer_latency_histogram.clone(),
                 ..Default::default()
             }
         }
 
-        pub async fn #async_inner_fn_iden(mut test_driver: Arc<RwLock<TestDriver>>, mut test_case: TestCase) -> Result<TestResult, TestResult> {
+        pub async fn #async_inner_fn_iden(mut test_driver: Arc<TestDriver>, mut test_case: TestCase) -> Result<TestResult, TestResult> {
             use fluvio::Fluvio;
             use fluvio_test_util::test_meta::TestCase;
             use fluvio_test_util::test_meta::test_result::TestResult;
@@ -146,11 +143,9 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
                 FluvioTestMeta::customize_test(&test_reqs, &mut test_case);
 
                 // Create topic before starting test
-                let mut lock = test_driver.write().await;
-                lock.create_topic(&test_case.environment)
+                test_driver.create_topic(&test_case.environment)
                     .await
                     .expect("Unable to create default topic");
-                drop(lock);
 
                 // start a timeout timer
                 let timeout_duration = test_case.environment.timeout();

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -22,7 +22,6 @@ once_cell = "1.7.2"
 dyn-clone = "1.0"
 semver = "1.0.0"
 hdrhistogram = "7.3.0"
-async-lock = "2.4.0"
 
 fluvio = { path = "../fluvio" }
 fluvio-future = { version = "0.3.0", features = ["task", "timer", "subscriber", "fixture"] }

--- a/crates/fluvio-test-util/test_meta/test_result.rs
+++ b/crates/fluvio-test-util/test_meta/test_result.rs
@@ -59,102 +59,102 @@ impl Display for TestResult {
             ["Duration", duration_str]
         );
 
-        let topic_create_latency_avg = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.topic_create_latency_histogram.mean() as u64)
-        );
-        let topic_create_latency_p50 = format!(
-            "{:.2?}",
-            Duration::from_nanos(
-                self.topic_create_latency_histogram
-                    .value_at_percentile(50.0)
-            )
-        );
-        let topic_create_latency_p90 = format!(
-            "{:.2?}",
-            Duration::from_nanos(
-                self.topic_create_latency_histogram
-                    .value_at_percentile(90.0)
-            )
-        );
-        let topic_create_latency_p99 = format!(
-            "{:.2?}",
-            Duration::from_nanos(
-                self.topic_create_latency_histogram
-                    .value_at_percentile(99.0)
-            )
-        );
-        let topic_create_latency_p999 = format!(
-            "{:.2?}",
-            Duration::from_nanos(
-                self.topic_create_latency_histogram
-                    .value_at_percentile(99.9)
-            )
-        );
+        //let topic_create_latency_avg = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.topic_create_latency_histogram.mean() as u64)
+        //);
+        //let topic_create_latency_p50 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(
+        //        self.topic_create_latency_histogram
+        //            .value_at_percentile(50.0)
+        //    )
+        //);
+        //let topic_create_latency_p90 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(
+        //        self.topic_create_latency_histogram
+        //            .value_at_percentile(90.0)
+        //    )
+        //);
+        //let topic_create_latency_p99 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(
+        //        self.topic_create_latency_histogram
+        //            .value_at_percentile(99.0)
+        //    )
+        //);
+        //let topic_create_latency_p999 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(
+        //        self.topic_create_latency_histogram
+        //            .value_at_percentile(99.9)
+        //    )
+        //);
 
-        let producer_latency_avg = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.producer_latency_histogram.mean() as u64)
-        );
-        let producer_latency_p50 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(50.0))
-        );
-        let producer_latency_p90 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(90.0))
-        );
-        let producer_latency_p99 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(99.0))
-        );
-        let producer_latency_p999 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(99.9))
-        );
+        //let producer_latency_avg = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.producer_latency_histogram.mean() as u64)
+        //);
+        //let producer_latency_p50 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(50.0))
+        //);
+        //let producer_latency_p90 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(90.0))
+        //);
+        //let producer_latency_p99 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(99.0))
+        //);
+        //let producer_latency_p999 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.producer_latency_histogram.value_at_percentile(99.9))
+        //);
 
-        let consumer_latency_avg = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.consumer_latency_histogram.mean() as u64)
-        );
-        let consumer_latency_p50 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(50.0))
-        );
-        let consumer_latency_p90 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(90.0))
-        );
-        let consumer_latency_p99 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(99.0))
-        );
-        let consumer_latency_p999 = format!(
-            "{:.2?}",
-            Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(99.9))
-        );
+        //let consumer_latency_avg = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.consumer_latency_histogram.mean() as u64)
+        //);
+        //let consumer_latency_p50 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(50.0))
+        //);
+        //let consumer_latency_p90 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(90.0))
+        //);
+        //let consumer_latency_p99 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(99.0))
+        //);
+        //let consumer_latency_p999 = format!(
+        //    "{:.2?}",
+        //    Duration::from_nanos(self.consumer_latency_histogram.value_at_percentile(99.9))
+        //);
 
-        let perf_results_header = table!(
-            [b->"Perf Results"]
-        );
+        //let perf_results_header = table!(
+        //    [b->"Perf Results"]
+        //);
 
-        let perf_created_table = table!(
-            [b->"Created", "#"],
-            ["Topic", self.topic_num],
-            ["Producer", self.producer_num],
-            ["Consumer", self.consumer_num]
-        );
+        //let perf_created_table = table!(
+        //    [b->"Created", "#"],
+        //    ["Topic", self.topic_num],
+        //    ["Producer", self.producer_num],
+        //    ["Consumer", self.consumer_num]
+        //);
 
-        let perf_latency_table = table!(
-            [b->"Latency", b->"Average", b->"P50", b->"P90", b->"P99", b->"P999"],
-            ["Topic create", topic_create_latency_avg, topic_create_latency_p50, topic_create_latency_p90, topic_create_latency_p99, topic_create_latency_p999],
-            ["Producer", producer_latency_avg, producer_latency_p50, producer_latency_p90, producer_latency_p99, producer_latency_p999],
-            ["Consumer", consumer_latency_avg, consumer_latency_p50, consumer_latency_p90, consumer_latency_p99, consumer_latency_p999]
-        );
+        //let perf_latency_table = table!(
+        //    [b->"Latency", b->"Average", b->"P50", b->"P90", b->"P99", b->"P999"],
+        //    ["Topic create", topic_create_latency_avg, topic_create_latency_p50, topic_create_latency_p90, topic_create_latency_p99, topic_create_latency_p999],
+        //    ["Producer", producer_latency_avg, producer_latency_p50, producer_latency_p90, producer_latency_p99, producer_latency_p999],
+        //    ["Consumer", consumer_latency_avg, consumer_latency_p50, consumer_latency_p90, consumer_latency_p99, consumer_latency_p999]
+        //);
 
-        write!(f, "{}", basic_results_table)?;
-        write!(f, "\n{}", perf_results_header)?;
-        write!(f, "\n{}", perf_created_table)?;
-        write!(f, "\n{}", perf_latency_table)
+        write!(f, "{}", basic_results_table)
+        //write!(f, "\n{}", perf_results_header)?;
+        //write!(f, "\n{}", perf_created_table)?;
+        //write!(f, "\n{}", perf_latency_table)
     }
 }

--- a/crates/fluvio-test-util/test_runner/test_driver/mod.rs
+++ b/crates/fluvio-test-util/test_runner/test_driver/mod.rs
@@ -7,26 +7,26 @@ use crate::test_meta::derive_attr::TestRequirements;
 use fluvio::{Fluvio, FluvioError};
 use std::sync::Arc;
 use fluvio::metadata::topic::TopicSpec;
-use hdrhistogram::Histogram;
+//use hdrhistogram::Histogram;
 use fluvio::{TopicProducer, RecordKey, PartitionConsumer};
-use futures_lite::stream::StreamExt;
+//use futures_lite::stream::StreamExt;
 use tracing::debug;
-use fluvio::Offset;
+//use fluvio::Offset;
 
 pub enum TestDriverType {
     Fluvio(Fluvio),
 }
 #[derive(Clone)]
 pub struct TestDriver {
-    pub admin_client: Arc<TestDriverType>,
-    pub topic_num: usize,
-    pub producer_num: usize,
-    pub consumer_num: usize,
-    pub producer_bytes: usize,
-    pub consumer_bytes: usize,
-    pub producer_latency_histogram: Histogram<u64>,
-    pub consumer_latency_histogram: Histogram<u64>,
-    pub topic_create_latency_histogram: Histogram<u64>,
+    pub client: Arc<TestDriverType>,
+    //pub topic_num: usize,
+    //pub producer_num: usize,
+    //pub consumer_num: usize,
+    //pub producer_bytes: usize,
+    //pub consumer_bytes: usize,
+    //pub producer_latency_histogram: Histogram<u64>,
+    //pub consumer_latency_histogram: Histogram<u64>,
+    //pub topic_create_latency_histogram: Histogram<u64>,
 }
 
 impl TestDriver {
@@ -35,12 +35,12 @@ impl TestDriver {
     }
 
     // Wrapper to getting a producer. We keep track of the number of producers we create
-    pub async fn create_producer(&mut self, topic: &str) -> TopicProducer {
+    pub async fn create_producer(&self, topic: &str) -> TopicProducer {
         debug!(topic, "creating producer");
         let fluvio_client = self.create_client().await.expect("cant' create client");
         match fluvio_client.topic_producer(topic).await {
             Ok(client) => {
-                self.producer_num += 1;
+                //self.producer_num += 1;
                 client
             }
             Err(err) => {
@@ -51,7 +51,7 @@ impl TestDriver {
 
     // Wrapper to producer send. We measure the latency and accumulation of message payloads sent.
     pub async fn send_count(
-        &mut self,
+        &self,
         p: &TopicProducer,
         key: RecordKey,
         message: Vec<u8>,
@@ -61,28 +61,28 @@ impl TestDriver {
 
         let result = p.send(key, message.clone()).await;
 
-        let produce_time = now.elapsed().unwrap().as_nanos();
+        let _produce_time = now.elapsed().unwrap().as_nanos();
 
-        debug!(
-            "(#{}) Produce latency (ns): {:?}",
-            self.producer_latency_histogram.len() + 1,
-            produce_time as u64
-        );
+        //debug!(
+        //    "(#{}) Produce latency (ns): {:?}",
+        //    self.producer_latency_histogram.len() + 1,
+        //    produce_time as u64
+        //);
 
-        self.producer_latency_histogram
-            .record(produce_time as u64)
-            .unwrap();
+        //self.producer_latency_histogram
+        //    .record(produce_time as u64)
+        //    .unwrap();
 
-        self.producer_bytes += message.len();
+        //self.producer_bytes += message.len();
 
         result
     }
 
-    pub async fn get_consumer(&mut self, topic: &str) -> PartitionConsumer {
+    pub async fn get_consumer(&self, topic: &str) -> PartitionConsumer {
         let fluvio_client = self.create_client().await.expect("cant' create client");
         match fluvio_client.partition_consumer(topic.to_string(), 0).await {
             Ok(client) => {
-                self.consumer_num += 1;
+                //self.consumer_num += 1;
                 client
             }
             Err(err) => {
@@ -91,56 +91,58 @@ impl TestDriver {
         }
     }
 
-    pub async fn stream_count(&mut self, consumer: PartitionConsumer, offset: Offset) {
-        use std::time::SystemTime;
-        let mut stream = consumer.stream(offset).await.expect("stream");
+    //pub async fn stream_count(&mut self, consumer: PartitionConsumer, offset: Offset) {
+    //    use std::time::SystemTime;
+    //    let mut stream = consumer.stream(offset).await.expect("stream");
 
-        loop {
-            // Take a timestamp
-            let now = SystemTime::now();
+    //    loop {
+    //        // Take a timestamp
+    //        let now = SystemTime::now();
 
-            if let Some(Ok(record)) = stream.next().await {
-                // Record latency
-                let consume_time = now.elapsed().clone().unwrap().as_nanos();
-                self.consumer_latency_histogram
-                    .record(consume_time as u64)
-                    .unwrap();
+    //        if let Some(Ok(record)) = stream.next().await {
+    //            // Record latency
+    //            let _consume_time = now.elapsed().clone().unwrap().as_nanos();
+    //            //self.consumer_latency_histogram
+    //            //    .record(consume_time as u64)
+    //            //    .unwrap();
 
-                // Record bytes consumed
-                self.consumer_bytes += record.as_ref().len();
-            } else {
-                debug!("No more bytes left to consume");
-                break;
-            }
-        }
+    //            //// Record bytes consumed
+    //            //self.consumer_bytes += record.as_ref().len();
+    //        } else {
+    //            debug!("No more bytes left to consume");
+    //            break;
+    //        }
+    //    }
+    //}
+
+    // TODO: This is a workaround. Handle stream inside impl
+    pub async fn consume_latency_record(&mut self, _latency: u64) {
+        unimplemented!()
+        //self.consumer_latency_histogram.record(latency).unwrap();
+        //debug!(
+        //    "(#{}) Recording consumer latency (ns): {:?}",
+        //    self.consumer_latency_histogram.len(),
+        //    latency
+        //);
     }
 
     // TODO: This is a workaround. Handle stream inside impl
-    pub async fn consume_latency_record(&mut self, latency: u64) {
-        self.consumer_latency_histogram.record(latency).unwrap();
-        debug!(
-            "(#{}) Recording consumer latency (ns): {:?}",
-            self.consumer_latency_histogram.len(),
-            latency
-        );
+    pub async fn consume_bytes_record(&mut self, _bytes_len: usize) {
+        unimplemented!()
+        //self.consumer_bytes += bytes_len;
+        //debug!(
+        //    "Recording consumer bytes len: {:?} (total: {})",
+        //    bytes_len, self.consumer_bytes
+        //);
     }
 
-    // TODO: This is a workaround. Handle stream inside impl
-    pub async fn consume_bytes_record(&mut self, bytes_len: usize) {
-        self.consumer_bytes += bytes_len;
-        debug!(
-            "Recording consumer bytes len: {:?} (total: {})",
-            bytes_len, self.consumer_bytes
-        );
-    }
-
-    pub async fn create_topic(&mut self, option: &EnvironmentSetup) -> Result<(), ()> {
+    pub async fn create_topic(&self, option: &EnvironmentSetup) -> Result<(), ()> {
         use std::time::SystemTime;
 
         let topic_name = option.topic_name();
         println!("Creating the topic: {}", &topic_name);
 
-        let TestDriverType::Fluvio(fluvio_client) = self.admin_client.as_ref();
+        let TestDriverType::Fluvio(fluvio_client) = self.client.as_ref();
         let admin = fluvio_client.admin().await;
 
         let topic_spec =
@@ -151,14 +153,14 @@ impl TestDriver {
 
         let topic_create = admin.create(topic_name.clone(), false, topic_spec).await;
 
-        let topic_time = now.elapsed().unwrap().as_nanos();
+        let _topic_time = now.elapsed().unwrap().as_nanos();
 
         if topic_create.is_ok() {
             println!("topic \"{}\" created", topic_name);
-            self.topic_create_latency_histogram
-                .record(topic_time as u64)
-                .unwrap();
-            self.topic_num += 1;
+            //self.topic_create_latency_histogram
+            //    .record(topic_time as u64)
+            //    .unwrap();
+            //self.topic_num += 1;
         } else {
             println!("topic \"{}\" already exists", topic_name);
         }

--- a/crates/fluvio-test-util/test_runner/test_meta.rs
+++ b/crates/fluvio-test-util/test_runner/test_meta.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use async_lock::RwLock;
 use crate::test_meta::{TestCase, TestOption};
 use crate::test_meta::test_result::TestResult;
 use super::test_driver::TestDriver;
@@ -9,7 +8,7 @@ use crate::test_meta::environment::EnvDetail;
 #[derive(Debug)]
 pub struct FluvioTestMeta {
     pub name: String,
-    pub test_fn: fn(Arc<RwLock<TestDriver>>, TestCase) -> Result<TestResult, TestResult>,
+    pub test_fn: fn(Arc<TestDriver>, TestCase) -> Result<TestResult, TestResult>,
     pub validate_fn: fn(Vec<String>) -> Box<dyn TestOption>,
     pub requirements: fn() -> TestRequirements,
 }

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -22,8 +22,7 @@ inventory = "0.1"
 tokio = { version = "1.4", features = ["macros"] }
 bencher = "0.1"
 prettytable-rs = "0.8"
-hdrhistogram = "7.3.0"
-async-lock = "2.4.0"
+#hdrhistogram = "7.3.0"
 crc = "2.0"
 
 # Fluvio dependencies

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -11,12 +11,11 @@ use std::panic::{self, AssertUnwindSafe};
 use fluvio_test_util::test_runner::test_driver::{TestDriver, TestDriverType};
 use fluvio_test_util::test_runner::test_meta::FluvioTestMeta;
 use fluvio_test_util::test_meta::test_timer::TestTimer;
-use hdrhistogram::Histogram;
+//use hdrhistogram::Histogram;
 
 // This is important for `inventory` crate
 #[allow(unused_imports)]
 use fluvio_test::tests as _;
-use async_lock::RwLock;
 
 fn main() {
     run_block_on(async {
@@ -93,7 +92,7 @@ async fn run_test(
     environment: EnvironmentSetup,
     test_opt: Box<dyn TestOption>,
     test_meta: &FluvioTestMeta,
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
 ) -> TestResult {
     let test_case = TestCase::new(environment, test_opt);
     let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
@@ -113,7 +112,7 @@ async fn cluster_cleanup(option: EnvironmentSetup) {
     }
 }
 
-async fn cluster_setup(option: &EnvironmentSetup) -> Arc<RwLock<TestDriver>> {
+async fn cluster_setup(option: &EnvironmentSetup) -> Arc<TestDriver> {
     let fluvio_client = if option.skip_cluster_start() {
         println!("skipping cluster start");
         // Connect to cluster in profile
@@ -132,17 +131,17 @@ async fn cluster_setup(option: &EnvironmentSetup) -> Arc<RwLock<TestDriver>> {
         ))
     };
 
-    Arc::new(RwLock::new(TestDriver {
-        admin_client: fluvio_client,
-        topic_num: 0,
-        producer_num: 0,
-        consumer_num: 0,
-        producer_bytes: 0,
-        consumer_bytes: 0,
-        producer_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
-        consumer_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
-        topic_create_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
-    }))
+    Arc::new(TestDriver {
+        client: fluvio_client,
+        //topic_num: 0,
+        //producer_num: 0,
+        //consumer_num: 0,
+        //producer_bytes: 0,
+        //consumer_bytes: 0,
+        //producer_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
+        //consumer_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
+        //topic_create_latency_histogram: Histogram::<u64>::new_with_bounds(1, u64::MAX, 2).unwrap(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/fluvio-test/src/tests/concurrent/consumer.rs
+++ b/crates/fluvio-test/src/tests/concurrent/consumer.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use async_lock::RwLock;
 use std::sync::mpsc::Receiver;
 use fluvio_test_util::test_runner::test_driver::TestDriver;
 use fluvio_test_util::test_meta::environment::EnvDetail;
@@ -10,13 +9,13 @@ use super::ConcurrentTestCase;
 use super::util::*;
 
 pub async fn consumer_stream(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     option: ConcurrentTestCase,
     digests: Receiver<String>,
 ) {
-    let mut lock = test_driver.write().await;
-
-    let consumer = lock.get_consumer(&option.environment.topic_name()).await;
+    let consumer = test_driver
+        .get_consumer(&option.environment.topic_name())
+        .await;
     let mut stream = consumer.stream(Offset::beginning()).await.unwrap();
 
     let mut index: i32 = 0;

--- a/crates/fluvio-test/src/tests/concurrent/mod.rs
+++ b/crates/fluvio-test/src/tests/concurrent/mod.rs
@@ -4,7 +4,6 @@ pub mod util;
 
 use std::any::Any;
 use std::sync::Arc;
-use async_lock::RwLock;
 use structopt::StructOpt;
 
 use fluvio_future::task::spawn;
@@ -49,14 +48,14 @@ impl TestOption for ConcurrentTestOption {
 
 #[fluvio_test(topic = "test-bug")]
 pub async fn concurrent(
-    mut test_driver: Arc<RwLock<FluvioTestDriver>>,
+    mut test_driver: Arc<FluvioTestDriver>,
     mut test_case: TestCase,
 ) -> TestResult {
     test_concurrent_consume_produce(test_driver.clone(), test_case.into()).await
 }
 
 pub async fn test_concurrent_consume_produce(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     option: ConcurrentTestCase,
 ) {
     println!("Testing concurrent consumer and producer");

--- a/crates/fluvio-test/src/tests/concurrent/producer.rs
+++ b/crates/fluvio-test/src/tests/concurrent/producer.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use async_lock::RwLock;
 use std::sync::mpsc::Sender;
 use fluvio::RecordKey;
 use fluvio_test_util::test_runner::test_driver::TestDriver;
@@ -9,13 +8,13 @@ use super::ConcurrentTestCase;
 use super::util::*;
 
 pub async fn producer(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     option: ConcurrentTestCase,
     digests: Sender<String>,
 ) {
-    let mut lock = test_driver.write().await;
-
-    let producer = lock.create_producer(&option.environment.topic_name()).await;
+    let producer = test_driver
+        .create_producer(&option.environment.topic_name())
+        .await;
 
     // Iterations ranging approx. 5000 - 20_000
     let iterations: u16 = (rand::random::<u16>() / 2) + 20000;

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use std::time::SystemTime;
-use async_lock::RwLock;
 use fluvio_test_util::test_runner::test_driver::TestDriver;
 use fluvio_test_util::test_meta::environment::EnvDetail;
 use futures_lite::StreamExt;
@@ -12,12 +11,10 @@ use fluvio_future::timer::sleep;
 use super::LongevityTestCase;
 use super::util::*;
 
-pub async fn consumer_stream(test_driver: Arc<RwLock<TestDriver>>, option: LongevityTestCase) {
-    let mut lock = test_driver.write().await;
-
-    let consumer = lock.get_consumer(&option.environment.topic_name()).await;
-
-    drop(lock);
+pub async fn consumer_stream(test_driver: Arc<TestDriver>, option: LongevityTestCase) {
+    let consumer = test_driver
+        .get_consumer(&option.environment.topic_name())
+        .await;
 
     // TODO: Support starting stream from consumer offset
     let mut stream = consumer.stream(Offset::from_end(0)).await.unwrap();
@@ -48,7 +45,7 @@ pub async fn consumer_stream(test_driver: Arc<RwLock<TestDriver>>, option: Longe
                                 serde_json::from_str(std::str::from_utf8(record_json.as_ref()).unwrap())
                                     .expect("Deserialize record failed");
 
-                            let consume_latency = now.elapsed().clone().unwrap().as_nanos();
+                            let _consume_latency = now.elapsed().clone().unwrap().as_nanos();
 
                             if option.option.verbose {
                                 println!(
@@ -61,13 +58,13 @@ pub async fn consumer_stream(test_driver: Arc<RwLock<TestDriver>>, option: Longe
 
                             assert!(record.validate_crc());
 
-                            let mut lock = test_driver.write().await;
+                            //let mut lock = test_driver.write().await;
 
-                            // record latency
-                            lock.consume_latency_record(consume_latency as u64).await;
-                            lock.consume_bytes_record(record.data.len()).await;
+                            //// record latency
+                            //lock.consume_latency_record(consume_latency as u64).await;
+                            //lock.consume_bytes_record(record.data.len()).await;
 
-                            drop(lock);
+                            //drop(lock);
 
                             index += 1;
                         } else {

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -17,7 +17,10 @@ pub async fn consumer_stream(test_driver: Arc<TestDriver>, option: LongevityTest
         .await;
 
     // TODO: Support starting stream from consumer offset
-    let mut stream = consumer.stream(Offset::from_end(0)).await.unwrap();
+    let mut stream = consumer
+        .stream(Offset::from_end(0))
+        .await
+        .expect("Unable to open stream");
 
     let mut index: i32 = 0;
 

--- a/crates/fluvio-test/src/tests/longevity/mod.rs
+++ b/crates/fluvio-test/src/tests/longevity/mod.rs
@@ -6,7 +6,6 @@ use std::any::Any;
 use std::num::ParseIntError;
 use std::sync::Arc;
 use std::time::Duration;
-use async_lock::RwLock;
 use structopt::StructOpt;
 
 use fluvio_future::task::spawn;
@@ -82,14 +81,14 @@ impl TestOption for LongevityTestOption {
 
 #[fluvio_test(topic = "longevity")]
 pub async fn longevity(
-    mut test_driver: Arc<RwLock<FluvioTestDriver>>,
+    mut test_driver: Arc<FluvioTestDriver>,
     mut test_case: TestCase,
 ) -> TestResult {
     test_longevity_consume_produce(test_driver.clone(), test_case.into()).await
 }
 
 pub async fn test_longevity_consume_produce(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     option: LongevityTestCase,
 ) {
     println!("Testing longevity consumer and producer");

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod smoke;
 pub mod concurrent;
 pub mod longevity;
-//pub mod producer_stress;
+pub mod producer_stress;
 //pub mod election;

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod smoke;
 pub mod concurrent;
-//pub mod longevity;
+pub mod longevity;
 //pub mod producer_stress;
 //pub mod election;

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod smoke;
-//pub mod concurrent;
+pub mod concurrent;
 //pub mod longevity;
 //pub mod producer_stress;
 //pub mod election;

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod smoke;
-pub mod concurrent;
-pub mod longevity;
-pub mod producer_stress;
-pub mod election;
+//pub mod concurrent;
+//pub mod longevity;
+//pub mod producer_stress;
+//pub mod election;

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -2,4 +2,4 @@ pub mod smoke;
 pub mod concurrent;
 pub mod longevity;
 pub mod producer_stress;
-//pub mod election;
+pub mod election;

--- a/crates/fluvio-test/src/tests/producer_stress.rs
+++ b/crates/fluvio-test/src/tests/producer_stress.rs
@@ -107,10 +107,10 @@ pub async fn run(
         }
     }
 
-    let lock = test_driver.read().await;
-    println!(
-        "Producer latency 99%: {:?}",
-        lock.producer_latency_histogram.value_at_quantile(0.99)
-    );
-    drop(lock);
+    //let lock = test_driver.read().await;
+    //println!(
+    //    "Producer latency 99%: {:?}",
+    //    lock.producer_latency_histogram.value_at_quantile(0.99)
+    //);
+    //drop(lock);
 }

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -4,9 +4,8 @@ use std::{io, time::Duration};
 use std::io::Write;
 use std::collections::HashMap;
 use std::sync::Arc;
-use async_lock::RwLock;
 
-use tracing::{info, debug};
+use tracing::{info};
 use futures_lite::stream::StreamExt;
 
 use fluvio_test_util::test_runner::test_driver::{TestDriver, TestDriverType};
@@ -22,7 +21,7 @@ type Offsets = HashMap<String, i64>;
 
 /// verify consumers
 pub async fn validate_consume_message(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     test_case: &SmokeTestCase,
     offsets: Offsets,
 ) {
@@ -63,7 +62,7 @@ fn validate_consume_message_cli(test_case: &SmokeTestCase, offsets: Offsets) {
 }
 
 async fn validate_consume_message_api(
-    test_driver: Arc<RwLock<TestDriver>>,
+    test_driver: Arc<TestDriver>,
     offsets: Offsets,
     test_case: &SmokeTestCase,
 ) {
@@ -84,9 +83,7 @@ async fn validate_consume_message_api(
             topic_name, base_offset, producer_iteration
         );
 
-        let mut lock = test_driver.write().await;
-        let consumer = lock.get_consumer(&topic_name).await;
-        drop(lock);
+        let consumer = test_driver.get_consumer(&topic_name).await;
 
         let mut stream = consumer
             .stream(
@@ -101,7 +98,7 @@ async fn validate_consume_message_api(
         let mut chunk_time = SystemTime::now();
 
         loop {
-            let now = SystemTime::now();
+            let _canow = SystemTime::now();
             select! {
 
                 stream_next = stream.next() => {
@@ -123,17 +120,17 @@ async fn validate_consume_message_api(
                         );
                         total_records += 1;
 
-                        let mut lock = test_driver.write().await;
+                        //let mut lock = test_driver.write().await;
 
                         // record latency
-                        let consume_time = now.elapsed().clone().unwrap().as_nanos();
-                        lock.consume_latency_record(consume_time as u64).await;
-                        lock.consume_bytes_record(bytes.len()).await;
+                        //let consume_time = now.elapsed().clone().unwrap().as_nanos();
+                        //lock.consume_latency_record(consume_time as u64).await;
+                        //lock.consume_bytes_record(bytes.len()).await;
 
-                       // debug!("Consume stat updates: {:?} {:?}", lock.consumer_latency_histogram, lock.consumer_bytes);
-                        debug!(consumer_bytes = lock.consumer_bytes, "Consume stat updates");
+                        // debug!("Consume stat updates: {:?} {:?}", lock.consumer_latency_histogram, lock.consumer_bytes);
+                        //debug!(consumer_bytes = lock.consumer_bytes, "Consume stat updates");
 
-                        drop(lock);
+                        //drop(lock);
 
                         // for each
                         if total_records % 100 == 0 {
@@ -164,14 +161,12 @@ async fn validate_consume_message_api(
         // wait 5 seconds to get status and ensure replication is done
         sleep(Duration::from_secs(5)).await;
 
-        let lock = test_driver.write().await;
-        let TestDriverType::Fluvio(fluvio_client) = lock.admin_client.as_ref();
+        let TestDriverType::Fluvio(fluvio_client) = test_driver.client.as_ref();
         let admin = fluvio_client.admin().await;
         let partitions = admin
             .list::<PartitionSpec, _>(vec![])
             .await
             .expect("partitions");
-        drop(lock);
 
         assert_eq!(partitions.len(), 1);
 
@@ -204,9 +199,7 @@ async fn validate_consume_message_api(
             topic_name, base_offset, producer_iteration
         );
 
-        let mut lock = test_driver.write().await;
-        let consumer = lock.get_consumer(&topic_name).await;
-        drop(lock);
+        let consumer = test_driver.get_consumer(&topic_name).await;
 
         let mut stream = consumer
             .stream(

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -14,7 +14,6 @@ use fluvio_test_util::test_meta::{TestOption, TestCase};
 use fluvio_test_util::test_meta::test_result::TestResult;
 use fluvio_test_util::test_runner::test_driver::TestDriver;
 use fluvio_test_util::test_runner::test_meta::FluvioTestMeta;
-use async_lock::RwLock;
 
 #[derive(Debug, Clone)]
 pub struct SmokeTestCase {
@@ -69,10 +68,7 @@ impl TestOption for SmokeTestOption {
 //}
 
 #[fluvio_test(topic = "test")]
-pub async fn smoke(
-    mut test_driver: Arc<RwLock<FluvioTestDriver>>,
-    mut test_case: TestCase,
-) -> TestResult {
+pub async fn smoke(mut test_driver: Arc<FluvioTestDriver>, mut test_case: TestCase) -> TestResult {
     println!("Starting smoke test");
     let smoke_test_case = test_case.into();
 


### PR DESCRIPTION
Removing `async_lock` and temporarily disabling stats in fluvio-test (Re-enabling stats tracked by #1689).