### PR TITLE
[Merged by Bors] - Use version from the client in SmartEngine to encode/decode input/output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make Fluvio cluster working on Apple Silicon ([#1896](https://github.com/infinyon/fluvio/pull/1896))
 * Rename `fluvio table` to `fluvio tableformat` ([#1918](https://github.com/infinyon/fluvio/pull/1918))
 * Restrict max version in fluvio client ([#1930](https://github.com/infinyon/fluvio/issues/1930))
+* Use version from the client in SmartEngine to encode/decode input/output ([#1924](https://github.com/infinyon/fluvio/pull/1924))
 
 ## Platform Version 0.9.12 - 2021-10-27
 * Add examples for ArrayMap. ([#1804](https://github.com/infinyon/fluvio/issues/1804))

--- a/crates/fluvio-dataplane-protocol/src/smartmodule.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartmodule.rs
@@ -191,10 +191,14 @@ mod encoding {
     pub enum SmartModuleKind {
         Filter,
         Map,
+        #[fluvio(min_version = 15)]
         ArrayMap,
-        FilterMap,
-        Join,
+        #[fluvio(min_version = 13)]
         Aggregate,
+        #[fluvio(min_version = 16)]
+        FilterMap,
+        #[fluvio(min_version = 16)]
+        Join,
     }
 
     impl Default for SmartModuleKind {

--- a/crates/fluvio-dataplane-protocol/src/smartmodule.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartmodule.rs
@@ -35,9 +35,9 @@ mod encoding {
         pub base_offset: Offset,
         /// The records for the SmartModule to process
         pub record_data: Vec<u8>,
+        pub params: SmartModuleExtraParams,
         #[fluvio(min_version = 16)]
         pub join_record: Vec<u8>,
-        pub params: SmartModuleExtraParams,
     }
     impl std::convert::TryFrom<Vec<Record>> for SmartModuleInput {
         type Error = std::io::Error;
@@ -85,7 +85,7 @@ mod encoding {
     pub struct SmartModuleAggregateOutput {
         /// The base output required by all SmartModules
         pub base: SmartModuleOutput,
-
+        #[fluvio(min_version = 16)]
         pub accumulator: Vec<u8>,
     }
 

--- a/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
@@ -11,7 +11,7 @@ use dataplane::smartmodule::{
 };
 
 const AGGREGATE_FN_NAME: &str = "aggregate";
-type AggregateFn = TypedFunc<(i32, i32), i32>;
+type AggregateFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleAggregate {
     base: SmartModuleContext,

--- a/crates/fluvio-smartengine/src/smartmodule/array_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/array_map.rs
@@ -8,7 +8,7 @@ use dataplane::smartmodule::{
 use crate::smartmodule::{SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance};
 
 const ARRAY_MAP_FN_NAME: &str = "array_map";
-type ArrayMapFn = TypedFunc<(i32, i32), i32>;
+type ArrayMapFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleArrayMap {
     base: SmartModuleContext,
@@ -20,7 +20,7 @@ impl SmartModuleArrayMap {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
-        version: i16
+        version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let map_fn: ArrayMapFn = base

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 use anyhow::Result;
-use fluvio_spu_schema::server::stream_fetch::WASM_MODULE_V2_API;
 use wasmtime::TypedFunc;
 
 use dataplane::smartmodule::{
@@ -21,8 +20,9 @@ impl SmartModuleFilter {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
+        version: i16
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params)?;
+        let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let filter_fn: FilterFn = base
             .instance
             .get_typed_func(&mut base.store, FILTER_FN_NAME)?;
@@ -33,7 +33,7 @@ impl SmartModuleFilter {
 
 impl SmartModuleInstance for SmartModuleFilter {
     fn process(&mut self, input: SmartModuleInput) -> Result<SmartModuleOutput> {
-        let slice = self.base.write_input(&input, WASM_MODULE_V2_API)?;
+        let slice = self.base.write_input(&input)?;
         let filter_output = self.filter_fn.call(&mut self.base.store, slice)?;
 
         if filter_output < 0 {
@@ -42,7 +42,7 @@ impl SmartModuleInstance for SmartModuleFilter {
             return Err(internal_error.into());
         }
 
-        let output: SmartModuleOutput = self.base.read_output(WASM_MODULE_V2_API)?;
+        let output: SmartModuleOutput = self.base.read_output()?;
         Ok(output)
     }
 

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -8,7 +8,7 @@ use dataplane::smartmodule::{
 use crate::smartmodule::{SmartModuleWithEngine, SmartEngine, SmartModuleContext, SmartModuleInstance};
 
 const FILTER_FN_NAME: &str = "filter";
-type FilterFn = TypedFunc<(i32, i32), i32>;
+type FilterFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleFilter {
     base: SmartModuleContext,
@@ -20,7 +20,7 @@ impl SmartModuleFilter {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
-        version: i16
+        version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let filter_fn: FilterFn = base

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -9,7 +9,7 @@ use crate::smartmodule::{
 };
 
 const FILTER_MAP_FN_NAME: &str = "filter_map";
-type FilterMapFn = TypedFunc<(i32, i32), i32>;
+type FilterMapFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleFilterMap {
     base: SmartModuleContext,

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -1,19 +1,37 @@
 use std::convert::TryFrom;
 use anyhow::Result;
-use wasmtime::TypedFunc;
+use wasmtime::{AsContextMut, Trap, TypedFunc};
 
 use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
-use crate::smartmodule::{
-    SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-    SmartModuleExtraParams,
+use crate::{
+    WasmSlice,
+    smartmodule::{
+        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
+        SmartModuleExtraParams,
+    },
 };
 
 const FILTER_MAP_FN_NAME: &str = "filter_map";
+type OldFilterMapFn = TypedFunc<(i32, i32), i32>;
 type FilterMapFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleFilterMap {
     base: SmartModuleContext,
-    filter_map_fn: FilterMapFn,
+    filter_map_fn: FilterMapFnKind,
+}
+
+enum FilterMapFnKind {
+    Old(OldFilterMapFn),
+    New(FilterMapFn),
+}
+
+impl FilterMapFnKind {
+    fn call(&self, store: impl AsContextMut, slice: WasmSlice) -> Result<i32, Trap> {
+        match self {
+            Self::Old(filter_fn) => filter_fn.call(store, (slice.0, slice.1)),
+            Self::New(filter_fn) => filter_fn.call(store, slice),
+        }
+    }
 }
 
 impl SmartModuleFilterMap {
@@ -24,9 +42,17 @@ impl SmartModuleFilterMap {
         version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
-        let filter_map_fn: FilterMapFn = base
+        let filter_map_fn = if let Ok(fmap_fn) = base
             .instance
-            .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)?;
+            .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
+        {
+            FilterMapFnKind::New(fmap_fn)
+        } else {
+            let fmap_fn: OldFilterMapFn = base
+                .instance
+                .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)?;
+            FilterMapFnKind::Old(fmap_fn)
+        };
 
         Ok(Self {
             base,

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -11,7 +11,7 @@ use crate::smartmodule::{
 };
 
 const JOIN_FN_NAME: &str = "join";
-type JoinFn = TypedFunc<(i32, i32), i32>;
+type JoinFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleJoin {
     base: SmartModuleContext,
@@ -23,7 +23,7 @@ impl SmartModuleJoin {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
-        version: i16
+        version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let join_fn: JoinFn = base

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use tracing::{debug, instrument};
 use wasmtime::TypedFunc;
 
-use fluvio_spu_schema::server::stream_fetch::SMART_MODULE_API;
 use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
 use crate::smartmodule::{
     SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
@@ -24,8 +23,9 @@ impl SmartModuleJoin {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
+        version: i16
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params)?;
+        let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let join_fn: JoinFn = base
             .instance
             .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
@@ -37,7 +37,7 @@ impl SmartModuleJoin {
 impl SmartModuleInstance for SmartModuleJoin {
     #[instrument(skip(self, input), name = "Join")]
     fn process(&mut self, input: SmartModuleInput) -> Result<SmartModuleOutput> {
-        let slice = self.base.write_input(&input, SMART_MODULE_API)?;
+        let slice = self.base.write_input(&input)?;
         debug!(len = slice.1, "WASM SLICE");
         let map_output = self.join_fn.call(&mut self.base.store, slice)?;
 
@@ -47,7 +47,7 @@ impl SmartModuleInstance for SmartModuleJoin {
             return Err(internal_error.into());
         }
 
-        let output: SmartModuleOutput = self.base.read_output(SMART_MODULE_API)?;
+        let output: SmartModuleOutput = self.base.read_output()?;
         Ok(output)
     }
 

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -2,20 +2,38 @@ use std::convert::TryFrom;
 
 use anyhow::Result;
 use tracing::{debug, instrument};
-use wasmtime::TypedFunc;
+use wasmtime::{AsContextMut, Trap, TypedFunc};
 
 use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
-use crate::smartmodule::{
-    SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-    SmartModuleExtraParams,
+use crate::{
+    WasmSlice,
+    smartmodule::{
+        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
+        SmartModuleExtraParams,
+    },
 };
 
 const JOIN_FN_NAME: &str = "join";
+type OldJoinFn = TypedFunc<(i32, i32), i32>;
 type JoinFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleJoin {
     base: SmartModuleContext,
-    join_fn: JoinFn,
+    join_fn: JoinFnKind,
+}
+
+pub enum JoinFnKind {
+    Old(OldJoinFn),
+    New(JoinFn),
+}
+
+impl JoinFnKind {
+    fn call(&self, store: impl AsContextMut, slice: WasmSlice) -> Result<i32, Trap> {
+        match self {
+            Self::Old(join_fn) => join_fn.call(store, (slice.0, slice.1)),
+            Self::New(join_fn) => join_fn.call(store, slice),
+        }
+    }
 }
 
 impl SmartModuleJoin {
@@ -26,10 +44,15 @@ impl SmartModuleJoin {
         version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
-        let join_fn: JoinFn = base
-            .instance
-            .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
-
+        let join_fn =
+            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
+                JoinFnKind::New(join_fn)
+            } else {
+                let join_fn = base
+                    .instance
+                    .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
+                JoinFnKind::Old(join_fn)
+            };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -11,7 +11,7 @@ use crate::smartmodule::{
 };
 
 const JOIN_FN_NAME: &str = "join";
-type JoinFn = TypedFunc<(i32, i32), i32>;
+type JoinFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleJoinStream {
     base: SmartModuleContext,
@@ -23,7 +23,7 @@ impl SmartModuleJoinStream {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
-        version: i16
+        version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let join_fn: JoinFn = base

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -2,20 +2,38 @@ use std::convert::TryFrom;
 
 use anyhow::Result;
 use tracing::{debug, instrument};
-use wasmtime::TypedFunc;
+use wasmtime::{AsContextMut, Trap, TypedFunc};
 
 use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
-use crate::smartmodule::{
-    SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-    SmartModuleExtraParams,
+use crate::{
+    WasmSlice,
+    smartmodule::{
+        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
+        SmartModuleExtraParams,
+    },
 };
 
 const JOIN_FN_NAME: &str = "join";
+type OldJoinFn = TypedFunc<(i32, i32), i32>;
 type JoinFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleJoinStream {
     base: SmartModuleContext,
-    join_fn: JoinFn,
+    join_fn: JoinFnKind,
+}
+
+pub enum JoinFnKind {
+    Old(OldJoinFn),
+    New(JoinFn),
+}
+
+impl JoinFnKind {
+    fn call(&self, store: impl AsContextMut, slice: WasmSlice) -> Result<i32, Trap> {
+        match self {
+            Self::Old(join_fn) => join_fn.call(store, (slice.0, slice.1)),
+            Self::New(join_fn) => join_fn.call(store, slice),
+        }
+    }
 }
 
 impl SmartModuleJoinStream {
@@ -26,10 +44,15 @@ impl SmartModuleJoinStream {
         version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
-        let join_fn: JoinFn = base
-            .instance
-            .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
-
+        let join_fn =
+            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
+                JoinFnKind::New(join_fn)
+            } else {
+                let join_fn = base
+                    .instance
+                    .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
+                JoinFnKind::Old(join_fn)
+            };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -9,7 +9,7 @@ use crate::smartmodule::{
 };
 
 const MAP_FN_NAME: &str = "map";
-type MapFn = TypedFunc<(i32, i32), i32>;
+type MapFn = TypedFunc<(i32, i32, u32), i32>;
 
 pub struct SmartModuleMap {
     base: SmartModuleContext,
@@ -21,7 +21,7 @@ impl SmartModuleMap {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
-        version: i16
+        version: i16,
     ) -> Result<Self> {
         let mut base = SmartModuleContext::new(engine, module, params, version)?;
         let map_fn: MapFn = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)?;

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -37,6 +37,8 @@ use fluvio_controlplane_metadata::smartmodule::{SmartModuleSpec};
 
 use self::join_stream::SmartModuleJoinStream;
 
+const DEFAULT_SMARTENGINE_VERSION: i16 = 16;
+
 #[derive(Default, Clone)]
 pub struct SmartEngine(pub(crate) Engine);
 
@@ -75,24 +77,26 @@ impl SmartEngine {
     pub fn create_module_from_payload(
         self,
         smart_payload: LegacySmartModulePayload,
+        maybe_version: Option<i16>,
     ) -> Result<Box<dyn SmartModuleInstance>> {
+        let version = maybe_version.unwrap_or(DEFAULT_SMARTENGINE_VERSION);
         let smartmodule = self.create_module_from_binary(&smart_payload.wasm.get_raw()?)?;
         let smartmodule_instance: Box<dyn SmartModuleInstance> = match &smart_payload.kind {
-            SmartModuleKind::Filter => Box::new(smartmodule.create_filter(smart_payload.params)?),
+            SmartModuleKind::Filter => Box::new(smartmodule.create_filter(smart_payload.params, version)?),
             SmartModuleKind::FilterMap => {
-                Box::new(smartmodule.create_filter_map(smart_payload.params)?)
+                Box::new(smartmodule.create_filter_map(smart_payload.params, version)?)
             }
-            SmartModuleKind::Map => Box::new(smartmodule.create_map(smart_payload.params)?),
+            SmartModuleKind::Map => Box::new(smartmodule.create_map(smart_payload.params, version)?),
             SmartModuleKind::ArrayMap => {
-                Box::new(smartmodule.create_array_map(smart_payload.params)?)
+                Box::new(smartmodule.create_array_map(smart_payload.params, version)?)
             }
-            SmartModuleKind::Join(_) => Box::new(smartmodule.create_join(smart_payload.params)?),
+            SmartModuleKind::Join(_) => Box::new(smartmodule.create_join(smart_payload.params, version)?),
             SmartModuleKind::JoinStream {
                 topic: _,
                 derivedstream: _,
-            } => Box::new(smartmodule.create_join_stream(smart_payload.params)?),
+            } => Box::new(smartmodule.create_join_stream(smart_payload.params, version)?),
             SmartModuleKind::Aggregate { accumulator } => {
-                Box::new(smartmodule.create_aggregate(smart_payload.params, accumulator.clone())?)
+                Box::new(smartmodule.create_aggregate(smart_payload.params, accumulator.clone(), version)?)
             }
         };
         Ok(smartmodule_instance)
@@ -111,33 +115,33 @@ pub struct SmartModuleWithEngine {
 }
 
 impl SmartModuleWithEngine {
-    fn create_filter(&self, params: SmartModuleExtraParams) -> Result<SmartModuleFilter> {
-        let filter = SmartModuleFilter::new(&self.engine, self, params)?;
+    fn create_filter(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleFilter> {
+        let filter = SmartModuleFilter::new(&self.engine, self, params, version)?;
         Ok(filter)
     }
 
-    fn create_map(&self, params: SmartModuleExtraParams) -> Result<SmartModuleMap> {
-        let map = SmartModuleMap::new(&self.engine, self, params)?;
+    fn create_map(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleMap> {
+        let map = SmartModuleMap::new(&self.engine, self, params, version)?;
         Ok(map)
     }
 
-    fn create_filter_map(&self, params: SmartModuleExtraParams) -> Result<SmartModuleFilterMap> {
-        let filter_map = SmartModuleFilterMap::new(&self.engine, self, params)?;
+    fn create_filter_map(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleFilterMap> {
+        let filter_map = SmartModuleFilterMap::new(&self.engine, self, params, version)?;
         Ok(filter_map)
     }
 
-    fn create_array_map(&self, params: SmartModuleExtraParams) -> Result<SmartModuleArrayMap> {
-        let map = SmartModuleArrayMap::new(&self.engine, self, params)?;
+    fn create_array_map(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleArrayMap> {
+        let map = SmartModuleArrayMap::new(&self.engine, self, params, version)?;
         Ok(map)
     }
 
-    fn create_join(&self, params: SmartModuleExtraParams) -> Result<SmartModuleJoin> {
-        let join = SmartModuleJoin::new(&self.engine, self, params)?;
+    fn create_join(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleJoin> {
+        let join = SmartModuleJoin::new(&self.engine, self, params, version)?;
         Ok(join)
     }
 
-    fn create_join_stream(&self, params: SmartModuleExtraParams) -> Result<SmartModuleJoinStream> {
-        let join = SmartModuleJoinStream::new(&self.engine, self, params)?;
+    fn create_join_stream(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleJoinStream> {
+        let join = SmartModuleJoinStream::new(&self.engine, self, params, version)?;
         Ok(join)
     }
 
@@ -145,8 +149,9 @@ impl SmartModuleWithEngine {
         &self,
         params: SmartModuleExtraParams,
         accumulator: Vec<u8>,
+        version: i16
     ) -> Result<SmartModuleAggregate> {
-        let aggregate = SmartModuleAggregate::new(&self.engine, self, params, accumulator)?;
+        let aggregate = SmartModuleAggregate::new(&self.engine, self, params, accumulator, version)?;
         Ok(aggregate)
     }
 }
@@ -156,6 +161,7 @@ pub struct SmartModuleContext {
     instance: Instance,
     records_cb: Arc<RecordsCallBack>,
     params: SmartModuleExtraParams,
+    version: i16,
 }
 
 impl SmartModuleContext {
@@ -163,6 +169,7 @@ impl SmartModuleContext {
         engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
+        version: i16,
     ) -> Result<Self> {
         let mut store = Store::new(&engine.0, ());
         let cb = Arc::new(RecordsCallBack::new());
@@ -188,13 +195,14 @@ impl SmartModuleContext {
             instance,
             records_cb,
             params,
+            version,
         })
     }
 
-    pub fn write_input<E: Encoder>(&mut self, input: &E, version: i16) -> Result<WasmSlice> {
+    pub fn write_input<E: Encoder>(&mut self, input: &E) -> Result<WasmSlice> {
         self.records_cb.clear();
         let mut input_data = Vec::new();
-        input.encode(&mut input_data, version)?;
+        input.encode(&mut input_data, self.version)?;
         debug!(len = input_data.len(), "input data");
         let array_ptr =
             self::memory::copy_memory_to_instance(&mut self.store, &self.instance, &input_data)?;
@@ -202,14 +210,14 @@ impl SmartModuleContext {
         Ok((array_ptr as i32, length as i32))
     }
 
-    pub fn read_output<D: Decoder + Default>(&mut self, version: i16) -> Result<D> {
+    pub fn read_output<D: Decoder + Default>(&mut self) -> Result<D> {
         let bytes = self
             .records_cb
             .get()
             .and_then(|m| m.copy_memory_from(&mut self.store).ok())
             .unwrap_or_default();
         let mut output = D::default();
-        output.decode(&mut std::io::Cursor::new(bytes), version)?;
+        output.decode(&mut std::io::Cursor::new(bytes), self.version)?;
         Ok(output)
     }
 }

--- a/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
@@ -51,7 +51,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleAggregateInput::default();
                 // 13 is version for aggregate
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::AGGREGATOR_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
@@ -61,7 +61,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 let records_input = smartmodule_input.base.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::AGGREGATOR_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -102,7 +102,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::AGGREGATOR_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::SMART_MODULE_API) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
@@ -36,7 +36,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn aggregate(ptr: &mut u8, len: usize) -> i32 {
+            pub unsafe fn aggregate(ptr: &mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleAggregateInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,SmartModuleAggregateOutput
@@ -51,7 +51,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleAggregateInput::default();
                 // 13 is version for aggregate
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
@@ -61,7 +61,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 let records_input = smartmodule_input.base.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -102,7 +102,7 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/array_map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/array_map.rs
@@ -36,7 +36,7 @@ pub fn generate_array_map_smartmodule(func: &SmartModuleFn, has_params: bool) ->
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn array_map(ptr: *mut u8, len: usize) -> i32 {
+            pub unsafe fn array_map(ptr: *mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,
@@ -51,13 +51,13 @@ pub fn generate_array_map_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleInput::default();
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
                 let records_input = smartmodule_input.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -95,7 +95,7 @@ pub fn generate_array_map_smartmodule(func: &SmartModuleFn, has_params: bool) ->
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/filter.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/filter.rs
@@ -35,7 +35,7 @@ pub fn generate_filter_smartmodule(func: &SmartModuleFn, has_params: bool) -> To
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn filter(ptr: *mut u8, len: usize) -> i32 {
+            pub unsafe fn filter(ptr: *mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,
@@ -50,13 +50,13 @@ pub fn generate_filter_smartmodule(func: &SmartModuleFn, has_params: bool) -> To
 
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleInput::default();
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
                 let records_input = smartmodule_input.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -92,7 +92,7 @@ pub fn generate_filter_smartmodule(func: &SmartModuleFn, has_params: bool) -> To
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/filter_map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/filter_map.rs
@@ -36,7 +36,7 @@ pub fn generate_filter_map_smartmodule(func: &SmartModuleFn, has_params: bool) -
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn filter_map(ptr: *mut u8, len: usize) -> i32 {
+            pub unsafe fn filter_map(ptr: *mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,
@@ -51,13 +51,13 @@ pub fn generate_filter_map_smartmodule(func: &SmartModuleFn, has_params: bool) -
 
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleInput::default();
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
                 let records_input = smartmodule_input.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -93,7 +93,7 @@ pub fn generate_filter_map_smartmodule(func: &SmartModuleFn, has_params: bool) -
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::ARRAY_MAP_WASM_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/join.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/join.rs
@@ -36,7 +36,7 @@ pub fn generate_join_smartmodule(func: &SmartModuleFn, has_params: bool) -> Toke
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn join(ptr: *mut u8, len: usize) -> i32 {
+            pub unsafe fn join(ptr: *mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,
@@ -51,19 +51,19 @@ pub fn generate_join_smartmodule(func: &SmartModuleFn, has_params: bool) -> Toke
 
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleInput::default();
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
                 let records_input = smartmodule_input.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
                 let join_last_record_input = smartmodule_input.join_record;
                 let mut join_last_record: Option<Record> = None;
-                if let Err(_err) = Decoder::decode(&mut join_last_record, &mut std::io::Cursor::new(join_last_record_input), fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_err) = Decoder::decode(&mut join_last_record, &mut std::io::Cursor::new(join_last_record_input), version) {
                     return SmartModuleInternalError::UndefinedRightRecord as i32;
                 };
                 let join_last_record = match join_last_record {
@@ -102,7 +102,7 @@ pub fn generate_join_smartmodule(func: &SmartModuleFn, has_params: bool) -> Toke
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::SMART_MODULE_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule-derive/src/generator/map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/map.rs
@@ -36,7 +36,7 @@ pub fn generate_map_smartmodule(func: &SmartModuleFn, has_params: bool) -> Token
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
-            pub unsafe fn map(ptr: *mut u8, len: usize) -> i32 {
+            pub unsafe fn map(ptr: *mut u8, len: usize, version: i16) -> i32 {
                 use fluvio_smartmodule::dataplane::smartmodule::{
                     SmartModuleInput, SmartModuleInternalError,
                     SmartModuleRuntimeError, SmartModuleKind, SmartModuleOutput,
@@ -51,13 +51,13 @@ pub fn generate_map_smartmodule(func: &SmartModuleFn, has_params: bool) -> Token
 
                 let input_data = Vec::from_raw_parts(ptr, len, len);
                 let mut smartmodule_input = SmartModuleInput::default();
-                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_err) = Decoder::decode(&mut smartmodule_input, &mut std::io::Cursor::new(input_data), version) {
                     return SmartModuleInternalError::DecodingBaseInput as i32;
                 }
 
                 let records_input = smartmodule_input.record_data;
                 let mut records: Vec<Record> = vec![];
-                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_err) = Decoder::decode(&mut records, &mut std::io::Cursor::new(records_input), version) {
                     return SmartModuleInternalError::DecodingRecords as i32;
                 };
 
@@ -92,7 +92,7 @@ pub fn generate_map_smartmodule(func: &SmartModuleFn, has_params: bool) -> Token
 
                 // ENCODING
                 let mut out = vec![];
-                if let Err(_) = Encoder::encode(&mut output, &mut out, fluvio_smartmodule::api_versions::WASM_MODULE_V2_API) {
+                if let Err(_) = Encoder::encode(&mut output, &mut out, version) {
                     return SmartModuleInternalError::EncodingOutput as i32;
                 }
 

--- a/crates/fluvio-smartmodule/src/lib.rs
+++ b/crates/fluvio-smartmodule/src/lib.rs
@@ -37,9 +37,3 @@ pub mod memory {
         std::mem::drop(data);
     }
 }
-
-pub mod api_versions {
-    pub use fluvio_spu_schema::server::stream_fetch::{
-        AGGREGATOR_API, SMART_MODULE_API, ARRAY_MAP_WASM_API, WASM_MODULE_V2_API,
-    };
-}

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -120,11 +120,11 @@ impl Default for SmartModuleInvocationWasm {
 pub enum SmartModuleKind {
     Filter,
     Map,
+    #[fluvio(min_version = ARRAY_MAP_WASM_API)]
+    ArrayMap,
     Aggregate {
         accumulator: Vec<u8>,
     },
-    #[fluvio(min_version = ARRAY_MAP_WASM_API)]
-    ArrayMap,
     #[fluvio(min_version = ARRAY_MAP_WASM_API)]
     FilterMap,
     #[fluvio(min_version = SMART_MODULE_API)]

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -128,11 +128,13 @@ impl StreamFetchHandler {
         msg: StreamFetchRequest<FileRecordSet>,
     ) -> Result<(), SocketError> {
         debug!("request: {:#?}", msg);
+        let version = header.api_version();
 
         let derivedstream_ctx = match SmartModuleContext::extract(
             msg.wasm_payload,
             msg.smartmodule,
             msg.derivedstream,
+            version,
             &ctx,
         )
         .await

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -49,7 +49,8 @@ cfg_if::cfg_if! {
             fn init_engine(&mut self, smart_payload: LegacySmartModulePayload) -> Result<(), FluvioError> {
                 let engine = SmartEngine::default();
                 let  smartmodule = engine.create_module_from_payload(
-                    smart_payload).map_err(|e| FluvioError::Other(format!("SmartEngine - {:?}", e)))?;
+                    smart_payload,
+                    None).map_err(|e| FluvioError::Other(format!("SmartEngine - {:?}", e)))?;
                 self.smartmodule_instance = Some(Arc::new(RwLock::new(smartmodule)));
                 Ok(())
             }


### PR DESCRIPTION
Closes https://github.com/infinyon/fluvio/issues/1894

Backward compatibility with old wasm modules is keep due to we now check for both 
```rust
 TypedFunc<(i32, i32), i32>;
 TypedFunc<(i32, i32, u32), i32>;
```