### PR TITLE
[Merged by Bors] - Fix smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,6 +676,7 @@ jobs:
         timeout-minutes: 10
         run: |
           date
+          sleep 15
           make ${{ matrix.test }}
       - name: Print version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4]
+        run: [r1]
         spu: [2]
         test:
           [
@@ -589,7 +589,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4]
+        run: [r1]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [2]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4]
         spu: [2]
         test:
           [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,6 @@ jobs:
             batch-failure,
             batch,
           ]
-      #   run: ${{ fromJson(needs.config.outputs.runs )}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4]
+        run: [r1]
         spu: [2]
         test:
           [
@@ -664,7 +664,6 @@ jobs:
         timeout-minutes: 5
         run: |
           fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log fluvio=debug ${{ env.TLS_ARGS }}
-          sleep 10
       - name: Start fluvio cluster TLS with root
         if: ${{ matrix.test == 'smoke-test-k8-tls-root-unclean' }}
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4]
         spu: [2]
         test:
           [
@@ -589,7 +589,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [2]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,8 @@ jobs:
           AUTH_POLICY=${{ env.AUTH_FILE }}
           X509_AUTH_SCOPES=${{ env.X509_SCOPE_FILE }}
           fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log fluvio=debug ${{ env.TLS_ARGS }}
+      - name: sleep
+        run: sleep 15
       - name: Run smoke-test
         if: ${{ matrix.test == 'smoke-test' }}
         timeout-minutes: 5

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -89,6 +89,7 @@ mod inner {
     use fluvio_types::{SpuId};
     use fluvio_storage::FileReplica;
     use fluvio_controlplane_metadata::spu::SpuSpec;
+    use tracing::info;
 
     use crate::{replication::leader::UpdateOffsetRequest, core::SharedSpuConfig};
     use crate::services::internal::FetchStreamRequest;
@@ -337,7 +338,7 @@ mod inner {
                             leader_endpoint, err
                         );
                         let wait = backoff.wait();
-                        debug!(
+                        info!(
                             seconds = wait.as_secs(),
                             "sleeping seconds to connect to leader"
                         );

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -175,6 +175,8 @@ pub async fn validate_consume_message_api(
                 .await
                 .expect("partitions");
 
+            println!("partitions: {:?}", partitions);
+
             assert_eq!(partitions.len(), 1);
 
             let test_topic = &partitions[0];
@@ -182,8 +184,6 @@ pub async fn validate_consume_message_api(
             let leader = &status.leader;
 
             assert_eq!(leader.leo, base_offset + producer_iteration as i64);
-            println!("status: {:#?}", status);
-
             assert_eq!(status.replicas.len() as u16, replication - 1);
 
             for i in 0..replication - 1 {

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -167,7 +167,7 @@ pub async fn validate_consume_message_api(
         if replication > 1 {
             println!("waiting 5 seconds to verify replication status...");
             // wait 5 seconds to get status and ensure replication is done
-            sleep(Duration::from_secs(5)).await;
+            sleep(Duration::from_secs(30)).await;
 
             let admin = test_driver.client().admin().await;
             let partitions = admin
@@ -175,7 +175,7 @@ pub async fn validate_consume_message_api(
                 .await
                 .expect("partitions");
 
-            println!("partitions: {:?}", partitions);
+            println!("partitions: {:#?}", partitions);
 
             assert_eq!(partitions.len(), 1);
 

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -165,9 +165,15 @@ pub async fn validate_consume_message_api(
     } else {
         let replication = test_case.environment.replication;
         if replication > 1 {
-            println!("waiting 5 seconds to verify replication status...");
+            let wait_value = std::env::var("FLV_SHORT_RECONCILLATION").unwrap_or_default();
+            let wait_delay_sec: u64 = wait_value.parse().unwrap_or(30);
+
+            println!(
+                "waiting {} seconds to verify replication status...",
+                wait_delay_sec
+            );
             // wait 5 seconds to get status and ensure replication is done
-            sleep(Duration::from_secs(30)).await;
+            sleep(Duration::from_secs(wait_delay_sec)).await;
 
             let admin = test_driver.client().admin().await;
             let partitions = admin


### PR DESCRIPTION
resolves #2065.

Wait 30 seconds before checking replication status since CI VM may be interrupted.  Seems to make it reliable with multiple run tests.  Also display replication status for easier debugging 