### PR TITLE
[Merged by Bors] - move smartstream engine to global context

### DIFF
--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -19,6 +19,7 @@ use crate::replication::leader::{
 };
 use crate::services::public::StreamPublishers;
 use crate::control_plane::{StatusMessageSink, SharedStatusUpdate};
+use crate::smartstream::SmartStreamEngine;
 
 use super::spus::SharedSpuLocalStore;
 use super::SharedReplicaLocalStore;
@@ -38,6 +39,7 @@ pub struct GlobalContext<S> {
     stream_publishers: StreamPublishers,
     spu_followers: SharedSpuUpdates,
     status_update: SharedStatusUpdate,
+    sm_engine: SmartStreamEngine,
 }
 
 // -----------------------------------
@@ -62,6 +64,7 @@ where
             stream_publishers: StreamPublishers::new(),
             spu_followers: FollowerNotifier::shared(),
             status_update: StatusMessageSink::shared(),
+            sm_engine: SmartStreamEngine::default(),
         }
     }
 
@@ -125,6 +128,10 @@ where
         self.spu_followers
             .sync_from_spus(self.spu_localstore(), self.local_spu_id())
             .await;
+    }
+
+    pub fn smartstream_owned(&self) -> SmartStreamEngine {
+        self.sm_engine.clone()
     }
 }
 

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -28,7 +28,7 @@ use fluvio_types::event::offsets::OffsetChangeListener;
 use crate::core::DefaultSharedGlobalContext;
 use crate::replication::leader::SharedFileLeaderState;
 use publishers::INIT_OFFSET;
-use crate::smartstream::{SmartStreamEngine, SmartStream};
+use crate::smartstream::{SmartStream};
 use crate::smartstream::file_batch::FileBatchIterator;
 use dataplane::batch::Batch;
 use dataplane::smartstream::SmartStreamRuntimeError;
@@ -128,7 +128,7 @@ impl StreamFetchHandler {
         msg: StreamFetchRequest<FileRecordSet>,
     ) -> Result<(), SocketError> {
         let max_bytes = msg.max_bytes as u32;
-        let sm_engine = SmartStreamEngine::default();
+        let sm_engine = ctx.smartstream_owned();
 
         let (smartstream, max_fetch_bytes) = if let Some(payload) = msg.wasm_payload {
             let wasm = &payload.wasm.get_raw()?;

--- a/crates/fluvio-spu/src/smartstream/mod.rs
+++ b/crates/fluvio-spu/src/smartstream/mod.rs
@@ -1,8 +1,11 @@
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use std::fmt::{self, Debug};
+
 use tracing::{debug, trace};
 use anyhow::{Result, Error};
 use wasmtime::{Memory, Store, Engine, Module, Func, Caller, Extern, Trap, Instance};
+
 use crate::smartstream::filter::SmartStreamFilter;
 use crate::smartstream::map::SmartStreamMap;
 use crate::smartstream::aggregate::SmartStreamAggregate;
@@ -19,13 +22,19 @@ pub mod file_batch;
 
 pub type WasmSlice = (i32, i32);
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SmartStreamEngine(pub(crate) Engine);
 
 impl SmartStreamEngine {
     pub fn create_module_from_binary(&self, bytes: &[u8]) -> Result<SmartStreamModule> {
         let module = Module::from_binary(&self.0, bytes)?;
         Ok(SmartStreamModule(module))
+    }
+}
+
+impl Debug for SmartStreamEngine {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SmartStreamEngine")
     }
 }
 


### PR DESCRIPTION
Instead of creating WASM engine every time request is made, a single global instance is shared