### PR TITLE
[Merged by Bors] - move join stream to lazy as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-spu-schema",
  "fluvio-storage",
+ "futures-util",
  "nix",
  "tracing",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -19,8 +19,7 @@ mod record_format;
 mod table_format;
 use table_format::{TableEventResponse, TableModel};
 
-use fluvio::{ConsumerConfig, Fluvio, FluvioError, MultiplePartitionConsumer, Offset};
-use fluvio_sc_schema::ApiError;
+use fluvio::{ConsumerConfig, Fluvio, MultiplePartitionConsumer, Offset};
 use fluvio::consumer::{PartitionSelectionStrategy, Record};
 use fluvio::consumer::{
     SmartModuleInvocation, SmartModuleInvocationWasm, SmartStreamKind, SmartStreamInvocation,
@@ -359,10 +358,12 @@ impl ConsumeOpt {
                             let result: std::result::Result<Record, _> = result;
                             let record = match result {
                                 Ok(record) => record,
+                                /*
                                 Err(FluvioError::AdminApi(ApiError::Code(code, _))) => {
                                     eprintln!("{}", code.to_sentence());
                                     continue;
                                 }
+                                */
                                 Err(other) => return Err(other.into()),
                             };
 
@@ -398,10 +399,12 @@ impl ConsumeOpt {
                 let result: std::result::Result<Record, _> = result;
                 let record = match result {
                     Ok(record) => record,
+                    /*
                     Err(FluvioError::AdminApi(ApiError::Code(code, _))) => {
                         eprintln!("{}", code.to_sentence());
                         continue;
                     }
+                    */
                     Err(other) => return Err(other.into()),
                 };
 

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -71,6 +71,8 @@ pub enum CliError {
     Other(String),
     #[error("Unexpected Infallible error")]
     Infallible(#[from] Infallible),
+    #[error("Dataplane error: {0}")]
+    DataPlaneError(#[from] ErrorCode),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -108,6 +108,9 @@ pub enum ErrorCode {
     #[fluvio(tag = 4000)]
     #[error("a SmartStream error occurred")]
     SmartStreamError(#[from] SmartStreamError),
+    #[fluvio(tag = 4001)]
+    #[error("a JoinStream has terminated")]
+    JoinStreamTerminated,
 
     // Managed Connector Errors
     #[fluvio(tag = 5000)]

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -108,9 +108,6 @@ pub enum ErrorCode {
     #[fluvio(tag = 4000)]
     #[error("a SmartStream error occurred")]
     SmartStreamError(#[from] SmartStreamError),
-    #[fluvio(tag = 4001)]
-    #[error("a JoinStream has terminated")]
-    JoinStreamTerminated,
 
     // Managed Connector Errors
     #[fluvio(tag = 5000)]

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -25,6 +25,10 @@ pub enum ErrorCode {
     #[error("ErrorCode indicated success. If you see this it is likely a bug.")]
     None,
 
+    #[fluvio(tag = 2)]
+    #[error("Other error: {0}")]
+    Other(String),
+
     #[fluvio(tag = 1)]
     #[error("Offset out of range")]
     OffsetOutOfRange,
@@ -182,6 +186,8 @@ pub enum SmartStreamError {
     UndefinedSmartModule(String),
     #[error("WASM module is not a valid '{0}' SmartStream due to {1}. Are you missing a #[smartstream({0})] attribute?")]
     InvalidSmartStreamModule(String, String),
+    #[error("JoinStream terminated: {0}")]
+    JoinStreamTerminated(String),
 }
 
 impl Default for SmartStreamError {

--- a/crates/fluvio-dataplane-protocol/src/record.rs
+++ b/crates/fluvio-dataplane-protocol/src/record.rs
@@ -487,6 +487,58 @@ where
     }
 }
 
+use Record as DefaultRecord;
+
+/// Record that can be used by Consumer which needs access to metadata
+pub struct ConsumerRecord<B = DefaultRecord> {
+    /// The offset of this Record into its partition
+    pub offset: i64,
+    /// The partition where this Record is stored
+    pub partition: i32,
+    /// The Record contents
+    pub record: B,
+}
+
+impl<B> ConsumerRecord<B> {
+    /// The offset from the initial offset for a given stream.
+    pub fn offset(&self) -> i64 {
+        self.offset
+    }
+
+    /// The partition where this Record is stored.
+    pub fn partition(&self) -> i32 {
+        self.partition
+    }
+
+    /// Returns the inner representation of the Record
+    pub fn into_inner(self) -> B {
+        self.record
+    }
+
+    /// Returns a ref to the inner representation of the Record
+    pub fn inner(&self) -> &B {
+        &self.record
+    }
+}
+
+impl ConsumerRecord<DefaultRecord> {
+    /// Returns the contents of this Record's key, if it exists
+    pub fn key(&self) -> Option<&[u8]> {
+        self.record.key().map(|it| it.as_ref())
+    }
+
+    /// Returns the contents of this Record's value
+    pub fn value(&self) -> &[u8] {
+        self.record.value().as_ref()
+    }
+}
+
+impl AsRef<[u8]> for ConsumerRecord<DefaultRecord> {
+    fn as_ref(&self) -> &[u8] {
+        self.value()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/fluvio-dataplane-protocol/src/smartstream.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartstream.rs
@@ -52,7 +52,13 @@ mod encoding {
 
     impl Display for SmartStreamInput {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "SmartStreamInput {{ base_offset: {:?}, record_data: {:?}, join_data: {:#?} }}", self.base_offset, self.record_data.len(), self.join_record.len())
+            write!(
+                f,
+                "SmartStreamInput {{ base_offset: {:?}, record_data: {:?}, join_data: {:#?} }}",
+                self.base_offset,
+                self.record_data.len(),
+                self.join_record.len()
+            )
         }
     }
 

--- a/crates/fluvio-dataplane-protocol/src/smartstream.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartstream.rs
@@ -4,7 +4,7 @@ pub use encoding::{
 };
 
 mod encoding {
-    use std::fmt;
+    use std::fmt::{self, Display};
     use crate::Offset;
     use crate::record::{Record, RecordData};
     use fluvio_protocol::{Encoder, Decoder};
@@ -47,6 +47,12 @@ mod encoding {
                 record_data,
                 ..Default::default()
             })
+        }
+    }
+
+    impl Display for SmartStreamInput {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "SmartStreamInput {{ base_offset: {:?}, record_data: {:?}, join_data: {:#?} }}", self.base_offset, self.record_data.len(), self.join_record.len())
         }
     }
 

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -20,6 +20,8 @@ wasmtime = "0.31"
 nix = "0.23"
 tracing = "0.1.27"
 anyhow = "1.0.38"
+futures-util = { version = "0.3.5", features = ["sink"] }
+
 fluvio-future = { version = "0.3.9", features = [
     "subscriber",
     "openssl_tls",
@@ -28,7 +30,7 @@ fluvio-future = { version = "0.3.9", features = [
 dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
-fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata",version = "0.12.4" , optional = true }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.12.4", optional = true }
 flate2 = { version = "1.0", optional = true }
 fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema" }
 

--- a/crates/fluvio-smartengine/src/smartstream/join.rs
+++ b/crates/fluvio-smartengine/src/smartstream/join.rs
@@ -34,10 +34,10 @@ impl SmartStreamJoin {
 }
 
 impl SmartStream for SmartStreamJoin {
-    #[instrument(skip(self, input))]
+    #[instrument(skip(self, input), name = "Join")]
     fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput> {
-        debug!("join processing");
         let slice = self.base.write_input(&input, SMART_MODULE_API)?;
+        debug!(len = slice.1, "WASM SLICE");
         let map_output = self.join_fn.call(&mut self.base.store, slice)?;
 
         if map_output < 0 {

--- a/crates/fluvio-smartengine/src/smartstream/join.rs
+++ b/crates/fluvio-smartengine/src/smartstream/join.rs
@@ -1,8 +1,10 @@
 use std::convert::TryFrom;
+
 use anyhow::Result;
-use fluvio_spu_schema::server::stream_fetch::SMART_MODULE_API;
+use tracing::instrument;
 use wasmtime::TypedFunc;
 
+use fluvio_spu_schema::server::stream_fetch::SMART_MODULE_API;
 use dataplane::smartstream::{SmartStreamInput, SmartStreamOutput, SmartStreamInternalError};
 use crate::smartstream::{
     SmartEngine, SmartStreamModule, SmartStreamContext, SmartStream, SmartStreamExtraParams,
@@ -32,6 +34,8 @@ impl SmartStreamJoin {
 }
 
 impl SmartStream for SmartStreamJoin {
+
+    #[instrument(skip(self, input))]
     fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput> {
         let slice = self.base.write_input(&input, SMART_MODULE_API)?;
         let map_output = self.join_fn.call(&mut self.base.store, slice)?;

--- a/crates/fluvio-smartengine/src/smartstream/join.rs
+++ b/crates/fluvio-smartengine/src/smartstream/join.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use anyhow::Result;
-use tracing::instrument;
+use tracing::{debug, instrument};
 use wasmtime::TypedFunc;
 
 use fluvio_spu_schema::server::stream_fetch::SMART_MODULE_API;
@@ -36,6 +36,7 @@ impl SmartStreamJoin {
 impl SmartStream for SmartStreamJoin {
     #[instrument(skip(self, input))]
     fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput> {
+        debug!("join processing");
         let slice = self.base.write_input(&input, SMART_MODULE_API)?;
         let map_output = self.join_fn.call(&mut self.base.store, slice)?;
 

--- a/crates/fluvio-smartengine/src/smartstream/join.rs
+++ b/crates/fluvio-smartengine/src/smartstream/join.rs
@@ -34,7 +34,6 @@ impl SmartStreamJoin {
 }
 
 impl SmartStream for SmartStreamJoin {
-
     #[instrument(skip(self, input))]
     fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput> {
         let slice = self.base.write_input(&input, SMART_MODULE_API)?;

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use std::fmt::{self, Debug};
 
+use dataplane::{ErrorCode};
 use dataplane::record::Record;
 use dataplane::smartstream::SmartStreamExtraParams;
 use tracing::{debug, trace};
@@ -201,17 +202,19 @@ impl SmartStreamContext {
     }
 }
 
+use futures_util::{StreamExt, stream::BoxStream};
+
 pub trait SmartStream: Send {
     fn process(&mut self, input: SmartStreamInput) -> Result<SmartStreamOutput>;
     fn params(&self) -> SmartStreamExtraParams;
 }
 
 impl dyn SmartStream + '_ {
-    pub fn process_batch(
+    pub async fn process_batch(
         &mut self,
         iter: &mut FileBatchIterator,
         max_bytes: usize,
-        join_last_record: Option<&Record>,
+        right_join: &mut Option<BoxStream<'static, Result<Record, ErrorCode>>>,
     ) -> Result<(Batch, Option<SmartStreamRuntimeError>), Error> {
         let mut smartstream_batch = Batch::<MemoryRecords>::default();
         smartstream_batch.base_offset = -1; // indicate this is unitialized
@@ -245,7 +248,18 @@ impl dyn SmartStream + '_ {
             let now = Instant::now();
 
             let mut join_record = vec![];
-            join_last_record.encode(&mut join_record, 0)?;
+            if let Some(right_join_stream) = right_join.as_mut() {
+                match right_join_stream.next().await {
+                    Some(Ok(record)) => {
+                        debug!("received join record");
+                        record.encode(&mut join_record, 0)?;
+                    }
+                    Some(Err(e)) => return Err(e.into()),
+                    None => {
+                        debug!("no more join records");
+                    }
+                }
+            }
 
             let input = SmartStreamInput {
                 base_offset: file_batch.batch.base_offset,

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -249,10 +249,14 @@ impl dyn SmartStream + '_ {
 
             let mut join_record = vec![];
             if let Some(right_join_stream) = right_join.as_mut() {
+                debug!("waiting for next join record");
                 match right_join_stream.next().await {
                     Some(Ok(record)) => {
-                        debug!("received join record");
+                
+                        debug!(offset = record.offset,value_len = record.record.value().len(),"received record from join");
+                       // debug!("record value: {}",record.record.value().as_str().unwrap_or(""));
                         record.into_inner().encode(&mut join_record, 0)?;
+                        debug!(join_record_len = join_record.len(),"join record encoded");
                     }
                     Some(Err(e)) => return Err(e.into()),
                     None => {

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -259,8 +259,9 @@ impl dyn SmartStream + '_ {
                             value_len = record.record.value().len(),
                             "received record from join"
                         );
+
                         // debug!("record value: {}",record.record.value().as_str().unwrap_or(""));
-                        record.into_inner().encode(&mut join_record, 0)?;
+                        Some(record.into_inner()).encode(&mut join_record, 0)?;
                         debug!(join_record_len = join_record.len(), "join record encoded");
                     }
                     Some(Err(e)) => return Err(e.into()),

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -252,11 +252,14 @@ impl dyn SmartStream + '_ {
                 debug!("waiting for next join record");
                 match right_join_stream.next().await {
                     Some(Ok(record)) => {
-                
-                        debug!(offset = record.offset,value_len = record.record.value().len(),"received record from join");
-                       // debug!("record value: {}",record.record.value().as_str().unwrap_or(""));
+                        debug!(
+                            offset = record.offset,
+                            value_len = record.record.value().len(),
+                            "received record from join"
+                        );
+                        // debug!("record value: {}",record.record.value().as_str().unwrap_or(""));
                         record.into_inner().encode(&mut join_record, 0)?;
-                        debug!(join_record_len = join_record.len(),"join record encoded");
+                        debug!(join_record_len = join_record.len(), "join record encoded");
                     }
                     Some(Err(e)) => return Err(e.into()),
                     None => {

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use std::fmt::{self, Debug};
 
 use dataplane::{ErrorCode};
-use dataplane::record::Record;
+use dataplane::record::{ConsumerRecord};
 use dataplane::smartstream::SmartStreamExtraParams;
 use tracing::{debug, trace};
 use anyhow::{Error, Result};
@@ -214,7 +214,7 @@ impl dyn SmartStream + '_ {
         &mut self,
         iter: &mut FileBatchIterator,
         max_bytes: usize,
-        right_join: &mut Option<BoxStream<'static, Result<Record, ErrorCode>>>,
+        right_join: &mut Option<BoxStream<'static, Result<ConsumerRecord, ErrorCode>>>,
     ) -> Result<(Batch, Option<SmartStreamRuntimeError>), Error> {
         let mut smartstream_batch = Batch::<MemoryRecords>::default();
         smartstream_batch.base_offset = -1; // indicate this is unitialized
@@ -252,7 +252,7 @@ impl dyn SmartStream + '_ {
                 match right_join_stream.next().await {
                     Some(Ok(record)) => {
                         debug!("received join record");
-                        record.encode(&mut join_record, 0)?;
+                        record.into_inner().encode(&mut join_record, 0)?;
                     }
                     Some(Err(e)) => return Err(e.into()),
                     None => {

--- a/crates/fluvio-smartstream/Cargo.toml
+++ b/crates/fluvio-smartstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartstream/Cargo.toml
+++ b/crates/fluvio-smartstream/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ['lib']
 [dependencies]
 eyre = { version = "0.6", default-features = false }
 fluvio-dataplane-protocol = { version = "0.8.0", path = "../fluvio-dataplane-protocol", default-features = false }
-fluvio-smartstream-derive = { version = "0.3", path = "../fluvio-smartstream-derive", optional = true }
+fluvio-smartstream-derive = { version = "0.3.1", path = "../fluvio-smartstream-derive", optional = true }
 fluvio-spu-schema = { version = "0.8", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]

--- a/crates/fluvio-smartstream/examples/Cargo.lock
+++ b/crates/fluvio-smartstream/examples/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartstream"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-array-map-object"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartstream",
  "serde_json",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-array-map-reddit"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartstream",
  "serde",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-filter-map"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartstream",
 ]

--- a/crates/fluvio-smartstream/examples/aggregate-average/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/aggregate-average/Cargo.toml
@@ -3,11 +3,12 @@ name = "fluvio-wasm-aggregate-average"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../",version = "0.4.0" }
 serde = "1"
 serde_json = "1"

--- a/crates/fluvio-smartstream/examples/aggregate-json/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/aggregate-json/Cargo.toml
@@ -3,11 +3,12 @@ name = "fluvio-wasm-aggregate-json"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fluvio-smartstream/examples/aggregate-sum/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/aggregate-sum/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-aggregate-sum"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/aggregate/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/aggregate/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-aggregate"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/array_map_json_array/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/array_map_json_array/Cargo.toml
@@ -3,10 +3,11 @@ name = "fluvio-wasm-array-map-array"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../.." }
+fluvio-smartstream = { path = "../..",version = "0.4.0" }
 serde_json = "1"

--- a/crates/fluvio-smartstream/examples/array_map_json_object/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/array_map_json_object/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fluvio-wasm-array-map-object"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../.." }
+fluvio-smartstream = { path = "../..", version = "0.4.0"}
 serde_json = "1"

--- a/crates/fluvio-smartstream/examples/array_map_json_reddit/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/array_map_json_reddit/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "fluvio-wasm-array-map-reddit"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../.." }
+fluvio-smartstream = { path = "../..", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fluvio-smartstream/examples/filter/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-filter"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/filter_json/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_json/Cargo.toml
@@ -3,6 +3,7 @@ name = "fluvio-wasm-filter-json"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
@@ -10,4 +11,4 @@ crate-type = ['cdylib']
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}

--- a/crates/fluvio-smartstream/examples/filter_map/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_map/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "fluvio-wasm-filter-map"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../.." }
+fluvio-smartstream = { path = "../..", version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/filter_odd/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_odd/Cargo.toml
@@ -3,10 +3,11 @@ name = "fluvio-wasm-filter-odd"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
 thiserror = "1"
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}

--- a/crates/fluvio-smartstream/examples/filter_regex/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_regex/Cargo.toml
@@ -3,10 +3,11 @@ name = "fluvio-wasm-filter-regex"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }
 regex = "1"

--- a/crates/fluvio-smartstream/examples/filter_with_parameters/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/filter_with_parameters/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-filter-with-parameters"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/join/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/join/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-join"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}

--- a/crates/fluvio-smartstream/examples/map/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/map/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-map"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}

--- a/crates/fluvio-smartstream/examples/map_double/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/map_double/Cargo.toml
@@ -3,9 +3,10 @@ name = "fluvio-wasm-map-double"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../",version = "0.4.0" }

--- a/crates/fluvio-smartstream/examples/map_json/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/map_json/Cargo.toml
@@ -3,12 +3,13 @@ name = "fluvio-wasm-map-json"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8.17"

--- a/crates/fluvio-smartstream/examples/map_regex/Cargo.toml
+++ b/crates/fluvio-smartstream/examples/map_regex/Cargo.toml
@@ -3,11 +3,12 @@ name = "fluvio-wasm-map-regex"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
+publish =  false
 
 [lib]
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartstream = { path = "../../" }
+fluvio-smartstream = { path = "../../", version = "0.4.0" }
 regex = "1"
 once_cell = "1"

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -72,7 +72,7 @@ where
     R: Debug + Decoder + Encoder,
 {
     const API_KEY: u16 = SpuServerApiKey::StreamFetch as u16;
-    const DEFAULT_API_VERSION: i16 = SMART_MODULE_API;
+    const DEFAULT_API_VERSION: i16 = JOIN_WASM_API;
     type Response = StreamFetchResponse<R>;
 }
 

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -72,7 +72,7 @@ where
     R: Debug + Decoder + Encoder,
 {
     const API_KEY: u16 = SpuServerApiKey::StreamFetch as u16;
-    const DEFAULT_API_VERSION: i16 = JOIN_WASM_API;
+    const DEFAULT_API_VERSION: i16 = SMART_MODULE_API;
     type Response = StreamFetchResponse<R>;
 }
 

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -23,15 +23,14 @@ use fluvio_spu_schema::server::stream_fetch::{
     DefaultStreamFetchRequest, FileStreamFetchRequest, StreamFetchRequest, StreamFetchResponse,
 };
 use fluvio_types::event::offsets::OffsetChangeListener;
+use publishers::INIT_OFFSET;
+use fluvio_smartengine::file_batch::FileBatchIterator;
+use dataplane::batch::Batch;
+use dataplane::smartstream::SmartStreamRuntimeError;
 
 use crate::core::DefaultSharedGlobalContext;
 use crate::replication::leader::SharedFileLeaderState;
 use crate::smartengine::SmartStreamContext;
-use publishers::INIT_OFFSET;
-use fluvio_smartengine::SmartStream;
-use fluvio_smartengine::file_batch::FileBatchIterator;
-use dataplane::batch::Batch;
-use dataplane::smartstream::SmartStreamRuntimeError;
 
 /// Fetch records as stream
 pub struct StreamFetchHandler {

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -183,10 +183,6 @@ impl StreamFetchHandler {
         starting_offset: Offset,
         mut smart_stream_ctx: Option<SmartStreamContext>,
     ) -> Result<(), SocketError> {
-        let (mut last_partition_offset, consumer_wait) = self
-            .send_back_records(starting_offset, &mut smart_stream_ctx)
-            .await?;
-
         // perform any initialization
         if let Some(ctx) = &mut smart_stream_ctx {
             ctx.update().await.map_err(|err| {
@@ -196,6 +192,10 @@ impl StreamFetchHandler {
                 ))
             })?;
         }
+
+        let (mut last_partition_offset, consumer_wait) = self
+            .send_back_records(starting_offset, &mut smart_stream_ctx)
+            .await?;
 
         let mut leader_offset_receiver = self.leader_state.offset_listener(&self.isolation);
         let mut counter: i32 = 0;

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use std::io::ErrorKind;
 use std::io::Error as IoError;
 
-use futures_util::StreamExt;
 use tracing::{debug, error, instrument, trace};
 use tokio::select;
 
@@ -183,8 +182,9 @@ impl StreamFetchHandler {
     async fn process(
         mut self,
         starting_offset: Offset,
-        smart_stream_ctx: Option<SmartStreamContext>,
+        mut smart_stream_ctx: Option<SmartStreamContext>,
     ) -> Result<(), SocketError> {
+        /*
         let (mut smartstream, mut right_consumer_stream) = if let Some(ctx) = smart_stream_ctx {
             let SmartStreamContext {
                 smartstream: st,
@@ -205,9 +205,10 @@ impl StreamFetchHandler {
         } else {
             None
         };
+        */
 
         let (mut last_partition_offset, consumer_wait) = self
-            .send_back_records(starting_offset, smartstream.as_mut(), join_record.as_ref())
+            .send_back_records(starting_offset, &mut smart_stream_ctx)
             .await?;
 
         let mut leader_offset_receiver = self.leader_state.offset_listener(&self.isolation);
@@ -231,11 +232,12 @@ impl StreamFetchHandler {
                     break;
                 },
 
-
+                /*
                 record = async {  right_consumer_stream.as_mut().expect("Unexpected crash").next().await }, if right_consumer_stream.is_some() =>  {
                     join_record = record.unwrap().ok();
                     debug!("Updated right stream");
                 },
+                */
 
                 // Received offset update from consumer, i.e. consumer acknowledged to this offset
                 consumer_offset_update = self.consumer_offset_listener.listen() => {
@@ -261,7 +263,7 @@ impl StreamFetchHandler {
                         last_partition_offset,
                         "Consumer offset updated and is behind, need to send records",
                     );
-                    let (offset, wait) = self.send_back_records(consumer_offset_update, smartstream.as_mut(), join_record.as_ref()).await?;
+                    let (offset, wait) = self.send_back_records(consumer_offset_update, &mut smart_stream_ctx).await?;
                     last_partition_offset = offset;
                     if wait {
                         last_known_consumer_offset = None;
@@ -302,7 +304,7 @@ impl StreamFetchHandler {
 
                     // We need to send the consumer all records since the last consumer offset
                     debug!(partition_offset_update, last_consumer_offset, "reading offset event");
-                    let (offset, wait) = self.send_back_records(last_consumer_offset, smartstream.as_mut(), join_record.as_ref()).await?;
+                    let (offset, wait) = self.send_back_records(last_consumer_offset, &mut smart_stream_ctx).await?;
                     last_partition_offset = offset;
                     if wait {
                         last_known_consumer_offset = None;
@@ -333,14 +335,13 @@ impl StreamFetchHandler {
     /// return (next offset, consumer wait)
     //  consumer wait flag tells that there are records send back to consumer
     #[instrument(
-        skip(self, smartstream, join_last_record),
+        skip(self, smart_stream_ctx),
         fields(stream_id = self.stream_id)
     )]
     async fn send_back_records(
         &mut self,
         starting_offset: Offset,
-        smartstream: Option<&mut Box<dyn SmartStream>>,
-        join_last_record: Option<&fluvio::consumer::Record>,
+        smart_stream_ctx: &mut Option<SmartStreamContext>,
     ) -> Result<(Offset, bool), SocketError> {
         let now = Instant::now();
         let mut file_partition_response = FilePartitionResponse {
@@ -384,14 +385,11 @@ impl StreamFetchHandler {
 
         // If a smartstream module is provided, we need to read records from file to memory
         // In-memory records are then processed by smartstream and returned to consumer
-        let output = match smartstream {
+        let output = match smart_stream_ctx {
             Some(smartstream) => {
                 let (batch, smartstream_error) = smartstream
-                    .process_batch(
-                        &mut file_batch_iterator,
-                        self.max_bytes as usize,
-                        join_last_record.map(|s| s.inner()),
-                    )
+                    .process_batch(&mut file_batch_iterator, self.max_bytes as usize)
+                    .await
                     .map_err(|err| {
                         IoError::new(ErrorKind::Other, format!("smartstream err {}", err))
                     })?;

--- a/crates/fluvio-spu/src/services/public/stream_fetch_test.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch_test.rs
@@ -50,7 +50,7 @@ use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest, SmartSt
 static NEXT_PORT: AtomicU16 = AtomicU16::new(12000);
 
 #[fluvio_future::test(ignore)]
-async fn test_stream_fetch() {
+async fn test_stream_fetch_basic() {
     let test_path = temp_dir().join("test_stream_fetch");
     ensure_clean_dir(&test_path);
 

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -1,15 +1,8 @@
-use anyhow::Error;
 use tracing::{debug, error};
 
-use dataplane::{
-    ErrorCode, SmartStreamError, batch::Batch, record::Record, smartstream::SmartStreamRuntimeError,
-};
-use fluvio::{
-    consumer::{
-        Record as ConsumerRecord, SmartModuleInvocation, SmartStreamInvocation, SmartStreamKind,
-    },
-};
-use fluvio_smartengine::{SmartStream, file_batch::FileBatchIterator};
+use dataplane::{ErrorCode, SmartStreamError};
+use fluvio::consumer::{SmartModuleInvocation, SmartStreamInvocation, SmartStreamKind};
+use fluvio_smartengine::{SmartStream};
 use fluvio_spu_schema::server::stream_fetch::{
     SmartModuleInvocationWasm, SmartStreamPayload, SmartStreamWasm,
 };
@@ -17,41 +10,10 @@ use futures_util::{StreamExt, stream::BoxStream};
 
 use crate::core::DefaultSharedGlobalContext;
 
-pub struct JoinStreamValue {
-    stream: BoxStream<'static, Result<ConsumerRecord, ErrorCode>>,
-    last_value: Option<ConsumerRecord>,
-}
-
-impl JoinStreamValue {
-    async fn update(&mut self) -> Result<(), ErrorCode> {
-        match self.stream.next().await {
-            Some(Ok(record)) => {
-                debug!(
-                    offset = record.offset,
-                    value_len = record.record.value().len(),
-                    "received initial record from right join"
-                );
-                self.last_value = Some(record);
-                Ok(())
-            }
-            Some(Err(e)) => Err(e),
-            None => {
-                debug!("right terminated");
-                Err(ErrorCode::SmartStreamError(
-                    SmartStreamError::JoinStreamTerminated("terminated".to_string()),
-                ))
-            }
-        }
-    }
-
-    fn last_value(&self) -> Option<&Record> {
-        self.last_value.as_ref().map(|r| r.inner())
-    }
-}
-
 pub struct SmartStreamContext {
     pub smartstream: Box<dyn SmartStream>,
-    pub right_consumer: Option<JoinStreamValue>,
+    pub right_consumer_stream:
+        Option<BoxStream<'static, Result<fluvio::consumer::Record, ErrorCode>>>,
 }
 
 impl SmartStreamContext {
@@ -71,7 +33,7 @@ impl SmartStreamContext {
                 if let Some(payload) = wasm_payload {
                     Ok(Some(Self {
                         smartstream: Self::payload_to_smartstream(payload, ctx)?,
-                        right_consumer: None,
+                        right_consumer_stream: None,
                     }))
                 } else {
                     Ok(None)
@@ -86,13 +48,13 @@ impl SmartStreamContext {
         ctx: &DefaultSharedGlobalContext,
     ) -> Result<Self, ErrorCode> {
         // check for right consumer stream exists, this only happens for join type
-        let right_consumer = match invocation.kind {
+        let right_consumer_stream = match invocation.kind {
             // for join, create consumer stream
             SmartStreamKind::Join(ref topic) => {
                 let consumer = ctx.leaders().partition_consumer(topic.to_owned(), 0).await;
 
-                Some(JoinStreamValue {
-                    stream: consumer
+                Some(
+                    consumer
                         .stream(fluvio::Offset::beginning())
                         .await
                         .map_err(|err| {
@@ -100,8 +62,7 @@ impl SmartStreamContext {
                             ErrorCode::SmartStreamJoinFetchError
                         })?
                         .boxed(),
-                    last_value: None,
-                })
+                )
             }
             _ => None,
         };
@@ -134,7 +95,7 @@ impl SmartStreamContext {
 
         Ok(Self {
             smartstream: Self::payload_to_smartstream(payload, ctx)?,
-            right_consumer,
+            right_consumer_stream,
         })
     }
 
@@ -163,30 +124,5 @@ impl SmartStreamContext {
                     err.to_string(),
                 ))
             })
-    }
-
-    pub fn process_batch(
-        &mut self,
-        iter: &mut FileBatchIterator,
-        max_bytes: usize,
-    ) -> Result<(Batch, Option<SmartStreamRuntimeError>), Error> {
-        self.smartstream.process_batch(
-            iter,
-            max_bytes,
-            if let Some(consumer) = &self.right_consumer {
-                consumer.last_value()
-            } else {
-                None
-            },
-        )
-    }
-
-    pub async fn update(&mut self) -> Result<(), ErrorCode> {
-        if let Some(consumer) = self.right_consumer.as_mut() {
-            debug!("updating consumer right");
-            consumer.update().await
-        } else {
-            Ok(())
-        }
     }
 }

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -183,6 +183,7 @@ impl SmartStreamContext {
 
     pub async fn update(&mut self) -> Result<(), ErrorCode> {
         if let Some(consumer) = self.right_consumer.as_mut() {
+            debug!("updating consumer right");
             consumer.update().await
         } else {
             Ok(())

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -37,7 +37,9 @@ impl JoinStreamValue {
             Some(Err(e)) => Err(e),
             None => {
                 debug!("right terminated");
-                Err(ErrorCode::JoinStreamTerminated)
+                Err(ErrorCode::SmartStreamError(
+                    SmartStreamError::JoinStreamTerminated("terminated".to_string()),
+                ))
             }
         }
     }

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -23,7 +23,6 @@ use dataplane::fetch::FetchPartition;
 use dataplane::fetch::FetchableTopic;
 use dataplane::fetch::FetchablePartitionResponse;
 use dataplane::record::RecordSet;
-use dataplane::record::Record as DefaultRecord;
 use dataplane::batch::Batch;
 use fluvio_types::event::offsets::OffsetPublisher;
 
@@ -31,6 +30,8 @@ use crate::FluvioError;
 use crate::offset::{Offset, fetch_offsets};
 use crate::spu::{SpuDirectory, SpuPool};
 use derive_builder::Builder;
+
+pub use dataplane::record::ConsumerRecord as Record;
 
 /// An interface for consuming events from a particular partition
 ///
@@ -958,54 +959,6 @@ impl MultiplePartitionConsumer {
         let streams = streams_result.into_iter().collect::<Result<Vec<_>, _>>()?;
 
         Ok(select_all(streams))
-    }
-}
-
-/// The individual record for a given stream.
-pub struct Record {
-    /// The offset of this Record into its partition
-    offset: i64,
-    /// The partition where this Record is stored
-    partition: i32,
-    /// The Record contents
-    record: DefaultRecord,
-}
-
-impl Record {
-    /// The offset from the initial offset for a given stream.
-    pub fn offset(&self) -> i64 {
-        self.offset
-    }
-
-    /// The partition where this Record is stored.
-    pub fn partition(&self) -> i32 {
-        self.partition
-    }
-
-    /// Returns the contents of this Record's key, if it exists
-    pub fn key(&self) -> Option<&[u8]> {
-        self.record.key().map(|it| it.as_ref())
-    }
-
-    /// Returns the contents of this Record's value
-    pub fn value(&self) -> &[u8] {
-        self.record.value().as_ref()
-    }
-
-    /// Returns the inner representation of the Record
-    pub fn into_inner(self) -> DefaultRecord {
-        self.record
-    }
-
-    /// Returns a ref to the inner representation of the Record
-    pub fn inner(&self) -> &DefaultRecord {
-        &self.record
-    }
-}
-
-impl AsRef<[u8]> for Record {
-    fn as_ref(&self) -> &[u8] {
-        self.value()
     }
 }
 


### PR DESCRIPTION
Instead of getting records from right stream in the beginning of fetch cycle, this PR move them in side batch processing.  This decouple join from fetch and allow integration of SmartStream steps.

Bump up SmartStream crates and mark all example as unpublished.  Part of #1843 