### PR TITLE
[Merged by Bors] - Add help description for fluvio connector

### DIFF
--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -151,6 +151,7 @@ mod root {
         )]
         Metadata(MetadataOpt),
 
+        /// Create and work with Managed Connectors
         #[structopt(name = "connector")]
         ManagedConnector(ManagedConnectorCmd),
 


### PR DESCRIPTION
Closes #1919, adding help description for `fluvio connector`

```
Fluvio command-line interface

fluvio-cli [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
        --tls                   Enable TLS
        --enable-client-cert    TLS: use client cert
    -h, --help                  Prints help information

OPTIONS:
    -c, --cluster <host:port>          Address of cluster
        --domain <domain>              Required if client cert is used
        --ca-cert <ca-cert>            Path to TLS ca cert, required when client cert is enabled
        --client-cert <client-cert>    Path to TLS client certificate
        --client-key <client-key>      Path to TLS client private key
    -P, --profile <profile>

SUBCOMMANDS:
    consume        Read messages from a topic/partition
    produce        Write messages to a topic/partition
    topic          Manage and view Topics
    partition      Manage and view Partitions
    smartmodule    Create and manage SmartModules
    profile        Manage Profiles, which describe linked clusters
    cluster        Install or uninstall Fluvio clusters
    install        Install Fluvio plugins
    update         Update the Fluvio CLI
    version        Print Fluvio version information
    connector      Create and work with Managed Connectors
    table          Create a table display specification
    smartstream
    help           Prints this message or the help of the given subcommand(s)
```