### PR TITLE
[Merged by Bors] - fluvio-test - Reverse cluster start/stop cli logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
         timeout-minutes: 2
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--keep-cluster smoke-test-tls-root
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start smoke-test-tls-root
           date
           kubectl get partitions
           kubectl get partitions  -o=jsonpath='{.items[0].status.leader.leo}' | grep 100
@@ -382,14 +382,14 @@ jobs:
         timeout-minutes: 3
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--keep-cluster election-test
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start election-test
           echo "election test done"
       - name: Run multiple-partition-test
         if: ${{ matrix.test == 'multiple-partition' }}
         timeout-minutes: 2
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--keep-cluster multiple-partition-test
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start multiple-partition-test
           echo "multiple partition test done"
       - name: Save logs
         if: failure()
@@ -520,7 +520,7 @@ jobs:
           FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--keep-cluster UNINSTALL=noclean smoke-test-k8-tls-root
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root
         # make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
       - name: Print version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ smoke-test-k8-tls-policy-setup:
 	kubectl delete configmap authorization --ignore-not-found
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
 smoke-test-k8-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization
+smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization $(EXTRA_ARG)
 smoke-test-k8-tls-policy: build_k8_image smoke-test-k8-tls-policy-setup smoke-test
 
 test-permission-k8:	SC_HOST=$(shell kubectl get node -o json | jq '.items[].status.addresses[0].address' | tr -d '"' )

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ smoke-test-tls: smoke-test
 
 smoke-test-tls-policy: TEST_ENV_AUTH_POLICY=AUTH_POLICY=$(SC_AUTH_CONFIG)/policy.json X509_AUTH_SCOPES=$(SC_AUTH_CONFIG)/scopes.json
 smoke-test-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks 
+smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks $(EXTRA_ARG)
 smoke-test-tls-policy: smoke-test
 
 # test rbac with ROOT user

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ smoke-test-tls: smoke-test
 
 smoke-test-tls-policy: TEST_ENV_AUTH_POLICY=AUTH_POLICY=$(SC_AUTH_CONFIG)/policy.json X509_AUTH_SCOPES=$(SC_AUTH_CONFIG)/scopes.json
 smoke-test-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks --keep-cluster
+smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks 
 smoke-test-tls-policy: smoke-test
 
 # test rbac with ROOT user
@@ -159,7 +159,7 @@ smoke-test-k8-tls-policy-setup:
 	kubectl delete configmap authorization --ignore-not-found
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
 smoke-test-k8-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization --keep-cluster
+smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization
 smoke-test-k8-tls-policy: build_k8_image smoke-test-k8-tls-policy-setup smoke-test
 
 test-permission-k8:	SC_HOST=$(shell kubectl get node -o json | jq '.items[].status.addresses[0].address' | tr -d '"' )


### PR DESCRIPTION
Resolves #1644

By default, we should use whatever cluster is available, instead of attempting to cleanup and start new clusters. We opt-in to cluster management instead of opt-out.

---

Removing the following fluvio-test options:

`--disable-install` + `-d`
Which was used to opt-out of deleting a cluster, then restarting a new cluster.

`--keep-cluster` + `-k`
Which was used to opt-out of deleting your test cluster at the end of the test

and the short flag `-s` used for `--spu`

---

And adding the following options:

`--cluster-start` + `-s` (Repurposed short flag)
Which will try to start a cluster before the test starts (no harm if cluster is already started)

`--cluster-start-fresh`
Which will try to delete a cluster then re-start a new one before a test starts

`--cluster-delete` + `-d` (Repurposed short flag)
Which will try to delete a cluster at the end of the test