### PR TITLE
[Merged by Bors] - Topic CRD changes for Retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
  "http-types",
  "indicatif",
  "k8-client",
- "k8-config 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config",
  "k8-types",
  "prettytable-rs",
  "semver 1.0.4",
@@ -1616,7 +1616,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "k8-client",
- "k8-config 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config",
  "k8-metadata-client",
  "k8-types",
  "nix",
@@ -2889,7 +2889,8 @@ dependencies = [
 [[package]]
 name = "k8-client"
 version = "5.5.0"
-source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d8b64d2b3f935a032944175f42286062cbfcaf4871c4ea6e739bbca04ae719"
 dependencies = [
  "async-trait",
  "base64",
@@ -2899,7 +2900,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "k8-config 1.5.0 (git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa)",
+ "k8-config",
  "k8-diff",
  "k8-metadata-client",
  "k8-types",
@@ -2928,32 +2929,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8-config"
-version = "1.5.0"
-source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
-dependencies = [
- "dirs 4.0.0",
- "hostfile",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "k8-diff"
 version = "0.1.2"
-source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef435d912eeb448129d7ae11d3c497691f1f383d2d2ff1dff4365a81c7bd4f3b"
 dependencies = [
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "k8-metadata-client"
 version = "3.3.1"
-source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e808b58bfcfaca07297ddb40ab8ca9905714413db3f606cea22f327b68c757a"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2968,7 +2958,8 @@ dependencies = [
 [[package]]
 name = "k8-types"
 version = "0.5.2"
-source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0728e18a0784829b97808fc21c667d6ff78e58e8150b75e2d7de90b6d8787bdb"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,7 +1674,6 @@ dependencies = [
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
- "log",
  "serde",
  "thiserror",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "8d09bbc040ce3758a0d32a8a910562104a853aea429dbe1a998beb065c2eacb2"
 dependencies = [
  "bytes",
  "fnv",
@@ -3403,9 +3403,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "300.0.2+3.0.0"
+version = "300.0.3+3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
+checksum = "c51ecedef28dcb23c303944dce1d44a9729f3d28d59f39e56f0c847329d1b134"
 dependencies = [
  "cc",
 ]
@@ -4401,9 +4401,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a7a75ea6f4a29c7cd5a752ddcfc5453bd5ed97688db68b50698fd3c82f343a"
+checksum = "c35dfd12afb7828318348b8c408383cf5071a086c1d4ab1c0f9840ec92dbb922"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "fluvio",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
  "http-types",
  "indicatif",
  "k8-client",
- "k8-config",
+ "k8-config 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-types",
  "prettytable-rs",
  "semver 1.0.4",
@@ -1616,7 +1616,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "k8-client",
- "k8-config",
+ "k8-config 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-metadata-client",
  "k8-types",
  "nix",
@@ -2889,9 +2889,8 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702cde04550bf080add52a38836f1e9b0e203f8a1956e98ac59220bd99c4da6"
+version = "5.5.0"
+source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
 dependencies = [
  "async-trait",
  "base64",
@@ -2901,7 +2900,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "k8-config",
+ "k8-config 1.5.0 (git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa)",
  "k8-diff",
  "k8-metadata-client",
  "k8-types",
@@ -2930,21 +2929,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8-diff"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef435d912eeb448129d7ae11d3c497691f1f383d2d2ff1dff4365a81c7bd4f3b"
+name = "k8-config"
+version = "1.5.0"
+source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
 dependencies = [
+ "dirs 4.0.0",
+ "hostfile",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
+name = "k8-diff"
+version = "0.1.2"
+source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "k8-metadata-client"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4a331f7fb753ac50d6d5d3ed5f26f4902849bcd4cc0477387d40af32c129bf"
+version = "3.3.1"
+source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2958,9 +2968,8 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751ac45e0d493bcfdeed2b536a3eb3e818e3ad5e7088dc9e2a4b12d8cf69235a"
+version = "0.5.2"
+source = "git+https://github.com/infinyon/k8-api.git?rev=ed6732580c13550dcb990fb9f89a59d475aeddaa#ed6732580c13550dcb990fb9f89a59d475aeddaa"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ members = [
 ]
 resolver = "2"
 
+[patch.crates-io]
+k8-client = {  git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
+k8-metadata-client = { git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
+k8-types = { git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds
 [profile.dev.package.backtrace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,6 @@ members = [
 ]
 resolver = "2"
 
-[patch.crates-io]
-k8-client = {  git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
-k8-metadata-client = { git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
-k8-types = { git = 'https://github.com/infinyon/k8-api.git', rev = "ed6732580c13550dcb990fb9f89a59d475aeddaa" }
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds
 [profile.dev.package.backtrace]

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -72,7 +72,7 @@ k8-config = { version = "1.4.0", optional = true }
 k8-client = { version = "5.4.0", optional = true }
 fluvio-cluster = { version = "0.0.0", path = "../fluvio-cluster", default-features = false, features = ["cli"], optional = true }
 
-fluvio = { version = "0.10.0", path = "../fluvio", default-features = false }
+fluvio = { version = "0.11.0", path = "../fluvio", default-features = false }
 fluvio-socket = { version = "0.10", path = "../fluvio-socket" }
 fluvio-command = { version = "0.2.0" }
 fluvio-package-index = { version = "0.5.0", path = "../fluvio-package-index" }
@@ -83,7 +83,7 @@ k8-types = { version = "0.5.0", features = ["core"] }
 # Optional Fluvio dependencies
 fluvio-types = { version = "0.2.0", path = "../fluvio-types", optional = true }
 fluvio-future = { version = "0.3.0", features = ["fs", "io", "subscriber", "native2_tls"], optional = true }
-fluvio-sc-schema = { version = "0.11.0", path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
+fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
 indicatif = "0.16.2"
 
 [dev-dependencies]

--- a/crates/fluvio-cli/src/connector/create.rs
+++ b/crates/fluvio-cli/src/connector/create.rs
@@ -4,6 +4,7 @@
 //! CLI tree to generate Create a Managed Connector
 //!
 
+use fluvio_controlplane_metadata::topic::ReplicaSpec;
 use structopt::StructOpt;
 use tracing::debug;
 
@@ -39,9 +40,9 @@ impl CreateManagedConnectorOpt {
 
         let admin = fluvio.admin().await;
         if config.create_topic {
-            let topic_spec = TopicSpec::Computed(TopicReplicaParam::new(1, 1, false));
-            debug!("topic spec: {:?}", topic_spec);
-            match admin.create(config.topic, false, topic_spec).await {
+            let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
+            debug!("topic spec: {:?}", replica_spec);
+            match admin.create(config.topic, false, replica_spec.into()).await {
                 Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
                     //println!("Topic already exists");
                     Ok(())

--- a/crates/fluvio-cli/src/connector/create.rs
+++ b/crates/fluvio-cli/src/connector/create.rs
@@ -42,7 +42,10 @@ impl CreateManagedConnectorOpt {
         if config.create_topic {
             let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
             debug!("topic spec: {:?}", replica_spec);
-            match admin.create(config.topic, false, replica_spec.into()).await {
+            match admin
+                .create::<TopicSpec>(config.topic, false, replica_spec.into())
+                .await
+            {
                 Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
                     //println!("Topic already exists");
                     Ok(())

--- a/crates/fluvio-cli/src/topic/create.rs
+++ b/crates/fluvio-cli/src/topic/create.rs
@@ -103,7 +103,7 @@ impl CreateTopicOpt {
         use fluvio::metadata::topic::TopicReplicaParam;
         use load::PartitionLoad;
 
-        let topic = if let Some(replica_assign_file) = &self.replica_assignment {
+        let replica_spec = if let Some(replica_assign_file) = &self.replica_assignment {
             ReplicaSpec::Assigned(PartitionMaps::file_decode(replica_assign_file).map_err(
                 |err| {
                     IoError::new(
@@ -132,7 +132,7 @@ impl CreateTopicOpt {
         }
 
         // return server separately from config
-        Ok((self.topic, topic))
+        Ok((self.topic, replica_spec.into()))
     }
 }
 

--- a/crates/fluvio-cli/src/topic/create.rs
+++ b/crates/fluvio-cli/src/topic/create.rs
@@ -8,6 +8,7 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
+use fluvio_controlplane_metadata::topic::ReplicaSpec;
 use fluvio_sc_schema::topic::validate::valid_topic_name;
 use tracing::debug;
 use structopt::StructOpt;
@@ -103,8 +104,8 @@ impl CreateTopicOpt {
         use load::PartitionLoad;
 
         let topic = if let Some(replica_assign_file) = &self.replica_assignment {
-            TopicSpec::Assigned(
-                PartitionMaps::file_decode(replica_assign_file).map_err(|err| {
+            ReplicaSpec::Assigned(PartitionMaps::file_decode(replica_assign_file).map_err(
+                |err| {
                     IoError::new(
                         ErrorKind::InvalidInput,
                         format!(
@@ -112,10 +113,10 @@ impl CreateTopicOpt {
                             replica_assign_file, err
                         ),
                     )
-                })?,
-            )
+                },
+            )?)
         } else {
-            TopicSpec::Computed(TopicReplicaParam {
+            ReplicaSpec::Computed(TopicReplicaParam {
                 partitions: self.partitions,
                 replication_factor: self.replication as i32,
                 ignore_rack_assignment: self.ignore_rack_assigment,

--- a/crates/fluvio-cli/src/topic/describe.rs
+++ b/crates/fluvio-cli/src/topic/describe.rs
@@ -120,7 +120,7 @@ mod display {
 
             key_values.push(("Name".to_owned(), Some(self.0.name.clone())));
             key_values.push(("Type".to_owned(), Some(spec.type_label().to_string())));
-            match spec.replicas {
+            match &spec.replicas {
                 ReplicaSpec::Computed(param) => {
                     key_values.push((
                         "Partition Count".to_owned(),

--- a/crates/fluvio-cli/src/topic/describe.rs
+++ b/crates/fluvio-cli/src/topic/describe.rs
@@ -45,6 +45,7 @@ impl DescribeTopicsOpt {
 
 mod display {
 
+    use fluvio_controlplane_metadata::topic::ReplicaSpec;
     use prettytable::Row;
     use prettytable::row;
     use serde::Serialize;
@@ -119,8 +120,8 @@ mod display {
 
             key_values.push(("Name".to_owned(), Some(self.0.name.clone())));
             key_values.push(("Type".to_owned(), Some(spec.type_label().to_string())));
-            match spec {
-                TopicSpec::Computed(param) => {
+            match spec.replicas {
+                ReplicaSpec::Computed(param) => {
                     key_values.push((
                         "Partition Count".to_owned(),
                         Some(param.partitions.to_string()),
@@ -134,7 +135,7 @@ mod display {
                         Some(param.ignore_rack_assignment.to_string()),
                     ));
                 }
-                TopicSpec::Assigned(_partitions) => {
+                ReplicaSpec::Assigned(_partitions) => {
                     /*
                     key_values.push((
                         "Assigned Partitions".to_owned(),

--- a/crates/fluvio-cli/src/topic/describe.rs
+++ b/crates/fluvio-cli/src/topic/describe.rs
@@ -120,7 +120,7 @@ mod display {
 
             key_values.push(("Name".to_owned(), Some(self.0.name.clone())));
             key_values.push(("Type".to_owned(), Some(spec.type_label().to_string())));
-            match &spec.replicas {
+            match spec.replicas() {
                 ReplicaSpec::Computed(param) => {
                     key_values.push((
                         "Partition Count".to_owned(),

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -56,7 +56,7 @@ nix = "0.23"
 rand = "0.8.4"
 
 # Fluvio dependencies
-fluvio = { version = "0.10.0", path = "../fluvio", default-features = false }
+fluvio = { version = "0.11.0", path = "../fluvio", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.3.0" }
 fluvio-command = { version = "0.2.0" }
@@ -64,7 +64,7 @@ fluvio-extension-common = { version = "0.5.0", path = "../fluvio-extension-commo
 fluvio-controlplane-metadata = { version = "0.13.0", path = "../fluvio-controlplane-metadata", features = [
     "k8",
 ] }
-fluvio-sc-schema = { version = "0.11.0", path = "../fluvio-sc-schema", default-features = false, optional = true }
+fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", default-features = false, optional = true }
 flv-util = "0.5.2"
 k8-config = { version = "1.4.0" }
 k8-client = { version = "5.4.0" }

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -165,17 +165,21 @@ impl StartOpt {
         self,
         platform_version: Version,
         upgrade: bool,
-        skip_sys: bool,
+        skip_sys: bool, // only applies to upgrade
     ) -> Result<(), ClusterCliError> {
         use crate::cli::start::local::process_local;
         use crate::cli::start::sys::process_sys;
         use crate::cli::start::k8::process_k8;
 
         if self.sys {
-            process_sys(self, upgrade)?;
+            process_sys(&self, upgrade)?;
         } else if self.local {
             process_local(self, platform_version).await?;
         } else {
+            // if upgrade and not skip sys, invoke sys
+            if upgrade && !skip_sys {
+                process_sys(&self, upgrade)?;
+            }
             process_k8(self, platform_version, upgrade, skip_sys).await?;
         }
 

--- a/crates/fluvio-cluster/src/cli/start/sys.rs
+++ b/crates/fluvio-cluster/src/cli/start/sys.rs
@@ -3,16 +3,16 @@ use crate::cli::ClusterCliError;
 use crate::charts::{ChartConfig, ChartInstallError, ChartInstaller};
 use crate::ClusterError;
 
-pub fn process_sys(opt: StartOpt, upgrade: bool) -> Result<(), ClusterCliError> {
+pub fn process_sys(opt: &StartOpt, upgrade: bool) -> Result<(), ClusterCliError> {
     install_sys_impl(opt, upgrade).map_err(ClusterError::InstallSys)?;
     Ok(())
 }
 
-fn install_sys_impl(opt: StartOpt, upgrade: bool) -> Result<(), ChartInstallError> {
+fn install_sys_impl(opt: &StartOpt, upgrade: bool) -> Result<(), ChartInstallError> {
     println!("installing sys chart");
 
     let config = ChartConfig::sys_builder()
-        .namespace(&opt.k8_config.namespace)
+        .namespace(opt.k8_config.namespace.clone())
         .version(opt.k8_config.chart_version.clone())
         .with(|builder| match &opt.k8_config.chart_location {
             // If a chart location is given, use it

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -16,7 +16,6 @@ use_serde = ["serde"]
 k8 = ["use_serde", "fluvio-stream-model/k8"]
 
 [dependencies]
-log = "0.4.8"
 tracing = "0.1.19"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
 async-trait = "0.1.21"

--- a/crates/fluvio-controlplane-metadata/src/topic/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/k8.rs
@@ -78,8 +78,10 @@ impl From<TopicSpecV1> for TopicSpec {
 impl From<TopicSpecV1> for ReplicaSpec {
     fn from(v1: TopicSpecV1) -> Self {
         match v1 {
-            TopicSpecV1::Assigned(partition_maps) =>  ReplicaSpec::Assigned(partition_maps),
-            TopicSpecV1::Computed(topic_replica_param) => ReplicaSpec::Computed(topic_replica_param),
+            TopicSpecV1::Assigned(partition_maps) => ReplicaSpec::Assigned(partition_maps),
+            TopicSpecV1::Computed(topic_replica_param) => {
+                ReplicaSpec::Computed(topic_replica_param)
+            }
         }
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/topic/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/k8.rs
@@ -59,10 +59,8 @@ impl Spec for TopicSpec {
 
 impl From<TopicSpecV1> for TopicSpec {
     fn from(v1: TopicSpecV1) -> Self {
-        TopicSpec {
-            replicas: v1.into(),
-            ..Default::default()
-        }
+        let replicas: ReplicaSpec = v1.into();
+        replicas.into()
     }
 }
 

--- a/crates/fluvio-controlplane-metadata/src/topic/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/k8.rs
@@ -1,9 +1,11 @@
 use crate::k8_types::{Crd, GROUP, V1, CrdNames, Spec, Status, DefaultHeader};
 
+use super::PartitionMaps;
+use super::TopicReplicaParam;
 use super::TopicStatus;
 use super::TopicSpec;
 
-const TOPIC_API: Crd = Crd {
+const TOPIC_V1_API: Crd = Crd {
     group: GROUP,
     version: V1,
     names: CrdNames {
@@ -13,13 +15,52 @@ const TOPIC_API: Crd = Crd {
     },
 };
 
+const TOPIC_V2_API: Crd = Crd {
+    group: GROUP,
+    version: "v2",
+    names: CrdNames {
+        kind: "Topic",
+        plural: "topics",
+        singular: "topic",
+    },
+};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(tag = "type")
+)]
+pub enum TopicSpecV1 {
+    Assigned(PartitionMaps),
+    Computed(TopicReplicaParam),
+}
+
+// -----------------------------------
+// Implementation
+// -----------------------------------
+impl Default for TopicSpecV1 {
+    fn default() -> Self {
+        Self::Assigned(PartitionMaps::default())
+    }
+}
+
+impl Spec for TopicSpecV1 {
+    type Status = TopicStatus;
+    type Header = DefaultHeader;
+
+    fn metadata() -> &'static Crd {
+        &TOPIC_V1_API
+    }
+}
+
+impl Status for TopicStatus {}
+
 impl Spec for TopicSpec {
     type Status = TopicStatus;
     type Header = DefaultHeader;
 
     fn metadata() -> &'static Crd {
-        &TOPIC_API
+        &TOPIC_V2_API
     }
 }
-
-impl Status for TopicStatus {}

--- a/crates/fluvio-controlplane-metadata/src/topic/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/k8.rs
@@ -46,15 +46,6 @@ impl Default for TopicSpecV1 {
     }
 }
 
-impl Spec for TopicSpecV1 {
-    type Status = TopicStatus;
-    type Header = DefaultHeader;
-
-    fn metadata() -> &'static Crd {
-        &TOPIC_V1_API
-    }
-}
-
 impl Status for TopicStatus {}
 
 impl Spec for TopicSpec {
@@ -83,5 +74,25 @@ impl From<TopicSpecV1> for ReplicaSpec {
                 ReplicaSpec::Computed(topic_replica_param)
             }
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(tag = "type")
+)]
+pub struct TopicV1Wrapper {
+    #[serde(flatten)]
+    pub inner: Option<TopicSpecV1>,
+}
+
+impl Spec for TopicV1Wrapper {
+    type Status = TopicStatus;
+    type Header = DefaultHeader;
+
+    fn metadata() -> &'static Crd {
+        &TOPIC_V1_API
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/topic/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/k8.rs
@@ -1,6 +1,7 @@
 use crate::k8_types::{Crd, GROUP, V1, CrdNames, Spec, Status, DefaultHeader};
 
 use super::PartitionMaps;
+use super::ReplicaSpec;
 use super::TopicReplicaParam;
 use super::TopicStatus;
 use super::TopicSpec;
@@ -62,5 +63,23 @@ impl Spec for TopicSpec {
 
     fn metadata() -> &'static Crd {
         &TOPIC_V2_API
+    }
+}
+
+impl From<TopicSpecV1> for TopicSpec {
+    fn from(v1: TopicSpecV1) -> Self {
+        TopicSpec {
+            replicas: v1.into(),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TopicSpecV1> for ReplicaSpec {
+    fn from(v1: TopicSpecV1) -> Self {
+        match v1 {
+            TopicSpecV1::Assigned(partition_maps) =>  ReplicaSpec::Assigned(partition_maps),
+            TopicSpecV1::Computed(topic_replica_param) => ReplicaSpec::Computed(topic_replica_param),
+        }
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -26,7 +26,7 @@ use dataplane::core::{Encoder, Decoder};
     serde(rename_all = "camelCase")
 )]
 pub struct TopicSpec {
-    #[serde(flatten)]
+    #[cfg_attr(feature = "use_serde", serde(flatten))]
     inner: TopicSpecInner,
 }
 

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -11,7 +11,7 @@ use std::io::{Error, ErrorKind};
 use std::collections::BTreeMap;
 use std::ops::Deref;
 
-use tracing::trace;
+use tracing::{trace, debug};
 use fluvio_types::{ReplicaMap, SpuId};
 use fluvio_types::{PartitionId, PartitionCount, ReplicationFactor, IgnoreRackAssignment};
 
@@ -67,6 +67,7 @@ impl Decoder for TopicSpec {
         T: Buf,
     {
         if version < 3 {
+            debug!("decoding classic TopicSpec");
             let mut replicas = ReplicaSpec::default();
             replicas.decode(src, version)?;
             self.inner.replicas = replicas;

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -23,7 +23,7 @@ use dataplane::core::{Encoder, Decoder};
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type")
+    serde(rename_all = "camelCase")
 )]
 pub struct TopicSpec {
     pub replicas: ReplicaSpec,
@@ -72,13 +72,11 @@ impl From<ReplicaSpec> for TopicSpec {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(
-    feature = "use_serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type")
-)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ReplicaSpec {
+    #[cfg_attr(feature = "use_serde", serde(rename = "assigned"))]
     Assigned(PartitionMaps),
+    #[cfg_attr(feature = "use_serde", serde(rename = "computed"))]
     Computed(TopicReplicaParam),
 }
 

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -26,8 +26,8 @@ use dataplane::core::{Encoder, Decoder};
     serde(tag = "type")
 )]
 pub struct TopicSpec {
-    replicas: ReplicaSpec,
-    cleanup_policy: Option<CleanupPolicy>,
+    pub replicas: ReplicaSpec,
+    pub cleanup_policy: Option<CleanupPolicy>,
 }
 
 impl Deref for TopicSpec {
@@ -61,6 +61,15 @@ impl TopicSpec {
     }
 }
 
+impl From<ReplicaSpec> for TopicSpec {
+    fn from(replicas: ReplicaSpec) -> Self {
+        Self {
+            replicas,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "use_serde",
@@ -88,7 +97,6 @@ impl Default for ReplicaSpec {
 }
 
 impl ReplicaSpec {
-
     pub fn new_assigned<J>(partition_map: J) -> Self
     where
         J: Into<PartitionMaps>,
@@ -101,9 +109,7 @@ impl ReplicaSpec {
         replication: ReplicationFactor,
         ignore_rack: Option<IgnoreRackAssignment>,
     ) -> Self {
-        Self::Computed(
-                (partitions, replication, ignore_rack.unwrap_or(false)).into(),
-            )
+        Self::Computed((partitions, replication, ignore_rack.unwrap_or(false)).into())
     }
 
     pub fn is_computed(&self) -> bool {

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -27,6 +27,7 @@ use dataplane::core::{Encoder, Decoder};
 )]
 pub struct TopicSpec {
     pub replicas: ReplicaSpec,
+    #[fluvio(min_version = 3)]
     pub cleanup_policy: Option<CleanupPolicy>,
 }
 

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -9,6 +9,7 @@
 //!
 use std::io::{Error, ErrorKind};
 use std::collections::BTreeMap;
+use std::ops::Deref;
 
 use tracing::trace;
 use fluvio_types::{ReplicaMap, SpuId};
@@ -18,32 +19,22 @@ use dataplane::core::Version;
 use dataplane::bytes::{Buf, BufMut};
 use dataplane::core::{Encoder, Decoder};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default, Encoder, Decoder)]
 #[cfg_attr(
     feature = "use_serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")
 )]
-pub enum TopicSpec {
-    Assigned(PartitionMaps),
-    Computed(TopicReplicaParam),
+pub struct TopicSpec {
+    replicas: ReplicaSpec,
+    cleanup_policy: Option<CleanupPolicy>,
 }
 
-impl std::fmt::Display for TopicSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            TopicSpec::Assigned(partition_map) => write!(f, "assigned::{}", partition_map),
-            TopicSpec::Computed(param) => write!(f, "computed::({})", param),
-        }
-    }
-}
+impl Deref for TopicSpec {
+    type Target = ReplicaSpec;
 
-// -----------------------------------
-// Implementation
-// -----------------------------------
-impl Default for TopicSpec {
-    fn default() -> TopicSpec {
-        TopicSpec::Assigned(PartitionMaps::default())
+    fn deref(&self) -> &Self::Target {
+        &self.replicas
     }
 }
 
@@ -52,7 +43,10 @@ impl TopicSpec {
     where
         J: Into<PartitionMaps>,
     {
-        TopicSpec::Assigned(partition_map.into())
+        Self {
+            replicas: ReplicaSpec::new_assigned(partition_map),
+            ..Default::default()
+        }
     }
 
     pub fn new_computed(
@@ -60,34 +54,83 @@ impl TopicSpec {
         replication: ReplicationFactor,
         ignore_rack: Option<IgnoreRackAssignment>,
     ) -> Self {
-        TopicSpec::Computed((partitions, replication, ignore_rack.unwrap_or(false)).into())
+        Self {
+            replicas: ReplicaSpec::new_computed(partitions, replication, ignore_rack),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(tag = "type")
+)]
+pub enum ReplicaSpec {
+    Assigned(PartitionMaps),
+    Computed(TopicReplicaParam),
+}
+
+impl std::fmt::Display for ReplicaSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Assigned(partition_map) => write!(f, "assigned::{}", partition_map),
+            Self::Computed(param) => write!(f, "computed::({})", param),
+        }
+    }
+}
+
+impl Default for ReplicaSpec {
+    fn default() -> Self {
+        Self::Assigned(PartitionMaps::default())
+    }
+}
+
+impl ReplicaSpec {
+
+    pub fn new_assigned<J>(partition_map: J) -> Self
+    where
+        J: Into<PartitionMaps>,
+    {
+        Self::Assigned(partition_map.into())
+    }
+
+    pub fn new_computed(
+        partitions: PartitionCount,
+        replication: ReplicationFactor,
+        ignore_rack: Option<IgnoreRackAssignment>,
+    ) -> Self {
+        Self::Computed(
+                (partitions, replication, ignore_rack.unwrap_or(false)).into(),
+            )
     }
 
     pub fn is_computed(&self) -> bool {
         match self {
-            TopicSpec::Computed(_) => true,
-            TopicSpec::Assigned(_) => false,
+            Self::Computed(_) => true,
+            Self::Assigned(_) => false,
         }
     }
 
     pub fn partitions(&self) -> PartitionCount {
-        match self {
-            TopicSpec::Computed(param) => param.partitions,
-            TopicSpec::Assigned(partition_map) => partition_map.partition_count(),
+        match &self {
+            Self::Computed(param) => param.partitions,
+            Self::Assigned(partition_map) => partition_map.partition_count(),
         }
     }
 
     pub fn replication_factor(&self) -> Option<ReplicationFactor> {
         match self {
-            TopicSpec::Computed(param) => Some(param.replication_factor),
-            TopicSpec::Assigned(partition_map) => partition_map.replication_factor(),
+            Self::Computed(param) => Some(param.replication_factor),
+            Self::Assigned(partition_map) => partition_map.replication_factor(),
         }
     }
 
     pub fn ignore_rack_assignment(&self) -> IgnoreRackAssignment {
         match self {
-            TopicSpec::Computed(param) => param.ignore_rack_assignment,
-            TopicSpec::Assigned(_) => false,
+            Self::Computed(param) => param.ignore_rack_assignment,
+            Self::Assigned(_) => false,
         }
     }
 
@@ -175,7 +218,7 @@ impl TopicSpec {
     }
 }
 
-impl Decoder for TopicSpec {
+impl Decoder for ReplicaSpec {
     fn decode<T>(&mut self, src: &mut T, version: Version) -> Result<(), Error>
     where
         T: Buf,
@@ -197,7 +240,7 @@ impl Decoder for TopicSpec {
             1 => {
                 let mut param = TopicReplicaParam::default();
                 param.decode(src, version)?;
-                *self = TopicSpec::Computed(param);
+                *self = Self::Computed(param);
                 Ok(())
             }
 
@@ -213,7 +256,7 @@ impl Decoder for TopicSpec {
 // -----------------------------------
 // Encoder / Decoder
 // -----------------------------------
-impl Encoder for TopicSpec {
+impl Encoder for ReplicaSpec {
     // compute size for fluvio replicas
     fn write_size(&self, version: Version) -> usize {
         let typ_size = (0u8).write_size(version);
@@ -241,14 +284,14 @@ impl Encoder for TopicSpec {
 
         match self {
             // encode assign partitions
-            TopicSpec::Assigned(partitions) => {
+            Self::Assigned(partitions) => {
                 let typ: u8 = 0;
                 typ.encode(dest, version)?;
                 partitions.encode(dest, version)?;
             }
 
             // encode computed partitions
-            TopicSpec::Computed(param) => {
+            Self::Computed(param) => {
                 let typ: u8 = 1;
                 typ.encode(dest, version)?;
                 param.encode(dest, version)?;
@@ -524,29 +567,45 @@ pub struct PartitionMap {
     pub replicas: Vec<SpuId>,
 }
 
-// -----------------------------------
-// Unit Tests
-// -----------------------------------
+#[derive(Decoder, Encoder, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CleanupPolicy {
+    Segment(SegmentBasedPolicy),
+}
+
+impl Default for CleanupPolicy {
+    fn default() -> Self {
+        CleanupPolicy::Segment(SegmentBasedPolicy::default())
+    }
+}
+
+#[derive(Decoder, Encoder, Default, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SegmentBasedPolicy {
+    pub time_in_seconds: u32,
+}
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
+
     use std::io::Cursor;
+
+    use super::*;
 
     #[test]
     fn test_is_computed_topic() {
         let p1: PartitionMaps = vec![(1, vec![0]), (2, vec![2])].into();
-        let t1 = TopicSpec::new_assigned(p1);
+        let t1 = ReplicaSpec::new_assigned(p1);
         assert!(!t1.is_computed());
 
-        let t2 = TopicSpec::new_computed(0, 0, None);
+        let t2 = ReplicaSpec::new_computed(0, 0, None);
         assert!(t2.is_computed());
     }
 
     #[test]
     fn test_valid_computed_replica_params() {
         // -1 indicates an unassigned partition
-        let t1_result = TopicSpec::valid_partition(&-1);
+        let t1_result = ReplicaSpec::valid_partition(&-1);
         assert!(t1_result.is_err());
         assert_eq!(
             format!("{}", t1_result.unwrap_err()),
@@ -554,18 +613,18 @@ pub mod test {
         );
 
         // 0 is not a valid partition
-        let t2_result = TopicSpec::valid_partition(&0);
+        let t2_result = ReplicaSpec::valid_partition(&0);
         assert!(t2_result.is_err());
         assert_eq!(
             format!("{}", t2_result.unwrap_err()),
             "partition must be greater than 0"
         );
 
-        let t3_result = TopicSpec::valid_partition(&1);
+        let t3_result = ReplicaSpec::valid_partition(&1);
         assert!(t3_result.is_ok());
 
         // -1 indicates an unassigned replication factor
-        let t4_result = TopicSpec::valid_replication_factor(&-1);
+        let t4_result = ReplicaSpec::valid_replication_factor(&-1);
         assert!(t4_result.is_err());
         assert_eq!(
             format!("{}", t4_result.unwrap_err()),
@@ -573,7 +632,7 @@ pub mod test {
         );
 
         // 0 is not a valid replication factor
-        let t5_result = TopicSpec::valid_replication_factor(&0);
+        let t5_result = ReplicaSpec::valid_replication_factor(&0);
         assert!(t5_result.is_err());
         assert_eq!(
             format!("{}", t5_result.unwrap_err()),
@@ -581,7 +640,7 @@ pub mod test {
         );
 
         // positive numbers are OK
-        let t6_result = TopicSpec::valid_replication_factor(&1);
+        let t6_result = ReplicaSpec::valid_replication_factor(&1);
         assert!(t6_result.is_ok());
     }
 
@@ -708,7 +767,7 @@ pub mod test {
             replicas: vec![5001, 5002],
         }]
         .into();
-        let topic_spec = TopicSpec::Assigned(partition_map);
+        let topic_spec = ReplicaSpec::Assigned(partition_map);
         let mut dest = vec![];
 
         // test encode
@@ -725,12 +784,12 @@ pub mod test {
         assert_eq!(dest, expected_dest);
 
         // test encode
-        let mut topic_spec_decoded = TopicSpec::default();
+        let mut topic_spec_decoded = ReplicaSpec::default();
         let result = topic_spec_decoded.decode(&mut Cursor::new(&expected_dest), 0);
         assert!(result.is_ok());
 
         match topic_spec_decoded {
-            TopicSpec::Assigned(partition_map) => {
+            ReplicaSpec::Assigned(partition_map) => {
                 assert_eq!(
                     partition_map,
                     vec![PartitionMap {
@@ -746,7 +805,7 @@ pub mod test {
 
     #[test]
     fn test_encode_decode_computed_topic_spec() {
-        let topic_spec = TopicSpec::Computed((2, 3, true).into());
+        let topic_spec = ReplicaSpec::Computed((2, 3, true).into());
         let mut dest = vec![];
 
         // test encode
@@ -762,12 +821,12 @@ pub mod test {
         assert_eq!(dest, expected_dest);
 
         // test encode
-        let mut topic_spec_decoded = TopicSpec::default();
+        let mut topic_spec_decoded = ReplicaSpec::default();
         let result = topic_spec_decoded.decode(&mut Cursor::new(&expected_dest), 0);
         assert!(result.is_ok());
 
         match topic_spec_decoded {
-            TopicSpec::Computed(param) => {
+            ReplicaSpec::Computed(param) => {
                 assert_eq!(param.partitions, 2);
                 assert_eq!(param.replication_factor, 3);
                 assert!(param.ignore_rack_assignment);
@@ -781,7 +840,7 @@ pub mod test {
         // Test multiple
         let p1: PartitionMaps =
             vec![(0, vec![0, 1, 3]), (1, vec![0, 2, 3]), (2, vec![1, 3, 4])].into();
-        let spec = TopicSpec::new_assigned(p1);
+        let spec = ReplicaSpec::new_assigned(p1);
         assert_eq!(
             spec.partition_map_str(),
             Some("0:[0, 1, 3], 1:[0, 2, 3], 2:[1, 3, 4]".to_string())
@@ -789,7 +848,7 @@ pub mod test {
 
         // Test empty
         let p2 = PartitionMaps::default();
-        let spec2 = TopicSpec::new_assigned(p2);
+        let spec2 = ReplicaSpec::new_assigned(p2);
         assert_eq!(spec2.partition_map_str(), Some("".to_string()));
     }
 }

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"
@@ -27,5 +27,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "1.0.0", features = ["serde"] }
 
-fluvio = { version = "0.10.0", path = "../fluvio", optional = true }
+fluvio = { version = "0.11.0", path = "../fluvio", optional = true }
 fluvio-package-index = { version = "0.5", path = "../fluvio-package-index" }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"

--- a/crates/fluvio-sc-schema/src/objects/create.rs
+++ b/crates/fluvio-sc-schema/src/objects/create.rs
@@ -29,7 +29,7 @@ pub struct CommonCreateRequest {
 
 impl Request for ObjectApiCreateRequest {
     const API_KEY: u16 = AdminPublicApiKey::Create as u16;
-    const DEFAULT_API_VERSION: i16 = 2;
+    const DEFAULT_API_VERSION: i16 = 3;
     type Response = Status;
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -27,7 +27,7 @@ where
 
 impl Request for ObjectApiListRequest {
     const API_KEY: u16 = AdminPublicApiKey::List as u16;
-    const DEFAULT_API_VERSION: i16 = 1;
+    const DEFAULT_API_VERSION: i16 = 3;
     type Response = ObjectApiListResponse;
 }
 

--- a/crates/fluvio-sc-schema/src/objects/watch.rs
+++ b/crates/fluvio-sc-schema/src/objects/watch.rs
@@ -26,7 +26,7 @@ pub struct WatchRequest<S: AdminSpec> {
 
 impl Request for ObjectApiWatchRequest {
     const API_KEY: u16 = AdminPublicApiKey::Watch as u16;
-    const DEFAULT_API_VERSION: i16 = 1;
+    const DEFAULT_API_VERSION: i16 = 3;
     type Response = ObjectApiWatchResponse;
 }
 

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -61,10 +61,10 @@ fluvio-controlplane-metadata = { version = "0.13.0", features = [
     "serde",
 ], path = "../fluvio-controlplane-metadata" }
 fluvio-stream-dispatcher = { version = "0.6.6", path = "../fluvio-stream-dispatcher" }
-k8-client = { version = "5.4.0", optional = true }
+k8-client = { version = "5.5.0", optional = true }
 k8-metadata-client = { version = "3.2.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-k8-types = { version = "0.5.0", features = ["app"] }
+k8-types = { version = "0.5.2", features = ["app"] }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
 dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-service = { path = "../fluvio-service", version = "0.0.0" }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -53,7 +53,7 @@ fluvio-future = { version = "0.3.0", features = [
 fluvio-types = { version = "0.2.0", path = "../fluvio-types", features = [
     "events",
 ] }
-fluvio-sc-schema = { version = "0.11.0", path = "../fluvio-sc-schema" }
+fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema" }
 fluvio-stream-model = { version = "0.5.4", path = "../fluvio-stream-model" }
 fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { version = "0.13.0", features = [

--- a/crates/fluvio-sc/src/controllers/topics/policy.rs
+++ b/crates/fluvio-sc/src/controllers/topics/policy.rs
@@ -172,7 +172,7 @@ impl TopicNextState {
         spu_store: &SpuAdminStore,
         partition_store: &PartitionAdminStore,
     ) -> TopicNextState {
-        match topic.spec().replicas {
+        match topic.spec().replicas() {
             // Computed Topic
             ReplicaSpec::Computed(ref param) => match topic.status.resolution {
                 TopicResolution::Init | TopicResolution::InvalidConfig => {

--- a/crates/fluvio-sc/src/controllers/topics/policy.rs
+++ b/crates/fluvio-sc/src/controllers/topics/policy.rs
@@ -29,9 +29,9 @@ pub fn validate_assigned_topic_parameters(partition_map: &PartitionMaps) -> Topi
 ///  * error is passed to the topic reason.
 ///
 pub fn validate_computed_topic_parameters(param: &TopicReplicaParam) -> TopicNextState {
-    if let Err(err) = TopicSpec::valid_partition(&param.partitions) {
+    if let Err(err) = ReplicaSpec::valid_partition(&param.partitions) {
         TopicStatus::next_resolution_invalid_config(&err.to_string()).into()
-    } else if let Err(err) = TopicSpec::valid_replication_factor(&param.replication_factor) {
+    } else if let Err(err) = ReplicaSpec::valid_replication_factor(&param.replication_factor) {
         TopicStatus::next_resolution_invalid_config(&err.to_string()).into()
     } else {
         TopicStatus::next_resolution_pending().into()
@@ -172,9 +172,9 @@ impl TopicNextState {
         spu_store: &SpuAdminStore,
         partition_store: &PartitionAdminStore,
     ) -> TopicNextState {
-        match topic.spec() {
+        match topic.spec().replicas {
             // Computed Topic
-            TopicSpec::Computed(ref param) => match topic.status.resolution {
+            ReplicaSpec::Computed(ref param) => match topic.status.resolution {
                 TopicResolution::Init | TopicResolution::InvalidConfig => {
                     validate_computed_topic_parameters(param)
                 }
@@ -203,7 +203,7 @@ impl TopicNextState {
             },
 
             // Assign Topic
-            TopicSpec::Assigned(ref partition_map) => match topic.status.resolution {
+            ReplicaSpec::Assigned(ref partition_map) => match topic.status.resolution {
                 TopicResolution::Init | TopicResolution::InvalidConfig => {
                     validate_assigned_topic_parameters(partition_map)
                 }

--- a/crates/fluvio-sc/src/init.rs
+++ b/crates/fluvio-sc/src/init.rs
@@ -36,7 +36,6 @@ where
     use crate::stores::smartmodule::SmartModuleSpec;
     use crate::stores::derivedstream::DerivedStreamSpec;
 
-
     let (sc_config, auth_policy) = sc_config_policy;
 
     let namespace = sc_config.namespace.clone();
@@ -142,4 +141,3 @@ where
 
     ctx
 }
-

--- a/crates/fluvio-sc/src/init.rs
+++ b/crates/fluvio-sc/src/init.rs
@@ -5,9 +5,6 @@
 //! and receivers.
 //!
 
-use sysinfo::System;
-use sysinfo::SystemExt;
-use tracing::info;
 use k8_metadata_client::SharedClient;
 use k8_metadata_client::MetadataClient;
 
@@ -39,19 +36,6 @@ where
     use crate::stores::smartmodule::SmartModuleSpec;
     use crate::stores::derivedstream::DerivedStreamSpec;
 
-    info!(PlatformVersion = &*crate::VERSION, "SC Platform Version");
-
-    let mut sys = System::new_all();
-    sys.refresh_all();
-    info!(version = &*crate::VERSION, "Platform");
-    info!(commit = env!("GIT_HASH"), "Git");
-    info!(name = ?sys.name(),"System");
-    info!(kernel = ?sys.kernel_version(),"System");
-    info!(os_version = ?sys.long_os_version(),"System");
-    info!(core_count = ?sys.physical_core_count(),"System");
-    info!(total_memory = sys.total_memory(), "System");
-    info!(available_memory = sys.available_memory(), "System");
-    info!(uptime = sys.uptime(), "Uptime in secs");
 
     let (sc_config, auth_policy) = sc_config_policy;
 
@@ -158,3 +142,4 @@ where
 
     ctx
 }
+

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -27,13 +27,13 @@ impl MigrationController {
             let new_spec: TopicSpec = old_spec.into();
             debug!("new spec: {:#?}", new_spec);
             let input: UpdatedK8Obj<TopicSpec> =
-            UpdatedK8Obj::new(new_spec, old_metadata.clone().into());
+                UpdatedK8Obj::new(new_spec, old_metadata.clone().into());
 
             let topicv2 = self.0.replace_item(input).await?;
             let update_status: UpdateK8ObjStatus<TopicSpec> =
                 UpdateK8ObjStatus::new(old_status, topicv2.metadata.clone().into());
             self.0.update_status(&update_status).await?;
-          //  self.0.delete_item::<TopicSpec, _>(&old_metadata).await?;
+            //  self.0.delete_item::<TopicSpec, _>(&old_metadata).await?;
         }
 
         Ok(())

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -1,4 +1,3 @@
 /// Migrate old version of CRD to new version
-pub(crate) struct MigrationController {
-
-}
+#[allow(unused)]
+pub(crate) struct MigrationController {}

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -29,11 +29,7 @@ impl MigrationController {
             let input: UpdatedK8Obj<TopicSpec> =
                 UpdatedK8Obj::new(new_spec, old_metadata.clone().into());
 
-            let topicv2 = self.0.replace_item(input).await?;
-            let update_status: UpdateK8ObjStatus<TopicSpec> =
-                UpdateK8ObjStatus::new(old_status, topicv2.metadata.clone().into());
-            self.0.update_status(&update_status).await?;
-            //  self.0.delete_item::<TopicSpec, _>(&old_metadata).await?;
+            let _topicv2 = self.0.replace_item(input).await?;
         }
 
         Ok(())

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use k8_client::{ClientError, K8Client, meta_client::MetadataClient};
 use fluvio_controlplane_metadata::topic::{TopicSpec, TopicSpecV1};
-use k8_types::{UpdateK8ObjStatus, UpdatedK8Obj};
+use k8_types::{UpdatedK8Obj};
 use tracing::{info, debug};
 
 /// Migrate old version of CRD to new version
@@ -20,7 +20,6 @@ impl MigrationController {
         let old_topics = self.0.retrieve_items::<TopicSpecV1, _>(ns).await?;
         for old_topic in old_topics.items {
             let old_spec = old_topic.spec;
-            let old_status = old_topic.status;
             let old_metadata = old_topic.metadata;
             info!(%old_metadata.name, "migrating topic");
             debug!("old topic: {:#?}", old_spec);

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -3,28 +3,37 @@ use std::sync::Arc;
 use k8_client::{ClientError, K8Client};
 use k8_metadata_client::MetadataClient;
 use fluvio_controlplane_metadata::topic::{TopicSpec, TopicSpecV1};
+use k8_types::{InputK8Obj, UpdateK8ObjStatus};
+use tracing::info;
 
 /// Migrate old version of CRD to new version
 
 pub(crate) struct MigrationController(Arc<K8Client>);
 
 impl MigrationController {
-   
-    /// migrate code 
-    pub(crate) fn migrate(client: Arc<K8Client>,ns: &str) {
+    /// migrate code
+    pub(crate) async fn migrate(client: Arc<K8Client>, ns: &str) -> Result<(), ClientError> {
         let controller = MigrationController(client);
-        controller.migrate_crd(ns);
+        controller.migrate_crd(ns).await
     }
 
-    async fn migrate_crd(&self,ns: &str) -> Result<(),ClientError> {
-        let old_topics = self.0.retrieve_items::<TopicSpecV1,_>(ns).await?;
+    async fn migrate_crd(&self, ns: &str) -> Result<(), ClientError> {
+        let old_topics = self.0.retrieve_items::<TopicSpecV1, _>(ns).await?;
         for old_topic in old_topics.items {
             let old_spec = old_topic.spec;
             let old_status = old_topic.status;
+            let old_metadata = old_topic.metadata;
             let new_spec: TopicSpec = old_spec.into();
-          //  self.0.create_item(ns,&new_spec).await?;
+            info!(%old_metadata.name, "migrating topic");
+            let input: InputK8Obj<TopicSpec> =
+                InputK8Obj::new(new_spec, old_metadata.clone().into());
+            self.0.apply(input).await?;
+            let update_status: UpdateK8ObjStatus<TopicSpec> =
+                UpdateK8ObjStatus::new(old_status, old_metadata.clone().into());
+            self.0.update_status(&update_status).await?;
+            self.0.delete_item::<TopicSpec, _>(&old_metadata).await?;
         }
+
         Ok(())
     }
-    
 }

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -22,7 +22,7 @@ impl MigrationController {
             let old_spec = old_topic.spec;
             let old_status = old_topic.status;
             let new_spec: TopicSpec = old_spec.into();
-            self.0.create_item(ns,&new_spec).await?;
+          //  self.0.create_item(ns,&new_spec).await?;
         }
         Ok(())
     }

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -1,3 +1,30 @@
+use std::sync::Arc;
+
+use k8_client::{ClientError, K8Client};
+use k8_metadata_client::MetadataClient;
+use fluvio_controlplane_metadata::topic::{TopicSpec, TopicSpecV1};
+
 /// Migrate old version of CRD to new version
-#[allow(unused)]
-pub(crate) struct MigrationController {}
+
+pub(crate) struct MigrationController(Arc<K8Client>);
+
+impl MigrationController {
+   
+    /// migrate code 
+    pub(crate) fn migrate(client: Arc<K8Client>,ns: &str) {
+        let controller = MigrationController(client);
+        controller.migrate_crd(ns);
+    }
+
+    async fn migrate_crd(&self,ns: &str) -> Result<(),ClientError> {
+        let old_topics = self.0.retrieve_items::<TopicSpecV1,_>(ns).await?;
+        for old_topic in old_topics.items {
+            let old_spec = old_topic.spec;
+            let old_status = old_topic.status;
+            let new_spec: TopicSpec = old_spec.into();
+            self.0.create_item(ns,&new_spec).await?;
+        }
+        Ok(())
+    }
+    
+}

--- a/crates/fluvio-sc/src/k8/migration/mod.rs
+++ b/crates/fluvio-sc/src/k8/migration/mod.rs
@@ -1,0 +1,4 @@
+/// Migrate old version of CRD to new version
+pub(crate) struct MigrationController {
+
+}

--- a/crates/fluvio-sc/src/k8/mod.rs
+++ b/crates/fluvio-sc/src/k8/mod.rs
@@ -38,7 +38,7 @@ pub fn main_k8_loop(opt: ScOpt) {
         let k8_client = new_shared(k8_config).expect("problem creating k8 client");
         let namespace = sc_config.namespace.clone();
         if let Err(err) =
-            migration::MigrationController::migrate(k8_client.clone(), namespace.clone()).await
+            migration::MigrationController::migrate(k8_client.clone(), &namespace).await
         {
             panic!("migration failed: {}", err);
         }

--- a/crates/fluvio-sc/src/k8/mod.rs
+++ b/crates/fluvio-sc/src/k8/mod.rs
@@ -7,6 +7,7 @@
 
 mod controllers;
 mod objects;
+mod migration;
 
 #[cfg(test)]
 mod fixture;

--- a/crates/fluvio-sc/src/k8/mod.rs
+++ b/crates/fluvio-sc/src/k8/mod.rs
@@ -16,7 +16,6 @@ use k8_client::new_shared;
 
 use crate::cli::ScOpt;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main_k8_loop(opt: ScOpt) {
     use std::time::Duration;
@@ -31,7 +30,9 @@ pub fn main_k8_loop(opt: ScOpt) {
     let is_local = opt.is_local();
     let ((sc_config, auth_policy), k8_config, tls_option) = opt.parse_cli_or_exit();
 
-    println!("starting sc server with k8: {}", VERSION);
+    println!("Starting SC, platform: {}",&*crate::VERSION);
+
+    inspect_system();
 
     run_block_on(async move {
         // init k8 service
@@ -63,6 +64,27 @@ pub fn main_k8_loop(opt: ScOpt) {
             sleep(Duration::from_secs(60)).await;
         }
     });
+}
+
+/// print out system information
+fn inspect_system() {
+
+    use tracing::info;
+    
+    use sysinfo::System;
+    use sysinfo::SystemExt;
+
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    info!(version = &*crate::VERSION, "Platform");
+    info!(commit = env!("GIT_HASH"), "Git");
+    info!(name = ?sys.name(),"System");
+    info!(kernel = ?sys.kernel_version(),"System");
+    info!(os_version = ?sys.long_os_version(),"System");
+    info!(core_count = ?sys.physical_core_count(),"System");
+    info!(total_memory = sys.total_memory(), "System");
+    info!(available_memory = sys.available_memory(), "System");
+    info!(uptime = sys.uptime(), "Uptime in secs");
 }
 
 mod proxy {

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -101,7 +101,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         );
     }
 
-    match &topic_spec.replicas {
+    match topic_spec.replicas() {
         ReplicaSpec::Computed(param) => {
             let next_state = validate_computed_topic_parameters(param);
             trace!("validating, computed topic: {:#?}", next_state);

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -11,6 +11,7 @@
 
 use std::io::{Error as IoError, ErrorKind};
 
+use fluvio_controlplane_metadata::topic::ReplicaSpec;
 use fluvio_sc_schema::objects::CommonCreateRequest;
 use fluvio_sc_schema::topic::validate::valid_topic_name;
 use tracing::{debug, trace, instrument};
@@ -100,7 +101,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         );
     }
 
-    match topic_spec.replicas {
+    match &topic_spec.replicas {
         ReplicaSpec::Computed(param) => {
             let next_state = validate_computed_topic_parameters(param);
             trace!("validating, computed topic: {:#?}", next_state);

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -100,8 +100,8 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         );
     }
 
-    match topic_spec {
-        TopicSpec::Computed(param) => {
+    match topic_spec.replicas {
+        ReplicaSpec::Computed(param) => {
             let next_state = validate_computed_topic_parameters(param);
             trace!("validating, computed topic: {:#?}", next_state);
             if next_state.resolution.is_invalid() {
@@ -124,7 +124,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
                 }
             }
         }
-        TopicSpec::Assigned(ref partition_map) => {
+        ReplicaSpec::Assigned(ref partition_map) => {
             let next_state = validate_assigned_topic_parameters(partition_map);
             trace!("validating, computed topic: {:#?}", next_state);
             if next_state.resolution.is_invalid() {

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.2.0"
+version = "0.1.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -30,6 +30,7 @@ dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package 
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.13.0", optional = true }
+
 flate2 = { version = "1.0", optional = true }
 fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema" }
 

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -30,7 +30,6 @@ dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package 
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.13.0", optional = true }
-
 flate2 = { version = "1.0", optional = true }
 fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema" }
 

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -44,7 +44,7 @@ once_cell = "1.5"
 sysinfo = "0.20.3"
 
 # Fluvio dependencies
-fluvio = { version = "0.10.0", path = "../fluvio" }
+fluvio = { version = "0.11.0", path = "../fluvio" }
 fluvio-types = { version = "0.2.3", features = [
     "events",
 ], path = "../fluvio-types" }

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -17,7 +17,7 @@ use fluvio_test_util::test_meta::{TestOption, TestCase};
 use fluvio_test_util::async_process;
 
 use fluvio::metadata::{
-    topic::{TopicSpec, TopicReplicaParam,ReplicaSpec},
+    topic::{TopicSpec, TopicReplicaParam, ReplicaSpec},
     connector::{ManagedConnectorSpec, SecretString},
 };
 use fluvio_future::timer::sleep;
@@ -110,7 +110,8 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
             // If the managed connector wants its topic created, don't fail if it already exists
             if config.create_topic {
                 println!("Attempt to create connector's topic");
-                let topic_spec: TopicSpec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
+                let topic_spec: TopicSpec =
+                    ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
                 debug!("topic spec: {:?}", topic_spec);
                 admin
                     .create(config.topic.clone(), false, topic_spec)

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -17,7 +17,7 @@ use fluvio_test_util::test_meta::{TestOption, TestCase};
 use fluvio_test_util::async_process;
 
 use fluvio::metadata::{
-    topic::{TopicSpec, TopicReplicaParam},
+    topic::{TopicSpec, TopicReplicaParam,ReplicaSpec},
     connector::{ManagedConnectorSpec, SecretString},
 };
 use fluvio_future::timer::sleep;
@@ -110,7 +110,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
             // If the managed connector wants its topic created, don't fail if it already exists
             if config.create_topic {
                 println!("Attempt to create connector's topic");
-                let topic_spec = TopicSpec::Computed(TopicReplicaParam::new(1, 1, false));
+                let topic_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
                 debug!("topic spec: {:?}", topic_spec);
                 admin
                     .create(config.topic.clone(), false, topic_spec)

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -110,7 +110,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
             // If the managed connector wants its topic created, don't fail if it already exists
             if config.create_topic {
                 println!("Attempt to create connector's topic");
-                let topic_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
+                let topic_spec: TopicSpec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
                 debug!("topic spec: {:?}", topic_spec);
                 admin
                     .create(config.topic.clone(), false, topic_spec)

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -45,7 +45,7 @@ async-trait = "0.1.51"
 # Fluvio dependencies
 fluvio-future = { version = "0.3.12", features = ["task", "openssl_tls", "task_unstable"] }
 fluvio-types = { version = "0.2.1", features = ["events"], path = "../fluvio-types" }
-fluvio-sc-schema = { version = "0.11.0", path = "../fluvio-sc-schema", default-features = false }
+fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
 dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -52,7 +52,7 @@ dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
-fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.2.0" }
+fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.1.0" }
 
 [target.'cfg(unix)'.dependencies]
 fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema", features = ["file"] }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -52,7 +52,7 @@ dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
-fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.1.0" }
+fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.2.0" }
 
 [target.'cfg(unix)'.dependencies]
 fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema", features = ["file"] }

--- a/k8-util/helm/README.md
+++ b/k8-util/helm/README.md
@@ -20,6 +20,7 @@ The packaged chart uses the app version, the fluvio cluster version.
 
 Fluvio cluster installer are build into CLI.  At the top of the repo:
 ```
+$ make -C k8-util/helm clean
 $ make build-cli
 ```
 

--- a/k8-util/helm/fluvio-sys/Chart.yaml
+++ b/k8-util/helm/fluvio-sys/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fluvio-sys
 description: A Helm chart for Fluvio
 type: application
-version: 0.9.5
+version: 0.9.6

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -124,7 +124,7 @@ spec:
                                   type: integer
                                   minimum: 0
                   oneOf:
-                    - required: ["managed"]
+                    - required: ["computed"]
                     - required: ["assigned"]
                 cleanupPolicy:
                   type: object

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -12,7 +12,7 @@ spec:
   versions: 
     - name: v1
       served: true
-      storage:  true
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -84,7 +84,7 @@ spec:
             jsonPath: .status.resolution
     - name: v2
       served: true
-      storage:  false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object
@@ -98,42 +98,42 @@ spec:
               properties:
                 replicas:
                   type: object
-                    properties:
-                      oneOf:
-                      - required: ["managed"]
-                      - required: ["assigned"]
-                      managed:
+                  properties:
+                    managed:
+                      type: object
+                      properties:
+                        partitions:
+                          type: integer
+                          minimum: 1
+                          maximum: 5000
+                        replicationFactor:
+                          type: integer
+                          minimum: 1
+                          maximum: 5000
+                    assigned:
+                      type: array
+                      items:
                         type: object
+                        required:
+                        - partition
                         properties:
-                          partitions:
-                            type: integer
-                            minimum: 1
-                            maximum: 5000
-                          replicationFactor:
-                            type: integer
-                            minimum: 1
-                            maximum: 5000
-                      assigned:
-                        type: array
-                        items:
-                          type: object
-                          required:
-                          - partition
-                          properties:
-                            partition:
-                              type: object
-                              required:
-                              - id
-                              - replicas
-                              properties:
-                                id:
+                          partition:
+                            type: object
+                            required:
+                            - id
+                            - replicas
+                            properties:
+                              id:
+                                type: integer
+                                minimum: 0
+                              replicas:
+                                type: array
+                                items:
                                   type: integer
                                   minimum: 0
-                                replicas:
-                                  type: array
-                                  items:
-                                    type: integer
-                                    minimum: 0
+                  oneOf:
+                    - required: ["managed"]
+                    - required: ["assigned"]
                 cleanUpPolicy:
                   type: object
                   properties:

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -102,6 +102,8 @@ spec:
                           type: integer
                           minimum: 1
                           maximum: 5000
+                        ignoreRackAssignment:
+                          type: boolean
                     assigned:
                       type: array
                       items:

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -34,6 +34,15 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 5000
+                cleanUpPolicy:
+                  type: object
+                  properties:
+                    segment:
+                      type: object
+                      properties:
+                        timeSeconds:
+                          type: integer
+                          minimum: 3600
                 ignoreRackAssignment:
                   type: boolean
                 customReplicaAssignment:

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -40,7 +40,7 @@ spec:
                     segment:
                       type: object
                       properties:
-                        timeSeconds:
+                        timeeconds:
                           type: integer
                           minimum: 3600
                 ignoreRackAssignment:
@@ -66,6 +66,7 @@ spec:
                             items:
                               type: integer
                               minimum: 0
+      
       subresources:
           status: {}
       additionalPrinterColumns:
@@ -77,6 +78,84 @@ spec:
             type: integer
             description: Replication Count
             jsonPath: .spec.replicationFactor
+          - name: Status
+            type: string
+            description: Topic Status
+            jsonPath: .status.resolution
+    - name: v2
+      served: true
+      storage:  false
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: object
+                    properties:
+                      oneOf:
+                      - required: ["managed"]
+                      - required: ["assigned"]
+                      managed:
+                        type: object
+                        properties:
+                          partitions:
+                            type: integer
+                            minimum: 1
+                            maximum: 5000
+                          replicationFactor:
+                            type: integer
+                            minimum: 1
+                            maximum: 5000
+                      assigned:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - partition
+                          properties:
+                            partition:
+                              type: object
+                              required:
+                              - id
+                              - replicas
+                              properties:
+                                id:
+                                  type: integer
+                                  minimum: 0
+                                replicas:
+                                  type: array
+                                  items:
+                                    type: integer
+                                    minimum: 0
+                cleanUpPolicy:
+                  type: object
+                  properties:
+                    segment:
+                      type: object
+                      properties:
+                        timeeconds:
+                          type: integer
+                          minimum: 3600
+                
+      
+      subresources:
+          status: {}
+      additionalPrinterColumns:
+          - name: Partitions
+            type: integer
+            description: Parition count
+            jsonPath: .spec.replica.managed.partitions
+          - name: Replications
+            type: integer
+            description: Replication Count
+            jsonPath: .spec.replica.managed.replicationFactor
           - name: Status
             type: string
             description: Topic Status

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -13,6 +13,7 @@ spec:
     - name: v1
       served: true
       storage: false
+      deprecated: true
       schema:
         openAPIV3Schema:
           type: object
@@ -140,7 +141,7 @@ spec:
                     segment:
                       type: object
                       properties:
-                        timeeconds:
+                        timeInSeconds:
                           type: integer
                           minimum: 3600
                 
@@ -160,6 +161,9 @@ spec:
             type: string
             description: Topic Status
             jsonPath: .status.resolution
-
+  conversion:
+    # None conversion assumes the same schema for all versions and only sets the apiVersion
+    # field of custom resources to the proper value
+    strategy: None
                    
 

--- a/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_topic.yaml
@@ -35,15 +35,6 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 5000
-                cleanUpPolicy:
-                  type: object
-                  properties:
-                    segment:
-                      type: object
-                      properties:
-                        timeeconds:
-                          type: integer
-                          minimum: 3600
                 ignoreRackAssignment:
                   type: boolean
                 customReplicaAssignment:
@@ -100,7 +91,7 @@ spec:
                 replicas:
                   type: object
                   properties:
-                    managed:
+                    computed:
                       type: object
                       properties:
                         partitions:
@@ -135,7 +126,7 @@ spec:
                   oneOf:
                     - required: ["managed"]
                     - required: ["assigned"]
-                cleanUpPolicy:
+                cleanupPolicy:
                   type: object
                   properties:
                     segment:


### PR DESCRIPTION
closes #1987 

Updated Topic CRD to accommodate Retention Policy.  Topic CRD is upgraded to v2 because the data structure schema need to be replaced instead of adding new fields.

- [x] Old Topic should be optional in migration (if already migrated then skip)
- [x] Backward compatibility for Topic
- [x] Sys Upgrade must be performed as part of the upgrade.
