### PR TITLE
[Merged by Bors] - ci: Install 4.x.x version of k3d

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -49,7 +49,8 @@ jobs:
         run: curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash
       - name: Set up K3d for Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: nolar/setup-k3d-k3s@v1        
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
       - name: Set up K8 for ubuntu(kind)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./k8-util/cluster/reset-k3d.sh
@@ -116,7 +117,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
           ./k8-util/cluster/reset-k3d.sh 
       - name: Run upgrade test
         timeout-minutes: 10
@@ -198,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh

--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -26,7 +26,7 @@ on:
 
 env:
   USE_VERSION: ${{ github.event.inputs.alt_version }}
-
+  K3D_VERSION: v4.4.8
 
 jobs:
   # test fluvio in local cluster 
@@ -50,7 +50,7 @@ jobs:
       - name: Set up K3d for Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Set up K8 for ubuntu(kind)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./k8-util/cluster/reset-k3d.sh
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
           ./k8-util/cluster/reset-k3d.sh 
       - name: Run upgrade test
         timeout-minutes: 10
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   USE_VERSION: ${{ github.event.inputs.alt_version }}
+  K3D_VERSION: v4.4.8
 
 jobs:
   installer_check:
@@ -77,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh
@@ -108,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.events.input.verbose }}
-
+  K3D_VERSION: v4.4.8
 
 jobs:
 
@@ -365,7 +365,7 @@ jobs:
         run: chmod +x ./fluvio ./fluvio-test && ./fluvio version
       - name: Set up cluster
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
           ./k8-util/cluster/reset-k3d.sh
       - name: Run smoke-test
         if: ${{ matrix.test == 'smoke' }}
@@ -496,7 +496,7 @@ jobs:
       - name: Install K3d
         if: ${{ matrix.k8 == 'k3d' }}
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
           ./k8-util/cluster/reset-k3d.sh
       - name: Load image to K3d
         if: ${{ matrix.k8 == 'k3d' }}
@@ -575,7 +575,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
           ./k8-util/cluster/reset-k3d.sh
       # Download artifacts
       - name: Download artifact - fluvio
@@ -650,7 +650,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
           ./k8-util/cluster/reset-k3d.sh
       - name: Install stable CLI and start Fluvio cluster
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: nolar/setup-k3d-k3s@v1
       - name: Download artifact - fluvio
         uses: actions/download-artifact@v2
         with:
@@ -365,7 +364,9 @@ jobs:
       - name: Print artifacts and mark executable
         run: chmod +x ./fluvio ./fluvio-test && ./fluvio version
       - name: Set up cluster
-        run: ./k8-util/cluster/reset-k3d.sh
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+          ./k8-util/cluster/reset-k3d.sh
       - name: Run smoke-test
         if: ${{ matrix.test == 'smoke' }}
         timeout-minutes: 2
@@ -495,7 +496,7 @@ jobs:
       - name: Install K3d
         if: ${{ matrix.k8 == 'k3d' }}
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
           ./k8-util/cluster/reset-k3d.sh
       - name: Load image to K3d
         if: ${{ matrix.k8 == 'k3d' }}
@@ -574,7 +575,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
           ./k8-util/cluster/reset-k3d.sh
       # Download artifacts
       - name: Download artifact - fluvio
@@ -649,7 +650,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install K3d
         run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
           ./k8-util/cluster/reset-k3d.sh
       - name: Install stable CLI and start Fluvio cluster
         run: |

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -18,6 +18,8 @@ jobs:
       fail-fast: false 
       matrix:
         os: [ubuntu-latest]
+    env:
+      K3D_VERSION: v4.4.8
     steps:
       - uses: actions/checkout@v2
 
@@ -52,7 +54,7 @@ jobs:
       # If they don't match, then let's run the test
 
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -52,7 +52,7 @@ jobs:
       # If they don't match, then let's run the test
 
       - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.8 bash
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh


### PR DESCRIPTION
Install version 4.X.X for now, since 5.0.0 new release removed the --no-hostip flag and it seems to be failing in the CI with an error similar to https://github.com/rancher/k3d/issues/772