### PR TITLE
[Merged by Bors] - fix CI Kubernetes test failure on minikube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,7 +618,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4,r5,r6]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [2]
@@ -648,7 +648,7 @@ jobs:
       - name: Print version
         run: fluvio version && fluvio-test -h
       # Retag image to remove arch from tag
-      - name: Load Fluvio Docker Image for K3d
+      - name: Load Fluvio Docker Image
         run: |
           ls -la /tmp
           docker image load --input /tmp/infinyon-fluvio-${{ matrix.rust-target }}.tar
@@ -672,9 +672,9 @@ jobs:
           k3d image import -k /tmp/infinyon-fluvio.tar -c fluvio
       - name: Install Minikube and import image
         if: matrix.k8 == 'minikube'
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
-          minikube version: "v1.22.0"
+          minikube version: "v1.24.0"
           kubernetes version: "v1.21.2"
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,7 +618,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6]
+        run: [r1]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [2]

--- a/crates/fluvio-sc/src/cli.rs
+++ b/crates/fluvio-sc/src/cli.rs
@@ -85,6 +85,7 @@ impl ScOpt {
         mut self,
     ) -> Result<(Config, K8Config, Option<(String, TlsConfig)>), ScError> {
         let k8_config = K8Config::load().expect("no k8 config founded");
+        info!(?k8_config,"k8 config");
 
         // if name space is specified, use one from k8 config
         if self.namespace.is_none() {

--- a/crates/fluvio-sc/src/cli.rs
+++ b/crates/fluvio-sc/src/cli.rs
@@ -85,7 +85,7 @@ impl ScOpt {
         mut self,
     ) -> Result<(Config, K8Config, Option<(String, TlsConfig)>), ScError> {
         let k8_config = K8Config::load().expect("no k8 config founded");
-        info!(?k8_config,"k8 config");
+        info!(?k8_config, "k8 config");
 
         // if name space is specified, use one from k8 config
         if self.namespace.is_none() {

--- a/crates/fluvio-sc/src/services/public_api/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/create.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 
 use dataplane::ErrorCode;
-use tracing::{debug, instrument, info};
+use tracing::{instrument, info};
 
 use dataplane::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::{Status};
@@ -18,7 +18,7 @@ pub async fn handle_create_request<AC: AuthContext>(
 ) -> Result<ResponseMessage<Status>, IoError> {
     let (header, obj_req) = request.get_header_request();
 
-    info!(?obj_req,"create request");
+    info!(?obj_req, "create request");
     let ObjectApiCreateRequest { common, request } = obj_req;
     let status = match request {
         ObjectCreateRequest::Topic(create) => {

--- a/crates/fluvio-sc/src/services/public_api/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/create.rs
@@ -1,7 +1,7 @@
 use std::io::Error as IoError;
 
 use dataplane::ErrorCode;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, info};
 
 use dataplane::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::{Status};
@@ -18,7 +18,7 @@ pub async fn handle_create_request<AC: AuthContext>(
 ) -> Result<ResponseMessage<Status>, IoError> {
     let (header, obj_req) = request.get_header_request();
 
-    debug!("create request: {:#?}", obj_req);
+    info!(?obj_req,"create request");
     let ObjectApiCreateRequest { common, request } = obj_req;
     let status = match request {
         ObjectCreateRequest::Topic(create) => {

--- a/crates/fluvio-sc/src/services/public_api/delete.rs
+++ b/crates/fluvio-sc/src/services/public_api/delete.rs
@@ -5,7 +5,7 @@
 //! and send K8 a delete message.
 //!
 use dataplane::ErrorCode;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument, trace, info};
 use std::io::Error;
 
 use dataplane::api::{RequestMessage, ResponseMessage};
@@ -23,7 +23,7 @@ pub async fn handle_delete_request<AC: AuthContext>(
 ) -> Result<ResponseMessage<Status>, Error> {
     let (header, del_req) = request.get_header_request();
 
-    debug!("del request: {:#?}", del_req);
+    info!(?del_req,"del request");
 
     let status = match del_req {
         ObjectApiDeleteRequest::Topic(req) => {

--- a/crates/fluvio-sc/src/services/public_api/delete.rs
+++ b/crates/fluvio-sc/src/services/public_api/delete.rs
@@ -5,7 +5,7 @@
 //! and send K8 a delete message.
 //!
 use dataplane::ErrorCode;
-use tracing::{debug, instrument, trace, info};
+use tracing::{instrument, trace, info};
 use std::io::Error;
 
 use dataplane::api::{RequestMessage, ResponseMessage};
@@ -23,7 +23,7 @@ pub async fn handle_delete_request<AC: AuthContext>(
 ) -> Result<ResponseMessage<Status>, Error> {
     let (header, del_req) = request.get_header_request();
 
-    info!(?del_req,"del request");
+    info!(?del_req, "del request");
 
     let status = match del_req {
         ObjectApiDeleteRequest::Topic(req) => {


### PR DESCRIPTION
resolves #2086.

This is due Kubernetes client not resolving K8 API controller inside sc pod:
```
2022-01-07T21:20:29.378618Z ERROR fluvio_sc::k8: migration failed: HyperError(
    hyper::Error(
        Connect,
        IoError(
            Custom {
                kind: Uncategorized,
                error: "failed to lookup address information: Try again",
            },
        ),
    ),
)

```

Try updating the minikube version.
Also object creation and deletion are log as info