### PR TITLE
[Merged by Bors] - Adding connector test to smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,7 +787,7 @@ jobs:
       - local_cluster_test
       - k8_cluster_test
       - k8_upgrade_test
-     # - k8_cli_smoke
+      - k8_cli_smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
           path: /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
 
   k8_cluster_test:
-    name: Kubernetes cluster test run (${{ matrix.run }}) k8 (${{ matrix.k8 }})
+    name: Kubernetes cluster test - ${{ matrix.make-target }} (${{ matrix.run }}) k8 (${{ matrix.k8 }})
     needs: build_image
     runs-on: ${{ matrix.os }}
     strategy:
@@ -501,7 +501,7 @@ jobs:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
         run: [r1]
-        make-target: [smoke-test-k8-tls-root,smoke-test-k8-tls]
+        make-target: [smoke-test-k8-tls-root,smoke-test-k8-tls,smoke-test-k8]
         k8: [k3d,minikube]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
         run: [r1]
+        make-target: [smoke-test-k8-tls-root,smoke-test-k8-tls]
         k8: [k3d,minikube]
     steps:
       - uses: actions/checkout@v2
@@ -566,7 +567,7 @@ jobs:
       #    FLV_DISPATCHER_WAIT: 300
         run: |
             date
-            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean smoke-test-k8-tls-root
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean ${{ matrix.make-target }} 
         # make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
       - name: Print version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,6 +581,7 @@ jobs:
           kubectl get pods
           kubectl get svc
           kubectl get spg
+          ./fluvio partition list
 
       - name: Save logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,14 +561,20 @@ jobs:
         run: |
           eval $(minikube -p minikube docker-env)
           docker image load --input /tmp/infinyon-fluvio.tar
+      # When we are ready to merge https://github.com/infinyon/fluvio/pull/1989
+      # The following two steps can be combined by removing the 2nd step, and removing the `if` from the first step
       - name: Run ${{ matrix.make-target }}
+        if: ${{ matrix.make-target == 'smoke-test-k8'}}
         timeout-minutes: 10
-      #  env:
-      #    FLV_DISPATCHER_WAIT: 300
         run: |
             date
             make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean ${{ matrix.make-target }} 
-        # make FLUVIO_BIN=./fluvio TEST_BIN=./flv-test smoke-test-k8-tls-root
+      - name: Run ${{ matrix.make-target }}
+        if: ${{ matrix.make-target != 'smoke-test-k8'}}
+        timeout-minutes: 10
+        run: |
+            date
+            make FLUVIO_BIN=./fluvio TEST_BIN=./fluvio-test EXTRA_ARG=--cluster-start UNINSTALL=noclean TEST_ARG_CONNECTOR_CONFIG= ${{ matrix.make-target }} 
       - name: Print version
         run: |
           ./fluvio version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,7 +561,7 @@ jobs:
         run: |
           eval $(minikube -p minikube docker-env)
           docker image load --input /tmp/infinyon-fluvio.tar
-      - name: Run smoke-test-k8-tls-root
+      - name: Run ${{ matrix.make-target }}
         timeout-minutes: 10
       #  env:
       #    FLV_DISPATCHER_WAIT: 300

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_yaml",
  "structopt",
  "syn",
  "tokio",

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ TEST_ARG_SKIP_CHECKS=
 TEST_ARG_EXTRA=
 TEST_ARG_CONSUMER_WAIT=
 TEST_ARG_PRODUCER_ITERATION=--producer-iteration=${DEFAULT_ITERATION}
+TEST_ARG_CONNECTOR_CONFIG=
 
 export PATH := $(shell pwd)/target/$(BUILD_PROFILE):${PATH}
 
@@ -80,7 +81,8 @@ smoke-test: test-setup
 			${TEST_ARG_EXTRA} \
 			-- \
 			${TEST_ARG_CONSUMER_WAIT} \
