### PR TITLE
[Merged by Bors] - Run publish crates after Release completes

### DIFF
--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,7 +5,10 @@ permissions:
 
 on:
   workflow_dispatch:
-
+  workflow_run:
+    workflows: [Release]
+    branches: [master]
+    types: [completed]
 #env:
 #  USE_COMMIT: ${{ github.event.inputs.commit }}
 #  FORCE_RELEASE: ${{ github.event.inputs.force }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,37 +372,3 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  publish_crates:
-    name: Publish crates to crates.io 
-    strategy:
-      matrix:
-        rust: [stable]
-    needs: [bump_stable_fluvio]
-    runs-on: ubuntu-latest
-    #permissions: write-all
-    steps:
-      - name: Install Rust ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-
-      - uses: actions/checkout@v2
-
-      - name: Run publish script
-        env:
-          VERBOSE: true
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          ./release-scripts/publish-crates.sh
-
-      - name: Slack Notification
-        uses: 8398a7/action-slack@v3
-        if: failure()
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Fixes #1802
Removes the publish job from Release workflow