### PR TITLE
[Merged by Bors] - Update workspace crates to Edition 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,6 +727,16 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Build smartmodules for E2E test
+        run: |
+          make build_smartmodules
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable 
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "admin"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "fluvio",
@@ -511,6 +511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +764,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "consume"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "fluvio",
@@ -1047,6 +1056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1265,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,7 +1368,7 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "echo"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "fluvio",
@@ -1578,7 +1607,7 @@ dependencies = [
  "sha2",
  "static_assertions",
  "structopt",
- "sysinfo",
+ "sysinfo 0.20.5",
  "tempdir",
  "thiserror",
  "tracing",
@@ -1681,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1702,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "fluvio",
@@ -1765,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "http-types",
  "lazy_static",
@@ -1779,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "fluvio-future",
@@ -1792,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "fluvio-protocol",
  "proc-macro2",
@@ -1854,7 +1883,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "sysinfo",
+ "sysinfo 0.21.1",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1895,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -1912,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -1923,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1932,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1993,7 +2022,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "structopt",
- "sysinfo",
+ "sysinfo 0.20.5",
  "thiserror",
  "tokio",
  "toml",
@@ -2003,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -2044,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "async-channel",
  "async-rwlock",
@@ -2066,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "async-rwlock",
  "event-listener",
@@ -2179,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "event-listener",
  "fluvio-future",
@@ -3135,13 +3164,11 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest 0.10.0",
 ]
 
 [[package]]
@@ -3715,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "produce"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "fluvio",
@@ -3731,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "produce-key-value"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "fluvio",
@@ -4593,6 +4620,21 @@ name = "sysinfo"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e223c65cd36b485a34c2ce6e38efa40777d31c4166d9076030c74cdcf971679f"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6c2c4a6ca462f07ca89841a2618dca6e405304d19ae238997e64915d89f513"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/crates/fluvio-auth/Cargo.toml
+++ b/crates/fluvio-auth/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-auth"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/infinyon/fluvio"
 description = "Authorization framework for Fluvio"
@@ -22,11 +22,11 @@ tracing = "0.1"
 tracing-futures = "0.2.4"
 x509-parser = "0.12.0"
 
-fluvio-controlplane-metadata = { version = "0.13.0", path = "../fluvio-controlplane-metadata" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata" }
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-future = { version = "0.3.0", features = ["net", "openssl_tls"] }
-fluvio-protocol = { path = "../fluvio-protocol",  version = "0.6" }
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
-fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
+fluvio-protocol = { path = "../fluvio-protocol" }
+fluvio-socket = { path = "../fluvio-socket" }
+fluvio-types = { path = "../fluvio-types" }
 flv-tls-proxy = { version = "0.5.0" }
 futures-util = { version = "0.3.5" }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-cli"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI"
 repository = "https://github.com/infinyon/fluvio"
@@ -70,20 +70,20 @@ futures = "0.3"
 # Fluvio dependencies
 k8-config = { version = "1.4.0", optional = true }
 k8-client = { version = "5.4.0", optional = true }
-fluvio-cluster = { version = "0.0.0", path = "../fluvio-cluster", default-features = false, features = ["cli"], optional = true }
+fluvio-cluster = { path = "../fluvio-cluster", default-features = false, features = ["cli"], optional = true }
 
-fluvio = { version = "0.11.0", path = "../fluvio", default-features = false }
-fluvio-socket = { version = "0.10", path = "../fluvio-socket" }
+fluvio = { path = "../fluvio", default-features = false }
+fluvio-socket = { path = "../fluvio-socket" }
 fluvio-command = { version = "0.2.0" }
-fluvio-package-index = { version = "0.5.0", path = "../fluvio-package-index" }
-fluvio-extension-common = { version = "0.5.0", path = "../fluvio-extension-common", features = ["target"] }
-fluvio-controlplane-metadata = { version = "0.13.0", path = "../fluvio-controlplane-metadata", features = ["use_serde", "k8"] }
+fluvio-package-index = { path = "../fluvio-package-index" }
+fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["use_serde", "k8"] }
 k8-types = { version = "0.5.0", features = ["core"] }
 
 # Optional Fluvio dependencies
