### PR TITLE
Fix dev local test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
         timeout-minutes: 2
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start smoke-test-tls-root
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean smoke-test-tls-root
           date
           kubectl get partitions
           kubectl get partitions  -o=jsonpath='{.items[0].status.leader.leo}' | grep 100
@@ -383,21 +383,21 @@ jobs:
         timeout-minutes: 3
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start election-test
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean election-test
           echo "election test done"
       - name: Run multiple-partition-test
         if: ${{ matrix.test == 'multiple-partition' }}
         timeout-minutes: 3
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start multiple-partition-test
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean multiple-partition-test
           echo "multiple partition test done"
       - name: Run reconnection-test
         if: ${{ matrix.test == 'reconnection' }}
         timeout-minutes: 3
         run: |
           date
-          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean EXTRA_ARG=--cluster-start reconnection-test
+          make  FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean reconnection-test
           echo "reconnection test done"
 
       - name: Save logs
@@ -529,7 +529,7 @@ jobs:
           FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test UNINSTALL=noclean smoke-test-k8-tls-root
         # make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
       - name: Print version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -81,26 +81,26 @@ smoke-test: test-setup
 			${TEST_ARG_CONSUMER_WAIT} \
 			${TEST_ARG_PRODUCER_ITERATION}
 
-smoke-test-local: TEST_ARG_EXTRA=--local  $(EXTRA_ARG)
+smoke-test-local: TEST_ARG_EXTRA=--local --cluster-start $(EXTRA_ARG)
 smoke-test-local: smoke-test
 
-smoke-test-stream: TEST_ARG_EXTRA=--local $(EXTRA_ARG)
+smoke-test-stream: TEST_ARG_EXTRA=--local --cluster-start $(EXTRA_ARG)
 smoke-test-stream: TEST_ARG_CONSUMER_WAIT=--consumer-wait=true
 smoke-test-stream: smoke-test
 
-smoke-test-tls: TEST_ARG_EXTRA=--tls --local $(EXTRA_ARG)
+smoke-test-tls: TEST_ARG_EXTRA=--tls --local --cluster-start $(EXTRA_ARG)
 smoke-test-tls: smoke-test
 
 smoke-test-tls-policy: TEST_ENV_AUTH_POLICY=AUTH_POLICY=$(SC_AUTH_CONFIG)/policy.json X509_AUTH_SCOPES=$(SC_AUTH_CONFIG)/scopes.json
 smoke-test-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks $(EXTRA_ARG)
+smoke-test-tls-policy: TEST_ARG_EXTRA=--tls --local --skip-checks --cluster-start $(EXTRA_ARG)
 smoke-test-tls-policy: smoke-test
 
 # test rbac with ROOT user
 smoke-test-tls-root: smoke-test-tls-policy test-permission-user1
 
 # election test only runs on local
-election-test: TEST_ARG_EXTRA=--local $(EXTRA_ARG)	
+election-test: TEST_ARG_EXTRA=--local --cluster-start $(EXTRA_ARG)	
 election-test: test-setup
 	$(TEST_BIN) election  \
 		${TEST_ARG_SPU} \
@@ -109,7 +109,7 @@ election-test: test-setup
 		${TEST_ARG_DEVELOP} \
 		${TEST_ARG_EXTRA}
 
-multiple-partition-test: TEST_ARG_EXTRA=--local $(EXTRA_ARG)
+multiple-partition-test: TEST_ARG_EXTRA=--local --cluster-start $(EXTRA_ARG)
 multiple-partition-test: test-setup
 	$(TEST_BIN) multiple_partition --partition 10 \
 		${TEST_ARG_SPU} \
@@ -119,7 +119,7 @@ multiple-partition-test: test-setup
                 ${TEST_ARG_EXTRA}
 
 
-reconnection-test: TEST_ARG_EXTRA=--local $(EXTRA_ARG)
+reconnection-test: TEST_ARG_EXTRA=--local --cluster-start $(EXTRA_ARG)
 reconnection-test: DEFAULT_SPU=1
 reconnection-test: REPL=1
 reconnection-test: test-setup
@@ -160,17 +160,17 @@ endif
 
 # Kubernetes Tests
 
-smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
+smoke-test-k8: TEST_ARG_EXTRA=--cluster-start $(EXTRA_ARG)
 smoke-test-k8: build_k8_image smoke-test 
 
-smoke-test-k8-tls: TEST_ARG_EXTRA=--tls $(EXTRA_ARG)
+smoke-test-k8-tls: TEST_ARG_EXTRA=--tls --cluster-start $(EXTRA_ARG)
 smoke-test-k8-tls: build_k8_image smoke-test
 
 smoke-test-k8-tls-policy-setup:
 	kubectl delete configmap authorization --ignore-not-found
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
 smoke-test-k8-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
-smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization $(EXTRA_ARG)
+smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization --cluster-start $(EXTRA_ARG)
 smoke-test-k8-tls-policy: build_k8_image smoke-test-k8-tls-policy-setup smoke-test
 
 test-permission-k8:	SC_HOST=$(shell kubectl get node -o json | jq '.items[].status.addresses[0].address' | tr -d '"' )


### PR DESCRIPTION
In CI, we start clusters before running tests. But locally on each of our dev environments this isn't always the case. 

This change adds `--cluster-start` to every fluvio-test related target in our Makefile. There shouldn't be any downside to attempting to start a cluster if one is already started.