### PR TITLE
[Merged by Bors] - Catch socket timeout and print nicely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.10 - UNRELEASED
+* Improve error handling for socket timeout ([#791](https://github.com/infinyon/fluvio/issues/791))
 
 ## Platform Version 0.9.9 - 2021-09-30
 * Add `impl std::error::Error for ErrorCode` for better error reporting ([#1693](https://github.com/infinyon/fluvio/pull/1693))

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -112,6 +112,12 @@ impl CliError {
                 }
                 _ => Err(self),
             },
+            Self::ClientError(FluvioError::Socket(SocketError::Io(io)))
+                if io.kind() == ErrorKind::TimedOut =>
+            {
+                println!("Timed out while waiting on socket response");
+                Ok(())
+            }
             #[cfg(feature = "k8s")]
             Self::ClusterCliError(ClusterCliError::TargetError(TargetError::ClientError(
                 FluvioError::Socket(SocketError::Io(io)),

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -115,7 +115,7 @@ impl CliError {
             Self::ClientError(FluvioError::Socket(SocketError::Io(io)))
                 if io.kind() == ErrorKind::TimedOut =>
             {
-                println!("Timed out while waiting on socket response");
+                println!("Network connection timed out while waiting for response");
                 Ok(())
             }
             #[cfg(feature = "k8s")]

--- a/crates/fluvio-socket/src/multiplexing.rs
+++ b/crates/fluvio-socket/src/multiplexing.rs
@@ -155,7 +155,7 @@ impl MultiplexerSocket {
 
                 Err(IoError::new(
                     ErrorKind::TimedOut,
-                    format!("time out in serial: {} request: {}", R::API_KEY, correlation_id),
+                    format!("Timed out waiting for response. API_KEY={}, CorrelationId={}", R::API_KEY, correlation_id),
                 ).into())
             },
 


### PR DESCRIPTION
Closes https://github.com/infinyon/fluvio/issues/791.

Now when the client encounters a socket timeout, they get the following printed:

```
$ fluvio produce topic
...
...
Timed out while waiting on socket response
```