### PR TITLE
[Merged by Bors] - Patch bump fluvio-protocol-codec

### DIFF
--- a/crates/fluvio-protocol-codec/Cargo.toml
+++ b/crates/fluvio-protocol-codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-codec"
 edition = "2018"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Frame encoder and decoder for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"


### PR DESCRIPTION
Embarrassing, but forgot to bump in #1687, despite being explicitly called out
Bumped `fluvio-protocol-core` instead

No changes to other crates needed, but crate will be re-published out of cycle for #1684 
