### PR TITLE
[Merged by Bors] - Make new clippy lints happy

### DIFF
--- a/crates/fluvio-sc/src/stores/spu.rs
+++ b/crates/fluvio-sc/src/stores/spu.rs
@@ -69,6 +69,8 @@ mod health_check {
         }
 
         /// update health check
+        // TODO: Determine if we can follow the clippy suggestion w/o negatively affecting functionality
+        #[allow(clippy::branches_sharing_code)]
         #[instrument(skip(self))]
         pub async fn update(&self, spu: SpuId, new_value: bool) {
             let mut write = self.health.write().await;

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -31,17 +31,13 @@ fn main() {
 
     let mut subcommand = vec![test_name.clone()];
 
-    // We want to get a TestOption compatible struct back
-    let test_opt: Box<dyn TestOption> = if let Some(TestCli::Args(args)) = option.test_cmd_args {
+    if let Some(TestCli::Args(args)) = option.test_cmd_args {
         // Add the args to the subcommand
         subcommand.extend(args);
+    }
 
-        // Parse the subcommand
-        (test_meta.validate_fn)(subcommand)
-    } else {
-        // No args
-        (test_meta.validate_fn)(subcommand)
-    };
+    // We want to get a TestOption compatible struct back
+    let test_opt: Box<dyn TestOption> = (test_meta.validate_fn)(subcommand);
 
     println!("Start running fluvio test runner");
     fluvio_future::subscriber::init_logger();


### PR DESCRIPTION
New clippy lints blocked rebuild. This PR fixes.

Fixed the lint in `fluvio-test` but placed `allow` in `fluvio-sc` since suggestion didn't seem as reasonable with dropping RwLockWriteGuard earlier.