### PR TITLE
Consumer table output update rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `#[smartstream(filter_map)]` for filtering and transforming at the same time. ([#1826](https://github.com/infinyon/fluvio/issues/1826))
 * Add table display output option to consumer for json objects ([#1642](https://github.com/infinyon/fluvio/issues/1642))
 * Streamlined Admin API ([#1803](https://github.com/infinyon/fluvio/issues/1803))
+* Update `fluvio consume <topic> --output=table` to render row updates over full terminal screen ([#1846](https://github.com/infinyon/fluvio/issues/1846))
 
 ## Platform Version 0.9.12 - 2021-10-27
 * Add examples for ArrayMap. ([#1804](https://github.com/infinyon/fluvio/issues/1804))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1023,56 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.8.0",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.9.0",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1514,6 +1570,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "content_inspector",
+ "crossterm 0.22.1",
  "ctrlc",
  "dirs 4.0.0",
  "eyre",
@@ -1548,6 +1605,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-futures",
+ "tui",
  "url",
  "which 4.2.2",
 ]
@@ -3142,6 +3200,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,6 +4985,19 @@ dependencies = [
  "serde_json",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "tui"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm 0.20.0",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
 dependencies = [
  "bitflags",
  "crossterm_winapi 0.9.0",
+ "futures-core",
  "libc",
  "mio",
  "parking_lot 0.11.2",
@@ -1585,6 +1586,7 @@ dependencies = [
  "fluvio-sc-schema",
  "fluvio-socket",
  "fluvio-types",
+ "futures",
  "handlebars",
  "hex",
  "home",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -63,8 +63,9 @@ colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = "1.0.22"
-crossterm = "0.22.1"
+crossterm = { version = "0.22.1", features = ['event-stream']}
 tui = { version = "0.16.0", default-features = false, features = ['crossterm'] }
+futures = "0.3"
 
 # Fluvio dependencies
 k8-config = { version = "1.3.0", optional = true }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -63,6 +63,8 @@ colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = "1.0.22"
+crossterm = "0.22.1"
+tui = { version = "0.16.0", default-features = false, features = ['crossterm'] }
 
 # Fluvio dependencies
 k8-config = { version = "1.3.0", optional = true }

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -343,17 +343,6 @@ impl ConsumeOpt {
                             &record,
                         );
 
-                        if let Some(ConsumeOutputType::table) = &self.output {
-                            // Exit handler
-                            // Need to handle signals in another thread. Crossbeam doesn't support
-                            if let Event::Key(key) = event::read()? {
-                                match key.code {
-                                    KeyCode::Char('q') => break,
-                                    _ => {}
-                                }
-                            }
-                        }
-
                     },
                     None => break,
                 },

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -28,7 +28,7 @@ use tui::Terminal;
 use tui::backend::CrosstermBackend;
 use tui::widgets::TableState;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode},
+    event::{DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, MouseEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -352,6 +352,14 @@ impl ConsumeOpt {
                                     KeyCode::Char('q')  => break,
                                     KeyCode::Down => view.next(),
                                     KeyCode::Up => view.previous(),
+                                    KeyCode::Home => view.first(),
+                                    KeyCode::End => view.last(),
+                                    _ => {}
+                                }
+                            } else if let Event::Mouse(event) = event {
+                                match event.kind {
+                                    MouseEventKind::ScrollDown => view.next(),
+                                    MouseEventKind::ScrollUp => view.previous(),
                                     _ => {}
                                 }
                             }
@@ -641,6 +649,13 @@ impl TableModel {
         self.headers.len()
     }
 
+    pub fn current_selected(&self) -> usize {
+        match self.state.selected() {
+            Some(i) => i,
+            None => 0,
+        }
+    }
+
     pub fn next(&mut self) {
         let i = match self.state.selected() {
             Some(i) => {
@@ -667,5 +682,13 @@ impl TableModel {
             None => 0,
         };
         self.state.select(Some(i));
+    }
+
+    pub fn first(&mut self) {
+        self.state.select(Some(0));
+    }
+
+    pub fn last(&mut self) {
+        self.state.select(Some(self.data.len() - 1));
     }
 }

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -7,8 +7,13 @@
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
 
 use std::io::Stdout;
-use tui::Terminal;
-use tui::backend::CrosstermBackend;
+use tui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, Table, TableState},
+    Frame, Terminal,
+};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
@@ -91,6 +96,7 @@ pub fn _format_table_record(_record: &[u8]) -> String {
 /// Print records in table format
 pub fn print_table_record(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    table_state: &mut TableState,
     record: &[u8],
 ) -> String {
     let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
@@ -130,7 +136,11 @@ pub fn print_table_record(
         })
         .collect();
 
-    //terminal.draw()
+    let header: Vec<&str> = keys_str.iter().map(|k| k.as_str()).collect();
+
+    terminal
+        .draw(|frame| ui(frame, table_state))
+        .expect("Could not render table frame");
 
     //let header: Row = Row::new(keys_str.iter().map(|k| cell!(k.to_owned())).collect());
     //let entries: Row = Row::new(values_str.iter().map(|v| Cell::new(v)).collect());
@@ -163,4 +173,48 @@ pub fn print_table_record(
 fn is_binary(bytes: &[u8]) -> bool {
     use content_inspector::{inspect, ContentType};
     matches!(inspect(bytes), ContentType::BINARY)
+}
+
+fn ui(f: &mut Frame<CrosstermBackend<Stdout>>, table_state: &mut TableState) {
+    let fake_data = vec![
+        vec!["Row11", "Row12", "Row13"],
+        vec!["Row21", "Row22", "Row23"],
+        vec!["Row31", "Row32", "Row33"],
+    ];
+
+    let rects = Layout::default()
+        .constraints([Constraint::Percentage(100)].as_ref())
+        .margin(5)
+        .split(f.size());
+
+    let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+    let normal_style = Style::default().bg(Color::Blue);
+    let header_cells = ["Header1", "Header2", "Header3"]
+        .iter()
+        .map(|h| Cell::from(*h).style(Style::default().fg(Color::Red)));
+    let header = Row::new(header_cells)
+        .style(normal_style)
+        .height(1)
+        .bottom_margin(1);
+    let rows = fake_data.iter().map(|item| {
+        let height = item
+            .iter()
+            .map(|content| content.chars().filter(|c| *c == '\n').count())
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let cells = item.iter().map(|c| Cell::from(*c));
+        Row::new(cells).height(height as u16).bottom_margin(1)
+    });
+    let t = Table::new(rows)
+        .header(header)
+        .block(Block::default().borders(Borders::ALL).title("Table"))
+        .highlight_style(selected_style)
+        .highlight_symbol(">> ")
+        .widths(&[
+            Constraint::Percentage(50),
+            Constraint::Length(30),
+            Constraint::Max(10),
+        ]);
+    f.render_stateful_widget(t, rects[0], table_state);
 }

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -98,6 +98,8 @@ pub fn _format_table_record(_record: &[u8]) -> String {
 pub fn print_table_record(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     table_view: &mut TableView,
+    // primary_key: Option<String>,
+    // column_order: Option<Vec<String>,
     record: &[u8],
 ) -> String {
     let maybe_json: serde_json::Value = match serde_json::from_slice(record) {

--- a/crates/fluvio-cli/src/consume/table_display.rs
+++ b/crates/fluvio-cli/src/consume/table_display.rs
@@ -114,7 +114,7 @@ impl TableModel {
                     self.data = Vec::new();
                     self.state.select(None);
                     TableEvent::InputHandled(user_input)
-                },
+                }
                 KeyCode::Up => {
                     self.previous();
                     TableEvent::InputHandled(user_input)
@@ -206,11 +206,10 @@ impl TableModel {
         });
         let t = Table::new(rows)
             .header(header)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(format!("Items: {} ('q' or ESC to exit)", self.data.len())),
-            )
+            .block(Block::default().borders(Borders::ALL).title(format!(
+                "('c' to clear table | 'q' or ESC to exit) | Items: {}",
+                self.data.len()
+            )))
             .highlight_style(selected_style)
             .highlight_symbol(selected_symbol.as_str())
             .widths(&column_constraints);

--- a/crates/fluvio-cli/src/consume/table_display.rs
+++ b/crates/fluvio-cli/src/consume/table_display.rs
@@ -110,6 +110,11 @@ impl TableModel {
         if let Event::Key(key) = user_input {
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
+                KeyCode::Char('c') => {
+                    self.data = Vec::new();
+                    self.state.select(None);
+                    TableEvent::InputHandled(user_input)
+                },
                 KeyCode::Up => {
                     self.previous();
                     TableEvent::InputHandled(user_input)

--- a/crates/fluvio-cli/src/consume/table_display.rs
+++ b/crates/fluvio-cli/src/consume/table_display.rs
@@ -1,0 +1,221 @@
+use crate::Result;
+use tui::widgets::TableState;
+use std::io::Stdout;
+use tui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, Table},
+    Frame, Terminal,
+};
+use crossterm::event::{Event, KeyCode, MouseEventKind};
+
+#[derive(Debug, Default, Clone)]
+pub struct TableModel {
+    pub state: TableState,
+    pub headers: Vec<String>,
+    pub data: Vec<Vec<String>>,
+    // primary key: set of keys to select when deciding to update table view: Default on 1st header key
+    // column display ordering rules: alphabetical, manual: Default alphabetical
+    // toggle for update-row vs append-row
+    // display-cache time?
+}
+
+impl TableModel {
+    // I think this should accept headers that don't exist in the data. Print empty columns
+    pub fn update_header(&mut self, headers: Vec<String>) -> Result<()> {
+        self.headers = headers;
+
+        Ok(())
+    }
+
+    // TODO: When we support manual column ordering
+    // I think this should accept headers that don't exist in the data. Just ignore the keys that don't exist. Don't error
+    //pub fn update_ordering(&mut self, headers: Vec<String>) -> Result<()> {}
+
+    // We should support a pure append-only workflow if we know that's what we want
+    //pub fn insert_row(&mut self, row: Vec<String>) -> Result<()> { }
+
+    // For now, this will look for the left-most column and if found, update that row
+    // Appends row if not found
+    // Issue: When we read in json data, it is sorted by key in alphanumeric order, so left-most will always be the alphabetical 1st
+    // This might cause issues w/r/t updates, since we treat 1st column as primary
+    pub fn update_row(&mut self, row: Vec<String>) -> Result<()> {
+        let mut found = None;
+
+        for (index, r) in self.data.iter().enumerate() {
+            if r[0] == row[0] {
+                found = Some(index);
+                break;
+            }
+        }
+
+        if let Some(row_index) = found {
+            self.data[row_index] = row;
+        } else {
+            self.data.push(row);
+        }
+
+        Ok(())
+    }
+
+    //TODO
+    //pub fn delete_row(&mut self, row_index: usize) -> Result<()> {}
+
+    pub fn num_columns(&self) -> usize {
+        self.headers.len()
+    }
+
+    pub fn current_selected(&self) -> usize {
+        self.state.selected().unwrap_or(0)
+    }
+
+    pub fn next(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i >= self.data.len() - 1 {
+                    0
+                } else {
+                    i + 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn previous(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i == 0 {
+                    self.data.len() - 1
+                } else {
+                    i - 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn first(&mut self) {
+        self.state.select(Some(0));
+    }
+
+    pub fn last(&mut self) {
+        self.state.select(Some(self.data.len() - 1));
+    }
+
+    pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
+        if let Event::Key(key) = user_input {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
+                KeyCode::Up => {
+                    self.previous();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::Down => {
+                    self.next();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::Home => {
+                    self.first();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::End => {
+                    self.last();
+                    TableEvent::InputHandled(user_input)
+                }
+                _ => TableEvent::InputIgnored(user_input),
+            }
+        } else if let Event::Mouse(event) = user_input {
+            match event.kind {
+                MouseEventKind::ScrollDown => {
+                    self.next();
+                    TableEvent::InputHandled(user_input)
+                }
+                MouseEventKind::ScrollUp => {
+                    self.previous();
+                    TableEvent::InputHandled(user_input)
+                }
+                _ => TableEvent::InputIgnored(user_input),
+            }
+        } else {
+            TableEvent::InputIgnored(user_input)
+        }
+    }
+
+    // This will take a full screen buffer
+    /// Print records in table format
+    ///
+    /// If you do not provide any column ordering, it will be alphabetized by the top-level keys
+    pub fn render(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+        // primary_key: Option<String>,
+        // column_order: Option<Vec<String>,
+        //record: &[u8],
+    ) {
+        terminal
+            .draw(|frame| self.table_ui(frame))
+            .expect("Could not render table frame");
+    }
+
+    pub fn table_ui(&mut self, f: &mut Frame<CrosstermBackend<Stdout>>) {
+        let rects = Layout::default()
+            .constraints([Constraint::Percentage(100)].as_ref())
+            .margin(5)
+            .split(f.size());
+
+        // Calculate the widths based on # of columns
+        let equal_column_width = (100 / self.num_columns()) as u16;
+
+        let mut column_constraints: Vec<Constraint> = Vec::new();
+
+        // Define the widths of the columns
+        for _ in 0..self.num_columns() {
+            column_constraints.push(Constraint::Percentage(equal_column_width));
+        }
+
+        let selected_symbol = format!("{} >> ", self.current_selected());
+
+        let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+        let normal_style = Style::default().bg(Color::Blue);
+        let header_cells = self
+            .headers
+            .iter()
+            .map(|h| Cell::from(h.as_str()).style(Style::default().fg(Color::Red)));
+        let header = Row::new(header_cells)
+            .style(normal_style)
+            .height(1)
+            .bottom_margin(1);
+        let rows = self.data.iter().map(|item| {
+            let height = item
+                .iter()
+                .map(|content| content.chars().filter(|c| *c == '\n').count())
+                .max()
+                .unwrap_or(0)
+                + 1;
+            let cells = item.iter().map(|c| Cell::from(c.as_str()));
+            Row::new(cells).height(height as u16).bottom_margin(1)
+        });
+        let t = Table::new(rows)
+            .header(header)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!("Items: {} ('q' or ESC to exit)", self.data.len())),
+            )
+            .highlight_style(selected_style)
+            .highlight_symbol(selected_symbol.as_str())
+            .widths(&column_constraints);
+        f.render_stateful_widget(t, rects[0], &mut self.state);
+    }
+}
+
+#[derive(Debug)]
+pub enum TableEvent {
+    InputHandled(Event),
+    InputIgnored(Event),
+    Terminate,
+}


### PR DESCRIPTION
Replace consumer output from using prettytable to tui. The row update is mandatory, and has no opt-out in this PR.

* Full screen table, exit with `q` or ESC (no ctrl+c in this PR)
* Evenly spaces columns based on number of keys
* Cell data clips (not wrap)
* First version alphabetizes the columns, and uses the 1st column as primary key for updating rows. No alternative ordering in this PR
* Scrolls with arrow up/down, and mouse wheel

Resolves #1846