### PR TITLE
Consume with end

### DIFF
--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -639,6 +639,19 @@ impl ConsumeOpt {
                 )
                 .bold()
             );
+<<<<<<< HEAD
+=======
+        // If --end-offset=X
+        } else if let Some(end) = self.end_offset {
+            eprintln!(
+                "{}",
+                format!(
+                    "Consuming records starting from the end record {} in topic '{}'",
+                    end, &self.topic
+                )
+                .bold()
+            );
+>>>>>>> 1acd71b6... rephrasing end offset message
         // If no offset config is given, read from the end
         } else {
             eprintln!(

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -639,8 +639,6 @@ impl ConsumeOpt {
                 )
                 .bold()
             );
-<<<<<<< HEAD
-=======
         // If --end-offset=X
         } else if let Some(end) = self.end_offset {
             eprintln!(
@@ -651,7 +649,6 @@ impl ConsumeOpt {
                 )
                 .bold()
             );
->>>>>>> 1acd71b6... rephrasing end offset message
         // If no offset config is given, read from the end
         } else {
             eprintln!(

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -724,6 +724,8 @@ pub struct ConsumerConfig {
     pub(crate) smartmodule: Option<SmartModuleInvocation>,
     #[builder(default)]
     pub(crate) derivedstream: Option<DerivedStreamInvocation>,
+    #[builder(default)]
+    pub end_offset: Option<i64>,
 }
 
 impl ConsumerConfig {


### PR DESCRIPTION
# What does this PR do?

This PR adds a new option for consuming called `end-offset` in order to cease reading from the stream when the ending offset is found in the stream's current record, instead of waiting for new inputs.
 
# Motivation

Helping out on good first issues.

# Related issues

A list of issues closed by or relevant to this PR.

- Supports [#1898] (https://github.com/infinyon/fluvio/issues/1898)
- Closes [#1940] (https://github.com/infinyon/fluvio/issues/1940).

# Additional Notes

None

# Checklist

- [ ] Created or updated all relevant documentation
- [ ] Added unit tests to relevant added or changed code
- [ ] Bumped required crate version numbers
- [ ] Updated CHANGELOG.md
