### PR TITLE
[Merged by Bors] - fix consuming with multiple segments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
         run: cargo test --manifest-path ./crates/${{ matrix.crate }}/Cargo.toml
 
   local_cluster_test:
-    name: Local cluster test run (${{ matrix.run }})
+    name: Local cluster test run (${{ matrix.run }})-${{ matrix.test }}
     runs-on: ${{ matrix.os }}
     needs:
       - build_primary_binaries

--- a/crates/fluvio-dataplane-protocol/src/fixture.rs
+++ b/crates/fluvio-dataplane-protocol/src/fixture.rs
@@ -37,7 +37,7 @@ impl BatchProducer {
         BatchProducerBuilder::default()
     }
 
-    fn generate_batch(&self) -> Batch {
+    pub fn new_batch(&self) -> Batch {
         let mut batches = Batch::default();
         let header = batches.get_mut_header();
         header.magic = 2;
@@ -52,7 +52,7 @@ impl BatchProducer {
     }
 
     pub fn records(&self) -> RecordSet {
-        RecordSet::default().add(self.generate_batch())
+        RecordSet::default().add(self.new_batch())
     }
 }
 

--- a/crates/fluvio-dataplane-protocol/src/fixture.rs
+++ b/crates/fluvio-dataplane-protocol/src/fixture.rs
@@ -37,7 +37,7 @@ impl BatchProducer {
         BatchProducerBuilder::default()
     }
 
-    pub fn generate_batch(&self) -> Batch {
+    fn generate_batch(&self) -> Batch {
         let mut batches = Batch::default();
         let header = batches.get_mut_header();
         header.magic = 2;

--- a/crates/fluvio-dataplane-protocol/src/fixture.rs
+++ b/crates/fluvio-dataplane-protocol/src/fixture.rs
@@ -37,7 +37,7 @@ impl BatchProducer {
         BatchProducerBuilder::default()
     }
 
-    fn generate_batch(&self) -> Batch {
+    pub fn generate_batch(&self) -> Batch {
         let mut batches = Batch::default();
         let header = batches.get_mut_header();
         header.magic = 2;

--- a/crates/fluvio-dataplane-protocol/src/fixture.rs
+++ b/crates/fluvio-dataplane-protocol/src/fixture.rs
@@ -37,7 +37,7 @@ impl BatchProducer {
         BatchProducerBuilder::default()
     }
 
-    pub fn new_batch(&self) -> Batch {
+    pub fn generate_batch(&self) -> Batch {
         let mut batches = Batch::default();
         let header = batches.get_mut_header();
         header.magic = 2;
@@ -52,7 +52,7 @@ impl BatchProducer {
     }
 
     pub fn records(&self) -> RecordSet {
-        RecordSet::default().add(self.new_batch())
+        RecordSet::default().add(self.generate_batch())
     }
 }
 

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -701,7 +701,7 @@ mod test_leader {
 
     #[async_trait]
     impl ReplicaStorage for MockStorage {
-        async fn create(
+        async fn create_or_load(
             _replica: &dataplane::ReplicaKey,
             _config: Self::Config,
         ) -> Result<Self, fluvio_storage::StorageError> {

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -102,7 +102,7 @@ impl FluvioService for PublicService {
                             "FetchOffsetsRequest"
                         ),
                         SpuServerRequest::FileStreamFetchRequest(request) => {
-                            StreamFetchHandler::spawn(
+                            StreamFetchHandler::fetch(
                                 request,
                                 context.clone(),
                                 shared_sink.clone(),

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -102,7 +102,7 @@ impl FluvioService for PublicService {
                             "FetchOffsetsRequest"
                         ),
                         SpuServerRequest::FileStreamFetchRequest(request) => {
-                            StreamFetchHandler::fetch(
+                            StreamFetchHandler::start(
                                 request,
                                 context.clone(),
                                 shared_sink.clone(),

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -50,7 +50,7 @@ pub struct StreamFetchHandler {
 
 impl StreamFetchHandler {
     /// handle fluvio continuous fetch request
-    pub async fn fetch(
+    pub async fn start(
         request: RequestMessage<FileStreamFetchRequest>,
         ctx: DefaultSharedGlobalContext,
         sink: ExclusiveFlvSink,
@@ -65,7 +65,7 @@ impl StreamFetchHandler {
             let consumer_offset_listener = offset_publisher.change_listner();
 
             spawn(async move {
-                if let Err(err) = StreamFetchHandler::setup(
+                if let Err(err) = StreamFetchHandler::fetch(
                     ctx,
                     sink,
                     end_event.clone(),
@@ -115,7 +115,7 @@ impl StreamFetchHandler {
             sink = sink.id()
         ))
     ]
-    pub async fn setup(
+    pub async fn fetch(
         ctx: DefaultSharedGlobalContext,
         sink: ExclusiveFlvSink,
         end_event: Arc<StickyEvent>,
@@ -212,7 +212,6 @@ impl StreamFetchHandler {
         handler.process(starting_offset, smartstream).await
     }
 
-    #[instrument(skip(self, smartstream))]
     async fn process(
         mut self,
         starting_offset: Offset,

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -108,6 +108,7 @@ impl StreamFetchHandler {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[instrument(
         skip(ctx,replica,end_event,leader_state,header,msg,consumer_offset_listener),
         fields(

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -6,6 +6,7 @@ use std::io::Error as IoError;
 use tracing::{error, debug, trace, instrument};
 use tokio::select;
 
+use dataplane::record::FileRecordSet;
 use fluvio_types::event::{StickyEvent, offsets::OffsetPublisher};
 use fluvio_future::task::spawn;
 use fluvio_socket::{ExclusiveFlvSink, SocketError};
@@ -19,7 +20,8 @@ use dataplane::{
 use dataplane::{Offset, Isolation, ReplicaKey};
 use dataplane::fetch::FilePartitionResponse;
 use fluvio_spu_schema::server::stream_fetch::{
-    FileStreamFetchRequest, DefaultStreamFetchRequest, StreamFetchResponse, SmartStreamKind,
+    DefaultStreamFetchRequest, FileStreamFetchRequest, SmartStreamKind, StreamFetchRequest,
+    StreamFetchResponse,
 };
 use fluvio_types::event::offsets::OffsetChangeListener;
 
@@ -49,132 +51,38 @@ pub struct StreamFetchHandler {
 
 impl StreamFetchHandler {
     /// handle fluvio continuous fetch request
-    pub async fn spawn(
+    pub async fn fetch(
         request: RequestMessage<FileStreamFetchRequest>,
         ctx: DefaultSharedGlobalContext,
         sink: ExclusiveFlvSink,
         end_event: Arc<StickyEvent>,
     ) -> Result<(), SocketError> {
-        spawn(async move {
-            if let Err(err) = StreamFetchHandler::start(request, ctx, sink, end_event.clone()).await
-            {
-                error!("error starting stream fetch handler: {:#?}", err);
-                end_event.notify();
-            }
-        });
-        debug!("spawned stream fetch controller");
-        Ok(())
-    }
-
-    #[instrument(skip(request, ctx, sink, end_event))]
-    pub async fn start(
-        request: RequestMessage<FileStreamFetchRequest>,
-        ctx: DefaultSharedGlobalContext,
-        sink: ExclusiveFlvSink,
-        end_event: Arc<StickyEvent>,
-    ) -> Result<(), SocketError> {
-        // first get receiver to offset update channel to we don't missed events
         let (header, msg) = request.get_header_request();
-
-        let current_offset = msg.fetch_offset;
-        let isolation = msg.isolation;
-        let replica = ReplicaKey::new(msg.topic, msg.partition);
-        let max_bytes = msg.max_bytes as u32;
+        let replica = ReplicaKey::new(msg.topic.clone(), msg.partition);
 
         if let Some(leader_state) = ctx.leaders_state().get(&replica) {
             let (stream_id, offset_publisher) =
                 ctx.stream_publishers().create_new_publisher().await;
-            let offset_listener = offset_publisher.change_listner();
+            let consumer_offset_listener = offset_publisher.change_listner();
 
-            debug!(
-                sink = sink.id(),
-                %replica,
-                current_offset,
-                max_bytes,
-                "start stream fetch"
-            );
-
-            let sm_engine = SmartStreamEngine::default();
-
-            let smartstream = if let Some(payload) = msg.wasm_payload {
-                let wasm = &payload.wasm.get_raw()?;
-                debug!(len = wasm.len(), "creating WASM module with bytes");
-                let module = sm_engine.create_module_from_binary(wasm).map_err(|err| {
-                    SocketError::Io(IoError::new(
-                        ErrorKind::Other,
-                        format!("module loading error {}", err),
-                    ))
-                })?;
-
-                let smartstream: Box<dyn SmartStream> = match payload.kind {
-                    SmartStreamKind::Filter => {
-                        debug!("Instantiating SmartStreamFilter");
-                        let filter = module.create_filter(&sm_engine).map_err(|err| {
-                            SocketError::Io(IoError::new(
-                                ErrorKind::Other,
-                                format!("Failed to instantiate SmartStreamFilter {}", err),
-                            ))
-                        })?;
-                        Box::new(filter)
-                    }
-                    SmartStreamKind::Map => {
-                        debug!("Instantiating SmartStreamMap");
-                        let map = module.create_map(&sm_engine).map_err(|err| {
-                            SocketError::Io(IoError::new(
-                                ErrorKind::Other,
-                                format!("Failed to instantiate SmartStreamMap {}", err),
-                            ))
-                        })?;
-                        Box::new(map)
-                    }
-                    SmartStreamKind::Aggregate { accumulator } => {
-                        debug!(
-                            accumulator_len = accumulator.len(),
-                            "Instantiating SmartStreamAggregate"
-                        );
-                        let aggregator =
-                            module
-                                .create_aggregate(&sm_engine, accumulator)
-                                .map_err(|err| {
-                                    SocketError::Io(IoError::new(
-                                        ErrorKind::Other,
-                                        format!(
-                                            "Failed to instantiate SmartStreamAggregate {}",
-                                            err
-                                        ),
-                                    ))
-                                })?;
-                        Box::new(aggregator)
-                    }
-                };
-
-                Some(smartstream)
-            } else {
-                None
-            };
-
-            // if we are filtered we should scan all batches instead of just limit to max bytes
-            let max_fetch_bytes = if smartstream.is_none() {
-                max_bytes
-            } else {
-                u32::MAX
-            };
-
-            let handler = Self {
-                ctx: ctx.clone(),
-                isolation,
-                replica,
-                header,
-                max_bytes,
-                sink,
-                end_event,
-                consumer_offset_listener: offset_listener,
-                stream_id,
-                leader_state: leader_state.clone(),
-                max_fetch_bytes,
-            };
-
-            handler.process(current_offset, smartstream).await;
+            spawn(async move {
+                if let Err(err) = StreamFetchHandler::setup(
+                    ctx,
+                    sink,
+                    end_event.clone(),
+                    leader_state,
+                    stream_id,
+                    header,
+                    replica,
+                    consumer_offset_listener,
+                    msg,
+                )
+                .await
+                {
+                    error!("error starting stream fetch handler: {:#?}", err);
+                    end_event.notify();
+                }
+            });
         } else {
             debug!(topic = %replica.topic," no leader founded, returning");
             let response = StreamFetchResponse {
@@ -202,23 +110,104 @@ impl StreamFetchHandler {
     }
 
     #[instrument(
-        skip(self, smartstream),
-        name = "stream fetch",
+        skip(ctx,replica,end_event,leader_state,header,msg,consumer_offset_listener),
         fields(
-            replica = %self.replica,
-            sink = self.sink.id()
-        )
-    )]
-    async fn process(mut self, starting_offset: Offset, smartstream: Option<Box<dyn SmartStream>>) {
-        if let Err(err) = self.inner_process(starting_offset, smartstream).await {
-            error!("error: {:#?}", err);
-            self.end_event.notify();
-        }
+            replica = %replica,
+            sink = sink.id()
+        ))
+    ]
+    pub async fn setup(
+        ctx: DefaultSharedGlobalContext,
+        sink: ExclusiveFlvSink,
+        end_event: Arc<StickyEvent>,
+        leader_state: SharedFileLeaderState,
+        stream_id: u32,
+        header: RequestHeader,
+        replica: ReplicaKey,
+        consumer_offset_listener: OffsetChangeListener,
+        msg: StreamFetchRequest<FileRecordSet>,
+    ) -> Result<(), SocketError> {
+        let current_offset = msg.fetch_offset;
+        let isolation = msg.isolation;
+        let replica = ReplicaKey::new(msg.topic, msg.partition);
+        let max_bytes = msg.max_bytes as u32;
+
+        let sm_engine = SmartStreamEngine::default();
+
+        let (smartstream, max_fetch_bytes) = if let Some(payload) = msg.wasm_payload {
+            let wasm = &payload.wasm.get_raw()?;
+            debug!(len = wasm.len(), "creating WASM module with bytes");
+            let module = sm_engine.create_module_from_binary(wasm).map_err(|err| {
+                SocketError::Io(IoError::new(
+                    ErrorKind::Other,
+                    format!("module loading error {}", err),
+                ))
+            })?;
+
+            let smartstream: Box<dyn SmartStream> = match payload.kind {
+                SmartStreamKind::Filter => {
+                    debug!("Instantiating SmartStreamFilter");
+                    let filter = module.create_filter(&sm_engine).map_err(|err| {
+                        SocketError::Io(IoError::new(
+                            ErrorKind::Other,
+                            format!("Failed to instantiate SmartStreamFilter {}", err),
+                        ))
+                    })?;
+                    Box::new(filter)
+                }
+                SmartStreamKind::Map => {
+                    debug!("Instantiating SmartStreamMap");
+                    let map = module.create_map(&sm_engine).map_err(|err| {
+                        SocketError::Io(IoError::new(
+                            ErrorKind::Other,
+                            format!("Failed to instantiate SmartStreamMap {}", err),
+                        ))
+                    })?;
+                    Box::new(map)
+                }
+                SmartStreamKind::Aggregate { accumulator } => {
+                    debug!(
+                        accumulator_len = accumulator.len(),
+                        "Instantiating SmartStreamAggregate"
+                    );
+                    let aggregator =
+                        module
+                            .create_aggregate(&sm_engine, accumulator)
+                            .map_err(|err| {
+                                SocketError::Io(IoError::new(
+                                    ErrorKind::Other,
+                                    format!("Failed to instantiate SmartStreamAggregate {}", err),
+                                ))
+                            })?;
+                    Box::new(aggregator)
+                }
+            };
+
+            (Some(smartstream), u32::MAX)
+        } else {
+            (None, max_bytes)
+        };
+
+        let handler = Self {
+            ctx: ctx.clone(),
+            isolation,
+            replica,
+            max_bytes,
+            sink,
+            end_event,
+            header,
+            consumer_offset_listener,
+            stream_id,
+            leader_state,
+            max_fetch_bytes,
+        };
+
+        handler.process(current_offset, smartstream).await
     }
 
     #[instrument(skip(self, smartstream))]
-    async fn inner_process(
-        &mut self,
+    async fn process(
+        mut self,
         starting_offset: Offset,
         mut smartstream: Option<Box<dyn SmartStream>>,
     ) -> Result<(), SocketError> {

--- a/crates/fluvio-spu/src/storage/mod.rs
+++ b/crates/fluvio-spu/src/storage/mod.rs
@@ -42,7 +42,7 @@ where
 {
     /// create new storage replica or restore from durable storage based on configuration
     pub async fn create(id: ReplicaKey, config: S::Config) -> Result<Self, StorageError> {
-        let storage = S::create(&id, config).await?;
+        let storage = S::create_or_load(&id, config).await?;
 
         let leo = Arc::new(OffsetPublisher::new(storage.get_leo()));
         let hw = Arc::new(OffsetPublisher::new(storage.get_hw()));

--- a/crates/fluvio-storage/src/index.rs
+++ b/crates/fluvio-storage/src/index.rs
@@ -93,14 +93,15 @@ impl LogIndex {
     ) -> Result<Self, IoError> {
         let index_file_path = generate_file_name(&option.base_dir, base_offset, EXTENSION);
 
-        debug!("opening index mm at: {:#?}", index_file_path);
+        debug!(?index_file_path, "opening index");
+
         // make sure it is log file
         let (m_file, file) =
             MemoryMappedFile::open(index_file_path, INDEX_ENTRY_SIZE as u64).await?;
 
         let len = (file.metadata().await?).len();
 
-        trace!("opening memory mapped file with len : {}", len);
+        debug!(len, "memory mapped len");
 
         if len > std::u32::MAX as u64 {
             return Err(IoError::new(
@@ -243,8 +244,8 @@ mod tests {
 
         let mut mut_index = MutLogIndex::create(921, &option).await.expect("create");
 
-        mut_index.send((5, 16, 70)).await.expect("send");
-        mut_index.send((10, 100, 70)).await.expect("send");
+        mut_index.write_index((5, 16, 70)).await.expect("send");
+        mut_index.write_index((10, 100, 70)).await.expect("send");
 
         mut_index.shrink().await.expect("shrink");
 

--- a/crates/fluvio-storage/src/lib.rs
+++ b/crates/fluvio-storage/src/lib.rs
@@ -141,7 +141,10 @@ mod inner {
 
         /// create new storage area,
         /// if there exists replica state, this should restore state
-        async fn create(replica: &ReplicaKey, config: Self::Config) -> Result<Self, StorageError>;
+        async fn create_or_load(
+            replica: &ReplicaKey,
+            config: Self::Config,
+        ) -> Result<Self, StorageError>;
 
         /// high water mark offset (records that has been replicated)
         fn get_hw(&self) -> Offset;

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -1,14 +1,13 @@
 use std::io::Error as IoError;
 use std::path::PathBuf;
 use std::path::Path;
+use std::fmt;
 use std::time::{Duration, Instant};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use async_lock::Mutex;
 
-use tracing::debug;
-use tracing::warn;
-use tracing::trace;
+use tracing::{debug, warn, trace};
 
 use futures_lite::io::AsyncWriteExt;
 use async_channel::Sender;
@@ -51,6 +50,12 @@ pub struct MutFileRecords {
     flush_count: Arc<AtomicU32>,
     path: PathBuf,
     flush_time_tx: Option<Sender<Instant>>,
+}
+
+impl fmt::Debug for MutFileRecords {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Log({})", self.base_offset)
+    }
 }
 
 impl Unpin for MutFileRecords {}

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -160,7 +160,6 @@ impl MutFileRecords {
 
         if f_sink.can_be_appended(buffer.len() as u64) {
             debug!(buffer_len = buffer.len(), "writing bytes");
-
             f_sink.write_all(&buffer).await?;
             self.cached_len = f_sink.get_current_len();
             drop(f_sink); // unlock because flush may reaqire the lock
@@ -185,6 +184,11 @@ impl MutFileRecords {
 
             Ok(true)
         } else {
+            debug!(
+                len = f_sink.get_current_len(),
+                buffer_len = buffer.len(),
+                "no more room to add"
+            );
             Ok(false)
         }
     }

--- a/crates/fluvio-storage/src/range_map.rs
+++ b/crates/fluvio-storage/src/range_map.rs
@@ -70,7 +70,8 @@ impl SegmentList {
         let mut segments = Self::new();
 
         for offset in offsets {
-            match ReadSegment::open_for_read(offset, option).await {
+            // for now, set end offset same as base, this will be reset when validation occurs
+            match ReadSegment::open_for_read(offset, offset, option).await {
                 Ok(segment) => segments.add_segment(segment),
                 Err(err) => error!("error opening segment: {:#?}", err),
             }
@@ -175,6 +176,8 @@ mod tests {
         assert!(index.is_some());
         let (pos, _) = index.unwrap();
         assert_eq!(*pos, 500);
+
+        assert!(list.find_segment(0).is_some());
     }
 
     const TEST_READ_DIR: &str = "segmentlist-read-many";

--- a/crates/fluvio-storage/src/range_map.rs
+++ b/crates/fluvio-storage/src/range_map.rs
@@ -18,17 +18,17 @@ use crate::util::log_path_get_offset;
 
 #[derive(Debug)]
 pub(crate) struct SegmentList {
-    segments: BTreeMap<Offset, ReadSegment>,
-    max_base_offset: Offset, // maximum number of offset for all segments
-    min_base_offset: Offset,
+    segments: BTreeMap<Offset, ReadSegment>, // max base offset of all segments
+    min_offset: Offset,
+    max_offset: Offset,
 }
 
 impl SegmentList {
     pub fn new() -> Self {
         SegmentList {
             segments: BTreeMap::new(),
-            max_base_offset: 0,
-            min_base_offset: -1,
+            max_offset: 0,
+            min_offset: -1,
         }
     }
 
@@ -85,23 +85,17 @@ impl SegmentList {
         self.segments.len()
     }
 
-    #[allow(dead_code)]
-    pub fn max_offset(&self) -> Offset {
-        self.max_base_offset
-    }
-
     pub fn min_offset(&self) -> Offset {
-        self.min_base_offset
+        self.min_offset
     }
 
     pub fn add_segment(&mut self, segment: ReadSegment) {
-        let base_offset = segment.get_base_offset();
         debug!(base_offset = segment.get_base_offset(),end_offset = segment.get_end_offset(),"inserting");
-        self.max_base_offset = max(self.max_base_offset, base_offset);
-        self.min_base_offset = if self.min_base_offset < 0 {
-            base_offset
+        self.max_offset = max(self.max_offset, segment.get_end_offset());
+        self.min_offset = if self.min_offset < 0 {
+            segment.get_base_offset()
         } else {
-            min(self.min_base_offset, base_offset)
+            min(self.min_offset, segment.get_base_offset())
         };
         self.segments.insert(segment.get_base_offset(), segment);
     }
@@ -113,7 +107,8 @@ impl SegmentList {
 
     pub fn find_segment(&self, offset: Offset) -> Option<(&Offset, &ReadSegment)> {
         (&self.segments)
-            .range((Excluded(offset - self.max_base_offset), Included(offset)))
+         //   .range((Included(offset), Included(offset)))
+            .range((Included(offset - self.max_offset  + self.min_offset + 1), Included(offset)))
             .next_back()
     }
 }
@@ -134,16 +129,15 @@ mod tests {
     use crate::segment::ReadSegment;
     use crate::config::ConfigOption;
 
-    const TEST_SEGMENT_DIR: &str = "segmentlist-test";
-
+    // create fake segment, this doesn't create a segment with all data, it just fill with a min data but with a valid end offset
     async fn create_segment(
         option: &ConfigOption,
         start: Offset,
-        _offsets: Offset,
+        end_offset: Offset,
     ) -> Result<ReadSegment, StorageError> {
         let mut mut_segment = MutableSegment::create(start, option).await?;
         mut_segment.write_batch(&mut create_batch()).await?;
-        //        mut_segment.set_end_offset(offsets);
+        mut_segment.set_end_offset(end_offset);        // only used for testing
         let segment = mut_segment.convert_to_segment().await?;
         Ok(segment)
     }
@@ -160,7 +154,7 @@ mod tests {
 
     #[fluvio_future::test]
     async fn test_segment_empty() {
-        let rep_dir = temp_dir().join(TEST_EMPTY_DIR);
+        let rep_dir = temp_dir().join("segmentlist-read-empty");
         ensure_new_dir(&rep_dir).expect("new");
         let option = default_option(rep_dir);
 
@@ -171,8 +165,8 @@ mod tests {
     }
 
     #[fluvio_future::test]
-    async fn test_segment_single() {
-        let rep_dir = temp_dir().join(TEST_SEGMENT_DIR);
+    async fn test_segment_single_base_zero() {
+        let rep_dir = temp_dir().join("segmentlist-single-zero");
         ensure_new_dir(&rep_dir).expect("new");
         let mut list = SegmentList::new();
 
@@ -181,14 +175,37 @@ mod tests {
         list.add_segment(create_segment(&option, 0, 500).await.expect("create"));
         println!("segments: {:#?}", list);
 
+        assert!(list.find_segment(-1).is_none());
         assert!(list.find_segment(0).is_some());
+        assert!(list.find_segment(1).is_some());
+        assert!(list.find_segment(499).is_some());
+        assert!(list.find_segment(500).is_none());
+        assert!(list.find_segment(501).is_none());
+    }
 
+    #[fluvio_future::test]
+    async fn test_segment_single_base_some() {
+        let rep_dir = temp_dir().join("segmentlist-single-some");
+        ensure_new_dir(&rep_dir).expect("new");
+        let mut list = SegmentList::new();
+
+        let option = default_option(rep_dir);
+
+        list.add_segment(create_segment(&option, 100, 500).await.expect("create"));
+        println!("segments: {:#?}", list);
+
+        assert!(list.find_segment(50).is_none());
+        assert!(list.find_segment(99).is_none());
+        assert!(list.find_segment(100).is_some());
+        assert!(list.find_segment(499).is_some());
+        assert!(list.find_segment(500).is_none());
     }
 
 
+
     #[fluvio_future::test]
-    async fn test_segmen_many_simple() {
-        let rep_dir = temp_dir().join(TEST_SEGMENT_DIR);
+    async fn test_segment_many_zero() {
+        let rep_dir = temp_dir().join("segmentlist-many-zero");
         ensure_new_dir(&rep_dir).expect("new");
         let mut list = SegmentList::new();
 
@@ -196,17 +213,18 @@ mod tests {
 
         list.add_segment(create_segment(&option, 0, 500).await.expect("create"));
         list.add_segment(create_segment(&option, 500, 2000).await.expect("create"));
-        list.add_segment(create_segment(&option, 2000, 1000).await.expect("create"));
-        list.add_segment(create_segment(&option, 3000, 2000).await.expect("create"));
-
-        let index = list.find_segment(1500);
-
-        assert!(index.is_some());
-        let (pos, _) = index.unwrap();
-        assert_eq!(*pos, 500);
+        list.add_segment(create_segment(&option, 2000, 3000).await.expect("create"));
+        list.add_segment(create_segment(&option, 3000, 4000).await.expect("create"));
 
         println!("segments: {:#?}", list);
-        assert!(list.find_segment(0).is_some());
+
+        assert_eq!(list.find_segment(0).expect("segment").0,&0);
+        assert_eq!(list.find_segment(1).expect("segment").0,&0);
+        assert_eq!(list.find_segment(499).expect("segment").0,&0);
+        assert_eq!(list.find_segment(500).expect("segment").0,&500);
+        assert_eq!(list.find_segment(1500).expect("segment").0,&500); // belong to 2nd segment
+        assert_eq!(list.find_segment(3000).expect("segment").0,&3000);
+        assert!(list.find_segment(4000).is_none());
     }
 
     const TEST_READ_DIR: &str = "segmentlist-read-many";
@@ -225,7 +243,6 @@ mod tests {
         let (segments, last_offset_res) = SegmentList::from_dir(&option).await.expect("from");
 
         assert_eq!(segments.len(), 3); // 0,500,2000
-        assert_eq!(segments.max_offset(), 2000);
         assert_eq!(segments.min_offset(), 10);
         let segment1 = segments.get_segment(10).expect("should have segment at 0 ");
         assert_eq!(segment1.get_base_offset(), 10);
@@ -236,8 +253,5 @@ mod tests {
             .expect("should have segment at 500");
         assert_eq!(segment2.get_base_offset(), 500);
     }
-
-    const TEST_EMPTY_DIR: &str = "segmentlist-read-empty";
-
     
 }

--- a/crates/fluvio-storage/src/range_map.rs
+++ b/crates/fluvio-storage/src/range_map.rs
@@ -122,7 +122,7 @@ impl SegmentList {
                 Included(offset - self.max_offset + self.min_offset + 1),
                 Included(offset),
             );
-            println!("range: {:?}", range);
+            //  println!("range: {:?}", range);
             (&self.segments).range(range).next_back()
         }
     }

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -63,7 +63,7 @@ impl FileRecordsSlice {
         self.base_offset
     }
 
-    pub async fn validate(&mut self) -> Result<Offset, LogValidationError> {
+    pub async fn validate(&self) -> Result<Offset, LogValidationError> {
         validate(&self.path).await
     }
 }

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -63,7 +63,6 @@ impl FileRecordsSlice {
         self.base_offset
     }
 
-    #[allow(dead_code)]
     pub async fn validate(&mut self) -> Result<Offset, LogValidationError> {
         validate(&self.path).await
     }

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -234,6 +234,7 @@ impl FileReplica {
     /// find the segment that contains offsets
     /// segment could be active segment which can be written
     /// or read only segment.
+    #[instrument(skip(self))]
     pub(crate) fn find_segment(&self, offset: Offset) -> Option<SegmentSlice> {
         let active_base_offset = self.active_segment.get_base_offset();
         if offset >= active_base_offset {
@@ -241,6 +242,7 @@ impl FileReplica {
             Some(self.active_segment.to_segment_slice())
         } else {
             debug!(offset, active_base_offset, "not in segment");
+            debug!("segments: {:#?}", self.prev_segments);
             self.prev_segments
                 .find_segment(offset)
                 .map(|(_, segment)| segment.to_segment_slice())

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -819,6 +819,8 @@ mod tests {
             .await
             .expect("write");
         assert_eq!(replica.prev_segments.len(), 1);
+        assert_eq!(replica.prev_segments.min_offset(), 0);
+        assert_eq!(replica.prev_segments.max_offset(), 4);
         println!("segments: {:#?}", replica.prev_segments);
         let first_segment = replica.prev_segments.get_segment(0).expect("some");
         assert_eq!(first_segment.get_base_offset(), 0);

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -804,11 +804,11 @@ mod tests {
 
         // this will create  1 segment
         new_replica
-            .write_batch(&mut producer.new_batch())
+            .write_batch(&mut producer.generate_batch())
             .await
             .expect("write");
         new_replica
-            .write_batch(&mut producer.new_batch())
+            .write_batch(&mut producer.generate_batch())
             .await
             .expect("write");
         assert_eq!(new_replica.prev_segments.len(), 0);
@@ -817,7 +817,7 @@ mod tests {
 
         // overflow, will create 2nd segment
         new_replica
-            .write_batch(&mut producer.new_batch())
+            .write_batch(&mut producer.generate_batch())
             .await
             .expect("write");
         assert_eq!(new_replica.prev_segments.len(), 1);

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -825,6 +825,5 @@ mod tests {
         assert_eq!(first_segment.get_base_offset(), 0);
         assert_eq!(first_segment.get_end_offset(), 4);
         assert!(replica.find_segment(0).is_some());
-        // assert!(!replica.find_segment(0).expect("some").is_active());
     }
 }

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -820,7 +820,6 @@ mod tests {
             .expect("write");
         assert_eq!(replica.prev_segments.len(), 1);
         assert_eq!(replica.prev_segments.min_offset(), 0);
-        assert_eq!(replica.prev_segments.max_offset(), 4);
         println!("segments: {:#?}", replica.prev_segments);
         let first_segment = replica.prev_segments.get_segment(0).expect("some");
         assert_eq!(first_segment.get_base_offset(), 0);

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -77,7 +77,7 @@ impl<I, L> Segment<I, L> {
         self.end_offset
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     /// set end offset, this is used by test
     pub(crate) fn set_end_offset(&mut self, offset: Offset) {
         self.end_offset = offset;

--- a/crates/fluvio-storage/tests/replica_test.rs
+++ b/crates/fluvio-storage/tests/replica_test.rs
@@ -62,7 +62,7 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
 
     ensure_clean_dir(&option.base_dir);
 
-    let mut replica = FileReplica::create(TOPIC_NAME, 0, START_OFFSET, option)
+    let mut replica = FileReplica::create_or_load(TOPIC_NAME, 0, START_OFFSET, option)
         .await
         .expect("test replica");
     replica

--- a/crates/fluvio-test/src/tests/election/mod.rs
+++ b/crates/fluvio-test/src/tests/election/mod.rs
@@ -18,7 +18,7 @@ use fluvio_test_util::test_runner::test_driver::{TestDriver};
 use fluvio_test_util::test_runner::test_meta::FluvioTestMeta;
 
 // time to wait for ac
-const ACK_WAIT: u64 = 10;
+const ACK_WAIT: u64 = 20;
 
 #[derive(Debug, Clone)]
 pub struct ElectionTestCase {


### PR DESCRIPTION
resolves #1568

* Remove unneeded spawn handle in Stream Fetch Handler
* Fix Storage segment list search
* Fix segmentload loading
* Properly update end offset when active segment is rollover