### PR TITLE
Do not display spinner in CI

### DIFF
--- a/crates/fluvio-cluster/src/check/render.rs
+++ b/crates/fluvio-cluster/src/check/render.rs
@@ -46,7 +46,7 @@ pub fn render_check_result(check_result: &CheckResult) {
 
 /// Render a single check result
 pub fn render_check_result_with_indicator(check_result: &CheckResult, pb: &ProgressRenderer) {
-    pb.println(check_result.msg());
+    pb.println(&check_result.msg());
 }
 
 /// Render a slice of `CheckStatus`es all at once

--- a/crates/fluvio-cluster/src/check/render.rs
+++ b/crates/fluvio-cluster/src/check/render.rs
@@ -2,10 +2,9 @@
 
 use futures_util::StreamExt;
 use async_channel::Receiver;
-use indicatif::ProgressBar;
 use crate::{
     CheckFailed, CheckResult, CheckResults, CheckStatus, CheckSuggestion,
-    render::ProgressRenderedText,
+    render::{ProgressRenderedText, ProgressRenderer},
 };
 
 const ISSUE_URL: &str = "https://github.com/infinyon/fluvio/issues/new/choose";
@@ -22,11 +21,11 @@ pub async fn render_check_progress(progress: &mut Receiver<CheckResult>) -> Chec
 
 pub async fn render_check_progress_with_indicator(
     progress: &mut Receiver<CheckResult>,
-    pb: &ProgressBar,
+    renderer: &ProgressRenderer,
 ) -> CheckResults {
     let mut check_results = vec![];
     while let Some(check_result) = progress.next().await {
-        render_check_result_with_indicator(&check_result, pb);
+        render_check_result_with_indicator(&check_result, renderer);
         check_results.push(check_result);
     }
     check_results
@@ -46,7 +45,7 @@ pub fn render_check_result(check_result: &CheckResult) {
 }
 
 /// Render a single check result
-pub fn render_check_result_with_indicator(check_result: &CheckResult, pb: &ProgressBar) {
+pub fn render_check_result_with_indicator(check_result: &CheckResult, pb: &ProgressRenderer) {
     pb.println(check_result.msg());
 }
 

--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -63,6 +63,10 @@ pub async fn process_k8(
         builder.service_type(service_type);
     }
 
+    if opt.hide_spinner {
+        builder.hide_spinner(true);
+    }
+
     let config = builder.build()?;
 
     debug!("cluster config: {:#?}", config);

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -40,6 +40,10 @@ pub async fn process_local(
         builder.skip_checks(true);
     }
 
+    if opt.hide_spinner {
+        builder.hide_spinner(true);
+    }
+
     let config = builder.build()?;
     let installer = LocalInstaller::from_config(config);
     if opt.setup {

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -147,6 +147,10 @@ pub struct StartOpt {
     #[structopt(long)]
     pub setup: bool,
 
+    /// Used to hide spinner animation for progress updates
+    #[structopt(long)]
+    pub hide_spinner: bool,
+
     /// Proxy address
     #[structopt(long)]
     pub proxy_addr: Option<String>,

--- a/crates/fluvio-cluster/src/render.rs
+++ b/crates/fluvio-cluster/src/render.rs
@@ -1,4 +1,48 @@
+use indicatif::ProgressBar;
+
 pub trait ProgressRenderedText {
     /// Rendered text of the last finished step in the progress
     fn msg(&self) -> String;
+}
+
+#[derive(Debug)]
+pub enum ProgressRenderer {
+    /// Render the progress using eprintln macro
+    Std,
+    /// Render the progress using Indicatiff
+    Indicatiff(ProgressBar),
+}
+
+impl ProgressRenderer {
+    pub fn println(&self, msg: String) {
+        match self {
+            ProgressRenderer::Std => eprintln!("{}", msg),
+            ProgressRenderer::Indicatiff(pb) => pb.println(&msg),
+        }
+    }
+
+    pub fn set_message(&self, msg: String) {
+        match self {
+            ProgressRenderer::Std => eprintln!("{}", msg),
+            ProgressRenderer::Indicatiff(pb) => pb.set_message(msg),
+        }
+    }
+
+    pub fn finish_and_clear(&self) {
+        if let ProgressRenderer::Indicatiff(pb) = self {
+            pb.finish_and_clear();
+        }
+    }
+}
+
+impl From<ProgressBar> for ProgressRenderer {
+    fn from(pb: ProgressBar) -> Self {
+        Self::Indicatiff(pb)
+    }
+}
+
+impl Default for ProgressRenderer {
+    fn default() -> Self {
+        Self::Std
+    }
 }

--- a/crates/fluvio-cluster/src/render.rs
+++ b/crates/fluvio-cluster/src/render.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use indicatif::ProgressBar;
 
 pub trait ProgressRenderedText {
@@ -14,14 +16,15 @@ pub enum ProgressRenderer {
 }
 
 impl ProgressRenderer {
-    pub fn println(&self, msg: String) {
+    pub fn println(&self, msg: &str) {
         match self {
             ProgressRenderer::Std => eprintln!("{}", msg),
-            ProgressRenderer::Indicatiff(pb) => pb.println(&msg),
+            ProgressRenderer::Indicatiff(pb) => pb.println(msg),
         }
     }
 
-    pub fn set_message(&self, msg: String) {
+    pub fn set_message(&self, msg: impl Into<Cow<'static, str>>) {
+        let msg = msg.into();
         match self {
             ProgressRenderer::Std => eprintln!("{}", msg),
             ProgressRenderer::Indicatiff(pb) => pb.set_message(msg),

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -643,7 +643,7 @@ impl ClusterInstaller {
 
         if self.config.render_checks {
             self.pb
-                .println(InstallProgressMessage::PreFlightCheck.msg());
+                .println(&InstallProgressMessage::PreFlightCheck.msg());
 
             let mut progress = checker.run_and_fix_with_progress();
             render_check_progress_with_indicator(&mut progress, &self.pb).await
@@ -697,7 +697,7 @@ impl ClusterInstaller {
             self.install_app().await?;
         } else {
             self.pb
-                .println(InstallProgressMessage::AlreadyInstalled.msg())
+                .println(&InstallProgressMessage::AlreadyInstalled.msg())
         }
 
         let namespace = &self.config.namespace;
@@ -712,7 +712,7 @@ impl ClusterInstaller {
         let address = format!("{}:{}", host_name, port);
 
         self.pb
-            .println(InstallProgressMessage::FoundSC(address.clone()).msg());
+            .println(&InstallProgressMessage::FoundSC(address.clone()).msg());
         let cluster_config =
             FluvioConfig::new(address.clone()).with_tls(self.config.client_tls_policy.clone());
 
@@ -723,16 +723,16 @@ impl ClusterInstaller {
             Some(fluvio) => fluvio,
             None => return Err(K8InstallError::SCServiceTimeout),
         };
-        self.pb.set_message("".into());
+        self.pb.set_message("");
 
         if self.config.save_profile {
             self.update_profile(&address)?;
-            self.pb.println(InstallProgressMessage::ProfileSet.msg());
+            self.pb.println(&InstallProgressMessage::ProfileSet.msg());
         }
 
         // Create a managed SPU cluster
         self.create_managed_spu_group(&fluvio).await?;
-        self.pb.println(InstallProgressMessage::Success.msg());
+        self.pb.println(&InstallProgressMessage::Success.msg());
         self.pb.finish_and_clear();
 
         Ok(StartStatus {
@@ -751,7 +751,7 @@ impl ClusterInstaller {
         );
 
         self.pb
-            .println(InstallProgressMessage::InstallingFluvio.msg());
+            .println(&InstallProgressMessage::InstallingFluvio.msg());
 
         // If configured with TLS, copy certs to server
         if let TlsPolicy::Verified(tls) = &self.config.server_tls_policy {
@@ -874,8 +874,8 @@ impl ClusterInstaller {
         installer.process(self.config.upgrade)?;
 
         self.pb
-            .println(InstallProgressMessage::ChartInstalled.msg());
-        self.pb.set_message("".into());
+            .println(&InstallProgressMessage::ChartInstalled.msg());
+        self.pb.set_message("");
 
         Ok(())
     }
@@ -1031,7 +1031,8 @@ impl ClusterInstaller {
                 .count();
 
             if self.config.spu_replicas as usize == ready_spu {
-                self.pb.println(InstallProgressMessage::SpusConfirmed.msg());
+                self.pb
+                    .println(&InstallProgressMessage::SpusConfirmed.msg());
 
                 return Ok(true);
             } else {
@@ -1109,7 +1110,7 @@ impl ClusterInstaller {
             external_addr,
             &self.config.client_tls_policy,
         )?;
-        self.pb.set_message("".into());
+        self.pb.set_message("");
         Ok(())
     }
 
@@ -1154,18 +1155,18 @@ impl ClusterInstaller {
             admin.create(name, false, spu_spec).await?;
 
             self.pb.println(
-                InstallProgressMessage::SpuGroupLaunched(self.config.spu_replicas as u16).msg(),
+                &InstallProgressMessage::SpuGroupLaunched(self.config.spu_replicas as u16).msg(),
             );
         } else {
             self.pb
-                .println(InstallProgressMessage::SpuGroupExists.msg());
+                .println(&InstallProgressMessage::SpuGroupExists.msg());
         }
 
         // Wait for the SPU cluster to spin up
         if !self.config.skip_spu_liveness_check {
             self.wait_for_spu(&admin).await?;
         }
-        self.pb.set_message("".into());
+        self.pb.set_message("");
 
         Ok(())
     }

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -409,7 +409,7 @@ impl LocalInstaller {
 
         if self.config.render_checks {
             self.pb
-                .println(InstallProgressMessage::PreFlightCheck.msg());
+                .println(&InstallProgressMessage::PreFlightCheck.msg());
             let mut progress = ClusterChecker::empty()
                 .with_local_checks()
                 .with_check(SysChartCheck::new(sys_config))
@@ -475,17 +475,17 @@ impl LocalInstaller {
 
         let fluvio = self.launch_sc(&address, port).await?;
 
-        self.pb.println(InstallProgressMessage::ScLaunched.msg());
+        self.pb.println(&InstallProgressMessage::ScLaunched.msg());
 
         self.launch_spu_group(client.clone()).await?;
         self.pb
-            .println(InstallProgressMessage::SpuGroupLaunched(self.config.spu_replicas).msg());
+            .println(&InstallProgressMessage::SpuGroupLaunched(self.config.spu_replicas).msg());
 
         self.confirm_spu(self.config.spu_replicas, &fluvio).await?;
 
         self.set_profile()?;
 
-        self.pb.println(InstallProgressMessage::Success.msg());
+        self.pb.println(&InstallProgressMessage::Success.msg());
 
         Ok(StartStatus {
             address,
@@ -542,7 +542,7 @@ impl LocalInstaller {
             &self.config.client_tls_policy,
         )?;
 
-        self.pb.println(InstallProgressMessage::ProfileSet.msg());
+        self.pb.println(&InstallProgressMessage::ProfileSet.msg());
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds the change to not display the spinner in the CI. It can also be hidden from the cli with the --hide-spinner flag

Closes #1968 