### PR TITLE
[Merged by Bors] - Rename test temp dir to be unique

### DIFF
--- a/crates/fluvio-storage/src/range_map.rs
+++ b/crates/fluvio-storage/src/range_map.rs
@@ -245,7 +245,7 @@ mod tests {
 
     #[fluvio_future::test]
     async fn test_segment_many_some() {
-        let rep_dir = temp_dir().join("segmentlist-many-zero");
+        let rep_dir = temp_dir().join("segmentlist-many-some");
         ensure_new_dir(&rep_dir).expect("new");
         let mut list = SegmentList::new();
 


### PR DESCRIPTION
I found that `make run-all-unit-test` was failing running locally, because the segmentlist-many-some and segmentlist-many-zero tests were stepping on each other's temp dirs, probably a copy-paste error. This fixes it.