### PR TITLE
Remove wasm payload from smartmodule list by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,6 @@ dependencies = [
  "ctrlc",
  "dirs 4.0.0",
  "eyre",
- "flate2",
  "fluvio",
  "fluvio-cluster",
  "fluvio-command",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -62,7 +62,6 @@ ctrlc = { version = "3.1.3", optional = true }
 colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
-flate2 = "1.0.22"
 
 # Fluvio dependencies
 k8-config = { version = "1.3.0", optional = true }

--- a/crates/fluvio-cli/src/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/smartmodule/create.rs
@@ -31,7 +31,7 @@ impl CreateSmartModuleOpt {
         */
 
         let spec: SmartModuleSpec = SmartModuleSpec {
-            wasm: SmartModuleWasm::from_binary_payload(buffer),
+            wasm: Some(SmartModuleWasm::from_binary_payload(buffer)),
             ..Default::default()
         };
         let admin = fluvio.admin().await;

--- a/crates/fluvio-cli/src/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/smartmodule/create.rs
@@ -3,8 +3,6 @@ use structopt::StructOpt;
 use crate::Result;
 use fluvio::Fluvio;
 use fluvio::metadata::smartmodule::{SmartModuleWasm, SmartModuleSpec};
-use flate2::{Compression, bufread::GzEncoder};
-use std::io::Read;
 
 /// Create a new SmartModule with a given name
 #[derive(Debug, StructOpt)]
@@ -22,16 +20,9 @@ pub struct CreateSmartModuleOpt {
 impl CreateSmartModuleOpt {
     pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let raw = std::fs::read(self.wasm_file)?;
-        let mut encoder = GzEncoder::new(raw.as_slice(), Compression::default());
-        let mut buffer = Vec::with_capacity(raw.len());
-        encoder.read_to_end(&mut buffer)?;
-        /*
-         * TODO: Fix the CRD to work with this
-        let buffer = vec!['a' as u8; self.size];
-        */
 
         let spec: SmartModuleSpec = SmartModuleSpec {
-            wasm: Some(SmartModuleWasm::from_binary_payload(buffer)),
+            wasm: Some(SmartModuleWasm::from_binary_payload(raw)),
             ..Default::default()
         };
         let admin = fluvio.admin().await;

--- a/crates/fluvio-cli/src/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/smartmodule/list.rs
@@ -92,7 +92,7 @@ mod output {
                     Row::new(vec![
                         Cell::new_align(&r.name, Alignment::RIGHT),
                         Cell::new_align(&r.status.to_string(), Alignment::RIGHT),
-                        Cell::new_align(&r.spec.wasm.payload.len().to_string(), Alignment::RIGHT),
+                        //Cell::new_align(&r.spec.wasm.payload.len().to_string(), Alignment::RIGHT),
                     ])
                 })
                 .collect()

--- a/crates/fluvio-cli/src/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/smartmodule/list.rs
@@ -75,7 +75,7 @@ mod output {
     impl TableOutputHandler for ListSmartModules {
         /// table header implementation
         fn header(&self) -> Row {
-            row!["NAME", "STATUS", "SIZE"]
+            row!["NAME", "STATUS"]
         }
 
         /// return errors in string format
@@ -92,7 +92,6 @@ mod output {
                     Row::new(vec![
                         Cell::new_align(&r.name, Alignment::RIGHT),
                         Cell::new_align(&r.status.to_string(), Alignment::RIGHT),
-                        //Cell::new_align(&r.spec.wasm.payload.len().to_string(), Alignment::RIGHT),
                     ])
                 })
                 .collect()

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -10,7 +10,7 @@ pub struct SmartModuleSpec {
     pub input_kind: SmartModuleInputKind,
     pub output_kind: SmartModuleOutputKind,
     pub source_code: Option<SmartModuleSourceCode>,
-    pub wasm: SmartModuleWasm,
+    pub wasm: Option<SmartModuleWasm>,
     pub parameters: Option<Vec<SmartModuleParameter>>,
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -48,9 +48,16 @@ pub enum ListRequest {
     CustomSpu(Vec<NameFilter>),
     Partition(Vec<NameFilter>),
     ManagedConnector(Vec<NameFilter>),
-    SmartModule(Vec<NameFilter>),
+    SmartModule(Vec<SmartModuleFilterMap>),
     Table(Vec<NameFilter>),
 }
+
+#[derive(Debug, Encoder, Decoder, Default)]
+pub struct SmartModuleFilterMap {
+    pub name: NameFilter,
+    pub include_wasm: bool,
+}
+impl ListFilter for SmartModuleFilterMap { }
 
 impl Default for ListRequest {
     fn default() -> Self {
@@ -264,7 +271,7 @@ mod encoding {
                 }
 
                 SmartModuleSpec::LABEL => {
-                    let mut response: Vec<NameFilter> = vec![];
+                    let mut response: Vec<SmartModuleFilterMap> = vec![];
                     response.decode(src, version)?;
                     *self = Self::SmartModule(response);
                     Ok(())

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -48,16 +48,9 @@ pub enum ListRequest {
     CustomSpu(Vec<NameFilter>),
     Partition(Vec<NameFilter>),
     ManagedConnector(Vec<NameFilter>),
-    SmartModule(Vec<SmartModuleFilterMap>),
+    SmartModule(Vec<NameFilter>),
     Table(Vec<NameFilter>),
 }
-
-#[derive(Debug, Encoder, Decoder, Default)]
-pub struct SmartModuleFilterMap {
-    pub name: NameFilter,
-    pub include_wasm: bool,
-}
-impl ListFilter for SmartModuleFilterMap { }
 
 impl Default for ListRequest {
     fn default() -> Self {
@@ -271,7 +264,7 @@ mod encoding {
                 }
 
                 SmartModuleSpec::LABEL => {
-                    let mut response: Vec<SmartModuleFilterMap> = vec![];
+                    let mut response: Vec<NameFilter> = vec![];
                     response.decode(src, version)?;
                     *self = Self::SmartModule(response);
                     Ok(())

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -25,7 +25,7 @@ mod convert {
     }
 
     impl ListSpec for SmartModuleSpec {
-        type Filter = NameFilter;
+        type Filter = SmartModuleFilterMap;
 
         fn into_list_request(filters: Vec<Self::Filter>) -> ListRequest {
             ListRequest::SmartModule(filters)
@@ -59,6 +59,4 @@ mod convert {
             }
         }
     }
-    /*
-     */
 }

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -25,7 +25,7 @@ mod convert {
     }
 
     impl ListSpec for SmartModuleSpec {
-        type Filter = SmartModuleFilterMap;
+        type Filter = NameFilter;
 
         fn into_list_request(filters: Vec<Self::Filter>) -> ListRequest {
             ListRequest::SmartModule(filters)

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/fetch.rs
@@ -2,7 +2,7 @@ use std::io::{Error, ErrorKind};
 
 use tracing::{debug, trace, instrument};
 
-use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata, SmartModuleFilterMap};
+use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata};
 use fluvio_sc_schema::smartmodule::SmartModuleSpec;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::store::KeyFilter;
@@ -12,7 +12,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_request<AC: AuthContext>(
-    filters: Vec<SmartModuleFilterMap>,
+    filters: Vec<NameFilter>,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse, Error> {
     trace!("fetching smart modules");
@@ -48,7 +48,7 @@ pub async fn handle_fetch_request<AC: AuthContext>(
                 Some(inner)
             } else {
                 if filters.iter().filter(|filter| {
-                    filter.name.filter(value.key())
+                    filter.filter(value.key())
                 }).count() > 0 {
                     Some(value.inner().clone().into())
                 } else {

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/fetch.rs
@@ -40,22 +40,22 @@ pub async fn handle_fetch_request<AC: AuthContext>(
         .values()
         .filter_map(|value| {
             if filters.is_empty() {
-                let mut inner : Metadata<SmartModuleSpec> = value.inner().clone().into();
+                let mut inner: Metadata<SmartModuleSpec> = value.inner().clone().into();
                 inner.spec = SmartModuleSpec {
                     wasm: None,
                     ..inner.spec
                 };
                 Some(inner)
+            } else if filters
+                .iter()
+                .filter(|filter| filter.filter(value.key()))
+                .count()
+                > 0
+            {
+                Some(value.inner().clone().into())
             } else {
-                if filters.iter().filter(|filter| {
-                    filter.filter(value.key())
-                }).count() > 0 {
-                    Some(value.inner().clone().into())
-                } else {
-                    None
-                }
+                None
             }
-                //Some(value.inner().clone().into())
         })
         .collect();
 


### PR DESCRIPTION
After playing with this for a while, I concluded that if you're just doing a `list` with no filter parameters, by default there shouldn't be a wasm playoad in the response. However, if you do have a list with any filter at all (normally this is just an index), you almost always want the wasm payload.