-			${TEST_ARG_PRODUCER_ITERATION}
+			${TEST_ARG_PRODUCER_ITERATION} \
+			${TEST_ARG_CONNECTOR_CONFIG}
 
 smoke-test-local: TEST_ARG_EXTRA=--local  $(EXTRA_ARG)
 smoke-test-local: smoke-test
@@ -162,9 +164,11 @@ endif
 # Kubernetes Tests
 
 smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
+smoke-test-k8: TEST_ARG_CONNECTOR_CONFIG=--connector-config ./tests/test-connector-config.yaml
 smoke-test-k8: build_k8_image smoke-test 
 
 smoke-test-k8-tls: TEST_ARG_EXTRA=--tls $(EXTRA_ARG)
+smoke-test-k8-tls: TEST_ARG_CONNECTOR_CONFIG=--connector-config ./tests/test-connector-config.yaml
 smoke-test-k8-tls: build_k8_image smoke-test
 
 smoke-test-k8-tls-policy-setup:
@@ -172,6 +176,7 @@ smoke-test-k8-tls-policy-setup:
 	kubectl create configmap authorization --from-file=POLICY=${SC_AUTH_CONFIG}/policy.json --from-file=SCOPES=${SC_AUTH_CONFIG}/scopes.json
 smoke-test-k8-tls-policy: TEST_ENV_FLV_SPU_DELAY=FLV_SPU_DELAY=$(SPU_DELAY)
 smoke-test-k8-tls-policy: TEST_ARG_EXTRA=--tls --authorization-config-map authorization $(EXTRA_ARG)
+smoke-test-k8-tls-policy: TEST_ARG_CONNECTOR_CONFIG=--connector-config ./tests/test-connector-config.yaml
 smoke-test-k8-tls-policy: build_k8_image smoke-test-k8-tls-policy-setup smoke-test
 
 test-permission-k8:	SC_HOST=$(shell kubectl get node -o json | jq '.items[].status.addresses[0].address' | tr -d '"' )

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8"
 md-5 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 serde_bytes = "0.11.5"
 inventory = "0.1"
 tokio = { version = "1.4", features = ["macros"] }

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -84,22 +84,19 @@ fn run_test(
 
     let test_case = TestCase::new(environment, test_opt);
 
-    if std::env::var("CI").is_ok() {
-        (test_meta.test_fn)(test_driver, test_case).unwrap()
-    } else {
-        let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
-            (test_meta.test_fn)(test_driver, test_case)
-        }));
+    // Run the test, but catch the panic so we can fail the test if event if we've got multiple processes running
+    let test_result = panic::catch_unwind(AssertUnwindSafe(move || {
+        (test_meta.test_fn)(test_driver, test_case)
+    }));
 
-        // If we've panicked from the test, we need to terminate all the child processes too to stop the test
-        match test_result {
-            Ok(r) => r.unwrap(),
-            Err(_) => {
-                // nix uses pid 0 to refer to the group process, so reap the child processes
-                let pid = Pid::from_raw(0);
-                kill(pid, Signal::SIGTERM).expect("Unable to kill test process");
-                exit(1);
-            }
+    // If we've panicked from the test, we need to terminate all the child processes too to stop the test
+    match test_result {
+        Ok(r) => r.unwrap(),
+        Err(_) => {
+            // nix uses pid 0 to refer to the group process, so reap the child processes
+            let pid = Pid::from_raw(0);
+            kill(pid, Signal::SIGTERM).expect("Unable to kill test process");
+            exit(1);
         }
     }
 }

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -109,7 +109,15 @@ pub async fn validate_consume_message_api(
                             offset,
                             bytes.len()
                         );
