### PR TITLE
[Merged by Bors] - Report error to client when SPU is given invalid WASM module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.10 - UNRELEASED
 * Improve error handling for socket timeout ([#791](https://github.com/infinyon/fluvio/issues/791))
+* Report error when using invalid WASM in SmartStream consumer ([#1713](https://github.com/infinyon/fluvio/pull/1713))
 
 ## Platform Version 0.9.9 - 2021-09-30
 * Add `impl std::error::Error for ErrorCode` for better error reporting ([#1693](https://github.com/infinyon/fluvio/pull/1693))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -138,7 +138,7 @@ pub enum SmartStreamError {
     #[error("Runtime error")]
     Runtime(#[from] SmartStreamRuntimeError),
     #[error("WASM Module error: {0}")]
-    Module(String),
+    InvalidWasmModule(String),
 }
 
 impl Default for SmartStreamError {

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -135,8 +135,10 @@ impl ErrorCode {
 // TODO: Add variant for reporting panics
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Encoder, Decoder)]
 pub enum SmartStreamError {
-    #[error("SmartStream Runtime error")]
+    #[error("Runtime error")]
     Runtime(#[from] SmartStreamRuntimeError),
+    #[error("WASM Module error: {0}")]
+    Module(String),
 }
 
 impl Default for SmartStreamError {

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -133,11 +133,10 @@ impl StreamFetchHandler {
         let (smartstream, max_fetch_bytes) = if let Some(payload) = msg.wasm_payload {
             let wasm = &payload.wasm.get_raw()?;
             debug!(len = wasm.len(), "creating WASM module with bytes");
-            let module_result = sm_engine.create_module_from_binary(wasm);
-            let module = match module_result {
+            let module = match sm_engine.create_module_from_binary(wasm) {
                 Ok(module) => module,
                 Err(e) => {
-                    let error = SmartStreamError::Module(e.to_string());
+                    let error = SmartStreamError::InvalidWasmModule(e.to_string());
                     let error_code = ErrorCode::SmartStreamError(error);
 
                     type DefaultPartitionResponse = FetchablePartitionResponse<RecordSet>;
@@ -168,8 +167,7 @@ impl StreamFetchHandler {
                     return Err(SocketError::Io(IoError::new(
                         ErrorKind::InvalidData,
                         "Invalid WASM module",
-                    ))
-                    .into());
+                    )));
                 }
             };
 
@@ -1751,7 +1749,7 @@ mod test {
         assert!(
             matches!(
                 response.partition.error_code,
-                ErrorCode::SmartStreamError(SmartStreamError::Module(_))
+                ErrorCode::SmartStreamError(SmartStreamError::InvalidWasmModule(_))
             ),
             "expected a SmartStream Module error for invalid WASM module"
         );

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -11,7 +11,7 @@ use fluvio_spu_schema::server::stream_fetch::{
     DefaultStreamFetchRequest, DefaultStreamFetchResponse, SmartStreamPayload, SmartStreamWasm,
     SmartStreamKind, WASM_MODULE_V2_API, GZIP_WASM_API,
 };
-use dataplane::{Isolation, SmartStreamError};
+use dataplane::Isolation;
 use dataplane::ReplicaKey;
 use dataplane::ErrorCode;
 use dataplane::fetch::DefaultFetchRequest;
@@ -372,8 +372,8 @@ impl PartitionConsumer {
                 let code = response.partition.error_code;
                 match code {
                     ErrorCode::None => None,
-                    ErrorCode::SmartStreamError(SmartStreamError::Runtime(error)) => {
-                        Some(Err(FluvioError::SmartStreamRuntime(error)))
+                    ErrorCode::SmartStreamError(error) => {
+                        Some(Err(FluvioError::SmartStream(error)))
                     }
                     _ => Some(Err(FluvioError::AdminApi(
                         fluvio_sc_schema::ApiError::Code(code, None),

--- a/crates/fluvio/src/error.rs
+++ b/crates/fluvio/src/error.rs
@@ -5,6 +5,7 @@ use fluvio_sc_schema::ApiError;
 use crate::config::ConfigError;
 use semver::Version;
 use dataplane::smartstream::SmartStreamRuntimeError;
+use dataplane::SmartStreamError;
 
 /// Possible errors that may arise when using Fluvio
 #[derive(thiserror::Error, Debug)]
@@ -17,7 +18,7 @@ pub enum FluvioError {
     PartitionNotFound(String, i32),
     #[error("Spu not found: {0}")]
     SPUNotFound(i32),
-    #[error("Fluvio socket error: {0}")]
+    #[error("Fluvio socket error")]
     Socket(#[from] SocketError),
     #[error("Fluvio controlplane error: {0}")]
     AdminApi(#[from] ApiError),
@@ -43,8 +44,11 @@ To interact with this cluster, please install the matching CLI version using the
     },
     #[error("Consumer config error: {0}")]
     ConsumerConfig(String),
+    #[deprecated(since = "0.9.8", note = "use 'FluvioError::SmartStream' instead")]
     #[error("Encountered a runtime error in the user's SmartStream: {0}")]
     SmartStreamRuntime(#[from] SmartStreamRuntimeError),
+    #[error("SmartStream error")]
+    SmartStream(#[from] SmartStreamError),
     #[error("Unknown error: {0}")]
     Other(String),
 }


### PR DESCRIPTION
Closes #1143.

When supplying an invalid WASM module to the consumer, the client will now return with the following error:

```
$ flvd consume fruits -B --filter=Cargo.toml          # note that Cargo.toml is not a valid WASM file
Consuming records starting 10 from the end of topic 'fruits'
Error:
   0: Fluvio client error
   1: SmartStream error
   2: WASM Module error: failed to parse WebAssembly module
```

Action items:

- [x] Implement error delivery
- [x] Add integration test