### PR TITLE
[Merged by Bors] - Fix installation failure

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -132,7 +132,6 @@ jobs:
         timeout-minutes: 10
         env:
           TEST_DATA_BYTES: 10000
-          FLV_DISPATCHER_WAIT: 300 
         run: |
             export PATH=~/.fluvio/bin:$PATH
             USE_LATEST=true make upgrade-test

--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -75,7 +75,7 @@ jobs:
             else
               export PROXY=""
           fi
-          fluvio cluster start --image-version latest $PROXY
+          fluvio cluster start --spu-storage-size 1 --image-version latest $PROXY
       - name: Run E2E Test
         timeout-minutes: 2
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15,r16]
+        run: [r1]
         k8: [k3d,minikube]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,7 +561,9 @@ jobs:
           eval $(minikube -p minikube docker-env)
           docker image load --input /tmp/infinyon-fluvio.tar
       - name: Run smoke-test-k8-tls-root
-        timeout-minutes: 5
+        timeout-minutes: 10
+        env:
+          FLV_DISPATCHER_WAIT: 300
         run: |
             date
             make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,9 +561,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           docker image load --input /tmp/infinyon-fluvio.tar
       - name: Run smoke-test-k8-tls-root
-        timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC
+        timeout-minutes: 5
         run: |
             date
             make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15,r16]
         k8: [k3d,minikube]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14]
         k8: [k3d,minikube]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,8 +562,8 @@ jobs:
           docker image load --input /tmp/infinyon-fluvio.tar
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 300
+      #  env:
+      #    FLV_DISPATCHER_WAIT: 300
         run: |
             date
             make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.head_ref || 'ci_mac_staging' }}
+  group: ${{ github.head_ref }}-ci_mac
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -305,7 +305,7 @@ jobs:
         timeout-minutes: 3
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  DEFAULT_SPU=1 REPL=1 EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8
       - name: Print version
         run: |
           ./fluvio version

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -295,7 +295,9 @@ jobs:
         run: |
           brew install kind
           kind version
-          kind create cluster --config k8-util/cluster/kind.yaml 
+          kind create cluster --config k8-util/cluster/kind.yaml
+          sleep 10
+          kind get clusters 
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -121,6 +121,7 @@ jobs:
   local_cluster_test:
     name: Local cluster test run (${{ matrix.run }})-${{ matrix.test }}
     runs-on: ${{ matrix.os }}
+    if: ${{ false }}
     needs:
       - build_primary_binaries
       - config

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -240,9 +240,7 @@ jobs:
       - name: Build Docker image
         run: k8-util/docker/build.sh ${{ matrix.rust-target }} ${{ github.sha }} "$(pwd)/fluvio-run"
       - name: Export Docker Image to tarball
-        run: |
-          docker image tag infinyon/fluvio:${{ github.sha }}-${{ matrix.k8-target }} infinyon/fluvio:${{ github.sha }}
-          docker image save infinyon/fluvio:${{ github.sha }} --output /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
+        run: docker image save infinyon/fluvio:${{ github.sha }} --output /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
       - name: Upload tarball as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -294,6 +294,7 @@ jobs:
         if: ${{ matrix.k8 == 'kind' }}
         run: |
           brew install kind
+          kind version
           kind create cluster --config k8-util/cluster/kind.yaml 
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -121,7 +121,6 @@ jobs:
   local_cluster_test:
     name: Local cluster test run (${{ matrix.run }})-${{ matrix.test }}
     runs-on: ${{ matrix.os }}
-    if: ${{ false }}
     needs:
       - build_primary_binaries
       - config
@@ -308,6 +307,7 @@ jobs:
         timeout-minutes: 3
         run: |
           ./fluvio cluster start  --develop --spu-storage-size 1 --proxy-addr  127.0.0.1
+      # run a simpler configuration to run in a constraint mac
       - name: Run smoke-test-k8
         timeout-minutes: 3
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -302,11 +302,15 @@ jobs:
         if: ${{ matrix.k8 == 'kind' }}
         run: |
           kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
