### PR TITLE
[Merged by Bors] - Add fluvio-run, fluvio-channel to stable tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,27 +347,8 @@ jobs:
         run: |
           ${HOME}/.fluvio/bin/fluvio package bump dynamic "${{ env.VERSION }}"
           ${HOME}/.fluvio/bin/fluvio package tag "fluvio:${{ env.VERSION }}" --tag=stable --force
-
-      - uses: actions/checkout@v2
-
-      # Enable this when we are confident in the workflow
-      - name: Bump stable branch
-        run: |
-          git fetch
-          CURRENT_STABLE=$(git rev-parse origin/stable)
-
-          echo "sha from repo: $CURRENT_STABLE"
-          echo "expected sha: ${{ env.TARGET_SHA }}"
-
-          if [[ "$CURRENT_STABLE" = "${{ env.TARGET_SHA }}" ]]; then
-            echo "Stable branch is up to date"
-          else
-            # FIXME: Needs more testing in Github Actions context
-            echo "TODO: Stable branch will be updated"
-            #git checkout stable
-            #git rebase origin/master
-            #git push origin stable
-          fi
+          ${HOME}/.fluvio/bin/fluvio package tag "fluvio-channel:${{ env.VERSION }}" --tag=stable --force
+          ${HOME}/.fluvio/bin/fluvio package tag "fluvio-run:${{ env.VERSION }}" --tag=stable --force
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -85,7 +85,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         return Status::new(
             name.to_string(),
             ErrorCode::TopicInvalidName,
-            Some(format!("Invalid topic name: '{}'. Topic name can contain only lowercase alphanumeric characters or '-'.", name)),
+            Some(format!("Invalid topic name: '{}'. Topic name can contain only lowercase alphanumeric characters or '-'.", name.to_string())),
         );
     }
 

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -85,7 +85,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         return Status::new(
             name.to_string(),
             ErrorCode::TopicInvalidName,
-            Some(format!("Invalid topic name: '{}'. Topic name can contain only lowercase alphanumeric characters or '-'.", name.to_string())),
+            Some(format!("Invalid topic name: '{}'. Topic name can contain only lowercase alphanumeric characters or '-'.", name)),
         );
     }
 


### PR DESCRIPTION
Resolves #2103 

Also ran these commands manually:

```
fluvio package tag "fluvio-run:0.9.17" --tag=stable --force
fluvio package tag "fluvio-channel:0.9.17" --tag=stable --force
```