### PR TITLE
[Merged by Bors] - implement SmartStream join

### DIFF
--- a/crates/fluvio-cli/test-data/smartstream/left.yaml
+++ b/crates/fluvio-cli/test-data/smartstream/left.yaml
@@ -4,7 +4,7 @@ input:
     name: left      
 steps:
   - join:
-      module: join2
+      module: join
       right:
         smartstream:
           name: rdoublee

--- a/crates/fluvio-cli/test-data/smartstream/simple_join.yaml
+++ b/crates/fluvio-cli/test-data/smartstream/simple_join.yaml
@@ -1,4 +1,4 @@
-name: ss1
+name: join1
 input:
   topic:
     name: left      

--- a/crates/fluvio-smartengine/src/smartstream/mod.rs
+++ b/crates/fluvio-smartengine/src/smartstream/mod.rs
@@ -87,9 +87,10 @@ impl SmartEngine {
                 Box::new(smart_module.create_array_map(smart_payload.params)?)
             }
             SmartStreamKind::Join(_) => Box::new(smart_module.create_join(smart_payload.params)?),
-            SmartStreamKind::JoinStream(_) => {
-                Box::new(smart_module.create_join_stream(smart_payload.params)?)
-            }
+            SmartStreamKind::JoinStream {
+                topic: _,
+                smartstream: _,
+            } => Box::new(smart_module.create_join_stream(smart_payload.params)?),
             SmartStreamKind::Aggregate { accumulator } => {
                 Box::new(smart_module.create_aggregate(smart_payload.params, accumulator.clone())?)
             }

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -127,7 +127,10 @@ pub enum SmartStreamKind {
     #[fluvio(min_version = SMART_MODULE_API)]
     Join(String),
     #[fluvio(min_version = SMART_MODULE_API)]
-    JoinStream(String),
+    JoinStream {
+        topic: String,
+        smartstream: String,
+    },
 }
 
 impl Default for SmartStreamKind {


### PR DESCRIPTION
resolves #1843.  Complete the SmartStream pipeline with joining topic or smartstream.

Simple join works:
```
flvd topic create right
flvd smartmodule create double --wasm-file crates/fluvio-smartstream/examples/target/wasm32-unknown-unknown/release/fluvio_wasm_map_double.wasm 
flvd smartstream create -c crates/fluvio-cli/test-data/smartstream/right.yaml 
flvd consume right --smartstream rdouble

flvd smartmodule create join --wasm-file crates/fluvio-smartstream/examples/target/wasm32-unknown-unknown/release/fluvio_wasm_join.wasm 
flvd smartstream create -c crates/fluvio-cli/test-data/smartstream/simpLe_join.yaml 
 flvd consume left --smartstream join1
 cho 1 | flvd produce left
```
name: join1
input:
  topic:
    name: left      
steps:
  - join:
      module: join
      right:
        topic:
          name: right
```

```