+      - name: Start Cluster
+        if: ${{ matrix.k8 == 'kind' }}
+        run: |
+          ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
       - name: Run smoke-test-k8
         timeout-minutes: 3
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  DEFAULT_SPU=1 REPL=1 EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  DEFAULT_SPU=1 REPL=1 UNINSTALL=noclean smoke-test-k8
       - name: Print version
         run: |
           ./fluvio version

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -305,7 +305,7 @@ jobs:
       - name: Start Cluster
         if: ${{ matrix.k8 == 'kind' }}
         run: |
-          ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
+          RUST_LOG=debug ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
       - name: Run smoke-test-k8
         timeout-minutes: 3
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -298,15 +298,16 @@ jobs:
           brew install kind
           kind version
           kind create cluster --config k8-util/cluster/kind.yaml
+          kind get clusters
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |
-          kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
+          kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar
       - name: Start Cluster
         if: ${{ matrix.k8 == 'kind' }}
-        timeout-minutes: 3
+        timeout-minutes: 1
         run: |
-          RUST_LOG=debug ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
+          ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
       - name: Run smoke-test-k8
         timeout-minutes: 3
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -297,7 +297,8 @@ jobs:
           kind version
           kind create cluster --config k8-util/cluster/kind.yaml
           sleep 10
-          kind get clusters 
+          kind get clusters
+          kubectl get nodes 
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -301,7 +301,7 @@ jobs:
         if: ${{ matrix.k8 == 'kind' }}
         run: |
           kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
-      - name: Run smoke-test-k8-tls-root
+      - name: Run smoke-test-k8
         timeout-minutes: 10
         env:
           FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -304,6 +304,7 @@ jobs:
           kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
       - name: Start Cluster
         if: ${{ matrix.k8 == 'kind' }}
+        timeout-minutes: 3
         run: |
           RUST_LOG=debug ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
       - name: Run smoke-test-k8

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -284,6 +284,7 @@ jobs:
         uses: docker-practice/actions-setup-docker@master
       # Retag image to remove arch from tag
       - name: Load Fluvio Docker Image for K3d
+        if: ${{ false }}
         run: |
           ls -la /tmp
           docker image load --input /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar
@@ -302,7 +303,7 @@ jobs:
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |
-          kind load docker-image infinyon/fluvio:${{ github.sha }}
+          kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 10
         env:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -305,9 +305,9 @@ jobs:
           kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar
       - name: Start Cluster
         if: ${{ matrix.k8 == 'kind' }}
-        timeout-minutes: 1
+        timeout-minutes: 3
         run: |