-fluvio-types = { version = "0.2.0", path = "../fluvio-types", optional = true }
+fluvio-types = { path = "../fluvio-types", optional = true }
 fluvio-future = { version = "0.3.0", features = ["fs", "io", "subscriber", "native2_tls"], optional = true }
-fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
+fluvio-sc-schema = { path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
 indicatif = "0.16.2"
 
 [dev-dependencies]

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-cluster"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"
@@ -56,15 +56,15 @@ nix = "0.23"
 rand = "0.8.4"
 
 # Fluvio dependencies
-fluvio = { version = "0.11.0", path = "../fluvio", default-features = false }
+fluvio = { path = "../fluvio", default-features = false }
 fluvio-helm = "0.4.1"
 fluvio-future = { version = "0.3.0" }
 fluvio-command = { version = "0.2.0" }
-fluvio-extension-common = { version = "0.5.0", path = "../fluvio-extension-common", optional = true }
-fluvio-controlplane-metadata = { version = "0.13.0", path = "../fluvio-controlplane-metadata", features = [
+fluvio-extension-common = { path = "../fluvio-extension-common", optional = true }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = [
     "k8",
 ] }
-fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", default-features = false, optional = true }
+fluvio-sc-schema = { path = "../fluvio-sc-schema", default-features = false, optional = true }
 flv-util = "0.5.2"
 k8-config = { version = "1.4.0" }
 k8-client = { version = "5.4.0" }

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-controlplane-metadata"
-edition = "2018"
+edition = "2021"
 version = "0.13.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
@@ -24,10 +24,10 @@ thiserror = "1.0.20"
 # Fluvio dependencies
 fluvio-future = { version = "0.3.0" }
 flv-util = { version = "0.5.0" }
-fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
-fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.5.0" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
+fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.6.0" }
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
+dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 base64 = "0.13.0"
 
 [dev-dependencies]

--- a/crates/fluvio-controlplane/Cargo.toml
+++ b/crates/fluvio-controlplane/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Fluvio control plane API"
 authors = ["fluvio.io"]
@@ -17,7 +17,7 @@ log = "0.4.8"
 tracing = "0.1.19"
 
 # Fluvio dependencies
-fluvio-types = { path = "../fluvio-types", version = "0.2.0" }
-fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.13.0" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-types = { path = "../fluvio-types" }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata" }
+fluvio-protocol = { path = "../fluvio-protocol" }
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.8.0"
-edition = "2018"
+version = "0.9.0"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"
 repository = "https://github.com/infinyon/fluvio"
@@ -27,13 +27,13 @@ thiserror = "1"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.1" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6", features = [
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7", features = [
     "derive",
     "api",
 ] }
 flv-util = { version = "0.5.0" }
 
 [dev-dependencies]
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
+fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-future = { version = "0.3.1", features = ["fixture", "fs"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.5.2"
-edition = "2018"
+version = "0.6.0"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"
 repository = "https://github.com/infinyon/fluvio"
@@ -28,4 +28,4 @@ thiserror = "1.0.20"
 semver = { version = "1.0.0", features = ["serde"] }
 
 fluvio = { version = "0.11.0", path = "../fluvio", optional = true }
-fluvio-package-index = { version = "0.5", path = "../fluvio-package-index" }
+fluvio-package-index = { version = "0.6", path = "../fluvio-package-index" }

--- a/crates/fluvio-package-index/Cargo.toml
+++ b/crates/fluvio-package-index/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fluvio-package-index"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 [lib]

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.3.2"
-edition = "2018"
+version = "0.4.0"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"
@@ -23,4 +23,4 @@ features = ["full"]
 
 [dev-dependencies]
 trybuild = { git = "https://github.com/infinyon/trybuild", branch = "check_option" }
-fluvio-protocol = { version = "0.6", path = "../fluvio-protocol", features = ["derive", "api"] }
+fluvio-protocol = { version = "0.7", path = "../fluvio-protocol", features = ["derive", "api"] }

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
-edition = "2018"
-version = "0.6.3"
+edition = "2021"
+version = "0.7.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"
@@ -17,7 +17,7 @@ store = ["fluvio-future"]
 
 [dependencies]
 tracing = "0.1"
-fluvio-protocol-derive = { version = "0.3.2", path = "../fluvio-protocol-derive", optional = true }
+fluvio-protocol-derive = { version = "0.4.0", path = "../fluvio-protocol-derive", optional = true }
 fluvio-future = { version = "0.3.0", optional = true }
 bytes = { version = "1" }
 tokio-util = { version = "0.6.4", features = [
@@ -27,7 +27,7 @@ tokio-util = { version = "0.6.4", features = [
 
 [dev-dependencies]
 flv-util = { version = "0.5.2" }
-fluvio-protocol-derive = { version = "0.3.0", path = "../fluvio-protocol-derive" }
+fluvio-protocol-derive = { version = "0.4.0", path = "../fluvio-protocol-derive" }
 fluvio-future = { version = "0.3.0", features = [
     "fixture",
     "subscriber",

--- a/crates/fluvio-run/Cargo.toml
+++ b/crates/fluvio-run/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-run"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Engine Runner"
 repository = "https://github.com/infinyon/fluvio"
@@ -30,6 +30,6 @@ serde_json = "1.0.64"
 
 # regardless of TLS, sc and spu always use openssl_tls for now because we need cert API
 fluvio-future = { version = "0.3.0", features = ["subscriber"] }
-fluvio-sc = { version = "0.0.0", path = "../fluvio-sc" }
-fluvio-spu = { version = "0.0.0", path = "../fluvio-spu" }
-fluvio-extension-common = { version = "0.5.0", path = "../fluvio-extension-common" }
+fluvio-sc = { path = "../fluvio-sc" }
+fluvio-spu = { path = "../fluvio-spu" }
+fluvio-extension-common = { path = "../fluvio-extension-common" }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-sc-schema"
 version = "0.12.0"
-edition = "2018"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"
 repository = "https://github.com/infinyon/fluvio"
@@ -23,10 +23,10 @@ static_assertions = "1.1.0"
 paste = "1.0"
 
 # Fluvio dependencies
-fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
+fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
 fluvio-controlplane-metadata = { version = "0.13.0", default-features = false, path = "../fluvio-controlplane-metadata" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
+dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc"
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Controller"
@@ -41,33 +41,33 @@ structopt = "0.3.22"
 semver = "1.0.0"
 once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
-sysinfo = "0.20.3"
+sysinfo = "0.21.1"
 
 # Fluvio dependencies
-fluvio-auth = { version = "0.0.0", path = "../fluvio-auth" }
+fluvio-auth = { path = "../fluvio-auth" }
 fluvio-future = { version = "0.3.0", features = [
     "subscriber",
     "openssl_tls",
     "zero_copy",
 ] }
-fluvio-types = { version = "0.2.0", path = "../fluvio-types", features = [
+fluvio-types = { path = "../fluvio-types", features = [
     "events",
 ] }
-fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema" }
-fluvio-stream-model = { version = "0.5.4", path = "../fluvio-stream-model" }
-fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
-fluvio-controlplane-metadata = { version = "0.13.0", features = [
+fluvio-sc-schema = { path = "../fluvio-sc-schema" }
+fluvio-stream-model = { path = "../fluvio-stream-model" }
+fluvio-controlplane = { path = "../fluvio-controlplane" }
+fluvio-controlplane-metadata = { features = [
     "k8",
     "serde",
 ], path = "../fluvio-controlplane-metadata" }
-fluvio-stream-dispatcher = { version = "0.6.6", path = "../fluvio-stream-dispatcher" }
+fluvio-stream-dispatcher = { path = "../fluvio-stream-dispatcher" }
 k8-client = { version = "5.5.0", optional = true }
 k8-metadata-client = { version = "3.2.0" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
+fluvio-protocol = { path = "../fluvio-protocol" }
 k8-types = { version = "0.5.2", features = ["app"] }
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-service = { path = "../fluvio-service", version = "0.0.0" }
+fluvio-socket = { path = "../fluvio-socket" }
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-service = { path = "../fluvio-service" }
 flv-tls-proxy = { version = "0.5.0" }
 
 [dev-dependencies]

--- a/crates/fluvio-service/Cargo.toml
+++ b/crates/fluvio-service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "fluvio-service"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -23,9 +23,9 @@ tokio = { version = "1.3.0", features = ["macros"] }
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.3.0" }
-fluvio-socket = { version = "0.10.0", path = "../fluvio-socket" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6", features = ["derive", "api", "codec"] }
-fluvio-types = { version = "0.2.3", features = ["events"], path = "../fluvio-types" }
+fluvio-socket = { path = "../fluvio-socket" }
+fluvio-protocol = { path = "../fluvio-protocol", features = ["derive", "api", "codec"] }
+fluvio-types = { features = ["events"], path = "../fluvio-types" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.0", features = ["fixture"] }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.1.1"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 keywords = ["streaming", "stream", "queue"]
@@ -26,12 +26,12 @@ fluvio-future = { version = "0.3.9", features = [
     "openssl_tls",
     "zero_copy",
 ] }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.13.0", optional = true }
 flate2 = { version = "1.0", optional = true }
-fluvio-spu-schema = { version = "0.8.0", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]
 fluvio-storage = { path = "../fluvio-storage" }

--- a/crates/fluvio-smartmodule-derive/Cargo.toml
+++ b/crates/fluvio-smartmodule-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartmodule-derive"
-version = "0.1.1"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["wasm", "database", "encoding"]

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -9,9 +9,6 @@ keywords = ["streaming", "stream", "wasm", "fluvio"]
 repository = "https://github.com/infinyon/fluvio"
 description = "Fluvio SmartModule WASM library"
 
-[features]
-default = ["derive"]
-derive = ["fluvio-smartmodule-derive"]
 
 [lib]
 crate-type = ['lib']
@@ -19,7 +16,7 @@ crate-type = ['lib']
 [dependencies]
 eyre = { version = "0.6", default-features = false }
 fluvio-dataplane-protocol = { version = "0.9.0", path = "../fluvio-dataplane-protocol", default-features = false }
-fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive", optional = true }
+fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 fluvio-spu-schema = { version = "0.9", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartmodule"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["wasm", "database", "encoding"]
@@ -18,9 +18,9 @@ crate-type = ['lib']
 
 [dependencies]
 eyre = { version = "0.6", default-features = false }
-fluvio-dataplane-protocol = { version = "0.8.0", path = "../fluvio-dataplane-protocol", default-features = false }
-fluvio-smartmodule-derive = { version = "0.1.0", path = "../fluvio-smartmodule-derive", optional = true }
-fluvio-spu-schema = { version = "0.8", path = "../fluvio-spu-schema" }
+fluvio-dataplane-protocol = { version = "0.9.0", path = "../fluvio-dataplane-protocol", default-features = false }
+fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive", optional = true }
+fluvio-spu-schema = { version = "0.9", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]
 trybuild = { git = "https://github.com/sehz/trybuild", branch = "check_option" }

--- a/crates/fluvio-smartmodule/examples/Cargo.lock
+++ b/crates/fluvio-smartmodule/examples/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "fluvio-protocol-derive",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-aggregate"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-aggregate-average"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "serde",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-aggregate-json"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "serde",
@@ -234,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-aggregate-sum"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-array-map-array"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "serde_json",
@@ -266,14 +266,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-filter"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-filter-json"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "serde",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-filter-odd"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "thiserror",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-filter-regex"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "regex",
@@ -305,35 +305,35 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-filter-with-parameters"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-join"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-map"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-map-double"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
 ]
 
 [[package]]
 name = "fluvio-wasm-map-json"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "serde",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-wasm-map-regex"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule",
  "once_cell",

--- a/crates/fluvio-smartmodule/examples/aggregate-average/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-average/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-wasm-aggregate-average"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 publish = false
@@ -9,6 +9,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde = "1"
 serde_json = "1"

--- a/crates/fluvio-smartmodule/examples/aggregate-average/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-average/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-aggregate-average"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/aggregate-json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-json/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-aggregate-json"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/aggregate-json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-json/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fluvio-smartmodule/examples/aggregate-sum/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-sum/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/aggregate-sum/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate-sum/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-aggregate-sum"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/aggregate/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/aggregate/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/aggregate/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-aggregate"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/array_map_json_array/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_array/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde_json = "1"

--- a/crates/fluvio-smartmodule/examples/array_map_json_array/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_array/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-array-map-array"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/array_map_json_object/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_object/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde_json = "1"

--- a/crates/fluvio-smartmodule/examples/array_map_json_object/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_object/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-array-map-object"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/array_map_json_reddit/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_reddit/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fluvio-smartmodule/examples/array_map_json_reddit/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/array_map_json_reddit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-array-map-reddit"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/filter/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-filter"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter_json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_json/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ['cdylib']
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/filter_json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_json/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-filter-json"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter_map/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_map/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/filter_map/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-filter-map"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter_odd/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_odd/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ['cdylib']
 
 [dependencies]
 thiserror = "1"
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/filter_odd/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_odd/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-filter-odd"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter_regex/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_regex/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-filter-regex"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/filter_regex/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_regex/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 regex = "1"

--- a/crates/fluvio-smartmodule/examples/filter_with_parameters/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_with_parameters/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/filter_with_parameters/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/filter_with_parameters/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-filter-with-parameters"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/join/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/join/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/join/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/join/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-join"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/map/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/map/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-map"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/map_double/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_double/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }

--- a/crates/fluvio-smartmodule/examples/map_double/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_double/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-map-double"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/map_json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_json/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-map-json"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/map_json/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_json/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.8.17"

--- a/crates/fluvio-smartmodule/examples/map_regex/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_regex/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-wasm-map-regex"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish =  false
 
 [lib]

--- a/crates/fluvio-smartmodule/examples/map_regex/Cargo.toml
+++ b/crates/fluvio-smartmodule/examples/map_regex/Cargo.toml
@@ -9,6 +9,6 @@ publish =  false
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { path = "../../", version = "0.1.0" }
+fluvio-smartmodule = { path = "../../" }
 regex = "1"
 once_cell = "1"

--- a/crates/fluvio-smartmodule/src/lib.rs
+++ b/crates/fluvio-smartmodule/src/lib.rs
@@ -3,7 +3,6 @@
 pub use fluvio_dataplane_protocol as dataplane;
 pub use dataplane::record::{Record, RecordData};
 
-
 pub use fluvio_smartmodule_derive::{smartmodule, SmartOpt};
 
 pub const ENCODING_ERROR: i32 = -1;

--- a/crates/fluvio-smartmodule/src/lib.rs
+++ b/crates/fluvio-smartmodule/src/lib.rs
@@ -3,7 +3,7 @@
 pub use fluvio_dataplane_protocol as dataplane;
 pub use dataplane::record::{Record, RecordData};
 
-#[cfg(feature = "derive")]
+
 pub use fluvio_smartmodule_derive::{smartmodule, SmartOpt};
 
 pub const ENCODING_ERROR: i32 = -1;

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-socket"
-version = "0.10.5"
-edition = "2018"
+version = "0.11.0"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-socket"
@@ -32,7 +32,7 @@ thiserror = "1.0.20"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.2", features = ["net", "task"] }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6", features = [
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7", features = [
     "derive",
     "api",
     "codec",

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.8.6"
-edition = "2018"
+version = "0.9.0"
+edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
 repository = "https://github.com/infinyon/fluvio"
@@ -23,6 +23,6 @@ serde = { version = "1.0.103", features = ['derive'] }
 static_assertions = "1.1.0"
 
 # Fluvio dependencies
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
-fluvio-types = { version = "0.2", path = "../fluvio-types" }
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
+dataplane = { version = "0.9", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-types = { version = "0.3", path = "../fluvio-types" }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu"
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Processing Unit"
@@ -44,24 +44,24 @@ once_cell = "1.5"
 sysinfo = "0.20.3"
 
 # Fluvio dependencies
-fluvio = { version = "0.11.0", path = "../fluvio" }
-fluvio-types = { version = "0.2.3", features = [
+fluvio = { path = "../fluvio" }
+fluvio-types = { features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-storage = { path = "../fluvio-storage" }
-fluvio-controlplane = { version = "0.0.0", path = "../fluvio-controlplane" }
-fluvio-controlplane-metadata = { version = "0.13.0", path = "../fluvio-controlplane-metadata" }
-fluvio-spu-schema = { version = "0.8", path = "../fluvio-spu-schema", features = [
+fluvio-controlplane = { path = "../fluvio-controlplane" }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata" }
+fluvio-spu-schema = { path = "../fluvio-spu-schema", features = [
     "file",
 ] }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0", features = [
+fluvio-protocol = { path = "../fluvio-protocol" }
+fluvio-socket = { path = "../fluvio-socket", features = [
     "file",
 ] }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
-fluvio-service = { path = "../fluvio-service", version = "0.0.0" }
+fluvio-service = { path = "../fluvio-service" }
 flv-tls-proxy = { version = "0.5.0" }
 flv-util = { version = "0.5.0" }
 fluvio-future = { version = "0.3.9", features = [
@@ -76,7 +76,7 @@ once_cell = "1.5.2"
 flv-util = { version = "0.5.2", features = ["fixture"] }
 fluvio-future = { version = "0.3.1", features = ["fixture", "subscriber"] }
 derive_builder = { version = "0.10.0" }
-dataplane = { version = "0.8", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "fixture",
 ] }
 serde_json = "1"

--- a/crates/fluvio-storage/Cargo.toml
+++ b/crates/fluvio-storage/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "fluvio-storage"
 version = "0.0.0"
 authors = ["fluvio.io"]
@@ -34,21 +34,21 @@ thiserror = "1"
 memmap = { version = "0.7.0" }
 
 # Fluvio dependencies
-fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
+fluvio-types = { path = "../fluvio-types" }
 fluvio-future = { version = "0.3.10", features = ["fs", "mmap", "zero_copy"] }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+fluvio-protocol = { path = "../fluvio-protocol" }
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.9", features = ["fixture"] }
 flv-util = { version = "0.5.2", features = ["fixture"] }
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0", features = [
+fluvio-socket = { path = "../fluvio-socket", features = [
     "file",
 ] }
 fluvio-storage = { path = ".", features = ["fixture"] }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "fixture",
 ] }
 derive_builder = { version = "0.10.0" }

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
-edition = "2018"
-version = "0.6.6"
+edition = "2021"
+version = "0.7.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"
@@ -25,10 +25,10 @@ tokio = { version = "1.3.0", features = ["macros"] }
 once_cell = "1.5"
 
 # Fluvio dependencies
-fluvio-types = { path = "../fluvio-types", version = "0.2.0" }
+fluvio-types = { path = "../fluvio-types", version = "0.3.0" }
 fluvio-stream-model = { features = [
     "k8",
-], version = "0.5.1", path = "../fluvio-stream-model" }
+], version = "0.6.0", path = "../fluvio-stream-model" }
 k8-metadata-client = { version = "3.2.0" }
 fluvio-future = { version = "0.3.0", features = ["task", "timer"] }
 

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
-edition = "2018"
-version = "0.5.4"
+edition = "2021"
+version = "0.6.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-test-derive/Cargo.toml
+++ b/crates/fluvio-test-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test-derive"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 description = "Fluvio Test Derive Macro"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test-util"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 description = "Fluvio Test utility"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 autotests = false
 description = "Fluvio Test Utility"
 repository = "https://github.com/infinyon/fluvio"
@@ -18,7 +18,7 @@ structopt = "0.3.5"
 async-trait = "0.1.21"
 syn = { version = "1.0", features = ["full"]}
 rand = "0.8"
-md-5 = "0.9"
+md-5 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
@@ -35,7 +35,7 @@ crossbeam-channel = "0.5"
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio" }
-fluvio-types = { version = "0.2.0", path = "../fluvio-types" }
+fluvio-types = { path = "../fluvio-types" }
 fluvio-future = { version = "0.3.0", features = ["task", "timer", "subscriber", "fixture"] }
 fluvio-command = { version = "0.2.0" }
 fluvio-cluster = { path = "../fluvio-cluster" }

--- a/crates/fluvio-test/src/tests/smoke/offsets.rs
+++ b/crates/fluvio-test/src/tests/smoke/offsets.rs
@@ -32,7 +32,6 @@ pub async fn find_offsets(test_driver: &TestDriver, test_case: &SmokeTestCase) -
 }
 
 async fn last_leo(admin: &mut FluvioAdmin, topic: &str) -> i64 {
-    use std::convert::TryInto;
 
     let partitions = admin
         .list::<PartitionSpec, _>(vec![])

--- a/crates/fluvio-test/src/tests/smoke/offsets.rs
+++ b/crates/fluvio-test/src/tests/smoke/offsets.rs
@@ -32,7 +32,6 @@ pub async fn find_offsets(test_driver: &TestDriver, test_case: &SmokeTestCase) -
 }
 
 async fn last_leo(admin: &mut FluvioAdmin, topic: &str) -> i64 {
-
     let partitions = admin
         .list::<PartitionSpec, _>(vec![])
         .await

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fluvio-types"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 description = "Fluvio common types and objects"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio"
 version = "0.11.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["database"]
@@ -44,23 +44,23 @@ async-trait = "0.1.51"
 
 # Fluvio dependencies
 fluvio-future = { version = "0.3.12", features = ["task", "openssl_tls", "task_unstable"] }
-fluvio-types = { version = "0.2.1", features = ["events"], path = "../fluvio-types" }
+fluvio-types = { version = "0.3.0", features = ["events"], path = "../fluvio-types" }
 fluvio-sc-schema = { version = "0.12.0", path = "../fluvio-sc-schema", default-features = false }
-fluvio-socket = { path = "../fluvio-socket", version = "0.10.0" }
-fluvio-protocol = { path = "../fluvio-protocol", version = "0.6" }
-dataplane = { version = "0.8.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
+fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
+dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
-fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.1.0" }
+fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.2.0" }
 
 [target.'cfg(unix)'.dependencies]
-fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema", features = ["file"] }
+fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema", features = ["file"] }
 [target.'cfg(windows)'.dependencies]
-fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fluvio-spu-schema = { version = "0.8.6", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", default-features = false }

--- a/crates/fluvio/src/producer/partitioning.rs
+++ b/crates/fluvio/src/producer/partitioning.rs
@@ -63,7 +63,6 @@ impl Partitioner for SiphashRoundRobinPartitioner {
 
 fn partition_siphash(key: &[u8], partition_count: i32) -> i32 {
     use std::hash::{Hash, Hasher};
-    use std::convert::TryFrom;
 
     assert!(partition_count >= 0, "Partition must not be less than zero");
     let mut hasher = SipHasher::new();

--- a/examples/00-produce/Cargo.toml
+++ b/examples/00-produce/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "produce"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/01-produce-batch/Cargo.toml
+++ b/examples/01-produce-batch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "produce-batch"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/01-produce-key-value/Cargo.toml
+++ b/examples/01-produce-key-value/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "produce-key-value"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/02-consume/Cargo.toml
+++ b/examples/02-consume/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "consume"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/03-echo/Cargo.toml
+++ b/examples/03-echo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "echo"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/04-admin-watch/Cargo.toml
+++ b/examples/04-admin-watch/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "admin"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
* Runs `cargo fix --edition` w/o fail
* Minor version bump every published crate
* Removed versions from local dependencies of crates from on the crates we don't publish
* Minor file edits where imports were no longer necessary
* A few dependency updates

Resolves #1798 