### PR TITLE
[Merged by Bors] - Consumer option to display json obj as table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add `#[smarstream(array_map)]` for expanding one record into many ([#1335](https://github.com/infinyon/fluvio/issues/1335))
 * Add capability to use input parameters in smartstreams ([#1643](https://github.com/infinyon/fluvio/issues/1643))
 * Make it easier to debug inline chart ([#1779](https://github.com/infinyon/fluvio/issues/1779))
+* Add table display output option to consumer for json objects ([#1642](https://github.com/infinyon/fluvio/issues/1642))
 
 ## Platform Version 0.9.10 - 2021-10-07
 * Improve error handling for socket timeout ([#791](https://github.com/infinyon/fluvio/issues/791))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.13 - UNRELEASED
 * Fix connector create with `create_topic` option to succeed if topic already exists. ([#1823](https://github.com/infinyon/fluvio/pull/1823))
 * Add `#[smartstream(filter_map)]` for filtering and transforming at the same time. ([#1826](https://github.com/infinyon/fluvio/issues/1826))
+* Add table display output option to consumer for json objects ([#1642](https://github.com/infinyon/fluvio/issues/1642))
 
 ## Platform Version 0.9.12 - 2021-10-27
 * Add examples for ArrayMap. ([#1804](https://github.com/infinyon/fluvio/issues/1804))
@@ -15,7 +16,6 @@
 * Add `#[smarstream(array_map)]` for expanding one record into many ([#1335](https://github.com/infinyon/fluvio/issues/1335))
 * Add capability to use input parameters in smartstreams ([#1643](https://github.com/infinyon/fluvio/issues/1643))
 * Make it easier to debug inline chart ([#1779](https://github.com/infinyon/fluvio/issues/1779))
-* Add table display output option to consumer for json objects ([#1642](https://github.com/infinyon/fluvio/issues/1642))
 
 ## Platform Version 0.9.10 - 2021-10-07
 * Improve error handling for socket timeout ([#791](https://github.com/infinyon/fluvio/issues/791))

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -256,7 +256,7 @@ impl ConsumeOpt {
             }
         };
 
-        //let mut is_table_titles_printed = false;
+        // This is used by table output, to print the table titles only once
         let mut record_count = 0;
         while let Some(result) = stream.next().await {
             let result: std::result::Result<Record, _> = result;
@@ -269,14 +269,6 @@ impl ConsumeOpt {
                 Err(other) => return Err(other.into()),
             };
 
-            //// If output table, print the headers ONCE before printing records
-            //if &self.output == &Some(ConsumeOutputType::table) && !is_table_titles_printed {
-            //    // Print the table titles
-            //    print_table_title(&record.value());
-
-            //    is_table_titles_printed = true;
-            //}
-
             self.print_record(templates.as_ref(), &record, record_count);
             record_count = record_count + 1;
         }
@@ -285,7 +277,6 @@ impl ConsumeOpt {
         Ok(())
     }
 
-    // Add a row counter? For the table printer to know how to handle titles
     /// Process fetch topic response based on output type
     pub fn print_record(&self, templates: Option<&Handlebars>, record: &Record, count: i32) {
         let formatted_key = record

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -270,7 +270,7 @@ impl ConsumeOpt {
             };
 
             self.print_record(templates.as_ref(), &record, record_count);
-            record_count = record_count + 1;
+            record_count += 1;
         }
 
         debug!("fetch loop exited");
@@ -312,7 +312,7 @@ impl ConsumeOpt {
         };
 
         // If the consume type is table, we don't want to accidentally print a newline
-        if &self.output != &Some(ConsumeOutputType::table) {
+        if self.output != Some(ConsumeOutputType::table) {
             match formatted_value {
                 Some(value) if self.key_value => {
                     println!("[{}] {}", formatted_key, value);

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -20,7 +20,8 @@ use fluvio::consumer::{PartitionSelectionStrategy, Record};
 use crate::{CliError, Result};
 use crate::common::FluvioExtensionMetadata;
 use self::record_format::{
-    format_text_record, format_binary_record, format_dynamic_record, format_raw_record, format_json,
+    format_text_record, format_binary_record, format_dynamic_record, format_raw_record,
+    format_json, format_table_record,
 };
 use handlebars::Handlebars;
 
@@ -266,6 +267,8 @@ impl ConsumeOpt {
                 Err(other) => return Err(other.into()),
             };
 
+            // If output table, print the headers ONCE before printing records
+
             self.print_record(templates.as_ref(), &record);
         }
 
@@ -292,6 +295,7 @@ impl ConsumeOpt {
                 Some(format_dynamic_record(record.value()))
             }
             (Some(ConsumeOutputType::raw), None) => Some(format_raw_record(record.value())),
+            (Some(ConsumeOutputType::table), None) => Some(format_table_record(record.value())),
             (_, Some(templates)) => {
                 let value = String::from_utf8_lossy(record.value()).to_string();
                 let object = serde_json::json!({
@@ -421,6 +425,7 @@ arg_enum! {
         binary,
         json,
         raw,
+        table,
     }
 }
 

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -73,13 +73,10 @@ pub fn format_raw_record(record: &[u8]) -> String {
 //  Table
 // -----------------------------------
 
-// TODO: This will eventually read for alternative formatting
 /// Print records in table format
 pub fn print_table_record(record: &[u8], count: i32) -> String {
     use prettytable::{Row, cell, Cell, Slice};
     use prettytable::format::{self, FormatBuilder};
-
-    //let mut hashmap : std::collections::HashMap<String, serde_json::Value> = std::collections::HashMap::new();
 
     let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
         Ok(value) => value,
@@ -107,23 +104,11 @@ pub fn print_table_record(record: &[u8], count: i32) -> String {
         .collect();
 
     let header: Row = Row::new(keys_str.iter().map(|k| cell!(k.to_owned())).collect());
-    let entries: Row = Row::new(
-        values_str
-            .iter()
-            .map(|v| {
-                let c = Cell::new(v);
-                c
-            })
-            .collect(),
-    );
+    let entries: Row = Row::new(values_str.iter().map(|v| Cell::new(v)).collect());
 
     // Print the table
-    let mut t_print = Vec::new();
-    // TODO: Don't print the headers in this table display
+    let t_print = vec![header, entries];
 
-    t_print.push(header);
-
-    t_print.push(entries);
     let mut table = prettytable::Table::init(t_print);
 
     let base_format: FormatBuilder = (*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR).into();
@@ -131,6 +116,7 @@ pub fn print_table_record(record: &[u8], count: i32) -> String {
     table.set_format(table_format.build());
 
     // FIXME: Live display of table data easily misaligns column widths
+    // if there is a length diff between the header and the data
     // The rows after the first (count == 0) don't line up with the header
     // prettytable might not support the live display use-case we want
     if count == 0 {


### PR DESCRIPTION
Resolves #1642 

Add `fluvio consume --output=table` for printing json data into tables with `prettytable`