### PR TITLE
CWE

### DIFF
--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -509,6 +509,13 @@ impl ConsumeOpt {
                     &mut None,
                     &mut None,
                 );
+
+                if let Some(potential_offset) = maybe_potential_offset {
+                    if record.offset >= potential_offset {
+                        eprintln!("End-offset has been reached; exiting");
+                        break;
+                    }
+                }
             }
         }
 

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -355,7 +355,9 @@ impl ConsumeOpt {
             if let Some(offset) = self.offset {
                 let o = offset as i64;
                 if end_offset < o {
-                    eprintln!("Argument end-offset must be greater than or equal to specified offset");
+                    eprintln!(
+                        "Argument end-offset must be greater than or equal to specified offset"
+                    );
                 }
             } else {
                 if end_offset < 0 {

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -659,6 +659,16 @@ impl ConsumeOpt {
                 )
                 .bold()
             );
+        // If --end-offset=X
+        } else if let Some(end) = self.end_offset {
+            eprintln!(
+                "{}",
+                format!(
+                    "Consuming records starting from the end until record {} in topic '{}'",
+                    end, &self.topic
+                )
+                .bold()
+            );
         // If no offset config is given, read from the end
         } else {
             eprintln!(

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -104,6 +104,10 @@ pub struct ConsumeOpt {
     #[structopt(short = "T", long, value_name = "integer", conflicts_with_all = &["from_beginning", "offset"])]
     pub tail: Option<Option<u32>>,
 
+    /// Consume records until end offset
+    #[structopt(long, value_name= "integer", conflicts_with_all = &["tail"])]
+    pub end_offset: Option<i64>,
+    
     /// Maximum number of bytes to be retrieved
     #[structopt(short = "b", long = "maxbytes", value_name = "integer")]
     pub max_bytes: Option<i32>,

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -388,6 +388,7 @@ impl ConsumeOpt {
         tableformat: Option<TableFormatSpec>,
     ) -> Result<()> {
         self.print_status();
+        let maybe_potential_offset: Option<i64> = config.end_offset;
         let mut stream = consumer.stream_with_config(offset, config).await?;
 
         let templates = match self.format.as_deref() {

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -107,7 +107,7 @@ pub struct ConsumeOpt {
     /// Consume records until end offset
     #[structopt(long, value_name= "integer", conflicts_with_all = &["tail"])]
     pub end_offset: Option<i64>,
-    
+
     /// Maximum number of bytes to be retrieved
     #[structopt(short = "b", long = "maxbytes", value_name = "integer")]
     pub max_bytes: Option<i32>,
@@ -349,6 +349,21 @@ impl ConsumeOpt {
 
         if self.disable_continuous {
             builder.disable_continuous(true);
+        }
+
+        if let Some(end_offset) = self.end_offset {
+            if let Some(offset) = self.offset {
+                let o = offset as i64;
+                if end_offset < o {
+                    eprintln!("Argument end-offset must be greater than or equal to specified offset");
+                }
+            } else {
+                if end_offset < 0 {
+                    eprintln!("Argument end-offset must be greater than or equal to zero");
+                } else {
+                    builder.end_offset(Some(end_offset));
+                }
+            }
         }
 
         let consume_config = builder.build()?;

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -458,6 +458,13 @@ impl ConsumeOpt {
                                 &mut maybe_terminal_stdout,
                                 &mut maybe_table_model,
                             );
+
+                            if let Some(potential_offset) = maybe_potential_offset {
+                                if record.offset >= potential_offset {
+                                    eprintln!("End-offset has been reached; exiting");
+                                    break;
+                                }
+                            }
                         },
                         None => break,
                     },

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.11.0"
+version = "0.10.1"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -725,7 +725,7 @@ pub struct ConsumerConfig {
     #[builder(default)]
     pub(crate) derivedstream: Option<DerivedStreamInvocation>,
     #[builder(default)]
-    end_offset: Option<i64>,
+    pub end_offset: Option<i64>,
 }
 
 impl ConsumerConfig {

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -724,6 +724,8 @@ pub struct ConsumerConfig {
     pub(crate) smartmodule: Option<SmartModuleInvocation>,
     #[builder(default)]
     pub(crate) derivedstream: Option<DerivedStreamInvocation>,
+    #[builder(default)]
+    end_offset: Option<i64>,
 }
 
 impl ConsumerConfig {


### PR DESCRIPTION
# What does this PR do?

This PR adds a new option for consuming called `end-offset` in order to cease reading from the stream when the ending offset is found in the stream's current record, instead of waiting for new inputs.
 
# Motivation

Helping out on good first issues.

# Related issues

A list of issues closed by or relevant to this PR.

- Supports [#1898] (https://github.com/infinyon/fluvio/issues/1898)
- Closes [#1940] (https://github.com/infinyon/fluvio/issues/1940).

# Additional Notes

None

# Checklist

- [ ] Created or updated all relevant documentation
- [ ] Added unit tests to relevant added or changed code
- [ ] Bumped required crate version numbers
- [ ] Updated CHANGELOG.md
