### PR TITLE
[Merged by Bors] - Add SmartStreamType::Flatmap

### DIFF
--- a/crates/fluvio-dataplane-protocol/src/smartstream.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartstream.rs
@@ -166,6 +166,7 @@ mod encoding {
     pub enum SmartStreamType {
         Filter,
         Map,
+        Flatmap,
         Aggregate,
     }
 

--- a/crates/fluvio-smartstream-derive/src/generator/flatmap.rs
+++ b/crates/fluvio-smartstream-derive/src/generator/flatmap.rs
@@ -84,7 +84,7 @@ pub fn generate_flatmap_smartstream(func: &SmartStreamFn, has_params: bool) -> T
                             let error = SmartStreamRuntimeError::new(
                                 &record,
                                 smartstream_input.base_offset,
-                                SmartStreamType::Map,
+                                SmartStreamType::Flatmap,
                                 err,
                             );
                             output.error = Some(error);


### PR DESCRIPTION
I forgot to add this in the Flatmap PR, this is used to print the correct SmartStream type when an error occurs.