### PR TITLE
[Merged by Bors] - Add to publish crates list

### DIFF
--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -1,0 +1,66 @@
+name: Publish crates to crates.io 
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+#env:
+#  USE_COMMIT: ${{ github.event.inputs.commit }}
+#  FORCE_RELEASE: ${{ github.event.inputs.force }}
+
+jobs:
+  #cd_dev_check:
+  #  name: CD_Dev check
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Login GH CLI
+  #      run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+  #    - name: Get status of latest CD_Dev run
+  #      id: cd_dev_check
+  #      run: |
+  #        gh api /repos/{owner}/{repo}/actions/workflows/cd_dev.yaml/runs | jq .workflow_runs[0] > /tmp/cd_dev_latest.txt  
+  #        echo "Latest CD_Dev run: $(cat /tmp/cd_dev_latest.txt | jq .html_url | tr -d '"')"
+  #        CD_DEV_CHECK=$(cat /tmp/cd_dev_latest.txt | jq .conclusion | tr -d '"')
+  #        if [[ "$CD_DEV_CHECK" = "success" ]]
+  #        then
+  #          echo ✅ Most recent CD_Dev run passed
+  #          exit 0;
+  #        else
+  #          echo ❌ Most recent CD_Dev run failed
+  #          exit 1;
+  #        fi
+  publish_crates:
+    name: Publish crates to crates.io 
+    strategy:
+      matrix:
+        rust: [stable]
+    runs-on: ubuntu-latest
+    #permissions: write-all
+    steps:
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
+      - uses: actions/checkout@v2
+
+      - name: Run publish script
+        env:
+          VERBOSE: true
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          ./release-scripts/publish-crates.sh
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -8,7 +8,6 @@ keywords = ["streaming", "stream", "queue"]
 categories = ["encoding", "api-bindings"]
 repository = "https://github.com/infinyon/fluvio"
 description = "The offical Fluvio SmartEngine"
-publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/fluvio-smartmodule-derive/Cargo.toml
+++ b/crates/fluvio-smartmodule-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule-derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -52,7 +52,7 @@ dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
-fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true}
+fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.1.0" }
 
 [target.'cfg(unix)'.dependencies]
 fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema", features = ["file"] }

--- a/release-scripts/publish-list
+++ b/release-scripts/publish-list
@@ -10,6 +10,8 @@ PUBLISH_CRATES=(
     fluvio-stream-model
     fluvio-controlplane-metadata
     fluvio-spu-schema
+    fluvio-smartmodule-derive
+    fluvio-smartmodule
     fluvio-sc-schema
     fluvio
     fluvio-stream-dispatcher

--- a/release-scripts/publish-list
+++ b/release-scripts/publish-list
@@ -10,6 +10,7 @@ PUBLISH_CRATES=(
     fluvio-stream-model
     fluvio-controlplane-metadata
     fluvio-spu-schema
+    fluvio-smartengine
     fluvio-smartmodule-derive
     fluvio-smartmodule
     fluvio-sc-schema

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -12,7 +12,8 @@
 set -eu
 
 # Read in PUBLISH_CRATES var
-source $(dirname -- ${BASH_SOURCE[0]})/publish-list
+# shellcheck source=/dev/null
+source "$(dirname -- "${BASH_SOURCE[0]}")/publish-list"
 
 ALL_CRATE_CHECK_PASS=true
 CHECK_CRATES=()
@@ -63,7 +64,7 @@ function check_if_crate_published() {
     # Requires: curl, xsv (crate binary)
     CRATE_NAME=$1
 
-    if $(xsv select name ./crates_io/db_snapshot/*/data/crates.csv | grep -E "^$CRATE_NAME$" > /dev/null);
+    if xsv select name ./crates_io/db_snapshot/*/data/crates.csv | grep -E "^$CRATE_NAME$" > /dev/null;
     then
         return 0
     else
@@ -272,6 +273,9 @@ function main() {
 
     # Download crates.io db
     download_crates_io_data;
+
+    echo "Order of crates:"
+    printf "* %s\n" "${PUBLISH_CRATES[@]}"
 
     for crate in "${PUBLISH_CRATES[@]}" ; do
         echo

--- a/release-scripts/test-crate-version.sh
+++ b/release-scripts/test-crate-version.sh
@@ -47,7 +47,7 @@ function toml2json_check() {
 # Check if we have xsv in path
 # If not, attempt to download it
 function xsv_check() {
-    if which toml2json;
+    if which xsv;
     then
         echo "🔧 xsv found"
     else
@@ -63,7 +63,7 @@ function check_if_crate_published() {
     # Requires: curl, xsv (crate binary)
     CRATE_NAME=$1
 
-    if xsv select name ./crates_io/db_snapshot/*/data/crates.csv | grep -E "^$CRATE_NAME$" > /dev/null;
+    if $(xsv select name ./crates_io/db_snapshot/*/data/crates.csv | grep -E "^$CRATE_NAME$" > /dev/null);
     then
         return 0
     else


### PR DESCRIPTION
Adding crates to publish list for future [`Release`](https://github.com/infinyon/fluvio/actions/workflows/release.yml) workflow runs.

* fluvio-smartengine
* fluvio-smartmodule-derive
* fluvio-smartmodule

This PR also adds
- Support test support for new crates that have not been published yet.
- New Github Actions workflow for publishing crates w/ `workflow_dispatch` outside of running Release workflow

Resolves #1934 
Completes half of #1802 