### PR TITLE
[Merged by Bors] - Fix hourly test after fluvio-test changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,11 @@ validate-release-stable:
 ifeq (${CI},true)
 # In CI, we expect all artifacts to already be built and loaded for the script
 longevity-test:
-	$(TEST_BIN) -d -k longevity -- --runtime-seconds=1800
+	$(TEST_BIN) longevity -- --runtime-seconds=1800
 else
 # When not in CI (i.e. development), load the dev k8 image before running test
 longevity-test: build-test
-	$(TEST_BIN) -d -k longevity -- $(VERBOSE_FLAG) --runtime-seconds=60
+	$(TEST_BIN) longevity -- $(VERBOSE_FLAG) --runtime-seconds=60
 endif
 
 


### PR DESCRIPTION
Removing the `-d` and `-k` flags from the makefile's `longevity-test` target