### PR TITLE
[Merged by Bors] - Add consumer output type full_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add table display output option to consumer for json objects ([#1642](https://github.com/infinyon/fluvio/issues/1642))
 * Streamlined Admin API ([#1803](https://github.com/infinyon/fluvio/issues/1803))
 * Add SpuDirectory trait to Fluvio Client ([#1863](https://github.com/infinyon/fluvio/issues/1863))
+* Add `fluvio consume <topic> --output=full_table` to render row updates over fullscreen terminal screen ([#1846](https://github.com/infinyon/fluvio/issues/1846))
 
 ## Platform Version 0.9.12 - 2021-10-27
 * Add examples for ArrayMap. ([#1804](https://github.com/infinyon/fluvio/issues/1804))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,57 +1026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.8.0",
- "libc",
- "mio",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.9.0",
- "futures-core",
- "libc",
- "mio",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1520,6 @@ dependencies = [
  "color-eyre",
  "colored",
  "content_inspector",
- "crossterm 0.22.1",
  "ctrlc",
  "dirs 4.0.0",
  "eyre",
@@ -1604,6 +1552,7 @@ dependencies = [
  "structopt",
  "sysinfo",
  "tempdir",
+ "termion",
  "thiserror",
  "tracing",
  "tracing-futures",
@@ -3202,28 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3275,12 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -3965,6 +3898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.10",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,17 +4361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-mio"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4628,18 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.10",
+ "redox_termios",
 ]
 
 [[package]]
@@ -4997,7 +4940,7 @@ checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.20.0",
+ "termion",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.8.0",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.9.0",
+ "futures-core",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1571,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "content_inspector",
+ "crossterm 0.22.1",
  "ctrlc",
  "dirs 4.0.0",
  "eyre",
@@ -1552,7 +1604,6 @@ dependencies = [
  "structopt",
  "sysinfo",
  "tempdir",
- "termion",
  "thiserror",
  "tracing",
  "tracing-futures",
@@ -3151,6 +3202,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,12 +3348,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -3898,15 +3965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall 0.2.10",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4361,6 +4419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4628,18 +4697,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall 0.2.10",
- "redox_termios",
 ]
 
 [[package]]
@@ -4940,7 +4997,7 @@ checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
 dependencies = [
  "bitflags",
  "cassowary",
- "termion",
+ "crossterm 0.20.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1023,57 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.8.0",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.9.0",
+ "futures-core",
+ "libc",
+ "mio",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1514,6 +1571,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "content_inspector",
+ "crossterm 0.22.1",
  "ctrlc",
  "dirs 4.0.0",
  "eyre",
@@ -1528,6 +1586,7 @@ dependencies = [
  "fluvio-sc-schema",
  "fluvio-socket",
  "fluvio-types",
+ "futures",
  "handlebars",
  "hex",
  "home",
@@ -1548,6 +1607,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-futures",
+ "tui",
  "url",
  "which 4.2.2",
 ]
@@ -3142,6 +3202,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4337,6 +4419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,6 +4987,19 @@ dependencies = [
  "serde_json",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "tui"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm 0.20.0",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -63,9 +63,8 @@ colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = "1.0.22"
-#crossterm = { version = "0.22.1", features = ['event-stream']}
-termion = "1.5"
-tui = { version = "0.16.0", default-features = false, features = ['termion'] }
+crossterm = { version = "0.22.1", features = ['event-stream']}
+tui = { version = "0.16.0", default-features = false, features = ['crossterm'] }
 futures = "0.3"
 
 # Fluvio dependencies

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -63,6 +63,9 @@ colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = "1.0.22"
+crossterm = { version = "0.22.1", features = ['event-stream']}
+tui = { version = "0.16.0", default-features = false, features = ['crossterm'] }
+futures = "0.3"
 
 # Fluvio dependencies
 k8-config = { version = "1.3.0", optional = true }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -63,8 +63,9 @@ colored = "2"
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = "1.0.22"
-crossterm = { version = "0.22.1", features = ['event-stream']}
-tui = { version = "0.16.0", default-features = false, features = ['crossterm'] }
+#crossterm = { version = "0.22.1", features = ['event-stream']}
+termion = "1.5"
+tui = { version = "0.16.0", default-features = false, features = ['termion'] }
 futures = "0.3"
 
 # Fluvio dependencies

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -456,11 +456,7 @@ impl ConsumeOpt {
             (Some(ConsumeOutputType::full_table), None) => {
                 if let Some(term) = terminal {
                     if let Some(ref mut table) = table_model {
-                        Some(format_fancy_table_record(
-                            record.value(),
-                            term,
-                            table,
-                        ))
+                        Some(format_fancy_table_record(record.value(), term, table))
                     } else {
                         unreachable!()
                     }

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -5,7 +5,8 @@
 //!
 
 use std::{io::Error as IoError, path::PathBuf};
-use std::io::{self, ErrorKind, Read, Stdout};
+//use std::io::{self, ErrorKind, Read, Stdout};
+use std::io::{ErrorKind, Read};
 use std::collections::{BTreeMap};
 use flate2::Compression;
 use flate2::bufread::GzEncoder;
@@ -16,7 +17,7 @@ use fluvio_future::io::StreamExt;
 
 mod record_format;
 mod table_format;
-use table_format::TableModel;
+//use table_format::TableModel;
 
 use fluvio::{ConsumerConfig, Fluvio, FluvioError, MultiplePartitionConsumer, Offset};
 use fluvio_sc_schema::ApiError;
@@ -25,8 +26,8 @@ use fluvio::consumer::{
     SmartModuleInvocation, SmartModuleInvocationWasm, SmartStreamKind, SmartStreamInvocation,
 };
 
-use tui::Terminal;
-use tui::backend::CrosstermBackend;
+//use tui::Terminal;
+//use tui::backend::CrosstermBackend;
 //use crossterm::{
 //    event::{DisableMouseCapture, EnableMouseCapture, EventStream},
 //    execute,
@@ -36,8 +37,13 @@ use tui::backend::CrosstermBackend;
 use crate::{CliError, Result};
 use crate::common::FluvioExtensionMetadata;
 use self::record_format::{
-    format_text_record, format_binary_record, format_dynamic_record, format_raw_record,
-    format_json, format_basic_table_record, format_fancy_table_record,
+    format_text_record,
+    format_binary_record,
+    format_dynamic_record,
+    format_raw_record,
+    format_json,
+    format_basic_table_record,
+    //format_json, format_basic_table_record, format_fancy_table_record,
 };
 use handlebars::Handlebars;
 
@@ -301,8 +307,8 @@ impl ConsumeOpt {
             }
         };
 
-        let stdout = io::stdout();
-        let mut terminal_stdout = self.create_terminal(stdout)?;
+        //let stdout = io::stdout();
+        //let mut terminal_stdout = self.create_terminal(stdout)?;
 
         // This is used by table output, to manage printing the table titles only one time
         let mut header_print = true;
@@ -318,7 +324,7 @@ impl ConsumeOpt {
             };
 
             self.print_record(
-                &mut terminal_stdout,
+                //&mut terminal_stdout,
                 templates.as_ref(),
                 &record,
                 &mut header_print,
@@ -329,17 +335,17 @@ impl ConsumeOpt {
         Ok(())
     }
 
-    fn create_terminal(&self, stdout: Stdout) -> Result<Terminal<CrosstermBackend<Stdout>>> {
-        let backend = CrosstermBackend::new(stdout);
-        let terminal = Terminal::new(backend)?;
+    //fn create_terminal(&self, stdout: Stdout) -> Result<Terminal<CrosstermBackend<Stdout>>> {
+    //    let backend = CrosstermBackend::new(stdout);
+    //    let terminal = Terminal::new(backend)?;
 
-        Ok(terminal)
-    }
+    //    Ok(terminal)
+    //}
 
     /// Process fetch topic response based on output type
     pub fn print_record(
         &self,
-        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+        //terminal: &mut Terminal<CrosstermBackend<Stdout>>,
         templates: Option<&Handlebars>,
         record: &Record,
         header_print: &mut bool,
@@ -371,12 +377,13 @@ impl ConsumeOpt {
                 Some(value)
             }
             (Some(ConsumeOutputType::full_table), None) => {
-                let mut table_model = TableModel::default();
-                Some(format_fancy_table_record(
-                    record.value(),
-                    terminal,
-                    &mut table_model,
-                ))
+                Some(String::new())
+                //let mut table_model = TableModel::default();
+                //Some(format_fancy_table_record(
+                //    record.value(),
+                //    terminal,
+                //    &mut table_model,
+                //))
             }
             (_, Some(templates)) => {
                 let value = String::from_utf8_lossy(record.value()).to_string();

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -334,6 +334,7 @@ impl ConsumeOpt {
             (Some(ConsumeOutputType::table), None) => {
                 Some(print_table_record(record.value(), count))
             }
+            (Some(ConsumeOutputType::full_table), None) => Some(String::new()),
             (_, Some(templates)) => {
                 let value = String::from_utf8_lossy(record.value()).to_string();
                 let object = serde_json::json!({
@@ -490,6 +491,7 @@ arg_enum! {
         json,
         raw,
         table,
+        full_table,
     }
 }
 

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -5,8 +5,7 @@
 //!
 
 use std::{io::Error as IoError, path::PathBuf};
-//use std::io::{self, ErrorKind, Read, Stdout};
-use std::io::{ErrorKind, Read};
+use std::io::{self, ErrorKind, Read, Stdout};
 use std::collections::{BTreeMap};
 use flate2::Compression;
 use flate2::bufread::GzEncoder;
@@ -26,8 +25,8 @@ use fluvio::consumer::{
     SmartModuleInvocation, SmartModuleInvocationWasm, SmartStreamKind, SmartStreamInvocation,
 };
 
-//use tui::Terminal;
-//use tui::backend::CrosstermBackend;
+use tui::Terminal;
+use tui::backend::CrosstermBackend;
 //use crossterm::{
 //    event::{DisableMouseCapture, EnableMouseCapture, EventStream},
 //    execute,
@@ -307,8 +306,12 @@ impl ConsumeOpt {
             }
         };
 
-        //let stdout = io::stdout();
-        //let mut terminal_stdout = self.create_terminal(stdout)?;
+        let mut _maybe_terminal_stdout = if let Some(ConsumeOutputType::full_table) = &self.output {
+            let stdout = io::stdout();
+            Some(self.create_terminal(stdout)?)
+        } else {
+            None
+        };
 
         // This is used by table output, to manage printing the table titles only one time
         let mut header_print = true;
@@ -335,12 +338,12 @@ impl ConsumeOpt {
         Ok(())
     }
 
-    //fn create_terminal(&self, stdout: Stdout) -> Result<Terminal<CrosstermBackend<Stdout>>> {
-    //    let backend = CrosstermBackend::new(stdout);
-    //    let terminal = Terminal::new(backend)?;
+    fn create_terminal(&self, stdout: Stdout) -> Result<Terminal<CrosstermBackend<Stdout>>> {
+        let backend = CrosstermBackend::new(stdout);
+        let terminal = Terminal::new(backend)?;
 
-    //    Ok(terminal)
-    //}
+        Ok(terminal)
+    }
 
     /// Process fetch topic response based on output type
     pub fn print_record(

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -28,6 +28,7 @@ use fluvio::consumer::{
 
 use tui::Terminal;
 use tui::backend::CrosstermBackend;
+use crossterm::event::EventStream;
 //use crossterm::{
 //    event::{DisableMouseCapture, EnableMouseCapture, EventStream},
 //    execute,
@@ -311,6 +312,7 @@ impl ConsumeOpt {
 
         // This is used by table output, to manage printing the table titles only one time
         let mut header_print = true;
+        let mut user_input_reader = EventStream::new();
 
         loop {
             select! {
@@ -334,7 +336,21 @@ impl ConsumeOpt {
                         );
                     },
                     None => break,
-                }
+                },
+                maybe_event = user_input_reader.next().fuse() => {
+                    match maybe_event {
+                        Some(Ok(_event)) => {
+                            //if let Some(model) = maybe_table_model.as_mut() {
+                            //    match model.event_handler(event) {
+                            //        TableEvent::Terminate => break,
+                            //        _ => continue
+                            //    }
+                            //}
+                        }
+                        Some(Err(e)) => println!("Error: {:?}\r", e),
+                        None => break,
+                    }
+                },
             }
         }
 

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -454,14 +454,16 @@ impl ConsumeOpt {
                 Some(value)
             }
             (Some(ConsumeOutputType::full_table), None) => {
-                let mut table_model = TableModel::default();
-
                 if let Some(term) = terminal {
-                    Some(format_fancy_table_record(
-                        record.value(),
-                        term,
-                        &mut table_model,
-                    ))
+                    if let Some(ref mut table) = table_model {
+                        Some(format_fancy_table_record(
+                            record.value(),
+                            term,
+                            table,
+                        ))
+                    } else {
+                        unreachable!()
+                    }
                 } else {
                     unreachable!()
                 }

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -5,7 +5,7 @@
 //!
 
 use std::{io::Error as IoError, path::PathBuf};
-use std::io::{self, ErrorKind, Read};
+use std::io::{self, ErrorKind, Read, Stdout};
 use std::collections::{BTreeMap};
 use flate2::Compression;
 use flate2::bufread::GzEncoder;
@@ -26,16 +26,14 @@ use fluvio::consumer::{
     SmartModuleInvocation, SmartModuleInvocationWasm, SmartStreamKind, SmartStreamInvocation,
 };
 
-use tui::{Terminal, backend::TermionBackend};
-
-use termion::{
-    async_stdin,
-    input::{MouseTerminal, TermRead},
-    raw::{IntoRawMode, RawTerminal},
-    screen::AlternateScreen,
+use tui::Terminal;
+use tui::backend::CrosstermBackend;
+use crossterm::tty::IsTty;
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture, EventStream},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-
-type TuiBackend = TermionBackend<AlternateScreen<MouseTerminal<RawTerminal<std::io::Stdout>>>>;
 
 use crate::{CliError, Result};
 use crate::common::FluvioExtensionMetadata;
@@ -308,17 +306,16 @@ impl ConsumeOpt {
         // TableModel and Terminal for full_table rendering
         let mut maybe_table_model = None;
         let mut maybe_terminal_stdout = if let Some(ConsumeOutputType::full_table) = &self.output {
-            if termion::is_tty(&io::stdout()) {
-                //let stdout = io::stdout();
-                //enable_raw_mode()?;
-                //let mut stdout = io::stdout();
-                //execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+            if io::stdout().is_tty() {
+                enable_raw_mode()?;
+                let mut stdout = io::stdout();
+                execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
 
                 let model = TableModel::default();
                 maybe_table_model = Some(model);
 
-                //let stdout = io::stdout();
-                Some(self.create_terminal()?)
+                let stdout = io::stdout();
+                Some(self.create_terminal(stdout)?)
             } else {
                 None
             }
@@ -333,10 +330,9 @@ impl ConsumeOpt {
         // Without TTY, we panic when attempting to read from EventStream
         // In CI, we do not have a TTY, so we need this check to avoid reading EventStream
         // EventStream is only used by Tui+Crossterm to interact with table
-        if termion::is_tty(&io::stdout()) {
+        if io::stdout().is_tty() {
             // This needs to know if it is a tty before opening this
-            //let mut user_input_reader = EventStream::new();
-            let mut user_input_reader = async_stdin().events();
+            let mut user_input_reader = EventStream::new();
 
             loop {
                 select! {
@@ -362,17 +358,8 @@ impl ConsumeOpt {
                         },
                         None => break,
                     },
-                    maybe_event = async{user_input_reader.next()}.fuse() => {
+                    maybe_event = user_input_reader.next().fuse() => {
                         match maybe_event {
-                            //Some(Ok(event)) => {
-                            //    match event {
-                            //        Event::Key(Key::Char('q')) => {
-                            //            println!("flkdjflks");
-                            //            break
-                            //        },
-                            //        _ => {}
-                            //    }
-                            //},
                             Some(Ok(event)) => {
                                 if let Some(model) = maybe_table_model.as_mut() {
                                     match model.event_handler(event) {
@@ -382,7 +369,7 @@ impl ConsumeOpt {
                                 }
                             }
                             Some(Err(e)) => println!("Error: {:?}\r", e),
-                            None => {},
+                            None => break,
                         }
                     },
                 }
@@ -410,27 +397,24 @@ impl ConsumeOpt {
             }
         }
 
-        //if let Some(ConsumeOutputType::full_table) = &self.output {
-        //    if let Some(mut terminal_stdout) = maybe_terminal_stdout {
-        //        //disable_raw_mode()?;
-        //        //execute!(
-        //        //    terminal_stdout.backend_mut(),
-        //        //    LeaveAlternateScreen,
-        //        //    DisableMouseCapture
-        //        //)?;
-        //        //terminal_stdout.show_cursor()?;
-        //    }
-        //}
+        if let Some(ConsumeOutputType::full_table) = &self.output {
+            if let Some(mut terminal_stdout) = maybe_terminal_stdout {
+                disable_raw_mode()?;
+                execute!(
+                    terminal_stdout.backend_mut(),
+                    LeaveAlternateScreen,
+                    DisableMouseCapture
+                )?;
+                terminal_stdout.show_cursor()?;
+            }
+        }
 
         debug!("fetch loop exited");
         Ok(())
     }
 
-    fn create_terminal(&self) -> Result<Terminal<TuiBackend>> {
-        let stdout = io::stdout().into_raw_mode()?;
-        let stdout = MouseTerminal::from(stdout);
-        let stdout = AlternateScreen::from(stdout);
-        let backend = TermionBackend::new(stdout);
+    fn create_terminal(&self, stdout: Stdout) -> Result<Terminal<CrosstermBackend<Stdout>>> {
+        let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend)?;
 
         Ok(terminal)
@@ -442,7 +426,7 @@ impl ConsumeOpt {
         templates: Option<&Handlebars>,
         record: &Record,
         header_print: &mut bool,
-        terminal: &mut Option<Terminal<TuiBackend>>,
+        terminal: &mut Option<Terminal<CrosstermBackend<Stdout>>>,
         table_model: &mut Option<TableModel>,
     ) {
         let formatted_key = record

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -454,15 +454,11 @@ impl ConsumeOpt {
                     *header_print = false;
                 }
 
-                Some(value)
+                value
             }
             (Some(ConsumeOutputType::full_table), None) => {
-                if let Some(term) = terminal {
-                    if let Some(ref mut table) = table_model {
-                        Some(format_fancy_table_record(record.value(), term, table))
-                    } else {
-                        unreachable!()
-                    }
+                if let Some(ref mut table) = table_model {
+                    format_fancy_table_record(record.value(), table)
                 } else {
                     unreachable!()
                 }

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -79,10 +79,12 @@ pub fn format_raw_record(record: &[u8]) -> String {
 }
 
 // -----------------------------------
-//  Table
+//  Table (basic table)
 // -----------------------------------
 
-/// Structure json data in table format
+/// Structure json data into table row
+/// Print table header if `print_header` is true
+/// Rows may not stay aligned with table header
 pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     use prettytable::{Row, cell, Cell, Slice};
     use prettytable::format::{self, FormatBuilder};
@@ -124,11 +126,6 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     let table_format = base_format;
     table.set_format(table_format.build());
 
-    // FIXME: Live display of table data easily misaligns column widths
-    // if there is a length diff between the header and the data
-    // The rows after the first (count == 0) don't line up with the header
-    // prettytable might not support the live display use-case we want
-
     let mut out = Vec::new();
     if print_header {
         table.print(&mut out).expect("Unable to print table");
@@ -140,6 +137,13 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     format!("{}", String::from_utf8_lossy(&out))
 }
 
+// -----------------------------------
+//  Full Table (fullscreen interactive table)
+// -----------------------------------
+
+/// Updates the TableModel used to render the TUI table during `TableModel::render()`
+/// Attempts to update relevant rows, but appends to table if the primary key doesn't exist
+/// Returned String is not intended to be used
 pub fn format_fancy_table_record(
     record: &[u8],
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -5,15 +5,15 @@
 //!
 
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
-use super::TableModel;
-
-use std::io::Stdout;
-use tui::{backend::CrosstermBackend, Terminal};
-use crossterm::{
-    event::DisableMouseCapture,
-    execute,
-    terminal::{disable_raw_mode, LeaveAlternateScreen},
-};
+//use super::TableModel;
+//
+//use std::io::Stdout;
+//use tui::{backend::CrosstermBackend, Terminal};
+//use crossterm::{
+//    event::DisableMouseCapture,
+//    execute,
+//    terminal::{disable_raw_mode, LeaveAlternateScreen},
+//};
 
 // -----------------------------------
 //  JSON
@@ -140,55 +140,55 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     format!("{}", String::from_utf8_lossy(&out))
 }
 
-pub fn format_fancy_table_record(
-    record: &[u8],
-    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-    table_model: &mut TableModel,
-) -> String {
-    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
-        Ok(value) => value,
-        Err(_e) => {
-            // restore terminal
-            disable_raw_mode().expect("Disabling raw mode failed");
-            execute!(
-                terminal.backend_mut(),
-                LeaveAlternateScreen,
-                DisableMouseCapture
-            )
-            .expect("Failed to leave alternate screen");
-            terminal.show_cursor().expect("Show terminal cursor failed");
-
-            panic!("Value not json")
-        }
-    };
-
-    let obj = maybe_json.as_object().unwrap();
-    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
-
-    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
-    let values_str: Vec<String> = obj
-        .values()
-        .map(|v| {
-            if v.is_string() {
-                v.as_str()
-                    .expect("Value not representable as str")
-                    .to_string()
-            } else {
-                v.to_string()
-            }
-        })
-        .collect();
-
-    let header = keys_str;
-    table_model
-        .update_header(header)
-        .expect("Unable to set table headers");
-    table_model
-        .update_row(values_str)
-        .expect("Unable to update table row");
-
-    String::new()
-}
+//pub fn format_fancy_table_record(
+//    record: &[u8],
+//    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+//    table_model: &mut TableModel,
+//) -> String {
+//    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
+//        Ok(value) => value,
+//        Err(_e) => {
+//            // restore terminal
+//            disable_raw_mode().expect("Disabling raw mode failed");
+//            execute!(
+//                terminal.backend_mut(),
+//                LeaveAlternateScreen,
+//                DisableMouseCapture
+//            )
+//            .expect("Failed to leave alternate screen");
+//            terminal.show_cursor().expect("Show terminal cursor failed");
+//
+//            panic!("Value not json")
+//        }
+//    };
+//
+//    let obj = maybe_json.as_object().unwrap();
+//    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
+//
+//    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
+//    let values_str: Vec<String> = obj
+//        .values()
+//        .map(|v| {
+//            if v.is_string() {
+//                v.as_str()
+//                    .expect("Value not representable as str")
+//                    .to_string()
+//            } else {
+//                v.to_string()
+//            }
+//        })
+//        .collect();
+//
+//    let header = keys_str;
+//    table_model
+//        .update_header(header)
+//        .expect("Unable to set table headers");
+//    table_model
+//        .update_row(values_str)
+//        .expect("Unable to update table row");
+//
+//    String::new()
+//}
 
 // -----------------------------------
 //  Utilities

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -7,14 +7,6 @@
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
 use super::TableModel;
 
-use std::io::Stdout;
-use tui::{backend::CrosstermBackend, Terminal};
-use crossterm::{
-    event::DisableMouseCapture,
-    execute,
-    terminal::{disable_raw_mode, LeaveAlternateScreen},
-};
-
 // -----------------------------------
 //  JSON
 // -----------------------------------

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -5,15 +5,15 @@
 //!
 
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
-//use super::TableModel;
-//
-//use std::io::Stdout;
-//use tui::{backend::CrosstermBackend, Terminal};
-//use crossterm::{
-//    event::DisableMouseCapture,
-//    execute,
-//    terminal::{disable_raw_mode, LeaveAlternateScreen},
-//};
+use super::TableModel;
+
+use std::io::Stdout;
+use tui::{backend::CrosstermBackend, Terminal};
+use crossterm::{
+    event::DisableMouseCapture,
+    execute,
+    terminal::{disable_raw_mode, LeaveAlternateScreen},
+};
 
 // -----------------------------------
 //  JSON
@@ -140,55 +140,55 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     format!("{}", String::from_utf8_lossy(&out))
 }
 
-//pub fn format_fancy_table_record(
-//    record: &[u8],
-//    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-//    table_model: &mut TableModel,
-//) -> String {
-//    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
-//        Ok(value) => value,
-//        Err(_e) => {
-//            // restore terminal
-//            disable_raw_mode().expect("Disabling raw mode failed");
-//            execute!(
-//                terminal.backend_mut(),
-//                LeaveAlternateScreen,
-//                DisableMouseCapture
-//            )
-//            .expect("Failed to leave alternate screen");
-//            terminal.show_cursor().expect("Show terminal cursor failed");
-//
-//            panic!("Value not json")
-//        }
-//    };
-//
-//    let obj = maybe_json.as_object().unwrap();
-//    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
-//
-//    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
-//    let values_str: Vec<String> = obj
-//        .values()
-//        .map(|v| {
-//            if v.is_string() {
-//                v.as_str()
-//                    .expect("Value not representable as str")
-//                    .to_string()
-//            } else {
-//                v.to_string()
-//            }
-//        })
-//        .collect();
-//
-//    let header = keys_str;
-//    table_model
-//        .update_header(header)
-//        .expect("Unable to set table headers");
-//    table_model
-//        .update_row(values_str)
-//        .expect("Unable to update table row");
-//
-//    String::new()
-//}
+pub fn format_fancy_table_record(
+    record: &[u8],
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    table_model: &mut TableModel,
+) -> String {
+    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
+        Ok(value) => value,
+        Err(_e) => {
+            // restore terminal
+            disable_raw_mode().expect("Disabling raw mode failed");
+            execute!(
+                terminal.backend_mut(),
+                LeaveAlternateScreen,
+                DisableMouseCapture
+            )
+            .expect("Failed to leave alternate screen");
+            terminal.show_cursor().expect("Show terminal cursor failed");
+
+            panic!("Value not json")
+        }
+    };
+
+    let obj = maybe_json.as_object().unwrap();
+    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
+
+    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
+    let values_str: Vec<String> = obj
+        .values()
+        .map(|v| {
+            if v.is_string() {
+                v.as_str()
+                    .expect("Value not representable as str")
+                    .to_string()
+            } else {
+                v.to_string()
+            }
+        })
+        .collect();
+
+    let header = keys_str;
+    table_model
+        .update_header(header)
+        .expect("Unable to set table headers");
+    table_model
+        .update_row(values_str)
+        .expect("Unable to update table row");
+
+    String::new()
+}
 
 // -----------------------------------
 //  Utilities

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -100,9 +100,12 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> Option<St
         .values()
         .map(|v| {
             if v.is_string() {
-                v.as_str()
-                    .expect("Value not representable as str")
-                    .to_string()
+                if let Some(s) = v.as_str() {
+                    s.to_string()
+                } else {
+                    println!("error: Value in json not representable as str");
+                    String::new()
+                }
             } else {
                 v.to_string()
             }
@@ -160,9 +163,12 @@ pub fn format_fancy_table_record(record: &[u8], table_model: &mut TableModel) ->
         .values()
         .map(|v| {
             if v.is_string() {
-                v.as_str()
-                    .expect("Value not representable as str")
-                    .to_string()
+                if let Some(s) = v.as_str() {
+                    s.to_string()
+                } else {
+                    println!("error: Value in json not representable as str");
+                    String::new()
+                }
             } else {
                 v.to_string()
             }

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -73,8 +73,8 @@ pub fn format_raw_record(record: &[u8]) -> String {
 //  Table
 // -----------------------------------
 
-/// Print records in table format
-pub fn print_table_record(record: &[u8], count: i32) -> String {
+/// Structure json data in table format
+pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
     use prettytable::{Row, cell, Cell, Slice};
     use prettytable::format::{self, FormatBuilder};
 
@@ -119,13 +119,16 @@ pub fn print_table_record(record: &[u8], count: i32) -> String {
     // if there is a length diff between the header and the data
     // The rows after the first (count == 0) don't line up with the header
     // prettytable might not support the live display use-case we want
-    if count == 0 {
-        table.printstd();
+
+    let mut out = Vec::new();
+    if print_header {
+        table.print(&mut out).expect("Unable to print table");
     } else {
         let slice = table.slice(1..);
-        slice.printstd();
+        slice.print(&mut out).expect("Unable to print row");
     }
-    format!("")
+
+    format!("{}", String::from_utf8_lossy(&out))
 }
 // -----------------------------------
 //  Utilities

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -89,7 +89,12 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> Option<St
         }
     };
 
-    let obj = maybe_json.as_object().unwrap();
+    let obj = if let Some(obj) = maybe_json.as_object() {
+        obj
+    } else {
+        println!("error: Unable to parse json as object map");
+        return None;
+    };
 
     // This is the case where we don't provide any table info. We want to print a table w/ all top-level keys as headers
     // Think about how we might only select specific keys
@@ -155,7 +160,13 @@ pub fn format_fancy_table_record(record: &[u8], table_model: &mut TableModel) ->
         }
     };
 
-    let obj = maybe_json.as_object().unwrap();
+    let obj = if let Some(obj) = maybe_json.as_object() {
+        obj
+    } else {
+        println!("error: Unable to parse json as object map");
+        return None;
+    };
+
     let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
 
     // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`

--- a/crates/fluvio-cli/src/consume/record_format.rs
+++ b/crates/fluvio-cli/src/consume/record_format.rs
@@ -5,6 +5,15 @@
 //!
 
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
+use super::TableModel;
+
+use std::io::Stdout;
+use tui::{backend::CrosstermBackend, Terminal};
+use crossterm::{
+    event::DisableMouseCapture,
+    execute,
+    terminal::{disable_raw_mode, LeaveAlternateScreen},
+};
 
 // -----------------------------------
 //  JSON
@@ -130,6 +139,57 @@ pub fn format_basic_table_record(record: &[u8], print_header: bool) -> String {
 
     format!("{}", String::from_utf8_lossy(&out))
 }
+
+pub fn format_fancy_table_record(
+    record: &[u8],
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    table_model: &mut TableModel,
+) -> String {
+    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
+        Ok(value) => value,
+        Err(_e) => {
+            // restore terminal
+            disable_raw_mode().expect("Disabling raw mode failed");
+            execute!(
+                terminal.backend_mut(),
+                LeaveAlternateScreen,
+                DisableMouseCapture
+            )
+            .expect("Failed to leave alternate screen");
+            terminal.show_cursor().expect("Show terminal cursor failed");
+
+            panic!("Value not json")
+        }
+    };
+
+    let obj = maybe_json.as_object().unwrap();
+    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
+
+    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
+    let values_str: Vec<String> = obj
+        .values()
+        .map(|v| {
+            if v.is_string() {
+                v.as_str()
+                    .expect("Value not representable as str")
+                    .to_string()
+            } else {
+                v.to_string()
+            }
+        })
+        .collect();
+
+    let header = keys_str;
+    table_model
+        .update_header(header)
+        .expect("Unable to set table headers");
+    table_model
+        .update_row(values_str)
+        .expect("Unable to update table row");
+
+    String::new()
+}
+
 // -----------------------------------
 //  Utilities
 // -----------------------------------

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -90,7 +90,7 @@ pub struct TableModel {
 
 impl TableModel {
     // I think this should accept headers that don't exist in the data. Print empty columns
-    pub fn update_header(&mut self, headers: Vec<String>) -> Result<()> {
+    pub fn _update_header(&mut self, headers: Vec<String>) -> Result<()> {
         self.headers = headers;
 
         Ok(())
@@ -107,7 +107,7 @@ impl TableModel {
     // Appends row if not found
     // Issue: When we read in json data, it is sorted by key in alphanumeric order, so left-most will always be the alphabetical 1st
     // This might cause issues w/r/t updates, since we treat 1st column as primary
-    pub fn update_row(&mut self, row: Vec<String>) -> Result<()> {
+    pub fn _update_row(&mut self, row: Vec<String>) -> Result<()> {
         let mut found = None;
 
         for (index, r) in self.data.iter().enumerate() {

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -181,9 +181,9 @@ impl TableModel {
         // column_order: Option<Vec<String>,
         //record: &[u8],
     ) {
-        terminal
-            .draw(|frame| self.table_ui(frame))
-            .expect("Could not render table frame");
+        if terminal.draw(|frame| self.table_ui(frame)).is_err() {
+            println!("Could not render table frame")
+        }
     }
 
     /// Render the frame for the table

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -64,3 +64,229 @@
 // -----------------------------------
 //  Utilities
 // -----------------------------------
+
+use crate::Result;
+use tui::widgets::TableState;
+//use std::io::Stdout;
+//use tui::{
+//    backend::CrosstermBackend,
+//    layout::{Constraint, Layout},
+//    style::{Color, Modifier, Style},
+//    widgets::{Block, Borders, Cell, Row, Table},
+//    Frame, Terminal,
+//};
+//use crossterm::event::{Event, KeyCode, MouseEventKind};
+
+#[derive(Debug, Default, Clone)]
+pub struct TableModel {
+    pub state: TableState,
+    pub headers: Vec<String>,
+    pub data: Vec<Vec<String>>,
+    // primary key: set of keys to select when deciding to update table view: Default on 1st header key
+    // column display ordering rules: alphabetical, manual: Default alphabetical
+    // toggle for update-row vs append-row
+    // display-cache time?
+}
+
+impl TableModel {
+    // I think this should accept headers that don't exist in the data. Print empty columns
+    pub fn update_header(&mut self, headers: Vec<String>) -> Result<()> {
+        self.headers = headers;
+
+        Ok(())
+    }
+
+    // TODO: When we support manual column ordering
+    // I think this should accept headers that don't exist in the data. Just ignore the keys that don't exist. Don't error
+    //pub fn update_ordering(&mut self, headers: Vec<String>) -> Result<()> {}
+
+    // We should support a pure append-only workflow if we know that's what we want
+    //pub fn insert_row(&mut self, row: Vec<String>) -> Result<()> { }
+
+    // For now, this will look for the left-most column and if found, update that row
+    // Appends row if not found
+    // Issue: When we read in json data, it is sorted by key in alphanumeric order, so left-most will always be the alphabetical 1st
+    // This might cause issues w/r/t updates, since we treat 1st column as primary
+    pub fn update_row(&mut self, row: Vec<String>) -> Result<()> {
+        let mut found = None;
+
+        for (index, r) in self.data.iter().enumerate() {
+            if r[0] == row[0] {
+                found = Some(index);
+                break;
+            }
+        }
+
+        if let Some(row_index) = found {
+            self.data[row_index] = row;
+        } else {
+            self.data.push(row);
+        }
+
+        Ok(())
+    }
+
+    //TODO
+    //pub fn delete_row(&mut self, row_index: usize) -> Result<()> {}
+
+    //pub fn num_columns(&self) -> usize {
+    //    self.headers.len()
+    //}
+
+    //pub fn current_selected(&self) -> usize {
+    //    self.state.selected().unwrap_or(0)
+    //}
+
+    //pub fn next(&mut self) {
+    //    let i = match self.state.selected() {
+    //        Some(i) => {
+    //            if i >= self.data.len() - 1 {
+    //                0
+    //            } else {
+    //                i + 1
+    //            }
+    //        }
+    //        None => 0,
+    //    };
+    //    self.state.select(Some(i));
+    //}
+
+    //pub fn previous(&mut self) {
+    //    let i = match self.state.selected() {
+    //        Some(i) => {
+    //            if i == 0 {
+    //                self.data.len() - 1
+    //            } else {
+    //                i - 1
+    //            }
+    //        }
+    //        None => 0,
+    //    };
+    //    self.state.select(Some(i));
+    //}
+
+    //pub fn first(&mut self) {
+    //    self.state.select(Some(0));
+    //}
+
+    //pub fn last(&mut self) {
+    //    self.state.select(Some(self.data.len() - 1));
+    //}
+
+    //pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
+    //    if let Event::Key(key) = user_input {
+    //        match key.code {
+    //            KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
+    //            KeyCode::Char('c') => {
+    //                self.data = Vec::new();
+    //                self.state.select(None);
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            KeyCode::Up => {
+    //                self.previous();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            KeyCode::Down => {
+    //                self.next();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            KeyCode::Home => {
+    //                self.first();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            KeyCode::End => {
+    //                self.last();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            _ => TableEvent::InputIgnored(user_input),
+    //        }
+    //    } else if let Event::Mouse(event) = user_input {
+    //        match event.kind {
+    //            MouseEventKind::ScrollDown => {
+    //                self.next();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            MouseEventKind::ScrollUp => {
+    //                self.previous();
+    //                TableEvent::InputHandled(user_input)
+    //            }
+    //            _ => TableEvent::InputIgnored(user_input),
+    //        }
+    //    } else {
+    //        TableEvent::InputIgnored(user_input)
+    //    }
+    //}
+
+    //// This will take a full screen buffer
+    ///// Print records in table format
+    /////
+    ///// If you do not provide any column ordering, it will be alphabetized by the top-level keys
+    //pub fn render(
+    //    &mut self,
+    //    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    //    // primary_key: Option<String>,
+    //    // column_order: Option<Vec<String>,
+    //    //record: &[u8],
+    //) {
+    //    terminal
+    //        .draw(|frame| self.table_ui(frame))
+    //        .expect("Could not render table frame");
+    //}
+
+    //pub fn table_ui(&mut self, f: &mut Frame<CrosstermBackend<Stdout>>) {
+    //    let rects = Layout::default()
+    //        .constraints([Constraint::Percentage(100)].as_ref())
+    //        .margin(5)
+    //        .split(f.size());
+
+    //    // Calculate the widths based on # of columns
+    //    let equal_column_width = (100 / self.num_columns()) as u16;
+
+    //    let mut column_constraints: Vec<Constraint> = Vec::new();
+
+    //    // Define the widths of the columns
+    //    for _ in 0..self.num_columns() {
+    //        column_constraints.push(Constraint::Percentage(equal_column_width));
+    //    }
+
+    //    let selected_symbol = format!("{} >> ", self.current_selected());
+
+    //    let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+    //    let normal_style = Style::default().bg(Color::Blue);
+    //    let header_cells = self
+    //        .headers
+    //        .iter()
+    //        .map(|h| Cell::from(h.as_str()).style(Style::default().fg(Color::Red)));
+    //    let header = Row::new(header_cells)
+    //        .style(normal_style)
+    //        .height(1)
+    //        .bottom_margin(1);
+    //    let rows = self.data.iter().map(|item| {
+    //        let height = item
+    //            .iter()
+    //            .map(|content| content.chars().filter(|c| *c == '\n').count())
+    //            .max()
+    //            .unwrap_or(0)
+    //            + 1;
+    //        let cells = item.iter().map(|c| Cell::from(c.as_str()));
+    //        Row::new(cells).height(height as u16).bottom_margin(1)
+    //    });
+    //    let t = Table::new(rows)
+    //        .header(header)
+    //        .block(Block::default().borders(Borders::ALL).title(format!(
+    //            "('c' to clear table | 'q' or ESC to exit) | Items: {}",
+    //            self.data.len()
+    //        )))
+    //        .highlight_style(selected_style)
+    //        .highlight_symbol(selected_symbol.as_str())
+    //        .widths(&column_constraints);
+    //    f.render_stateful_widget(t, rects[0], &mut self.state);
+    //}
+}
+
+//#[derive(Debug)]
+//pub enum TableEvent {
+//    InputHandled(Event),
+//    InputIgnored(Event),
+//    Terminate,
+//}

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -1,68 +1,5 @@
 // -----------------------------------
-//  Basic Table
-// -----------------------------------
-
-///// Print records in text-based table format
-//pub fn print_table_record(record: &[u8], count: i32) -> String {
-//    use prettytable::{Row, cell, Cell, Slice};
-//    use prettytable::format::{self, FormatBuilder};
-//
-//    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
-//        Ok(value) => value,
-//        Err(_e) => panic!("Value not json"),
-//    };
-//
-//    let obj = maybe_json.as_object().unwrap();
-//
-//    // This is the case where we don't provide any table info. We want to print a table w/ all top-level keys as headers
-//    // Think about how we might only select specific keys
-//    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
-//
-//    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
-//    let values_str: Vec<String> = obj
-//        .values()
-//        .map(|v| {
-//            if v.is_string() {
-//                v.as_str()
-//                    .expect("Value not representable as str")
-//                    .to_string()
-//            } else {
-//                v.to_string()
-//            }
-//        })
-//        .collect();
-//
-//    let header: Row = Row::new(keys_str.iter().map(|k| cell!(k.to_owned())).collect());
-//    let entries: Row = Row::new(values_str.iter().map(|v| Cell::new(v)).collect());
-//
-//    // Print the table
-//    let t_print = vec![header, entries];
-//
-//    let mut table = prettytable::Table::init(t_print);
-//
-//    let base_format: FormatBuilder = (*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR).into();
-//    let table_format = base_format;
-//    table.set_format(table_format.build());
-//
-//    // FIXME: Live display of table data easily misaligns column widths
-//    // if there is a length diff between the header and the data
-//    // The rows after the first (count == 0) don't line up with the header
-//    // prettytable might not support the live display use-case we want
-//    if count == 0 {
-//        table.printstd();
-//    } else {
-//        let slice = table.slice(1..);
-//        slice.printstd();
-//    }
-//    format!("")
-//}
-
-// -----------------------------------
-//  Fancy Table
-// -----------------------------------
-
-// -----------------------------------
-//  Utilities
+//  Full Table
 // -----------------------------------
 
 use crate::Result;
@@ -129,14 +66,17 @@ impl TableModel {
     //TODO
     //pub fn delete_row(&mut self, row_index: usize) -> Result<()> {}
 
+    /// Return number of rows in cache
     pub fn num_columns(&self) -> usize {
         self.headers.len()
     }
 
+    /// Return the row selected
     pub fn current_selected(&self) -> usize {
         self.state.selected().unwrap_or(0)
     }
 
+    /// Select next row from current selection. Wrap to top
     pub fn next(&mut self) {
         if !self.data.is_empty() {
             let i = match self.state.selected() {
@@ -153,6 +93,7 @@ impl TableModel {
         }
     }
 
+    /// Select previous row from current selection. Wrap to bottom.
     pub fn previous(&mut self) {
         if !self.data.is_empty() {
             let i = match self.state.selected() {
@@ -169,59 +110,63 @@ impl TableModel {
         }
     }
 
+    /// Select first row in data
     pub fn first(&mut self) {
         if !self.data.is_empty() {
             self.state.select(Some(0));
         }
     }
 
+    /// Select last row in data
     pub fn last(&mut self) {
         if !self.data.is_empty() {
             self.state.select(Some(self.data.len() - 1));
         }
     }
 
-    pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
+    /// Takes in `user_input` and handles the side-effect, (except for exiting table)
+    /// Returns the appropriate `TableEventResponse`
+    pub fn event_handler(&mut self, user_input: Event) -> TableEventResponse {
         if let Event::Key(key) = user_input {
             match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
+                KeyCode::Char('q') | KeyCode::Esc => TableEventResponse::Terminate,
                 KeyCode::Char('c') => {
                     self.data = Vec::new();
                     self.state.select(None);
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
                 KeyCode::Up => {
                     self.previous();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
                 KeyCode::Down => {
                     self.next();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
                 KeyCode::Home => {
                     self.first();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
                 KeyCode::End => {
                     self.last();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
-                _ => TableEvent::InputIgnored(user_input),
+                _ => TableEventResponse::InputIgnored(user_input),
             }
         } else if let Event::Mouse(event) = user_input {
             match event.kind {
                 MouseEventKind::ScrollDown => {
                     self.next();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
                 MouseEventKind::ScrollUp => {
                     self.previous();
-                    TableEvent::InputHandled(user_input)
+                    TableEventResponse::InputHandled(user_input)
                 }
-                _ => TableEvent::InputIgnored(user_input),
+                _ => TableEventResponse::InputIgnored(user_input),
             }
         } else {
-            TableEvent::InputIgnored(user_input)
+            TableEventResponse::InputIgnored(user_input)
         }
     }
 
@@ -241,6 +186,8 @@ impl TableModel {
             .expect("Could not render table frame");
     }
 
+    /// Render the frame for the table
+    /// Re-calculates the table frame so it can be drawn on screen
     pub fn table_ui(&mut self, f: &mut Frame<CrosstermBackend<Stdout>>) {
         let rects = Layout::default()
             .constraints([Constraint::Percentage(100)].as_ref())
@@ -298,8 +245,9 @@ impl TableModel {
     }
 }
 
+/// Return response from user input on TUI table
 #[derive(Debug)]
-pub enum TableEvent {
+pub enum TableEventResponse {
     InputHandled(Event),
     InputIgnored(Event),
     Terminate,

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -90,7 +90,7 @@ pub struct TableModel {
 
 impl TableModel {
     // I think this should accept headers that don't exist in the data. Print empty columns
-    pub fn _update_header(&mut self, headers: Vec<String>) -> Result<()> {
+    pub fn update_header(&mut self, headers: Vec<String>) -> Result<()> {
         self.headers = headers;
 
         Ok(())
@@ -107,7 +107,7 @@ impl TableModel {
     // Appends row if not found
     // Issue: When we read in json data, it is sorted by key in alphanumeric order, so left-most will always be the alphabetical 1st
     // This might cause issues w/r/t updates, since we treat 1st column as primary
-    pub fn _update_row(&mut self, row: Vec<String>) -> Result<()> {
+    pub fn update_row(&mut self, row: Vec<String>) -> Result<()> {
         let mut found = None;
 
         for (index, r) in self.data.iter().enumerate() {

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -138,39 +138,47 @@ impl TableModel {
     }
 
     pub fn next(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i >= self.data.len() - 1 {
-                    0
-                } else {
-                    i + 1
+        if !self.data.is_empty() {
+            let i = match self.state.selected() {
+                Some(i) => {
+                    if i >= self.data.len() - 1 {
+                        0
+                    } else {
+                        i + 1
+                    }
                 }
-            }
-            None => 0,
-        };
-        self.state.select(Some(i));
+                None => 0,
+            };
+            self.state.select(Some(i));
+        }
     }
 
     pub fn previous(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.data.len() - 1
-                } else {
-                    i - 1
+        if !self.data.is_empty() {
+            let i = match self.state.selected() {
+                Some(i) => {
+                    if i == 0 {
+                        self.data.len() - 1
+                    } else {
+                        i - 1
+                    }
                 }
-            }
-            None => 0,
-        };
-        self.state.select(Some(i));
+                None => 0,
+            };
+            self.state.select(Some(i));
+        }
     }
 
     pub fn first(&mut self) {
-        self.state.select(Some(0));
+        if !self.data.is_empty() {
+            self.state.select(Some(0));
+        }
     }
 
     pub fn last(&mut self) {
-        self.state.select(Some(self.data.len() - 1));
+        if !self.data.is_empty() {
+            self.state.select(Some(self.data.len() - 1));
+        }
     }
 
     pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
@@ -240,7 +248,13 @@ impl TableModel {
             .split(f.size());
 
         // Calculate the widths based on # of columns
-        let equal_column_width = (100 / self.num_columns()) as u16;
+        let equal_column_width = if self.num_columns() > 1 {
+            (100 / self.num_columns()) as u16
+        } else {
+            // If you're here, there isn't any headers set. Likely no data too.
+            // This is just going to prevent immediate panic from division by zero
+            100
+        };
 
         let mut column_constraints: Vec<Constraint> = Vec::new();
 

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -67,15 +67,15 @@
 
 use crate::Result;
 use tui::widgets::TableState;
-//use std::io::Stdout;
-//use tui::{
-//    backend::CrosstermBackend,
-//    layout::{Constraint, Layout},
-//    style::{Color, Modifier, Style},
-//    widgets::{Block, Borders, Cell, Row, Table},
-//    Frame, Terminal,
-//};
-//use crossterm::event::{Event, KeyCode, MouseEventKind};
+use std::io::Stdout;
+use tui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, Table},
+    Frame, Terminal,
+};
+use crossterm::event::{Event, KeyCode, MouseEventKind};
 
 #[derive(Debug, Default, Clone)]
 pub struct TableModel {
@@ -129,164 +129,164 @@ impl TableModel {
     //TODO
     //pub fn delete_row(&mut self, row_index: usize) -> Result<()> {}
 
-    //pub fn num_columns(&self) -> usize {
-    //    self.headers.len()
-    //}
+    pub fn num_columns(&self) -> usize {
+        self.headers.len()
+    }
 
-    //pub fn current_selected(&self) -> usize {
-    //    self.state.selected().unwrap_or(0)
-    //}
+    pub fn current_selected(&self) -> usize {
+        self.state.selected().unwrap_or(0)
+    }
 
-    //pub fn next(&mut self) {
-    //    let i = match self.state.selected() {
-    //        Some(i) => {
-    //            if i >= self.data.len() - 1 {
-    //                0
-    //            } else {
-    //                i + 1
-    //            }
-    //        }
-    //        None => 0,
-    //    };
-    //    self.state.select(Some(i));
-    //}
+    pub fn next(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i >= self.data.len() - 1 {
+                    0
+                } else {
+                    i + 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
 
-    //pub fn previous(&mut self) {
-    //    let i = match self.state.selected() {
-    //        Some(i) => {
-    //            if i == 0 {
-    //                self.data.len() - 1
-    //            } else {
-    //                i - 1
-    //            }
-    //        }
-    //        None => 0,
-    //    };
-    //    self.state.select(Some(i));
-    //}
+    pub fn previous(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i == 0 {
+                    self.data.len() - 1
+                } else {
+                    i - 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
 
-    //pub fn first(&mut self) {
-    //    self.state.select(Some(0));
-    //}
+    pub fn first(&mut self) {
+        self.state.select(Some(0));
+    }
 
-    //pub fn last(&mut self) {
-    //    self.state.select(Some(self.data.len() - 1));
-    //}
+    pub fn last(&mut self) {
+        self.state.select(Some(self.data.len() - 1));
+    }
 
-    //pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
-    //    if let Event::Key(key) = user_input {
-    //        match key.code {
-    //            KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
-    //            KeyCode::Char('c') => {
-    //                self.data = Vec::new();
-    //                self.state.select(None);
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            KeyCode::Up => {
-    //                self.previous();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            KeyCode::Down => {
-    //                self.next();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            KeyCode::Home => {
-    //                self.first();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            KeyCode::End => {
-    //                self.last();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            _ => TableEvent::InputIgnored(user_input),
-    //        }
-    //    } else if let Event::Mouse(event) = user_input {
-    //        match event.kind {
-    //            MouseEventKind::ScrollDown => {
-    //                self.next();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            MouseEventKind::ScrollUp => {
-    //                self.previous();
-    //                TableEvent::InputHandled(user_input)
-    //            }
-    //            _ => TableEvent::InputIgnored(user_input),
-    //        }
-    //    } else {
-    //        TableEvent::InputIgnored(user_input)
-    //    }
-    //}
+    pub fn event_handler(&mut self, user_input: Event) -> TableEvent {
+        if let Event::Key(key) = user_input {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => TableEvent::Terminate,
+                KeyCode::Char('c') => {
+                    self.data = Vec::new();
+                    self.state.select(None);
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::Up => {
+                    self.previous();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::Down => {
+                    self.next();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::Home => {
+                    self.first();
+                    TableEvent::InputHandled(user_input)
+                }
+                KeyCode::End => {
+                    self.last();
+                    TableEvent::InputHandled(user_input)
+                }
+                _ => TableEvent::InputIgnored(user_input),
+            }
+        } else if let Event::Mouse(event) = user_input {
+            match event.kind {
+                MouseEventKind::ScrollDown => {
+                    self.next();
+                    TableEvent::InputHandled(user_input)
+                }
+                MouseEventKind::ScrollUp => {
+                    self.previous();
+                    TableEvent::InputHandled(user_input)
+                }
+                _ => TableEvent::InputIgnored(user_input),
+            }
+        } else {
+            TableEvent::InputIgnored(user_input)
+        }
+    }
 
-    //// This will take a full screen buffer
-    ///// Print records in table format
-    /////
-    ///// If you do not provide any column ordering, it will be alphabetized by the top-level keys
-    //pub fn render(
-    //    &mut self,
-    //    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-    //    // primary_key: Option<String>,
-    //    // column_order: Option<Vec<String>,
-    //    //record: &[u8],
-    //) {
-    //    terminal
-    //        .draw(|frame| self.table_ui(frame))
-    //        .expect("Could not render table frame");
-    //}
+    // This will take a full screen buffer
+    /// Print records in table format
+    ///
+    /// If you do not provide any column ordering, it will be alphabetized by the top-level keys
+    pub fn render(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+        // primary_key: Option<String>,
+        // column_order: Option<Vec<String>,
+        //record: &[u8],
+    ) {
+        terminal
+            .draw(|frame| self.table_ui(frame))
+            .expect("Could not render table frame");
+    }
 
-    //pub fn table_ui(&mut self, f: &mut Frame<CrosstermBackend<Stdout>>) {
-    //    let rects = Layout::default()
-    //        .constraints([Constraint::Percentage(100)].as_ref())
-    //        .margin(5)
-    //        .split(f.size());
+    pub fn table_ui(&mut self, f: &mut Frame<CrosstermBackend<Stdout>>) {
+        let rects = Layout::default()
+            .constraints([Constraint::Percentage(100)].as_ref())
+            .margin(5)
+            .split(f.size());
 
-    //    // Calculate the widths based on # of columns
-    //    let equal_column_width = (100 / self.num_columns()) as u16;
+        // Calculate the widths based on # of columns
+        let equal_column_width = (100 / self.num_columns()) as u16;
 
-    //    let mut column_constraints: Vec<Constraint> = Vec::new();
+        let mut column_constraints: Vec<Constraint> = Vec::new();
 
-    //    // Define the widths of the columns
-    //    for _ in 0..self.num_columns() {
-    //        column_constraints.push(Constraint::Percentage(equal_column_width));
-    //    }
+        // Define the widths of the columns
+        for _ in 0..self.num_columns() {
+            column_constraints.push(Constraint::Percentage(equal_column_width));
+        }
 
-    //    let selected_symbol = format!("{} >> ", self.current_selected());
+        let selected_symbol = format!("{} >> ", self.current_selected());
 
-    //    let selected_style = Style::default().add_modifier(Modifier::REVERSED);
-    //    let normal_style = Style::default().bg(Color::Blue);
-    //    let header_cells = self
-    //        .headers
-    //        .iter()
-    //        .map(|h| Cell::from(h.as_str()).style(Style::default().fg(Color::Red)));
-    //    let header = Row::new(header_cells)
-    //        .style(normal_style)
-    //        .height(1)
-    //        .bottom_margin(1);
-    //    let rows = self.data.iter().map(|item| {
-    //        let height = item
-    //            .iter()
-    //            .map(|content| content.chars().filter(|c| *c == '\n').count())
-    //            .max()
-    //            .unwrap_or(0)
-    //            + 1;
-    //        let cells = item.iter().map(|c| Cell::from(c.as_str()));
-    //        Row::new(cells).height(height as u16).bottom_margin(1)
-    //    });
-    //    let t = Table::new(rows)
-    //        .header(header)
-    //        .block(Block::default().borders(Borders::ALL).title(format!(
-    //            "('c' to clear table | 'q' or ESC to exit) | Items: {}",
-    //            self.data.len()
-    //        )))
-    //        .highlight_style(selected_style)
-    //        .highlight_symbol(selected_symbol.as_str())
-    //        .widths(&column_constraints);
-    //    f.render_stateful_widget(t, rects[0], &mut self.state);
-    //}
+        let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+        let normal_style = Style::default().bg(Color::Blue);
+        let header_cells = self
+            .headers
+            .iter()
+            .map(|h| Cell::from(h.as_str()).style(Style::default().fg(Color::Red)));
+        let header = Row::new(header_cells)
+            .style(normal_style)
+            .height(1)
+            .bottom_margin(1);
+        let rows = self.data.iter().map(|item| {
+            let height = item
+                .iter()
+                .map(|content| content.chars().filter(|c| *c == '\n').count())
+                .max()
+                .unwrap_or(0)
+                + 1;
+            let cells = item.iter().map(|c| Cell::from(c.as_str()));
+            Row::new(cells).height(height as u16).bottom_margin(1)
+        });
+        let t = Table::new(rows)
+            .header(header)
+            .block(Block::default().borders(Borders::ALL).title(format!(
+                "('c' to clear table | 'q' or ESC to exit) | Items: {}",
+                self.data.len()
+            )))
+            .highlight_style(selected_style)
+            .highlight_symbol(selected_symbol.as_str())
+            .widths(&column_constraints);
+        f.render_stateful_widget(t, rects[0], &mut self.state);
+    }
 }
 
-//#[derive(Debug)]
-//pub enum TableEvent {
-//    InputHandled(Event),
-//    InputIgnored(Event),
-//    Terminate,
-//}
+#[derive(Debug)]
+pub enum TableEvent {
+    InputHandled(Event),
+    InputIgnored(Event),
+    Terminate,
+}

--- a/crates/fluvio-cli/src/consume/table_format.rs
+++ b/crates/fluvio-cli/src/consume/table_format.rs
@@ -1,0 +1,66 @@
+// -----------------------------------
+//  Basic Table
+// -----------------------------------
+
+///// Print records in text-based table format
+//pub fn print_table_record(record: &[u8], count: i32) -> String {
+//    use prettytable::{Row, cell, Cell, Slice};
+//    use prettytable::format::{self, FormatBuilder};
+//
+//    let maybe_json: serde_json::Value = match serde_json::from_slice(record) {
+//        Ok(value) => value,
+//        Err(_e) => panic!("Value not json"),
+//    };
+//
+//    let obj = maybe_json.as_object().unwrap();
+//
+//    // This is the case where we don't provide any table info. We want to print a table w/ all top-level keys as headers
+//    // Think about how we might only select specific keys
+//    let keys_str: Vec<String> = obj.keys().map(|k| k.to_string()).collect();
+//
+//    // serde_json's Value::String() gets wrapped in quotes if we use `to_string()`
+//    let values_str: Vec<String> = obj
+//        .values()
+//        .map(|v| {
+//            if v.is_string() {
+//                v.as_str()
+//                    .expect("Value not representable as str")
+//                    .to_string()
+//            } else {
+//                v.to_string()
+//            }
+//        })
+//        .collect();
+//
+//    let header: Row = Row::new(keys_str.iter().map(|k| cell!(k.to_owned())).collect());
+//    let entries: Row = Row::new(values_str.iter().map(|v| Cell::new(v)).collect());
+//
+//    // Print the table
+//    let t_print = vec![header, entries];
+//
+//    let mut table = prettytable::Table::init(t_print);
+//
+//    let base_format: FormatBuilder = (*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR).into();
+//    let table_format = base_format;
+//    table.set_format(table_format.build());
+//
+//    // FIXME: Live display of table data easily misaligns column widths
+//    // if there is a length diff between the header and the data
+//    // The rows after the first (count == 0) don't line up with the header
+//    // prettytable might not support the live display use-case we want
+//    if count == 0 {
+//        table.printstd();
+//    } else {
+//        let slice = table.slice(1..);
+//        slice.printstd();
+//    }
+//    format!("")
+//}
+
+// -----------------------------------
+//  Fancy Table
+// -----------------------------------
+
+// -----------------------------------
+//  Utilities
+// -----------------------------------


### PR DESCRIPTION
Leaving `--output=table` intact and adding full screen table render at `--output=full_table`

Consideration for CI was made that caused some code duplication, because `full_table` requires a TTY to read events from keyboard + mouse. Without this guard, tests using consumer would panic in CI.

- Full screen table, exit with q or ESC (no ctrl+c in this PR)
- Evenly spaces columns based on number of keys
- Cell data clips (not wrap)
- First version alphabetizes the columns, and uses the 1st column as primary key for updating rows. No alternative ordering in this PR
- The row update behavior is mandatory, and has no opt-out in this PR.
- Scrolls with arrow up/down, and mouse wheel

Attempt 2 
Resolves #1846

Tested on Linux and MacOS in VSCode + Alacrtty terminals using live and still data to validate fullscreen drawing, keyboard + mouse scrolling, table clearing and table exiting.