-          ./fluvio cluster start  --develop --proxy-addr  127.0.0.1
+          ./fluvio cluster start  --develop --spu-storage-size 1 --proxy-addr  127.0.0.1
       - name: Run smoke-test-k8
         timeout-minutes: 3
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ 'ci_tier2' }}
+  group: ${{ github.head_ref || 'ci_mac_staging' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -341,6 +341,7 @@ jobs:
           kubectl get pods
           kubectl get svc
           kubectl get spg
+          kubectl describe pod  `(kubectl get pod -l app=fluvio-sc  -o jsonpath="{.items[0].metadata.name}")`
           kubectl logs fluvio-spg-main-0  > /tmp/k8_${{ matrix.run }}_spu0.log || true
           kubectl logs fluvio-spg-main-1  > /tmp/k8_${{ matrix.run }}_spu1.log || true
           ./dev-tools/sc-pod-log.sh > /tmp/k8_${{ matrix.run }}_sc.log || true

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -298,7 +298,7 @@ jobs:
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |
-          kind load docker-image infinyon/fluvio:${{ github.sha }}
+          kind load docker-image infinyon/fluvio:${{ github.sha }} fluvio
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 10
         env:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -297,9 +297,6 @@ jobs:
           brew install kind
           kind version
           kind create cluster --config k8-util/cluster/kind.yaml
-          sleep 10
-          kind get clusters
-          kubectl get nodes 
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |
@@ -310,7 +307,7 @@ jobs:
           FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8-tls
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8
       - name: Print version
         run: |
           ./fluvio version

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -299,7 +299,7 @@ jobs:
       - name: Load image to kind
         if: ${{ matrix.k8 == 'kind' }}
         run: |
-          kind load docker-image infinyon/fluvio:${{ github.sha }} fluvio
+          kind load docker-image infinyon/fluvio:${{ github.sha }}
       - name: Run smoke-test-k8-tls-root
         timeout-minutes: 10
         env:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -302,9 +302,7 @@ jobs:
         run: |
           kind load image-archive /tmp/infinyon-fluvio-${{ matrix.k8-target }}.tar --name fluvio
       - name: Run smoke-test-k8
-        timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 300   # k3d in Github make take while to provision PVC
+        timeout-minutes: 3
         run: |
             date
             make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test  EXTRA_ARG="--cluster-start --proxy-addr  127.0.0.1" UNINSTALL=noclean smoke-test-k8

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -240,7 +240,9 @@ jobs:
       - name: Build Docker image
         run: k8-util/docker/build.sh ${{ matrix.rust-target }} ${{ github.sha }} "$(pwd)/fluvio-run"
       - name: Export Docker Image to tarball
-        run: docker image save infinyon/fluvio:${{ github.sha }}-${{ matrix.rust-target }} --output /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
+        run: |
+          docker image tag infinyon/fluvio:${{ github.sha }}-${{ matrix.k8-target }} infinyon/fluvio:${{ github.sha }}
+          docker image save infinyon/fluvio:${{ github.sha }} --output /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
       - name: Upload tarball as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.14 - UNRELEASED
 * Add support for tuple structs in fluvio-protocol derived macros. ([#1828](https://github.com/infinyon/fluvio/issues/1828))
 * Expose fluvio completions in the top-level subcommand. ([#1850](https://github.com/infinyon/fluvio/issues/1850))
+* Make installation more reliable ([#1961](https://github.com/infinyon/fluvio/pull/1961))
 
 ## Platform Version 0.9.13 - 2021-11-19
 * Fix connector create with `create_topic` option to succeed if topic already exists. ([#1823](https://github.com/infinyon/fluvio/pull/1823))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Makefile
+++ b/Makefile
@@ -327,11 +327,11 @@ upgrade: build-cli build_k8_image
 	$(FLUVIO_BIN) cluster upgrade --sys
 	$(FLUVIO_BIN) cluster upgrade --rust-log $(SERVER_LOG) --develop
 
-clean_charts:
-	make -C k8-util/helm clean
 
-clean:	clean_charts
+
+clean:
 	cargo clean
+	make -C k8-util/helm clean
 
 
 .EXPORT_ALL_VARIABLES:

--- a/Makefile
+++ b/Makefile
@@ -327,10 +327,11 @@ upgrade: build-cli build_k8_image
 	$(FLUVIO_BIN) cluster upgrade --sys
 	$(FLUVIO_BIN) cluster upgrade --rust-log $(SERVER_LOG) --develop
 
-
-clean:
-	cargo clean
+clean_charts:
 	make -C k8-util/helm clean
+
+clean:	clean_charts
+	cargo clean
 
 
 .EXPORT_ALL_VARIABLES:

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -627,7 +627,7 @@ impl ClusterInstaller {
 
         // HACK. set FLV_DISPATCHER if not set
         if env::var(DISPATCHER_WAIT).is_err() {
-            env::set_var("FLV_DISPATCHER_WAIT", "300");
+            env::set_var(DISPATCHER_WAIT, "300");
         }
 
         let mut sys_config: ChartConfig = ChartConfig::sys_builder()

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -627,7 +627,7 @@ impl ClusterInstaller {
 
         // HACK. set FLV_DISPATCHER if not set
         if env::var(DISPATCHER_WAIT).is_err() {
-            env::set_var(DISPATCHER_WAIT, "300");
+           // env::set_var(DISPATCHER_WAIT, "300");
         }
 
         let mut sys_config: ChartConfig = ChartConfig::sys_builder()

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -627,7 +627,7 @@ impl ClusterInstaller {
 
         // HACK. set FLV_DISPATCHER if not set
         if env::var(DISPATCHER_WAIT).is_err() {
-           // env::set_var(DISPATCHER_WAIT, "300");
+            env::set_var(DISPATCHER_WAIT, "300");
         }
 
         let mut sys_config: ChartConfig = ChartConfig::sys_builder()

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -623,6 +623,13 @@ impl ClusterInstaller {
     /// [`update_context`]: ./struct.ClusterInstaller.html#method.update_context
     #[instrument(skip(self))]
     pub async fn setup(&self) -> CheckResults {
+        const DISPATCHER_WAIT: &str = "FLV_DISPATCHER_WAIT";
+
+        // HACK. set FLV_DISPATCHER if not set
+        if env::var(DISPATCHER_WAIT).is_err() {
+            env::set_var("FLV_DISPATCHER_WAIT", "300");
+        }
+
         let mut sys_config: ChartConfig = ChartConfig::sys_builder()
             .version(self.config.chart_version.clone())
             .namespace(&self.config.namespace)

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/stream.rs
+++ b/crates/fluvio-socket/src/stream.rs
@@ -13,6 +13,7 @@ use futures_util::stream::{Stream, StreamExt};
 use tokio_util::codec::{FramedRead};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::compat::Compat;
+use tracing::debug;
 use tracing::error;
 use tracing::trace;
 
@@ -96,7 +97,7 @@ impl FluvioStream {
                 }
             }
         } else {
-            error!("no more response. server has terminated connection");
+            debug!("no more response. server has terminated connection");
             Err(IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection").into())
         }
     }

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -85,7 +85,7 @@ fn run_test(
     let test_case = TestCase::new(environment, test_opt);
 
     if std::env::var("CI").is_ok() {
-        test_driver.run_test(test_case, test_meta);
+        test_driver.run_test(test_case, test_meta)
     } else {
         let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
             (test_meta.test_fn)(test_driver, test_case)

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -85,7 +85,7 @@ fn run_test(
     let test_case = TestCase::new(environment, test_opt);
 
     if std::env::var("CI").is_ok() {
-        test_driver.run_test(test_case, test_meta)
+        (test_meta.test_fn)(test_driver, test_case).unwrap()
     } else {
         let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
             (test_meta.test_fn)(test_driver, test_case)

--- a/k8-util/cluster/cluster-type.sh
+++ b/k8-util/cluster/cluster-type.sh
@@ -8,7 +8,7 @@ if echo ${nodes} | grep -q minikube;  then
     echo 'minikube'
 elif echo ${nodes} | grep -q k3d; then
     echo "k3d"
-elif echo ${nodes} | grep -q kind; then
+elif echo ${nodes} | grep -q control-plane; then
     echo "kind"
 elif echo ${nodes} | grep -q microk8s; then
     echo "microk8"

--- a/k8-util/cluster/kind.yaml
+++ b/k8-util/cluster/kind.yaml
@@ -5,15 +5,15 @@ nodes:
   - role: control-plane
     # port forward 80 on the host to 80 on this node
     extraPortMappings:
-      - containerPort: 31003 #sc
-        hostPort: 31003
+      - containerPort: 30003 #sc
+        hostPort: 30003
         protocol: TCP
-      - containerPort: 31004 #spu 1
-        hostPort: 31004
+      - containerPort: 30004 #spu 1
+        hostPort: 30004
         protocol: TCP
-      - containerPort: 31005 #spu 2
+      - containerPort: 30005 #spu 2
+        hostPort: 30005
+        protocol: TCP
+      - containerPort: 30006 #spu 3
         hostPort: 31005
-        protocol: TCP
-      - containerPort: 31006 #spu 3
-        hostPort: 31006
         protocol: TCP

--- a/k8-util/cluster/kind.yaml
+++ b/k8-util/cluster/kind.yaml
@@ -1,6 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: fluvio
 nodes:
   - role: control-plane
     # port forward 80 on the host to 80 on this node

--- a/k8-util/docker/build.sh
+++ b/k8-util/docker/build.sh
@@ -46,7 +46,7 @@ main() {
   if [ "$K8" = "kind" ]; then
     echo "export image to kind cluster"
     docker image save "$docker_repo:$commit_hash" --output /tmp/infinyon-fluvio.tar
-    kind load image-archive /tmp/infinyon-fluvio.tar --name fluvio
+    kind load image-archive /tmp/infinyon-fluvio.tar
   fi
 
   if [ "$K8" = "microk8" ]; then

--- a/k8-util/docker/build.sh
+++ b/k8-util/docker/build.sh
@@ -45,7 +45,8 @@ main() {
 
   if [ "$K8" = "kind" ]; then
     echo "export image to kind cluster"
-    kind load docker-image $docker_repo:$commit_hash
+    docker image save "$docker_repo:$commit_hash" --output /tmp/infinyon-fluvio.tar
+    kind load image-archive /tmp/infinyon-fluvio.tar --name fluvio
   fi
 
   if [ "$K8" = "microk8" ]; then

--- a/k8-util/helm/Makefile
+++ b/k8-util/helm/Makefile
@@ -20,5 +20,5 @@ pkg_app:	fluvio-app/*.* ../../VERSION
 	helm package ./fluvio-app --app-version $(APP_VERSION) -d pkg_app
 	cd pkg_app;mv fluvio-app-* fluvio-chart-app.tgz
 
-package:	pkg_sys pkg_app
+package:	clean pkg_sys pkg_app
 	echo "Packaged charts are in pkg_sys and pkg_app"

--- a/k8-util/helm/Makefile
+++ b/k8-util/helm/Makefile
@@ -20,5 +20,5 @@ pkg_app:	fluvio-app/*.* ../../VERSION
 	helm package ./fluvio-app --app-version $(APP_VERSION) -d pkg_app
 	cd pkg_app;mv fluvio-app-* fluvio-chart-app.tgz
 
-package:	clean pkg_sys pkg_app
+package:	pkg_sys pkg_app
 	echo "Packaged charts are in pkg_sys and pkg_app"

--- a/k8-util/helm/fluvio-app/Chart.yaml
+++ b/k8-util/helm/fluvio-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fluvio-app
 description: A Helm chart for Fluvio
 type: application
-version: 0.9.1
+version: 0.9.2

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -23,7 +23,7 @@ scPod:
       memory: 512Mi
   nodeSelector: {}
   publicPort: 9003
-  nodePort: 31003
+  nodePort: null
 spuPod:
   resources:
     requests:
@@ -32,7 +32,7 @@ spuPod:
       memory: 1Gi
   nodeSelector: {}
   storageClass: null
-  baseNodePort: 31004
+  baseNodePort: null
 
 rbac:
   create: true

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -23,7 +23,7 @@ scPod:
       memory: 512Mi
   nodeSelector: {}
   publicPort: 9003
-  nodePort: null
+  nodePort: 30003
 spuPod:
   resources:
     requests:
@@ -32,7 +32,7 @@ spuPod:
       memory: 1Gi
   nodeSelector: {}
   storageClass: null
-  baseNodePort: null
+  baseNodePort: 30004
 
 rbac:
   create: true

--- a/k8-util/helm/fluvio-sys/Chart.yaml
+++ b/k8-util/helm/fluvio-sys/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fluvio-sys
 description: A Helm chart for Fluvio
 type: application
-version: 0.9.4
+version: 0.9.5

--- a/k8-util/helm/fluvio-sys/templates/minikube-storage.yaml
+++ b/k8-util/helm/fluvio-sys/templates/minikube-storage.yaml
@@ -1,7 +1,0 @@
-# This is deprecated since 0.9.0.  
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: fluvio-spu
-provisioner: k8s.io/minikube-hostpath
-reclaimPolicy: Delete


### PR DESCRIPTION
* Set `FLV_DISPATCHER_WAIT` (store wait) to 300 during the cluster installation process.  This is set during the CI which reason why it doesn't fail in the CI but can fail in a normal installation.  This PR sets the env variable during installation if not previously set.

* Set nodeport = 30003 to make it more reliable to provision.
* fixes mac ci

closes #1960.