### PR TITLE
[Merged by Bors] - Use a random available port for tests instead of a fixed one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "futures-util",
  "once_cell",
  "pin-project",
+ "portpicker",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3668,6 +3669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "portpicker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
+dependencies = [
+ "rand 0.8.4",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -46,6 +46,7 @@ fluvio-future = { version = "0.3.1", features = [
     "native2_tls",
 ] }
 flv-util = { version = "0.5.0", features = ["fixture"] }
+portpicker = "0.1.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 async-net = "1.4.3"

--- a/crates/fluvio-socket/src/sink.rs
+++ b/crates/fluvio-socket/src/sink.rs
@@ -303,8 +303,9 @@ mod tests {
 
     #[fluvio_future::test]
     async fn test_sink_copy() {
-        let addr = "127.0.0.1:9999";
+        let port = portpicker::pick_unused_port().expect("No free ports left");
+        let addr = format!("127.0.0.1:{}", port);
 
-        let _r = join(setup_client(addr), test_server(addr)).await;
+        let _r = join(setup_client(&addr), test_server(&addr)).await;
     }
 }


### PR DESCRIPTION
While looking into #1131 I found `sink::test_sink_copy` failing because the port hardcoded in that test was used on my machine. This prevents such a failure.