### PR TITLE
[Merged by Bors] - Add capability to create module from smartmodulespec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1849,6 +1849,8 @@ name = "fluvio-smartengine"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "flate2",
+ "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
  "fluvio-storage",

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2018"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -36,7 +36,7 @@ impl Default for SmartModuleSourceCodeLanguage {
 #[derive(Clone, Default, PartialEq, Encoder, Decoder)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SmartModuleWasm {
-    format: SmartModuleWasmFormat,
+    pub format: SmartModuleWasmFormat,
     #[cfg_attr(feature = "use_serde", serde(with = "base64"))]
     pub payload: Vec<u8>,
 }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+smartmodule = ["fluvio-controlplane-metadata", "flate2"]
+
 [dependencies]
 wasmtime = "0.30"
 nix = "0.23"
@@ -19,6 +22,8 @@ tracing = "0.1.27"
 anyhow = "1.0.38"
 fluvio-future = { version = "0.3.9", features = ["subscriber", "openssl_tls", "zero_copy"] }
 dataplane = { version = "0.7.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" , features=["file"]}
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", optional = true }
+flate2 = { version = "1.0", optional = true }
 
 [dev-dependencies]
 fluvio-storage = { path = "../fluvio-storage" }


### PR DESCRIPTION
This changes will remove the direct dependency to flate2 to create wasm_time modules

Fixes https://github.com/infinyon/fluvio/issues/1812