### PR TITLE
[Merged by Bors] - Add filter-map smartstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.13 - UNRELEASED
 * Fix connector create with `create_topic` option to succeed if topic already exists. ([#1823](https://github.com/infinyon/fluvio/pull/1823))
+* Add `#[smartstream(filter_map)]` for filtering and transforming at the same time. ([#1826](https://github.com/infinyon/fluvio/issues/1826))
 
 ## Platform Version 0.9.12 - 2021-10-27
 * Add examples for ArrayMap. ([#1804](https://github.com/infinyon/fluvio/issues/1804))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -107,6 +107,10 @@ pub struct ConsumeOpt {
     #[structopt(long, group("smartstream"))]
     pub map: Option<PathBuf>,
 
+    /// Path to a SmartStream filter_map wasm file
+    #[structopt(long, group("smartstream"))]
+    pub filter_map: Option<PathBuf>,
+
     /// Path to a SmartStream array_map wasm file
     #[structopt(long, group("smartstream"))]
     pub array_map: Option<PathBuf>,
@@ -194,6 +198,10 @@ impl ConsumeOpt {
             let buffer = std::fs::read(map_path)?;
             debug!(len = buffer.len(), "read array_map bytes");
             builder.wasm_array_map(buffer, extra_params);
+        } else if let Some(filter_map_path) = &self.filter_map {
+            let buffer = std::fs::read(filter_map_path)?;
+            debug!(len = buffer.len(), "read filter-map bytes");
+            builder.wasm_filter_map(buffer, extra_params);
         } else {
             match (&self.aggregate, &self.initial) {
                 (Some(wasm_path), Some(acc_path)) => {

--- a/crates/fluvio-dataplane-protocol/src/smartstream.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartstream.rs
@@ -167,6 +167,7 @@ mod encoding {
         Filter,
         Map,
         ArrayMap,
+        FilterMap,
         Aggregate,
     }
 

--- a/crates/fluvio-smartengine/src/smartstream/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartstream/filter_map.rs
@@ -1,0 +1,54 @@
+use std::convert::TryFrom;
+use anyhow::Result;
+use wasmtime::TypedFunc;
+
+use dataplane::smartstream::{SmartStreamInput, SmartStreamOutput, SmartStreamInternalError};
+use crate::smartstream::{
+    SmartEngine, SmartStreamModule, SmartStreamContext, SmartStream, SmartStreamExtraParams,
+};
+
+const FILTER_MAP_FN_NAME: &str = "filter_map";
+type FilterMapFn = TypedFunc<(i32, i32), i32>;
+
+pub struct SmartStreamFilterMap {
+    base: SmartStreamContext,
+    filter_map_fn: FilterMapFn,
+}
+
+impl SmartStreamFilterMap {
+    pub fn new(
+        engine: &SmartEngine,
+        module: &SmartStreamModule,
+        params: SmartStreamExtraParams,
+    ) -> Result<Self> {
+        let mut base = SmartStreamContext::new(engine, module, params)?;
+        let filter_map_fn: FilterMapFn = base
+            .instance
+            .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)?;
+
+        Ok(Self {
+            base,
+            filter_map_fn,
+        })
+    }
+}
+
+impl SmartStream for SmartStreamFilterMap {
+    fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput> {
+        let slice = self.base.write_input(&input)?;
+        let map_output = self.filter_map_fn.call(&mut self.base.store, slice)?;
+
+        if map_output < 0 {
+            let internal_error = SmartStreamInternalError::try_from(map_output)
+                .unwrap_or(SmartStreamInternalError::UnknownError);
+            return Err(internal_error.into());
+        }
+
+        let output: SmartStreamOutput = self.base.read_output()?;
+        Ok(output)
+    }
+
+    fn params(&self) -> SmartStreamExtraParams {
+        self.base.params.clone()
+    }
+}

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -9,6 +9,7 @@ use wasmtime::{Memory, Store, Engine, Module, Func, Caller, Extern, Trap, Instan
 
 use crate::smartstream::filter::SmartStreamFilter;
 use crate::smartstream::map::SmartStreamMap;
+use crate::filter_map::SmartStreamFilterMap;
 use crate::smartstream::array_map::SmartStreamArrayMap;
 use crate::smartstream::aggregate::SmartStreamAggregate;
 use dataplane::core::{Encoder, Decoder};
@@ -21,6 +22,7 @@ mod memory;
 pub mod filter;
 pub mod map;
 pub mod array_map;
+pub mod filter_map;
 pub mod aggregate;
 pub mod file_batch;
 
@@ -91,6 +93,15 @@ impl SmartStreamModule {
     ) -> Result<SmartStreamMap> {
         let map = SmartStreamMap::new(engine, self, params)?;
         Ok(map)
+    }
+
+    pub fn create_filter_map(
+        &self,
+        engine: &SmartEngine,
+        params: SmartStreamExtraParams,
+    ) -> Result<SmartStreamFilterMap> {
+        let filter_map = SmartStreamFilterMap::new(engine, self, params)?;
+        Ok(filter_map)
     }
 
     pub fn create_array_map(

--- a/crates/fluvio-smartstream-derive/Cargo.toml
+++ b/crates/fluvio-smartstream-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream-derive"
-version = "0.3.1"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartstream-derive/Cargo.toml
+++ b/crates/fluvio-smartstream-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream-derive"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartstream-derive/src/ast.rs
+++ b/crates/fluvio-smartstream-derive/src/ast.rs
@@ -46,6 +46,7 @@ pub enum SmartStreamKind {
     Filter,
     Map,
     ArrayMap,
+    FilterMap,
 }
 
 impl SmartStreamKind {
@@ -61,6 +62,7 @@ impl SmartStreamKind {
                                 "filter" => Some(Self::Filter),
                                 "map" => Some(Self::Map),
                                 "array_map" => Some(Self::ArrayMap),
+                                "filter_map" => Some(Self::FilterMap),
                                 _ => None,
                             }
                         })

--- a/crates/fluvio-smartstream-derive/src/generator/filter_map.rs
+++ b/crates/fluvio-smartstream-derive/src/generator/filter_map.rs
@@ -1,0 +1,108 @@
+use quote::quote;
+use proc_macro2::TokenStream;
+use crate::SmartStreamFn;
+
+pub fn generate_filter_map_smartstream(func: &SmartStreamFn, has_params: bool) -> TokenStream {
+    let user_code = &func.func;
+    let user_fn = &func.name;
+
+    let params_parsing = if has_params {
+        quote!(
+            use std::convert::TryInto;
+
+            let params = match smartstream_input.params.try_into(){
+                Ok(params) => params,
+                Err(err) => return SmartStreamInternalError::ParsingExtraParams as i32,
+            };
+
+        )
+    } else {
+        quote!()
+    };
+
+    let function_call = if has_params {
+        quote!(
+            super:: #user_fn(&record, &params)
+        )
+    } else {
+        quote!(
+            super:: #user_fn(&record)
+        )
+    };
+
+    quote! {
+        #user_code
+
+        mod __system {
+            #[no_mangle]
+            #[allow(clippy::missing_safety_doc)]
+            pub unsafe fn filter_map(ptr: *mut u8, len: usize) -> i32 {
+                use fluvio_smartstream::dataplane::smartstream::{
+                    SmartStreamInput, SmartStreamInternalError,
+                    SmartStreamRuntimeError, SmartStreamType, SmartStreamOutput,
+                };
+                use fluvio_smartstream::dataplane::core::{Encoder, Decoder};
+                use fluvio_smartstream::dataplane::record::{Record, RecordData};
+
+                // DECODING
+                extern "C" {
+                    fn copy_records(putr: i32, len: i32);
+                }
+
+                let input_data = Vec::from_raw_parts(ptr, len, len);
+                let mut smartstream_input = SmartStreamInput::default();
+                if let Err(_err) = Decoder::decode(&mut smartstream_input, &mut std::io::Cursor::new(input_data), 0) {
+                    return SmartStreamInternalError::DecodingBaseInput as i32;
+                }
+
+                let records_input = smartstream_input.record_data;
+                let mut records: Vec<Record> = vec![];
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), 0) {
+                    return SmartStreamInternalError::DecodingRecords as i32;
+                };
+
+                #params_parsing
+
+                // PROCESSING
+                let mut output = SmartStreamOutput {
+                    successes: Vec::with_capacity(records.len()),
+                    error: None,
+                };
+
+                for mut record in records.into_iter() {
+                    let result = #function_call;
+                    match result {
+                        Ok(Some((maybe_key, value))) => {
+                            record.key = maybe_key;
+                            record.value = value;
+                            output.successes.push(record);
+                        }
+                        Ok(None) => {},
+                        Err(err) => {
+                            let error = SmartStreamRuntimeError::new(
+                                &record,
+                                smartstream_input.base_offset,
+                                SmartStreamType::FilterMap,
+                                err,
+                            );
+                            output.error = Some(error);
+                            break;
+                        }
+                    }
+                }
+
+                // ENCODING
+                let mut out = vec![];
+                if let Err(_) = Encoder::encode(&mut output, &mut out, 0) {
+                    return SmartStreamInternalError::EncodingOutput as i32;
+                }
+
+                let out_len = out.len();
+                let ptr = out.as_mut_ptr();
+                std::mem::forget(out);
+                copy_records(ptr as i32, out_len as i32);
+                output.successes.len() as i32
+            }
+        }
+    }
+}

--- a/crates/fluvio-smartstream-derive/src/generator/mod.rs
+++ b/crates/fluvio-smartstream-derive/src/generator/mod.rs
@@ -4,6 +4,7 @@ use crate::{SmartStreamConfig, SmartStreamFn, SmartStreamKind};
 mod filter;
 mod map;
 mod array_map;
+mod filter_map;
 mod aggregate;
 
 pub mod opt;
@@ -14,6 +15,9 @@ pub fn generate_smartstream(config: &SmartStreamConfig, func: &SmartStreamFn) ->
             self::filter::generate_filter_smartstream(func, config.has_params)
         }
         SmartStreamKind::Map => self::map::generate_map_smartstream(func, config.has_params),
+        SmartStreamKind::FilterMap => {
+            self::filter_map::generate_filter_map_smartstream(func, config.has_params)
+        }
         SmartStreamKind::Aggregate => {
             self::aggregate::generate_aggregate_smartstream(func, config.has_params)
         }

--- a/crates/fluvio-smartstream/Cargo.toml
+++ b/crates/fluvio-smartstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartstream/Cargo.toml
+++ b/crates/fluvio-smartstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream"
-version = "0.3.1"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b462b453b9efd394e6d02017f600088d5475285a5efd3ecb3667cd1bdc54e6d"
+checksum = "d2645caef3993b4bcb8a4aa90da3546d993a9ce8a710acebb5fed588d4c2f1e7"
 dependencies = [
  "fluvio-wasm-timer",
  "fluvio_ws_stream_wasm",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -226,6 +226,13 @@ dependencies = [
  "fluvio-smartstream",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fluvio-wasm-filter-map"
+version = "0.1.0"
+dependencies = [
+ "fluvio-smartstream",
 ]
 
 [[package]]
@@ -588,9 +595,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -771,9 +778,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fluvio-smartstream/examples/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "array_map_json_array",
     "array_map_json_object",
     "array_map_json_reddit",
+    "filter_map",
 ]
 
 # lto is need to reduce wasm binary size

--- a/crates/fluvio-smartstream/examples/filter_map/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_map/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fluvio-wasm-filter-map"
+version = "0.1.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+edition = "2018"
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+fluvio-smartstream = { path = "../.." }

--- a/crates/fluvio-smartstream/examples/filter_map/src/lib.rs
+++ b/crates/fluvio-smartstream/examples/filter_map/src/lib.rs
@@ -1,0 +1,17 @@
+//! This SmartStream filters out all odd numbers, and divides all even numbers by 2.
+
+use fluvio_smartstream::{smartstream, Record, RecordData, Result};
+
+#[smartstream(filter_map)]
+pub fn filter_map(record: &Record) -> Result<Option<(Option<RecordData>, RecordData)>> {
+    let key = record.key.clone();
+    let string = String::from_utf8_lossy(record.value.as_ref()).to_string();
+    let int: i32 = string.parse()?;
+
+    if int % 2 == 0 {
+        let output = int / 2;
+        Ok(Some((key.clone(), RecordData::from(output.to_string()))))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -84,11 +84,13 @@ pub struct SmartStreamPayload {
 pub enum SmartStreamKind {
     Filter,
     Map,
-    #[fluvio(min_version = ARRAY_MAP_WASM_API)]
-    ArrayMap,
     Aggregate {
         accumulator: Vec<u8>,
     },
+    #[fluvio(min_version = ARRAY_MAP_WASM_API)]
+    ArrayMap,
+    #[fluvio(min_version = ARRAY_MAP_WASM_API)]
+    FilterMap,
 }
 
 impl Default for SmartStreamKind {

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -1923,6 +1923,100 @@ mod test {
     }
 
     #[fluvio_future::test(ignore)]
+    async fn test_stream_fetch_filter_map() {
+        let test_path = temp_dir().join("test_stream_fetch_filter_map");
+        ensure_clean_dir(&test_path);
+
+        let addr = "127.0.0.1:12011";
+        let mut spu_config = SpuConfig::default();
+        spu_config.log.base_dir = test_path;
+        let ctx = GlobalContext::new_shared_context(spu_config);
+
+        let server_end_event = create_public_server(addr.to_owned(), ctx.clone()).run();
+
+        // wait for stream controller async to start
+        sleep(Duration::from_millis(100)).await;
+
+        let client_socket =
+            MultiplexerSocket::shared(FluvioSocket::connect(addr).await.expect("connect"));
+
+        // perform for two versions
+        let topic = "test_filter_map";
+        let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
+        let test_id = test.id.clone();
+        let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+            .await
+            .expect("replica");
+        ctx.leaders_state().insert(test_id, replica.clone());
+
+        // Input: the following records:
+        //
+        // 11
+        // 22
+        // 33
+        // 44
+        // 55
+        let mut records = BatchProducer::builder()
+            .records(5u16)
+            .record_generator(Arc::new(|i, _| Record::new(((i + 1) * 11).to_string())))
+            .build()
+            .expect("batch")
+            .records();
+
+        replica
+            .write_record_set(&mut records, ctx.follower_notifier())
+            .await
+            .expect("write");
+
+        let wasm = load_wasm_module("fluvio_wasm_filter_map");
+        let wasm_payload = SmartStreamPayload {
+            wasm: SmartStreamWasm::Raw(wasm),
+            kind: SmartStreamKind::FilterMap,
+            ..Default::default()
+        };
+
+        let stream_request = DefaultStreamFetchRequest {
+            topic: topic.to_owned(),
+            partition: 0,
+            fetch_offset: 0,
+            isolation: Isolation::ReadUncommitted,
+            max_bytes: 10000,
+            wasm_module: Vec::new(),
+            wasm_payload: Some(wasm_payload),
+            ..Default::default()
+        };
+
+        let mut stream = client_socket
+            .create_stream(RequestMessage::new_request(stream_request), 11)
+            .await
+            .expect("create stream");
+
+        let response = stream
+            .next()
+            .await
+            .expect("should get response")
+            .expect("response should be Ok");
+
+        assert_eq!(response.partition.records.batches.len(), 1);
+        let batch = &response.partition.records.batches[0];
+        assert_eq!(batch.records().len(), 2);
+
+        // Output:
+        //
+        // 11 -> _
+        // 22 -> 11
+        // 33 -> _
+        // 44 -> 22
+        // 55 -> _
+        let records = batch.records();
+        assert_eq!(records[0].value, RecordData::from(11.to_string()));
+        assert_eq!(records[1].value, RecordData::from(22.to_string()));
+
+        server_end_event.notify();
+        debug!("terminated controller");
+    }
+
+    #[fluvio_future::test(ignore)]
     async fn test_stream_fetch_filter_with_params() {
         use std::collections::BTreeMap;
         let test_path = temp_dir().join("test_stream_fetch_filter");

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -183,6 +183,18 @@ impl StreamFetchHandler {
                     };
                     Box::new(map)
                 }
+                SmartStreamKind::FilterMap => {
+                    debug!("Instantiating SmartStreamFilterMap");
+                    let filter_map = module
+                        .create_filter_map(&sm_engine, payload.params)
+                        .map_err(|err| {
+                            SocketError::Io(IoError::new(
+                                ErrorKind::Other,
+                                format!("Failed to instantiate SmartStreamFilterMap {}", err),
+                            ))
+                        })?;
+                    Box::new(filter_map)
+                }
                 SmartStreamKind::ArrayMap => {
                     debug!("Instantiating SmartStreamArrayMap");
                     let array_map = match module.create_array_map(&sm_engine, payload.params) {

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -725,6 +725,20 @@ impl ConsumerConfigBuilder {
         self
     }
 
+    /// Adds a SmartStream filter_map to this ConsumerConfig
+    pub fn wasm_filter_map<T: Into<Vec<u8>>>(
+        &mut self,
+        filter_map: T,
+        params: BTreeMap<String, String>,
+    ) -> &mut Self {
+        self.wasm_module(SmartStreamPayload {
+            wasm: SmartStreamWasm::Raw(filter_map.into()),
+            kind: SmartStreamKind::FilterMap,
+            params: params.into(),
+        });
+        self
+    }
+
     /// Adds a SmartStream array_map to this ConsumerConfig
     pub fn wasm_array_map<T: Into<Vec<u8>>>(
         &mut self,


### PR DESCRIPTION
Closes https://github.com/infinyon/fluvio/issues/1826

Here is the implementation of filter-map. I am opening this as a Draft PR so it may be reviewed, I am currently finishing up the integration test for it.

This may be used with the `fluvio consume <topic> --filter-map=path/to/wasm` flag

The first example is in `crates/fluvio-smartstream/examples/filter-map/`