### PR TITLE
[Merged by Bors] - Add spinner to consume command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for tuple structs in fluvio-protocol derived macros. ([#1828](https://github.com/infinyon/fluvio/issues/1828))
 * Expose fluvio completions in the top-level subcommand. ([#1850](https://github.com/infinyon/fluvio/issues/1850))
 * Make installation more reliable ([#1961](https://github.com/infinyon/fluvio/pull/1961))
+* Add Spinner to `fluvio consume` command. ([#1881](https://github.com/infinyon/fluvio/issues/1881))
 
 ## Platform Version 0.9.13 - 2021-11-19
 * Fix connector create with `create_topic` option to succeed if topic already exists. ([#1823](https://github.com/infinyon/fluvio/pull/1823))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "hex",
  "home",
  "http-types",
+ "indicatif",
  "k8-client",
  "k8-config",
  "k8-types",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -84,6 +84,7 @@ k8-types = { version = "0.5.0", features = ["core"] }
 fluvio-types = { version = "0.2.0", path = "../fluvio-types", optional = true }
 fluvio-future = { version = "0.3.0", features = ["fs", "io", "subscriber", "native2_tls"], optional = true }
 fluvio-sc-schema = { version = "0.11.0", path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
+indicatif = "0.16.2"
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -16,6 +16,7 @@ mod connector;
 mod tableformat;
 mod smartmodule;
 mod derivedstream;
+mod render;
 
 pub(crate) use error::{Result, CliError};
 

--- a/crates/fluvio-cli/src/render.rs
+++ b/crates/fluvio-cli/src/render.rs
@@ -1,0 +1,30 @@
+use indicatif::ProgressBar;
+
+#[derive(Debug)]
+pub enum ProgressRenderer {
+    /// Render the progress using eprintln macro
+    Std,
+    /// Render the progress using Indicatiff
+    Indicatiff(ProgressBar),
+}
+
+impl ProgressRenderer {
+    pub fn println(&self, msg: &str) {
+        match self {
+            ProgressRenderer::Std => println!("{}", msg),
+            ProgressRenderer::Indicatiff(pb) => pb.println(msg),
+        }
+    }
+}
+
+impl From<ProgressBar> for ProgressRenderer {
+    fn from(pb: ProgressBar) -> Self {
+        Self::Indicatiff(pb)
+    }
+}
+
+impl Default for ProgressRenderer {
+    fn default() -> Self {
+        Self::Std
+    }
+}


### PR DESCRIPTION
Closes #1881

Add spinner to consume commmand, the spinner will not be rendered if we are in a non-tty environment


https://user-images.githubusercontent.com/22335041/144466096-1eb8df62-7601-475e-82e6-8504f5b1e3a2.mp4