-                        validate_message(producer_iteration, offset, test_case, bytes);
+
+                        if test_case.option.skip_consumer_validate {
+                            info!(
+                                "Skipped message validation",
+                            );
+                        } else {
+                            validate_message(producer_iteration, offset, test_case, bytes);
+                        };
+
                         info!(
                             " total records: {}, validated offset: {}",
                             total_records, offset
@@ -221,7 +229,15 @@ pub async fn validate_consume_message_api(
                         bytes.len()
                     );
 
-                    validate_message(producer_iteration, offset, test_case, bytes);
+                    if test_case.option.skip_consumer_validate {
+                        info!(
+                            "Skipped message validation",
+                        );
+                    } else {
+                        validate_message(producer_iteration, offset, test_case, bytes);
+                    };
+
+
                     info!(
                         "2nd fetch total records: {}, validated offset: {}",
                         total_records, offset

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -159,37 +159,41 @@ pub async fn validate_consume_message_api(
         }
     }
 
-    let replication = test_case.environment.replication;
-    if replication > 1 {
-        println!("waiting 5 seconds to verify replication status...");
-        // wait 5 seconds to get status and ensure replication is done
-        sleep(Duration::from_secs(5)).await;
+    // This check is unreliable when we are testing w/ connectors, so skip it
+    if test_case.option.connector_config.is_some() {
+        println!("skipping replication status verification");
+    } else {
+        let replication = test_case.environment.replication;
+        if replication > 1 {
+            println!("waiting 5 seconds to verify replication status...");
+            // wait 5 seconds to get status and ensure replication is done
+            sleep(Duration::from_secs(5)).await;
 
-        let admin = test_driver.client().admin().await;
-        let partitions = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+            let admin = test_driver.client().admin().await;
+            let partitions = admin
+                .list::<PartitionSpec, _>(vec![])
+                .await
+                .expect("partitions");
 
-        assert_eq!(partitions.len(), 1);
+            assert_eq!(partitions.len(), 1);
 
-        let test_topic = &partitions[0];
-        let status = &test_topic.status;
-        let leader = &status.leader;
+            let test_topic = &partitions[0];
+            let status = &test_topic.status;
+            let leader = &status.leader;
 
-        assert_eq!(leader.leo, base_offset + producer_iteration as i64);
-        println!("status: {:#?}", status);
+            assert_eq!(leader.leo, base_offset + producer_iteration as i64);
+            println!("status: {:#?}", status);
 
-        assert_eq!(status.replicas.len() as u16, replication - 1);
+            assert_eq!(status.replicas.len() as u16, replication - 1);
 
-        for i in 0..replication - 1 {
-            let follower_status = &status.replicas[i as usize];
-            assert_eq!(follower_status.hw, producer_iteration as i64);
-            assert_eq!(follower_status.leo, producer_iteration as i64);
+            for i in 0..replication - 1 {
+                let follower_status = &status.replicas[i as usize];
+                assert_eq!(follower_status.hw, producer_iteration as i64);
+                assert_eq!(follower_status.leo, producer_iteration as i64);
+            }
         }
+        println!("replication status verified");
     }
-
-    println!("replication status verified");
 
     println!("performing 2nd fetch check. waiting 5 seconds");
 

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -120,23 +120,11 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
             // If the connector already exists, don't fail
             println!("Attempt to create connector");
-            if std::env::var("CI").is_ok() {
-                println!("Using fluvio binary to create connector");
-                std::process::Command::new("./fluvio")
-                    .args([
-                        "connector",
-                        "create",
-                        "--config",
-                        &format!("{}", &connector_config.as_path().display()),
-                    ])
-                    .spawn()
-                    .expect("Failed to run fluvio cli to start connectors");
-            } else {
-                admin
-                    .create(name.to_string(), false, spec)
-                    .await
-                    .unwrap_or(());
-            };
+            admin
+                .create(name.to_string(), false, spec)
+                .await
+                .unwrap_or(());
+
             // Build a new SmokeTestCase so we can use the consumer verify
             // Ending after a static number of records received
             let new_smoke_test_case = SmokeTestCase {

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -130,15 +130,17 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
             let new_smoke_test_case = SmokeTestCase {
                 environment: EnvironmentSetup {
                     topic_name: Some(config.topic.clone()),
-                    //tls: smoke_test_case.environment.tls.clone(),
-                    //tls_user: smoke_test_case.environment.tls_user().clone(),
+                    tls: smoke_test_case.environment.tls,
+                    tls_user: smoke_test_case.environment.tls_user(),
                     spu: smoke_test_case.environment.spu,
+                    replication: smoke_test_case.environment.replication,
                     partition: smoke_test_case.environment.partition,
                     ..Default::default()
                 },
                 option: SmokeTestOption {
                     skip_consumer_validate: true,
                     producer_iteration: 100,
+                    connector_config: smoke_test_case.option.connector_config.clone(),
                     ..Default::default()
                 },
             };

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -152,7 +152,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
             println!("Verify connector is creating data: (start: {})", start);
 
-            const CI_TIME: u64 = 60;
+            const CI_TIME: u64 = 90;
             const DEV_TIME: u64 = 10;
 
             let wait_sec = if std::env::var("CI").is_ok() {

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -120,11 +120,23 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
             // If the connector already exists, don't fail
             println!("Attempt to create connector");
-            admin
-                .create(name.to_string(), false, spec)
-                .await
-                .unwrap_or(());
-
+            if std::env::var("CI").is_ok() {
+                println!("Using fluvio binary to create connector");
+                std::process::Command::new("./fluvio")
+                    .args([
+                        "connector",
+                        "create",
+                        "--config",
+                        &format!("{}", &connector_config.as_path().display()),
+                    ])
+                    .spawn()
+                    .expect("Failed to run fluvio cli to start connectors");
+            } else {
+                admin
+                    .create(name.to_string(), false, spec)
+                    .await
+                    .unwrap_or(());
+            };
             // Build a new SmokeTestCase so we can use the consumer verify
             // Ending after a static number of records received
             let new_smoke_test_case = SmokeTestCase {

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -152,7 +152,8 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
             println!("Verify connector is creating data: (start: {})", start);
 
-            let wait_sec = 10;
+            let wait_sec = if std::env::var("CI").is_ok() { 30 } else { 10 };
+
             println!("Waiting {} seconds to let connector write", &wait_sec);
             sleep(Duration::from_secs(wait_sec)).await;
 

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -2,15 +2,31 @@ pub mod consume;
 pub mod produce;
 pub mod message;
 pub mod offsets;
+use crate::tests::smoke::consume::validate_consume_message_api;
 
 use std::any::Any;
+use std::fmt;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use structopt::StructOpt;
 
 use fluvio_test_derive::fluvio_test;
-use fluvio_test_util::test_meta::environment::EnvironmentSetup;
+use fluvio_test_util::test_meta::environment::{EnvironmentSetup};
 use fluvio_test_util::test_meta::{TestOption, TestCase};
 use fluvio_test_util::async_process;
+
+use fluvio::metadata::{
+    topic::{TopicSpec, TopicReplicaParam},
+    connector::{ManagedConnectorSpec, SecretString},
+};
+use fluvio_future::timer::sleep;
+
+use tracing::debug;
+use std::fs::File;
+use std::io::Read;
+use std::collections::BTreeMap;
+use serde::{Deserialize};
 
 #[derive(Debug, Clone)]
 pub struct SmokeTestCase {
@@ -44,6 +60,10 @@ pub struct SmokeTestOption {
     pub producer_record_size: u32,
     #[structopt(long)]
     pub consumer_wait: bool,
+    #[structopt(long)]
+    pub connector_config: Option<PathBuf>,
+    #[structopt(long)]
+    pub skip_consumer_validate: bool,
 }
 
 impl TestOption for SmokeTestOption {
@@ -66,43 +86,184 @@ impl TestOption for SmokeTestOption {
 
 #[fluvio_test(topic = "test")]
 pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
-    let smoke_test_case = test_case.into();
+    let smoke_test_case: SmokeTestCase = test_case.into();
 
-    // We're going to handle the `--consumer-wait` flag in this process
-    let producer_wait = async_process!(async {
-        let mut test_driver_consumer_wait = test_driver.clone();
-
-        test_driver
-            .connect()
-            .await
-            .expect("Connecting to cluster failed");
-        println!("About to start producer test");
-
-        let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
-
-        // If we've passed in `--consumer-wait` then we should start the consumer after the producer
-        if smoke_test_case.option.consumer_wait {
-            test_driver_consumer_wait
-                .connect()
-                .await
-                .expect("Connecting to cluster failed");
-            use crate::tests::smoke::consume::validate_consume_message_api;
-            validate_consume_message_api(test_driver_consumer_wait, start_offset, &smoke_test_case)
-                .await;
-        }
-    });
-
-    // By default, we should run the consumer and producer at the same time
-    if !smoke_test_case.option.consumer_wait {
-        let consumer_wait = async_process!(async {
+    // If connector tests requested
+    let maybe_connector = if let Some(ref connector_config) =
+        smoke_test_case.option.connector_config
+    {
+        let connector_process = async_process!(async {
             test_driver
                 .connect()
                 .await
                 .expect("Connecting to cluster failed");
-            consume::validate_consume_message(test_driver, &smoke_test_case).await;
+
+            // Add a connector CRD
+            let admin = test_driver.client().admin().await;
+            // Create a managed connector
+            let config = ConnectorConfig::from_file(&connector_config).unwrap();
+            let spec: ManagedConnectorSpec = config.clone().into();
+            let name = spec.name.clone();
+
+            debug!("creating managed_connector: {}, spec: {:#?}", name, spec);
+
+            // If the managed connector wants its topic created, don't fail if it already exists
+            if config.create_topic {
+                println!("Attempt to create connector's topic");
+                let topic_spec = TopicSpec::Computed(TopicReplicaParam::new(1, 1, false));
+                debug!("topic spec: {:?}", topic_spec);
+                admin
+                    .create(config.topic.clone(), false, topic_spec)
+                    .await
+                    .unwrap_or(());
+            }
+
+            // If the connector already exists, don't fail
+            println!("Attempt to create connector");
+            admin
+                .create(name.to_string(), false, spec)
+                .await
+                .unwrap_or(());
+
+            // Build a new SmokeTestCase so we can use the consumer verify
+            // Ending after a static number of records received
+            let new_smoke_test_case = SmokeTestCase {
+                environment: EnvironmentSetup {
+                    topic_name: Some(config.topic.clone()),
+                    //tls: smoke_test_case.environment.tls.clone(),
+                    //tls_user: smoke_test_case.environment.tls_user().clone(),
+                    spu: smoke_test_case.environment.spu,
+                    partition: smoke_test_case.environment.partition,
+                    ..Default::default()
+                },
+                option: SmokeTestOption {
+                    skip_consumer_validate: true,
+                    producer_iteration: 100,
+                    ..Default::default()
+                },
+            };
+
+            // Verify that connector is creating data
+            let start_offset =
+                offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
+            let start = start_offset.get(&config.topic.clone()).expect("offsets");
+
+            println!("Verify connector is creating data: (start: {})", start);
+
+            let wait_sec = 10;
+            println!("Waiting {} seconds to let connector write", &wait_sec);
+            sleep(Duration::from_secs(wait_sec)).await;
+
+            let check_offset =
+                offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
+            let check = check_offset.get(&config.topic.clone()).expect("offsets");
+
+            if check > start {
+                println!("Connector is receiving data: (check: {})", check)
+            } else {
+                panic!("Connector not receiving data")
+            };
+
+            println!("Run consume test against connector topic");
+            validate_consume_message_api(test_driver, start_offset, &new_smoke_test_case.clone())
+                .await;
         });
 
-        let _ = consumer_wait.join();
+        Some(connector_process)
+
+        // Wait a few seconds to allow the connector a chance to deploy and store data
+    } else {
+        None
+    };
+
+    //// We're going to handle the `--consumer-wait` flag in this process
+    //let producer_wait = async_process!(async {
+    //    let mut test_driver_consumer_wait = test_driver.clone();
+
+    //    test_driver
+    //        .connect()
+    //        .await
+    //        .expect("Connecting to cluster failed");
+    //    println!("About to start producer test");
+
+    //    let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
+
+    //    // If we've passed in `--consumer-wait` then we should start the consumer after the producer
+    //    if smoke_test_case.option.consumer_wait {
+    //        test_driver_consumer_wait
+    //            .connect()
+    //            .await
+    //            .expect("Connecting to cluster failed");
+    //        validate_consume_message_api(test_driver_consumer_wait, start_offset, &smoke_test_case)
+    //            .await;
+    //    }
+    //});
+
+    //// By default, we should run the consumer and producer at the same time
+    //if !smoke_test_case.option.consumer_wait {
+    //    let consumer_wait = async_process!(async {
+    //        test_driver
+    //            .connect()
+    //            .await
+    //            .expect("Connecting to cluster failed");
+    //        consume::validate_consume_message(test_driver, &smoke_test_case).await;
+    //    });
+
+    //    let _ = consumer_wait.join();
+    //}
+    //let _ = producer_wait.join();
+
+    if let Some(connector_wait) = maybe_connector {
+        let _ = connector_wait.join();
+    };
+}
+
+// Copied from CLI Connector create
+#[derive(Debug, Deserialize, Clone)]
+pub struct ConnectorConfig {
+    name: String,
+    #[serde(rename = "type")]
+    type_: String,
+    pub(crate) topic: String,
+    pub(crate) connector_version: Option<String>,
+    #[serde(default)]
+    pub(crate) create_topic: bool,
+    #[serde(default)]
+    parameters: BTreeMap<String, String>,
+    #[serde(default)]
+    secrets: BTreeMap<String, SecretString>,
+}
+
+#[derive(Debug)]
+pub struct ConnectorConfigLoadErr;
+
+impl fmt::Display for ConnectorConfigLoadErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Connector config load err")
     }
-    let _ = producer_wait.join();
+}
+
+impl std::error::Error for ConnectorConfigLoadErr {}
+
+impl ConnectorConfig {
+    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, ConnectorConfigLoadErr> {
+        let mut file = File::open(path.into()).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        let connector_config: Self = serde_yaml::from_str(&contents).unwrap();
+        Ok(connector_config)
+    }
+}
+
+impl From<ConnectorConfig> for ManagedConnectorSpec {
+    fn from(config: ConnectorConfig) -> ManagedConnectorSpec {
+        ManagedConnectorSpec {
+            name: config.name,
+            type_: config.type_,
+            topic: config.topic,
+            parameters: config.parameters,
+            secrets: config.secrets,
+            connector_version: config.connector_version,
+        }
+    }
 }

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -176,42 +176,42 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         None
     };
 
-    //// We're going to handle the `--consumer-wait` flag in this process
-    //let producer_wait = async_process!(async {
-    //    let mut test_driver_consumer_wait = test_driver.clone();
+    // We're going to handle the `--consumer-wait` flag in this process
+    let producer_wait = async_process!(async {
+        let mut test_driver_consumer_wait = test_driver.clone();
 
-    //    test_driver
-    //        .connect()
-    //        .await
-    //        .expect("Connecting to cluster failed");
-    //    println!("About to start producer test");
+        test_driver
+            .connect()
+            .await
+            .expect("Connecting to cluster failed");
+        println!("About to start producer test");
 
-    //    let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
+        let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
 
-    //    // If we've passed in `--consumer-wait` then we should start the consumer after the producer
-    //    if smoke_test_case.option.consumer_wait {
-    //        test_driver_consumer_wait
-    //            .connect()
-    //            .await
-    //            .expect("Connecting to cluster failed");
-    //        validate_consume_message_api(test_driver_consumer_wait, start_offset, &smoke_test_case)
-    //            .await;
-    //    }
-    //});
+        // If we've passed in `--consumer-wait` then we should start the consumer after the producer
+        if smoke_test_case.option.consumer_wait {
+            test_driver_consumer_wait
+                .connect()
+                .await
+                .expect("Connecting to cluster failed");
+            validate_consume_message_api(test_driver_consumer_wait, start_offset, &smoke_test_case)
+                .await;
+        }
+    });
 
-    //// By default, we should run the consumer and producer at the same time
-    //if !smoke_test_case.option.consumer_wait {
-    //    let consumer_wait = async_process!(async {
-    //        test_driver
-    //            .connect()
-    //            .await
-    //            .expect("Connecting to cluster failed");
-    //        consume::validate_consume_message(test_driver, &smoke_test_case).await;
-    //    });
+    // By default, we should run the consumer and producer at the same time
+    if !smoke_test_case.option.consumer_wait {
+        let consumer_wait = async_process!(async {
+            test_driver
+                .connect()
+                .await
+                .expect("Connecting to cluster failed");
+            consume::validate_consume_message(test_driver, &smoke_test_case).await;
+        });
 
-    //    let _ = consumer_wait.join();
-    //}
-    //let _ = producer_wait.join();
+        let _ = consumer_wait.join();
+    }
+    let _ = producer_wait.join();
 
     if let Some(connector_wait) = maybe_connector {
         let _ = connector_wait.join();

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -152,7 +152,14 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
             println!("Verify connector is creating data: (start: {})", start);
 
-            let wait_sec = if std::env::var("CI").is_ok() { 30 } else { 10 };
+            const CI_TIME: u64 = 60;
+            const DEV_TIME: u64 = 10;
+
+            let wait_sec = if std::env::var("CI").is_ok() {
+                CI_TIME
+            } else {
+                DEV_TIME
+            };
 
             println!("Waiting {} seconds to let connector write", &wait_sec);
             sleep(Duration::from_secs(wait_sec)).await;

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -139,7 +139,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
                 },
                 option: SmokeTestOption {
                     skip_consumer_validate: true,
-                    producer_iteration: 100,
+                    producer_iteration: 10,
                     connector_config: smoke_test_case.option.connector_config.clone(),
                     ..Default::default()
                 },

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -9,18 +9,18 @@ load "$TEST_HELPER_DIR"/bats-support/load.bash
 load "$TEST_HELPER_DIR"/bats-assert/load.bash
 
 setup_file() {
-    # Compile the smartmodule examples
+    # Compile the smart-module examples
     pushd "$BATS_TEST_DIRNAME/../../.." && make build_smartmodules && popd
     SMARTMODULE_BUILD_DIR="$BATS_TEST_DIRNAME/../../../crates/fluvio-smartmodule/examples/target/wasm32-unknown-unknown/release/"
     export SMARTMODULE_BUILD_DIR
     
 }
 
-@test "smartmodule map" {
-    # Load the smartmodule
+@test "smart-module map" {
+    # Load the smart-module
     SMARTMODULE_NAME="uppercase"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_map.wasm 
     assert_success
 
     # Create topic
@@ -47,16 +47,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule filter" {
-    # Load the smartmodule
+@test "smart-module filter" {
+    # Load the smart-module
     SMARTMODULE_NAME="contains-a"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter.wasm 
     assert_success
 
     # Create topic
@@ -81,7 +81,7 @@ setup_file() {
     assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
     assert_line --index 1 "$TEST_MESSAGE"
 
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    # Consume from topic with smart-module and verify we don't see the $NEGATIVE_TEST_MESSAGE
     EXPECTED_OUTPUT="${TEST_MESSAGE}"
     export EXPECTED_OUTPUT
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
@@ -92,16 +92,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule filter w/ params" {
-    # Load the smartmodule
+@test "smart-module filter w/ params" {
+    # Load the smart-module
     SMARTMODULE_NAME="contains-a-or-param"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_with_parameters.wasm 
     assert_success
 
     # Create topic
@@ -132,7 +132,7 @@ setup_file() {
     assert_line --index 1 "$DEFAULT_PARAM_MESSAGE"
     assert_line --index 2 "$TEST_PARAM_MESSAGE"
 
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    # Consume from topic with smart-module and verify we don't see the $NEGATIVE_TEST_MESSAGE
     EXPECTED_OUTPUT="${DEFAULT_PARAM_MESSAGE}"
     export EXPECTED_OUTPUT
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter "$SMARTMODULE_NAME"
@@ -153,16 +153,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule filter-map" {
-    # Load the smartmodule
+@test "smart-module filter-map" {
+    # Load the smart-module
     SMARTMODULE_NAME="divide-even-by-2"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_filter_map.wasm 
     assert_success
 
     # Create topic
@@ -187,7 +187,7 @@ setup_file() {
     assert_line --index 0 "$NEGATIVE_TEST_MESSAGE"
     assert_line --index 1 "$TEST_MESSAGE"
 
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    # Consume from topic with smart-module and verify we don't see the $NEGATIVE_TEST_MESSAGE
     EXPECTED_OUTPUT="${TEST_MESSAGE}"
     export EXPECTED_OUTPUT
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --filter-map "$SMARTMODULE_NAME"
@@ -198,16 +198,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule array-map" {
-    # Load the smartmodule
+@test "smart-module array-map" {
+    # Load the smart-module
     SMARTMODULE_NAME="json-object-flatten"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_array_map_object.wasm 
 
     assert_success
 
@@ -233,7 +233,7 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
     assert_output "$FULL_TEST_MESSAGE"
 
-    # Consume from topic with smartmodule and verify we don't see the $NEGATIVE_TEST_MESSAGE
+    # Consume from topic with smart-module and verify we don't see the $NEGATIVE_TEST_MESSAGE
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d --array-map "$SMARTMODULE_NAME"
     assert_line --index 0 "$FIRST_MESSAGE"
     assert_line --index 1 "$SECOND_MESSAGE"
@@ -243,16 +243,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule aggregate" {
-    # Load the smartmodule
+@test "smart-module aggregate" {
+    # Load the smart-module
     SMARTMODULE_NAME="concat-strings"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_aggregate.wasm 
     assert_success
 
     # Create topic
@@ -281,16 +281,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }
 
-@test "smartmodule join" {
-    # Load the smartmodule
+@test "smart-module join" {
+    # Load the smart-module
     SMARTMODULE_NAME="join-sum"
     export SMARTMODULE_NAME
-    run timeout 15s "$FLUVIO_BIN" smartmodule create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_join.wasm 
+    run timeout 15s "$FLUVIO_BIN" smart-module create $SMARTMODULE_NAME --wasm-file $SMARTMODULE_BUILD_DIR/fluvio_wasm_join.wasm 
     assert_success
 
     # Create topic
@@ -330,7 +330,7 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" topic delete "$JOIN_TOPIC_NAME"
     assert_success
 
-    # Delete smartmodule
-    run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
+    # Delete smart-module
+    run timeout 15s "$FLUVIO_BIN" smart-module delete "$SMARTMODULE_NAME"
     assert_success
 }

--- a/tests/test-connector-config.yaml
+++ b/tests/test-connector-config.yaml
@@ -1,11 +1,6 @@
 version: v1
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
+name: my-test-connector
+type: test-connector
+topic: my-test-connector-topic
 create_topic: true 
 direction: source
-parameters:
-  mqtt-url: "mqtt.hsl.fi"
-  mqtt-topic: "/hfp/v2/journey/#"
-secrets:
-  foo: bar

--- a/tests/test-connector-config.yaml
+++ b/tests/test-connector-config.yaml
@@ -1,0 +1,11 @@
+version: v1
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: true 
+direction: source
+parameters:
+  mqtt-url: "mqtt.hsl.fi"
+  mqtt-topic: "/hfp/v2/journey/#"
+secrets:
+  foo: bar


### PR DESCRIPTION
Fixes #1982 

Pass a connector config to the smoke test to include in consume testing. Checks that connector topic actively receives data.

- Made changes to test runner to catch test panics in CI so errors and exit codes would report accurately as failures
- Added CLI tests to publish requirements
- Left a note in the `k8_cluster_test` for how to change the way the k8 smoke tests w/ tls run when the support comes in.