### PR TITLE
[Merged by Bors] - Add support for tuple structs in fluvio protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.14 - UNRELEASED
+* Add support for tuple structs in fluvio-protocol derived macros. ([#1828](https://github.com/infinyon/fluvio/issues/1828))
 
 ## Platform Version 0.9.13 - 2021-11-19
 * Fix connector create with `create_topic` option to succeed if topic already exists. ([#1823](https://github.com/infinyon/fluvio/pull/1823))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "fluvio-future",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fluvio-protocol",
  "proc-macro2",

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"

--- a/crates/fluvio-protocol-derive/src/ast/struct.rs
+++ b/crates/fluvio-protocol-derive/src/ast/struct.rs
@@ -1,7 +1,12 @@
-use crate::ast::prop::NamedProp;
+use crate::ast::prop::{NamedProp, UnnamedProp};
 use syn::{Fields, Generics, Ident, ItemStruct};
 
-pub(crate) struct FluvioStruct {
+pub(crate) enum FluvioStruct {
+    Named(FluvioNamedStruct),
+    Tuple(FluvioTupleStruct),
+}
+
+pub(crate) struct FluvioNamedStruct {
     pub struct_ident: Ident,
     pub props: Vec<NamedProp>,
     pub generics: Generics,
@@ -10,21 +15,72 @@ pub(crate) struct FluvioStruct {
 impl FluvioStruct {
     pub fn from_ast(item: &ItemStruct) -> syn::Result<Self> {
         let struct_ident = item.ident.clone();
-        let props: Vec<NamedProp> = if let Fields::Named(fields) = &item.fields {
-            let mut prp = vec![];
-            for field in fields.named.iter() {
-                prp.push(NamedProp::from_ast(field)?);
-            }
-            prp
-        } else {
-            vec![]
-        };
         let generics = item.generics.clone();
 
-        Ok(FluvioStruct {
-            struct_ident,
-            props,
-            generics,
-        })
+        let fluvio_struct = match &item.fields {
+            Fields::Named(fields) => {
+                let mut props = vec![];
+                for field in fields.named.iter() {
+                    props.push(NamedProp::from_ast(field)?);
+                }
+
+                FluvioStruct::Named(FluvioNamedStruct {
+                    struct_ident,
+                    props,
+                    generics,
+                })
+            }
+            Fields::Unnamed(fields) => {
+                let mut props = vec![];
+                for field in fields.unnamed.iter() {
+                    props.push(UnnamedProp::from_ast(field)?);
+                }
+                FluvioStruct::Tuple(FluvioTupleStruct {
+                    struct_ident,
+                    props,
+                    generics,
+                })
+            }
+
+            Fields::Unit => FluvioStruct::Tuple(FluvioTupleStruct {
+                struct_ident,
+                props: vec![],
+                generics,
+            }),
+        };
+
+        Ok(fluvio_struct)
     }
+
+    pub fn struct_ident(&self) -> &Ident {
+        match self {
+            FluvioStruct::Named(inner) => &inner.struct_ident,
+            FluvioStruct::Tuple(inner) => &inner.struct_ident,
+        }
+    }
+
+    pub fn generics(&self) -> &Generics {
+        match self {
+            FluvioStruct::Named(inner) => &inner.generics,
+            FluvioStruct::Tuple(inner) => &inner.generics,
+        }
+    }
+
+    pub fn props(&self) -> FluvioStructProps {
+        match self {
+            FluvioStruct::Named(inner) => FluvioStructProps::Named(inner.props.clone()),
+            FluvioStruct::Tuple(inner) => FluvioStructProps::Unnamed(inner.props.clone()),
+        }
+    }
+}
+
+pub(crate) enum FluvioStructProps {
+    Named(Vec<NamedProp>),
+    Unnamed(Vec<UnnamedProp>),
+}
+
+pub(crate) struct FluvioTupleStruct {
+    pub struct_ident: Ident,
+    pub props: Vec<UnnamedProp>,
+    pub generics: Generics,
 }

--- a/crates/fluvio-protocol-derive/src/de.rs
+++ b/crates/fluvio-protocol-derive/src/de.rs
@@ -18,7 +18,7 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
         DeriveItem::Struct(kf_struct, _attrs) => {
             // TODO: struct level attrs is not used.
             let field_tokens =
-                generate_struct_fields(&kf_struct.props(), &kf_struct.struct_ident());
+                generate_struct_fields(&kf_struct.props(), kf_struct.struct_ident());
             let ident = &kf_struct.struct_ident();
             let (impl_generics, ty_generics, where_clause) = kf_struct.generics().split_for_impl();
             quote! {

--- a/crates/fluvio-protocol-derive/src/de.rs
+++ b/crates/fluvio-protocol-derive/src/de.rs
@@ -1,3 +1,5 @@
+use crate::ast::prop::UnnamedProp;
+use crate::ast::r#struct::FluvioStructProps;
 use crate::ast::{
     container::ContainerAttributes, prop::NamedProp, r#enum::EnumProp, r#enum::FieldKind,
     DeriveItem,
@@ -15,9 +17,10 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
     match &input {
         DeriveItem::Struct(kf_struct, _attrs) => {
             // TODO: struct level attrs is not used.
-            let field_tokens = generate_struct_fields(&kf_struct.props, &kf_struct.struct_ident);
-            let ident = &kf_struct.struct_ident;
-            let (impl_generics, ty_generics, where_clause) = kf_struct.generics.split_for_impl();
+            let field_tokens =
+                generate_struct_fields(&kf_struct.props(), &kf_struct.struct_ident());
+            let ident = &kf_struct.struct_ident();
+            let (impl_generics, ty_generics, where_clause) = kf_struct.generics().split_for_impl();
             quote! {
                 impl #impl_generics fluvio_protocol::Decoder for #ident #ty_generics #where_clause {
                     fn decode<T>(&mut self, src: &mut T,version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::Buf {
@@ -53,7 +56,24 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
     }
 }
 
-pub(crate) fn generate_struct_fields(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
+pub(crate) fn generate_struct_fields(
+    props: &FluvioStructProps,
+    struct_ident: &Ident,
+) -> TokenStream {
+    match props {
+        FluvioStructProps::Named(named_fields) => {
+            generate_struct_named_fields(named_fields, struct_ident)
+        }
+        FluvioStructProps::Unnamed(unnamed_fields) => {
+            generate_struct_unnamed_fields(unnamed_fields, struct_ident)
+        }
+    }
+}
+
+pub(crate) fn generate_struct_named_fields(
+    props: &[NamedProp],
+    struct_ident: &Ident,
+) -> TokenStream {
     let recurse = props.iter().map(|prop| {
         let fname = format_ident!("{}", prop.field_name);
         if prop.attrs.varint {
@@ -75,6 +95,43 @@ pub(crate) fn generate_struct_fields(props: &[NamedProp], struct_ident: &Ident) 
                     tracing::trace!("decoding struct: <{}> field: <{}> => {:#?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
                 } else {
                     tracing::trace!("error decoding <{}> ==> {}",stringify!(#fname),result.as_ref().unwrap_err());
+                    return result;
+                }
+            };
+
+            prop.version_check_token_stream(base)
+        }
+    });
+    quote! {
+        #(#recurse)*
+    }
+}
+
+pub(crate) fn generate_struct_unnamed_fields(
+    props: &[UnnamedProp],
+    struct_ident: &Ident,
+) -> TokenStream {
+    let recurse = props.iter().enumerate().map(|(idx, prop)| {
+        let field_idx = syn::Index::from(idx);
+        if prop.attrs.varint {
+            quote! {
+                tracing::trace!("start decoding varint field <{}>", stringify!(#idx));
+                let result = self.#field_idx.decode_varint(src);
+                if result.is_ok() {
+                    tracing::trace!("decoding ok varint <{}> => {:?}",stringify!(#idx),&self.#field_idx);
+                } else {
+                    tracing::trace!("decoding varint error <{}> ==> {}",stringify!(#idx),result.as_ref().unwrap_err());
+                    return result;
+                }
+            }
+        } else {
+            let base = quote! {
+                tracing::trace!("start decoding struct: <{}> field: <{}>",stringify!(#struct_ident),stringify!(#idx));
+                let result = self.#field_idx.decode(src,version);
+                if result.is_ok() {
+                    tracing::trace!("decoding struct: <{}> field: <{}> => {:#?}",stringify!(#struct_ident),stringify!(#idx),&self.#field_idx);
+                } else {
+                    tracing::trace!("error decoding <{}> ==> {}",stringify!(#idx),result.as_ref().unwrap_err());
                     return result;
                 }
             };
@@ -295,9 +352,9 @@ fn generate_try_enum_from_kf_enum(
 pub(crate) fn generate_default_trait_impls(input: &DeriveItem) -> TokenStream {
     match &input {
         DeriveItem::Struct(kf_struct, _attrs) => {
-            let ident = &kf_struct.struct_ident;
-            let field_tokens = generate_default_impls(&kf_struct.props);
-            let (impl_generics, ty_generics, where_clause) = kf_struct.generics.split_for_impl();
+            let ident = &kf_struct.struct_ident();
+            let field_tokens = generate_default_impls(&kf_struct.props());
+            let (impl_generics, ty_generics, where_clause) = kf_struct.generics().split_for_impl();
             quote! {
                 impl #impl_generics Default for #ident #ty_generics #where_clause {
                     fn default() -> Self {
@@ -312,7 +369,15 @@ pub(crate) fn generate_default_trait_impls(input: &DeriveItem) -> TokenStream {
     }
 }
 
-pub(crate) fn generate_default_impls(props: &[NamedProp]) -> TokenStream {
+pub(crate) fn generate_default_impls(props: &FluvioStructProps) -> TokenStream {
+    match props {
+        FluvioStructProps::Named(named_fields) => generate_default_impls_named_fields(named_fields),
+        FluvioStructProps::Unnamed(unnamed_fields) => {
+            generate_default_impls_unnamed_fields(unnamed_fields)
+        }
+    }
+}
+pub(crate) fn generate_default_impls_named_fields(props: &[NamedProp]) -> TokenStream {
     let recurse = props.iter().map(|prop| {
         let fname = format_ident!("{}", prop.field_name);
         if let Some(def) = &prop.attrs.default_value {
@@ -328,6 +393,31 @@ pub(crate) fn generate_default_impls(props: &[NamedProp]) -> TokenStream {
         } else {
             quote! {
                 #fname: std::default::Default::default(),
+            }
+        }
+    });
+    quote! {
+        #(#recurse)*
+    }
+}
+
+pub(crate) fn generate_default_impls_unnamed_fields(props: &[UnnamedProp]) -> TokenStream {
+    let recurse = props.iter().enumerate().map(|(idx, prop)| {
+        let field_idx = syn::Index::from(idx);
+
+        if let Some(def) = &prop.attrs.default_value {
+            if let Ok(liter) = TokenStream::from_str(def) {
+                quote! {
+                    #field_idx: #liter,
+                }
+            } else {
+                quote! {
+                    #field_idx: std::default::Default::default(),
+                }
+            }
+        } else {
+            quote! {
+                #field_idx: std::default::Default::default(),
             }
         }
     });

--- a/crates/fluvio-protocol-derive/src/de.rs
+++ b/crates/fluvio-protocol-derive/src/de.rs
@@ -17,8 +17,7 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
     match &input {
         DeriveItem::Struct(kf_struct, _attrs) => {
             // TODO: struct level attrs is not used.
-            let field_tokens =
-                generate_struct_fields(&kf_struct.props(), kf_struct.struct_ident());
+            let field_tokens = generate_struct_fields(&kf_struct.props(), kf_struct.struct_ident());
             let ident = &kf_struct.struct_ident();
             let (impl_generics, ty_generics, where_clause) = kf_struct.generics().split_for_impl();
             quote! {

--- a/crates/fluvio-protocol-derive/src/ser.rs
+++ b/crates/fluvio-protocol-derive/src/ser.rs
@@ -59,15 +59,14 @@ pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
 }
 
 fn parse_struct_props_encoding(props: &FluvioStructProps, struct_ident: &Ident) -> TokenStream {
-    let recurse = match props {
+    match props {
         FluvioStructProps::Named(named_props) => {
             parse_struct_named_props_encoding(named_props, struct_ident)
         }
         FluvioStructProps::Unnamed(unnamed_props) => {
             parse_struct_unnamed_props_encoding(unnamed_props, struct_ident)
         }
-    };
-    recurse
+    }
 }
 
 fn parse_struct_named_props_encoding(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
@@ -133,15 +132,14 @@ fn parse_struct_unnamed_props_encoding(props: &[UnnamedProp], struct_ident: &Ide
 }
 
 fn parse_struct_props_size(props: &FluvioStructProps, struct_ident: &Ident) -> TokenStream {
-    let recurse = match props {
+    match props {
         FluvioStructProps::Named(named_props) => {
             parse_struct_named_props_size(named_props, struct_ident)
         }
         FluvioStructProps::Unnamed(unnamed_props) => {
             parse_struct_unnamed_props_size(unnamed_props, struct_ident)
         }
-    };
-    recurse
+    }
 }
 
 fn parse_struct_named_props_size(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {

--- a/crates/fluvio-protocol-derive/src/ser.rs
+++ b/crates/fluvio-protocol-derive/src/ser.rs
@@ -1,3 +1,5 @@
+use crate::ast::prop::UnnamedProp;
+use crate::ast::r#struct::FluvioStructProps;
 use crate::ast::{
     container::ContainerAttributes, prop::NamedProp, r#enum::EnumProp, r#enum::FieldKind,
     DeriveItem,
@@ -12,10 +14,10 @@ use syn::{Ident, LitInt, Token};
 pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
     match &input {
         DeriveItem::Struct(kf_struct, _attrs) => {
-            let ident = &kf_struct.struct_ident;
-            let (impl_generics, ty_generics, where_clause) = kf_struct.generics.split_for_impl();
-            let encoded_field_tokens = parse_struct_props_encoding(&kf_struct.props, ident);
-            let size_field_tokens = parse_struct_props_size(&kf_struct.props, ident);
+            let ident = kf_struct.struct_ident();
+            let (impl_generics, ty_generics, where_clause) = kf_struct.generics().split_for_impl();
+            let encoded_field_tokens = parse_struct_props_encoding(&kf_struct.props(), ident);
+            let size_field_tokens = parse_struct_props_size(&kf_struct.props(), ident);
             quote! {
                 impl #impl_generics fluvio_protocol::Encoder for #ident #ty_generics #where_clause {
                     fn encode<T>(&self, dest: &mut T, version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::BufMut {
@@ -56,10 +58,21 @@ pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
     }
 }
 
-fn parse_struct_props_encoding(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
+fn parse_struct_props_encoding(props: &FluvioStructProps, struct_ident: &Ident) -> TokenStream {
+    let recurse = match props {
+        FluvioStructProps::Named(named_props) => {
+            parse_struct_named_props_encoding(named_props, struct_ident)
+        }
+        FluvioStructProps::Unnamed(unnamed_props) => {
+            parse_struct_unnamed_props_encoding(unnamed_props, struct_ident)
+        }
+    };
+    recurse
+}
+
+fn parse_struct_named_props_encoding(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
     let recurse = props.iter().map(|prop| {
         let fname = format_ident!("{}", prop.field_name);
-
         if prop.attrs.varint {
             quote! {
                 tracing::trace!("encoding varint struct: <{}> field <{}> => {:?}",stringify!(#struct_ident),stringify!(#fname),&self.#fname);
@@ -88,7 +101,50 @@ fn parse_struct_props_encoding(props: &[NamedProp], struct_ident: &Ident) -> Tok
     }
 }
 
-fn parse_struct_props_size(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
+fn parse_struct_unnamed_props_encoding(props: &[UnnamedProp], struct_ident: &Ident) -> TokenStream {
+    let recurse = props.iter().enumerate().map(|(idx, prop)| {
+        let field_idx = syn::Index::from(idx);
+        if prop.attrs.varint {
+            quote! {
+                tracing::trace!("encoding varint struct: <{}> field <{}> => {:?}",stringify!(#struct_ident),stringify!(#idx),&self.#field_idx);
+                let result = self.#field_idx.encode_varint(dest);
+                if result.is_err() {
+                    tracing::error!("error varint encoding <{}> ==> {}",stringify!(#idx),result.as_ref().unwrap_err());
+                    return result;
+                }
+            }
+        } else {
+            let base = quote! {
+                tracing::trace!("encoding struct: <{}>, field <{}> => {:?}",stringify!(#struct_ident),stringify!(#idx),&self.#field_idx);
+                let result = self.#field_idx.encode(dest,version);
+                if result.is_err() {
+                    tracing::error!("Error Encoding <{}> ==> {}",stringify!(#idx),result.as_ref().unwrap_err());
+                    return result;
+                }
+            };
+
+            prop.version_check_token_stream(base)
+        }
+    });
+
+    quote! {
+        #(#recurse)*
+    }
+}
+
+fn parse_struct_props_size(props: &FluvioStructProps, struct_ident: &Ident) -> TokenStream {
+    let recurse = match props {
+        FluvioStructProps::Named(named_props) => {
+            parse_struct_named_props_size(named_props, struct_ident)
+        }
+        FluvioStructProps::Unnamed(unnamed_props) => {
+            parse_struct_unnamed_props_size(unnamed_props, struct_ident)
+        }
+    };
+    recurse
+}
+
+fn parse_struct_named_props_size(props: &[NamedProp], struct_ident: &Ident) -> TokenStream {
     let recurse = props.iter().map(|prop| {
         let fname = format_ident!("{}", prop.field_name);
         if prop.attrs.varint {
@@ -101,6 +157,29 @@ fn parse_struct_props_size(props: &[NamedProp], struct_ident: &Ident) -> TokenSt
             let base = quote! {
                 let write_size = self.#fname.write_size(version);
                 tracing::trace!("write size: <{}> field: <{}> => {}",stringify!(#struct_ident),stringify!(#fname),write_size);
+                len += write_size;
+            };
+            prop.version_check_token_stream(base)
+        }
+    });
+    quote! {
+        #(#recurse)*
+    }
+}
+
+fn parse_struct_unnamed_props_size(props: &[UnnamedProp], struct_ident: &Ident) -> TokenStream {
+    let recurse = props.iter().enumerate().map(|(idx, prop)| {
+        let field_idx = syn::Index::from(idx);
+        if prop.attrs.varint {
+            quote! {
+                let write_size = self.#field_idx.var_write_size();
+                tracing::trace!("varint write size: <{}>, field: <{}> is: {}",stringify!(#struct_ident),stringify!(#idx),write_size);
+                len += write_size;
+            }
+        } else {
+            let base = quote! {
+                let write_size = self.#field_idx.write_size(version);
+                tracing::trace!("write size: <{}> field: <{}> => {}",stringify!(#struct_ident),stringify!(#idx),write_size);
                 len += write_size;
             };
             prop.version_check_token_stream(base)

--- a/crates/fluvio-protocol-derive/ui-tests/pass_derive_decode.rs
+++ b/crates/fluvio-protocol-derive/ui-tests/pass_derive_decode.rs
@@ -61,3 +61,6 @@ impl Default for PassNamedEnum {
         }
     }
 }
+
+#[derive(Encoder, Default)]
+struct PassTupleStruct (u16, String);

--- a/crates/fluvio-protocol-derive/ui-tests/pass_derive_encode.rs
+++ b/crates/fluvio-protocol-derive/ui-tests/pass_derive_encode.rs
@@ -32,3 +32,6 @@ enum PassNamedEnum {
     Alpha { name: String, number: i32 },
     Beta { data: Vec<u8> },
 }
+
+#[derive(Encoder)]
+struct PassTupleStruct (u16, String);

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2018"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"
@@ -17,7 +17,7 @@ store = ["fluvio-future"]
 
 [dependencies]
 tracing = "0.1"
-fluvio-protocol-derive = { version = "0.3.0", path = "../fluvio-protocol-derive", optional = true }
+fluvio-protocol-derive = { version = "0.3.2", path = "../fluvio-protocol-derive", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
 bytes = { version = "1" }
 tokio-util = { version = "0.6.4", features = [

--- a/crates/fluvio-protocol/tests/tuple_struct.rs
+++ b/crates/fluvio-protocol/tests/tuple_struct.rs
@@ -8,9 +8,10 @@ pub struct TupleStruct(String, i32);
 
 #[test]
 fn test_encode_tuple_struct() -> Result<(), Error> {
-    let mut v1 = TupleStruct::default();
-    v1.0 = format!("Struct without named fields");
-    v1.1 = 42;
+    let v1 = TupleStruct {
+        0: "Struct without named fields".to_string(),
+        1: 42,
+    };
     let mut src = vec![];
     v1.encode(&mut src, 0)?;
 

--- a/crates/fluvio-protocol/tests/tuple_struct.rs
+++ b/crates/fluvio-protocol/tests/tuple_struct.rs
@@ -1,0 +1,24 @@
+use std::io::Cursor;
+use std::io::Error;
+
+use fluvio_protocol::{Decoder, Encoder};
+
+#[derive(Encoder, Default, Decoder, Debug)]
+pub struct TupleStruct(String, i32);
+
+#[test]
+fn test_encode_tuple_struct() -> Result<(), Error> {
+    let mut v1 = TupleStruct::default();
+    v1.0 = format!("Struct without named fields");
+    v1.1 = 42;
+    let mut src = vec![];
+    v1.encode(&mut src, 0)?;
+
+    // 29 bytes (String) + 4 bytes (i32)
+    assert_eq!(src.len(), 33);
+    let v2 = TupleStruct::decode_from(&mut Cursor::new(src), 0)?;
+    assert_eq!(v2.0, "Struct without named fields");
+    assert_eq!(v2.1, 42);
+
+    Ok(())
+}

--- a/crates/fluvio-protocol/tests/tuple_struct.rs
+++ b/crates/fluvio-protocol/tests/tuple_struct.rs
@@ -6,6 +6,9 @@ use fluvio_protocol::{Decoder, Encoder};
 #[derive(Encoder, Default, Decoder, Debug)]
 pub struct TupleStruct(String, i32);
 
+#[derive(Encoder, Default, Decoder, Debug)]
+pub struct TestString(String);
+
 #[test]
 fn test_encode_tuple_struct() -> Result<(), Error> {
     let v1 = TupleStruct {
@@ -20,6 +23,22 @@ fn test_encode_tuple_struct() -> Result<(), Error> {
     let v2 = TupleStruct::decode_from(&mut Cursor::new(src), 0)?;
     assert_eq!(v2.0, "Struct without named fields");
     assert_eq!(v2.1, 42);
+
+    Ok(())
+}
+
+#[test]
+fn test_encode_test_string() -> Result<(), Error> {
+    let v1 = TestString {
+        0: "Inner string".to_string(),
+    };
+    let mut src = vec![];
+    v1.encode(&mut src, 0)?;
+
+    // 14 bytes (String)
+    assert_eq!(src.len(), 14);
+    let v2 = TestString::decode_from(&mut Cursor::new(src), 0)?;
+    assert_eq!(v2.0, "Inner string");
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio/issues/1828

Allows use to successfully encode/decode tuple structs, eg:
```rust
pub struct MyTupleStruct(i32, HashMap<String, String>);
```