### PR TITLE
[Merged by Bors] - Add Smart module CLI tests

### DIFF
--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -9,6 +9,8 @@ load "$TEST_HELPER_DIR"/bats-support/load.bash
 load "$TEST_HELPER_DIR"/bats-assert/load.bash
 
 setup_file() {
+    # Compile the smartmodule examples
+    pushd "$BATS_TEST_DIRNAME/../../.." && make build_smartmodules && popd
     SMARTMODULE_BUILD_DIR="$BATS_TEST_DIRNAME/../../../crates/fluvio-smartmodule/examples/target/wasm32-unknown-unknown/release/"
     export SMARTMODULE_BUILD_DIR
     

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -203,50 +203,50 @@ setup_file() {
 #    assert_success
 #}
 
-@test "smartmodule array-map" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="json-object-flatten"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
-
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    FULL_TEST_MESSAGE='{"a": "Apple", "b": "Banana", "c": "Cranberry"}'
-    export FULL_TEST_MESSAGE
-    FIRST_MESSAGE='"Apple"'
-    export FIRST_MESSAGE
-    SECOND_MESSAGE='"Banana"'
-    export SECOND_MESSAGE
-    THIRD_MESSAGE='"Cranberry"'
-    export THIRD_MESSAGE
-    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic and verify we should have the json message
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-    assert_output "$FULL_TEST_MESSAGE"
-
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
-    assert_line --index 0 "$FIRST_MESSAGE"
-    assert_line --index 1 "$SECOND_MESSAGE"
-    assert_line --index 2 "$THIRD_MESSAGE"
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
+#@test "smartmodule array-map" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="json-object-flatten"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
+#
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    FULL_TEST_MESSAGE='{"a": "Apple", "b": "Banana", "c": "Cranberry"}'
+#    export FULL_TEST_MESSAGE
+#    FIRST_MESSAGE='"Apple"'
+#    export FIRST_MESSAGE
+#    SECOND_MESSAGE='"Banana"'
+#    export SECOND_MESSAGE
+#    THIRD_MESSAGE='"Cranberry"'
+#    export THIRD_MESSAGE
+#    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic and verify we should have the json message
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+#    assert_output "$FULL_TEST_MESSAGE"
+#
+#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+#    assert_line --index 0 "$FIRST_MESSAGE"
+#    assert_line --index 1 "$SECOND_MESSAGE"
+#    assert_line --index 2 "$THIRD_MESSAGE"
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
 
 #@test "smartmodule aggregate" {
 #    # Load the smartmodule
@@ -262,18 +262,20 @@ setup_file() {
 #    assert_success
 #
 #    # Produce to topic
-#    TEST_MESSAGE="$(random_string 10)"
-#    export TEST_MESSAGE
-#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    TEST_MESSAGE_1="$(random_string 10)"
+#    export TEST_MESSAGE_1
+#    run bash -c 'echo "$TEST_MESSAGE_1" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    TEST_MESSAGE_2="$(random_string 10)"
+#    export TEST_MESSAGE_2
+#    run bash -c 'echo "$TEST_MESSAGE_2" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
 #    assert_success
 #
 #    # Consume from topic
-#    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-#    #export EXPECTED_OUTPUT
-#    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
-#
-#    #assert_output --partial "$EXPECTED_OUTPUT"
-#    #assert_success
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
+#    assert_line --index 0 "$TEST_MESSAGE_1"
+#    assert_line --index 1 "$TEST_MESSAGE_1$TEST_MESSAGE_2"
 #
 #    # Delete topic
 #    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
@@ -283,7 +285,7 @@ setup_file() {
 #    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
 #    assert_success
 #}
-#
+
 #@test "smartmodule join" {
 #    # Load the smartmodule
 #    SMARTMODULE_NAME="concat-strings"

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -16,275 +16,275 @@ setup_file() {
     
 }
 
-#@test "smartmodule map" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="uppercase"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    TEST_MESSAGE="$(random_string 10)"
-#    export TEST_MESSAGE
-#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic
-#    EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-#    export EXPECTED_OUTPUT
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --map "$SMARTMODULE_NAME"
-#
-#    assert_output --partial "$EXPECTED_OUTPUT"
-#    assert_success
-#
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
-#
-#@test "smartmodule filter" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="contains-a"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    NEGATIVE_TEST_MESSAGE="zzzzzzzzzzzzzz"
-#    export NEGATIVE_TEST_MESSAGE
-#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    TEST_MESSAGE="$(random_string 10)aaa"
-#    export TEST_MESSAGE
-#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic and verify we should have 2 entries
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
-#    assert_line --index 1 "$TEST_MESSAGE"
-#
-#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-#    EXPECTED_OUTPUT="${TEST_MESSAGE}"
-#    export EXPECTED_OUTPUT
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
-#    refute_line "$NEGATIVE_TEST_MESSAGE"
-#    assert_output "$EXPECTED_OUTPUT"
-#
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
+@test "smartmodule map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="uppercase"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
+    assert_success
 
-#@test "smartmodule filter w/ params" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="contains-a-or-param"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    NEGATIVE_TEST_MESSAGE="xxxxx"
-#    export NEGATIVE_TEST_MESSAGE
-#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    DEFAULT_PARAM_MESSAGE="aaaaa"
-#    export DEFAULT_PARAM_MESSAGE
-#    run bash -c 'echo "$DEFAULT_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    TEST_PARAM_MESSAGE="zzzzz"
-#    export TEST_PARAM_MESSAGE
-#    run bash -c 'echo "$TEST_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic and verify we should have 3 entries
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
-#    assert_line --index 1 "$DEFAULT_PARAM_MESSAGE"
-#    assert_line --index 2 "$TEST_PARAM_MESSAGE"
-#
-#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-#    EXPECTED_OUTPUT="${DEFAULT_PARAM_MESSAGE}"
-#    export EXPECTED_OUTPUT
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
-#    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
-#    refute_line --partial "$TEST_PARAM_MESSAGE"
-#    assert_output "$EXPECTED_OUTPUT"
-#
-#
-#    EXPECTED_OUTPUT="${TEST_PARAM_MESSAGE}"
-#    export EXPECTED_OUTPUT
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME" --extra-params key=z
-#    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
-#    refute_line --partial "$DEFAULT_PARAM_MESSAGE"
-#    assert_output "$EXPECTED_OUTPUT"
-#
-# 
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
 
-#@test "smartmodule filter-map" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="divide-even-by-2"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    NEGATIVE_TEST_MESSAGE="37"
-#    export NEGATIVE_TEST_MESSAGE
-#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    TEST_MESSAGE="100"
-#    export TEST_MESSAGE
-#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic and verify we should have 2 entries
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
-#    assert_line --index 1 "$TEST_MESSAGE"
-#
-#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-#    EXPECTED_OUTPUT="${TEST_MESSAGE}"
-#    export EXPECTED_OUTPUT
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
-#    refute_line "$NEGATIVE_TEST_MESSAGE"
-#    assert_output "$((EXPECTED_OUTPUT/2))"
-#
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
 
-#@test "smartmodule array-map" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="json-object-flatten"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
-#
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    FULL_TEST_MESSAGE='{"a": "Apple", "b": "Banana", "c": "Cranberry"}'
-#    export FULL_TEST_MESSAGE
-#    FIRST_MESSAGE='"Apple"'
-#    export FIRST_MESSAGE
-#    SECOND_MESSAGE='"Banana"'
-#    export SECOND_MESSAGE
-#    THIRD_MESSAGE='"Cranberry"'
-#    export THIRD_MESSAGE
-#    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic and verify we should have the json message
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-#    assert_output "$FULL_TEST_MESSAGE"
-#
-#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
-#    assert_line --index 0 "$FIRST_MESSAGE"
-#    assert_line --index 1 "$SECOND_MESSAGE"
-#    assert_line --index 2 "$THIRD_MESSAGE"
-#
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
+    # Consume from topic
+    EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --map "$SMARTMODULE_NAME"
 
-#@test "smartmodule aggregate" {
-#    # Load the smartmodule
-#    SMARTMODULE_NAME="concat-strings"
-#    export SMARTMODULE_NAME
-#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
-#    assert_success
-#
-#    # Create topic
-#    TOPIC_NAME="$(random_string)"
-#    export TOPIC_NAME
-#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-#    assert_success
-#
-#    # Produce to topic
-#    TEST_MESSAGE_1="$(random_string 10)"
-#    export TEST_MESSAGE_1
-#    run bash -c 'echo "$TEST_MESSAGE_1" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    TEST_MESSAGE_2="$(random_string 10)"
-#    export TEST_MESSAGE_2
-#    run bash -c 'echo "$TEST_MESSAGE_2" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-#    assert_success
-#
-#    # Consume from topic
-#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
-#    assert_line --index 0 "$TEST_MESSAGE_1"
-#    assert_line --index 1 "$TEST_MESSAGE_1$TEST_MESSAGE_2"
-#
-#    # Delete topic
-#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-#    assert_success
-#
-#    # Delete smartmodule
-#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-#    assert_success
-#}
+    assert_output --partial "$EXPECTED_OUTPUT"
+    assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="contains-a"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    NEGATIVE_TEST_MESSAGE="zzzzzzzzzzzzzz"
+    export NEGATIVE_TEST_MESSAGE
+    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    TEST_MESSAGE="$(random_string 10)aaa"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic and verify we should have 2 entries
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+    assert_line --index 1 "$TEST_MESSAGE"
+
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    EXPECTED_OUTPUT="${TEST_MESSAGE}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
+    refute_line "$NEGATIVE_TEST_MESSAGE"
+    assert_output "$EXPECTED_OUTPUT"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter w/ params" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="contains-a-or-param"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    NEGATIVE_TEST_MESSAGE="xxxxx"
+    export NEGATIVE_TEST_MESSAGE
+    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    DEFAULT_PARAM_MESSAGE="aaaaa"
+    export DEFAULT_PARAM_MESSAGE
+    run bash -c 'echo "$DEFAULT_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    TEST_PARAM_MESSAGE="zzzzz"
+    export TEST_PARAM_MESSAGE
+    run bash -c 'echo "$TEST_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic and verify we should have 3 entries
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+    assert_line --index 1 "$DEFAULT_PARAM_MESSAGE"
+    assert_line --index 2 "$TEST_PARAM_MESSAGE"
+
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    EXPECTED_OUTPUT="${DEFAULT_PARAM_MESSAGE}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
+    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
+    refute_line --partial "$TEST_PARAM_MESSAGE"
+    assert_output "$EXPECTED_OUTPUT"
+
+
+    EXPECTED_OUTPUT="${TEST_PARAM_MESSAGE}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME" --extra-params key=z
+    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
+    refute_line --partial "$DEFAULT_PARAM_MESSAGE"
+    assert_output "$EXPECTED_OUTPUT"
+
+ 
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter-map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="divide-even-by-2"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    NEGATIVE_TEST_MESSAGE="37"
+    export NEGATIVE_TEST_MESSAGE
+    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    TEST_MESSAGE="100"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic and verify we should have 2 entries
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+    assert_line --index 1 "$TEST_MESSAGE"
+
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    EXPECTED_OUTPUT="${TEST_MESSAGE}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
+    refute_line "$NEGATIVE_TEST_MESSAGE"
+    assert_output "$((EXPECTED_OUTPUT/2))"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule array-map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="json-object-flatten"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
+
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    FULL_TEST_MESSAGE='{"a": "Apple", "b": "Banana", "c": "Cranberry"}'
+    export FULL_TEST_MESSAGE
+    FIRST_MESSAGE='"Apple"'
+    export FIRST_MESSAGE
+    SECOND_MESSAGE='"Banana"'
+    export SECOND_MESSAGE
+    THIRD_MESSAGE='"Cranberry"'
+    export THIRD_MESSAGE
+    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic and verify we should have the json message
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_output "$FULL_TEST_MESSAGE"
+
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+    assert_line --index 0 "$FIRST_MESSAGE"
+    assert_line --index 1 "$SECOND_MESSAGE"
+    assert_line --index 2 "$THIRD_MESSAGE"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule aggregate" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="concat-strings"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE_1="$(random_string 10)"
+    export TEST_MESSAGE_1
+    run bash -c 'echo "$TEST_MESSAGE_1" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    TEST_MESSAGE_2="$(random_string 10)"
+    export TEST_MESSAGE_2
+    run bash -c 'echo "$TEST_MESSAGE_2" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
+    assert_line --index 0 "$TEST_MESSAGE_1"
+    assert_line --index 1 "$TEST_MESSAGE_1$TEST_MESSAGE_2"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
 
 @test "smartmodule join" {
     # Load the smartmodule

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup_file() {
+    SMARTMODULE_BUILD_DIR="$BATS_TEST_DIRNAME/../../../crates/fluvio-smartmodule/examples/target/wasm32-unknown-unknown/release/"
+    export SMARTMODULE_BUILD_DIR
+    
+}
+
+@test "smartmodule map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="uppercase"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --map "$SMARTMODULE_NAME"
+
+    assert_output --partial "$EXPECTED_OUTPUT"
+    assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="contains-a"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    #export EXPECTED_OUTPUT
+    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
+
+    #assert_output --partial "$EXPECTED_OUTPUT"
+    #assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter w/ params" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="contains-a-or-param"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    #export EXPECTED_OUTPUT
+    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME" -e key=b
+
+    #assert_output --partial "$EXPECTED_OUTPUT"
+    #assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule filter-map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="divide-even-by-2"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    #export EXPECTED_OUTPUT
+    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
+
+    #assert_output --partial "$EXPECTED_OUTPUT"
+    #assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule array-map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="divide-even-by-2"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    #export EXPECTED_OUTPUT
+    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+
+    #assert_output --partial "$EXPECTED_OUTPUT"
+    #assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+@test "smartmodule aggregate" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="concat-strings"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    TEST_MESSAGE="$(random_string 10)"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic
+    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+    #export EXPECTED_OUTPUT
+    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
+
+    #assert_output --partial "$EXPECTED_OUTPUT"
+    #assert_success
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
+
+# Expect that we already have a 2 wasm modules. One each for positive and negative test
+
+# Create topic
+# Produce known records 
+
+# Positive test
+
+# Consume topic w/ smartstream and compare output is less than total records, and meets 
+
+# Negative test
+
+# Consume topic w/ smartstream and confirm no output 

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -16,122 +16,147 @@ setup_file() {
     
 }
 
-@test "smartmodule map" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="uppercase"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
-    assert_success
+#@test "smartmodule map" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="uppercase"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    TEST_MESSAGE="$(random_string 10)"
+#    export TEST_MESSAGE
+#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic
+#    EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+#    export EXPECTED_OUTPUT
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --map "$SMARTMODULE_NAME"
+#
+#    assert_output --partial "$EXPECTED_OUTPUT"
+#    assert_success
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
+#
+#@test "smartmodule filter" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="contains-a"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    NEGATIVE_TEST_MESSAGE="zzzzzzzzzzzzzz"
+#    export NEGATIVE_TEST_MESSAGE
+#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    TEST_MESSAGE="$(random_string 10)aaa"
+#    export TEST_MESSAGE
+#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic and verify we should have 2 entries
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+#    assert_line --index 1 "$TEST_MESSAGE"
+#
+#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+#    EXPECTED_OUTPUT="${TEST_MESSAGE}"
+#    export EXPECTED_OUTPUT
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
+#    refute_line "$NEGATIVE_TEST_MESSAGE"
+#    assert_output "$EXPECTED_OUTPUT"
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
 
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    TEST_MESSAGE="$(random_string 10)"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic
-    EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-    export EXPECTED_OUTPUT
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --map "$SMARTMODULE_NAME"
-
-    assert_output --partial "$EXPECTED_OUTPUT"
-    assert_success
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
-
-@test "smartmodule filter" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="contains-a"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    NEGATIVE_TEST_MESSAGE="zzzzzzzzzzzzzz"
-    export NEGATIVE_TEST_MESSAGE
-    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    TEST_MESSAGE="$(random_string 10)aaa"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic and verify we should have 2 entries
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
-    assert_line --index 1 "$TEST_MESSAGE"
-
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-    EXPECTED_OUTPUT="${TEST_MESSAGE}"
-    export EXPECTED_OUTPUT
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
-    refute_line "$NEGATIVE_TEST_MESSAGE"
-    assert_output "$EXPECTED_OUTPUT"
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
-
-@test "smartmodule filter w/ params" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="contains-a-or-param"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    TEST_MESSAGE="$(random_string 10)"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic
-    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-    #export EXPECTED_OUTPUT
-    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME" -e key=b
-
-    #assert_output --partial "$EXPECTED_OUTPUT"
-    #assert_success
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
+#@test "smartmodule filter w/ params" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="contains-a-or-param"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    NEGATIVE_TEST_MESSAGE="xxxxx"
+#    export NEGATIVE_TEST_MESSAGE
+#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    DEFAULT_PARAM_MESSAGE="aaaaa"
+#    export DEFAULT_PARAM_MESSAGE
+#    run bash -c 'echo "$DEFAULT_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    TEST_PARAM_MESSAGE="zzzzz"
+#    export TEST_PARAM_MESSAGE
+#    run bash -c 'echo "$TEST_PARAM_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic and verify we should have 3 entries
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+#    assert_line --index 1 "$DEFAULT_PARAM_MESSAGE"
+#    assert_line --index 2 "$TEST_PARAM_MESSAGE"
+#
+#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+#    EXPECTED_OUTPUT="${DEFAULT_PARAM_MESSAGE}"
+#    export EXPECTED_OUTPUT
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
+#    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
+#    refute_line --partial "$TEST_PARAM_MESSAGE"
+#    assert_output "$EXPECTED_OUTPUT"
+#
+#
+#    EXPECTED_OUTPUT="${TEST_PARAM_MESSAGE}"
+#    export EXPECTED_OUTPUT
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME" --extra-params key=z
+#    refute_line --partial "$NEGATIVE_TEST_MESSAGE"
+#    refute_line --partial "$DEFAULT_PARAM_MESSAGE"
+#    assert_output "$EXPECTED_OUTPUT"
+#
+# 
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
 
 @test "smartmodule filter-map" {
     # Load the smartmodule
@@ -147,18 +172,27 @@ setup_file() {
     assert_success
 
     # Produce to topic
-    TEST_MESSAGE="$(random_string 10)"
+    NEGATIVE_TEST_MESSAGE="37"
+    export NEGATIVE_TEST_MESSAGE
+    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    TEST_MESSAGE="100"
     export TEST_MESSAGE
     run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
     assert_success
 
-    # Consume from topic
-    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-    #export EXPECTED_OUTPUT
-    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
+    # Consume from topic and verify we should have 2 entries
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+    assert_line --index 1 "$TEST_MESSAGE"
 
-    #assert_output --partial "$EXPECTED_OUTPUT"
-    #assert_success
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    EXPECTED_OUTPUT="${TEST_MESSAGE}"
+    export EXPECTED_OUTPUT
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
+    refute_line "$NEGATIVE_TEST_MESSAGE"
+    assert_output "$((EXPECTED_OUTPUT/2))"
 
     # Delete topic
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
@@ -169,88 +203,110 @@ setup_file() {
     assert_success
 }
 
-@test "smartmodule array-map" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="divide-even-by-2"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    TEST_MESSAGE="$(random_string 10)"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic
-    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-    #export EXPECTED_OUTPUT
-    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
-
-    #assert_output --partial "$EXPECTED_OUTPUT"
-    #assert_success
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
-
-@test "smartmodule aggregate" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="concat-strings"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    TEST_MESSAGE="$(random_string 10)"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic
-    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-    #export EXPECTED_OUTPUT
-    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
-
-    #assert_output --partial "$EXPECTED_OUTPUT"
-    #assert_success
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
-
-
-# Expect that we already have a 2 wasm modules. One each for positive and negative test
-
-# Create topic
-# Produce known records 
-
-# Positive test
-
-# Consume topic w/ smartstream and compare output is less than total records, and meets 
-
-# Negative test
-
-# Consume topic w/ smartstream and confirm no output 
+#@test "smartmodule array-map" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="divide-even-by-2"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    TEST_MESSAGE="$(random_string 10)"
+#    export TEST_MESSAGE
+#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic
+#    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+#    #export EXPECTED_OUTPUT
+#    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+#
+#    #assert_output --partial "$EXPECTED_OUTPUT"
+#    #assert_success
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
+#
+#@test "smartmodule aggregate" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="concat-strings"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    TEST_MESSAGE="$(random_string 10)"
+#    export TEST_MESSAGE
+#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic
+#    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+#    #export EXPECTED_OUTPUT
+#    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
+#
+#    #assert_output --partial "$EXPECTED_OUTPUT"
+#    #assert_success
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}
+#
+#@test "smartmodule join" {
+#    # Load the smartmodule
+#    SMARTMODULE_NAME="concat-strings"
+#    export SMARTMODULE_NAME
+#    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_join.wasm 
+#    assert_success
+#
+#    # Create topic
+#    TOPIC_NAME="$(random_string)"
+#    export TOPIC_NAME
+#    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+#    assert_success
+#
+#    # Produce to topic
+#    TEST_MESSAGE="$(random_string 10)"
+#    export TEST_MESSAGE
+#    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    # Consume from topic
+#    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
+#    #export EXPECTED_OUTPUT
+#    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --aggregate "$SMARTMODULE_NAME"
+#
+#    #assert_output --partial "$EXPECTED_OUTPUT"
+#    #assert_success
+#
+#    # Delete topic
+#    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+#    assert_success
+#
+#    # Delete smartmodule
+#    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+#    assert_success
+#}

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -158,52 +158,7 @@ setup_file() {
 #    assert_success
 #}
 
-@test "smartmodule filter-map" {
-    # Load the smartmodule
-    SMARTMODULE_NAME="divide-even-by-2"
-    export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
-    assert_success
-
-    # Create topic
-    TOPIC_NAME="$(random_string)"
-    export TOPIC_NAME
-    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
-    assert_success
-
-    # Produce to topic
-    NEGATIVE_TEST_MESSAGE="37"
-    export NEGATIVE_TEST_MESSAGE
-    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    TEST_MESSAGE="100"
-    export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
-    assert_success
-
-    # Consume from topic and verify we should have 2 entries
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
-    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
-    assert_line --index 1 "$TEST_MESSAGE"
-
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
-    EXPECTED_OUTPUT="${TEST_MESSAGE}"
-    export EXPECTED_OUTPUT
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
-    refute_line "$NEGATIVE_TEST_MESSAGE"
-    assert_output "$((EXPECTED_OUTPUT/2))"
-
-    # Delete topic
-    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
-    assert_success
-
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
-    assert_success
-}
-
-#@test "smartmodule array-map" {
+#@test "smartmodule filter-map" {
 #    # Load the smartmodule
 #    SMARTMODULE_NAME="divide-even-by-2"
 #    export SMARTMODULE_NAME
@@ -217,18 +172,27 @@ setup_file() {
 #    assert_success
 #
 #    # Produce to topic
-#    TEST_MESSAGE="$(random_string 10)"
+#    NEGATIVE_TEST_MESSAGE="37"
+#    export NEGATIVE_TEST_MESSAGE
+#    run bash -c 'echo "$NEGATIVE_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+#    assert_success
+#
+#    TEST_MESSAGE="100"
 #    export TEST_MESSAGE
 #    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
 #    assert_success
 #
-#    # Consume from topic
-#    #EXPECTED_OUTPUT="${TEST_MESSAGE^^}"
-#    #export EXPECTED_OUTPUT
-#    #run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+#    # Consume from topic and verify we should have 2 entries
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+#    assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
+#    assert_line --index 1 "$TEST_MESSAGE"
 #
-#    #assert_output --partial "$EXPECTED_OUTPUT"
-#    #assert_success
+#    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+#    EXPECTED_OUTPUT="${TEST_MESSAGE}"
+#    export EXPECTED_OUTPUT
+#    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
+#    refute_line "$NEGATIVE_TEST_MESSAGE"
+#    assert_output "$((EXPECTED_OUTPUT/2))"
 #
 #    # Delete topic
 #    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
@@ -238,7 +202,52 @@ setup_file() {
 #    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
 #    assert_success
 #}
-#
+
+@test "smartmodule array-map" {
+    # Load the smartmodule
+    SMARTMODULE_NAME="json-object-flatten"
+    export SMARTMODULE_NAME
+    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
+
+    assert_success
+
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    assert_success
+
+    # Produce to topic
+    FULL_TEST_MESSAGE='{"a": "Apple", "b": "Banana", "c": "Cranberry"}'
+    export FULL_TEST_MESSAGE
+    FIRST_MESSAGE='"Apple"'
+    export FIRST_MESSAGE
+    SECOND_MESSAGE='"Banana"'
+    export SECOND_MESSAGE
+    THIRD_MESSAGE='"Cranberry"'
+    export THIRD_MESSAGE
+    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    assert_success
+
+    # Consume from topic and verify we should have the json message
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_output "$FULL_TEST_MESSAGE"
+
+    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
+    assert_line --index 0 "$FIRST_MESSAGE"
+    assert_line --index 1 "$SECOND_MESSAGE"
+    assert_line --index 2 "$THIRD_MESSAGE"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    assert_success
+
+    # Delete smartmodule
+    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    assert_success
+}
+
 #@test "smartmodule aggregate" {
 #    # Load the smartmodule
 #    SMARTMODULE_NAME="concat-strings"

--- a/tests/cli/test_helper/fluvio_dev.bash
+++ b/tests/cli/test_helper/fluvio_dev.bash
@@ -28,9 +28,9 @@ function random_string() {
     # Ensure we don't end up with a string that starts or ends with '-'
     # https://github.com/infinyon/fluvio/issues/1864
 
-    HEAD=$(shuf -zer -n1 {a..z} {0..9})
-    BODY=$(shuf -zer -n"$(($STRING_LEN - 2))" {a..z} {0..9} "-")
-    FOOT=$(shuf -zer -n1 {a..z} {0..9})
+    HEAD=$(shuf -zer -n1 {a..z} {0..9} | tr -d '\0')
+    BODY=$(shuf -zer -n"$(($STRING_LEN - 2))" {a..z} {0..9} "-" | tr -d '\0')
+    FOOT=$(shuf -zer -n1 {a..z} {0..9} | tr -d '\0')
 
     RANDOM_STRING=$HEAD$BODY$FOOT
 


### PR DESCRIPTION
Resolves #1474 

Uses a selection of tests from the [`fluvio-smartmodule` examples directory](https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartmodule/examples), creates a smartmodule, and validates the workflow inputs and outputs w/ the smartmodule applied. 

* map
* filter
* filter-map
* array-map
* aggregate
* join

Added into the `CLI Smoke tests` job.

Admittedly a very verbose set of tests, but it's a start.