### PR TITLE
[Merged by Bors] - Removing crate check/publish for missing crates

### DIFF
--- a/release-scripts/publish-crates.sh
+++ b/release-scripts/publish-crates.sh
@@ -3,11 +3,9 @@
 set -eu
 
 PUBLISH_CRATES=(
-    fluvio-protocol-core
     fluvio-smartstream-derive
     fluvio-types
     fluvio-protocol-derive
-    fluvio-protocol-codec
     fluvio-protocol
     fluvio-dataplane-protocol
     fluvio-socket

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -3,13 +3,11 @@
 set -eu
 
 PUBLISH_CRATES=(
-    fluvio-protocol-core
     fluvio-smartstream
     fluvio-smartstream-derive
     #fluvio-smartstream-executor
     fluvio-types
     fluvio-protocol-derive
-    fluvio-protocol-codec
     fluvio-protocol
     fluvio-dataplane-protocol
     fluvio-socket


### PR DESCRIPTION
fluvio-protocol-core + fluvio-protocol-codec were consolidated in #1594

Their removal is the motivator of #1802, but this change is only to help the Release workflow pass. The most recent [workflow failure](https://github.com/infinyon/fluvio/runs/3980648905?check_suite_focus=true) is due to these crates missing in our repo.