### PR TITLE
[Merged by Bors] - properly catch failure in the test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.head_ref || 'ci_staging' }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.head_ref }}-ci_mac
+  group: ci-mac${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: houly-${{ github.ref }}
+  group: hourly-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.head_ref || 'ci_hourly_longevity' }}
+  group: houly-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -172,14 +172,12 @@ jobs:
       #      echo "Longevity data does not exist"
       #    fi
 
-      - name: Print partition list
-        run: |
-          fluvio partition list
-          sleep 15
 
       - name: Run longevity test
         timeout-minutes: 60
-        run: fluvio-test longevity -- --runtime-seconds=${{ env.RUN_TIME }} --producers ${{ env.PRODUCER }} --consumers ${{ env.PRODUCER }}
+        run: |
+          sleep 10
+          fluvio-test longevity -- --runtime-seconds=${{ env.RUN_TIME }} --producers ${{ env.PRODUCER }} --consumers ${{ env.PRODUCER }}
           
       ## If the test passed, then copy the data from cluster to store into artifacts
       #- name: Export data from the cluster for caching

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -3,9 +3,9 @@ name: Hourly tests
 permissions:
   contents: read
 
-#concurrency:
-#  group: ${{ github.head_ref || 'ci_hourly_longevity' }}
-#  cancel-in-progress: true
+concurrency:
+  group: ${{ github.head_ref || 'ci_hourly_longevity' }}
+  cancel-in-progress: true
 
 on:
 #  schedule:

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -83,7 +83,7 @@ jobs:
       - build_long_binaries
     timeout-minutes: 60
     strategy:
-      fail-fast: false 
+      fail-fast: true 
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -92,7 +92,7 @@ jobs:
     env:
       K3D_VERSION: v4.4.8
       TEST_BINARY: fluvio-test-x86_64-unknown-linux-musl
-      RUN_TIME: 60
+      RUN_TIME: 1800
       PRODUCER: 10
     steps:
       - uses: actions/checkout@v2
@@ -174,7 +174,7 @@ jobs:
 
 
       - name: Run longevity test
-        timeout-minutes: 60
+        timeout-minutes: 35
         run: |
           sleep 10
           fluvio-test longevity -- --runtime-seconds=${{ env.RUN_TIME }} --producers ${{ env.PRODUCER }} --consumers ${{ env.PRODUCER }}

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -205,7 +205,7 @@ jobs:
       #    path: longevity-data.tar
       #    retention-days: 5
       - name: Run diagnostics
-        if: ${{ !success() }}
+        if: failure()
         timeout-minutes: 5
         run: fluvio cluster diagnostics
       - name: Upload diagnostics

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -3,21 +3,21 @@ name: Hourly tests
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.head_ref || 'ci_hourly_longevity' }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.head_ref || 'ci_hourly_longevity' }}
+#  cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 * * * *'
-#  pull_request:
-#    branches: [master]
+#  schedule:
+#    - cron: '0 * * * *'
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 jobs:
 
   build_long_binaries:
     name: Test buiild for ${{ matrix.binary }}  on (${{ matrix.os }})
-    if: ${{ false }}
+#    if: ${{ false }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -79,8 +79,8 @@ jobs:
   longevity:
     name: Hourly Longevity test 
     runs-on: ${{ matrix.os }}
-#    needs:
-#      - build_long_binaries
+    needs:
+      - build_long_binaries
     timeout-minutes: 60
     strategy:
       fail-fast: false 
@@ -92,34 +92,34 @@ jobs:
     env:
       K3D_VERSION: v4.4.8
       TEST_BINARY: fluvio-test-x86_64-unknown-linux-musl
-      RUN_TIME: 1800
+      RUN_TIME: 60
       PRODUCER: 10
     steps:
       - uses: actions/checkout@v2
 
       - name: Login GH CLI
-  #      if: ${{ false }}
+        if: ${{ false }}
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
 
       - name: Download dev release
-  #      if: ${{ false }}
+        if: ${{ false }}
         run: gh release download dev -R infinyon/fluvio -D /tmp/release
 
       - name: Unpack fluvio-test from dev release
-  #      if: ${{ false }}
+        if: ${{ false }}
         run: |
           cd /tmp/release; unzip ${{ env.TEST_BINARY }}.zip; chmod +x fluvio-test
           echo "/tmp/release" >> $GITHUB_PATH
 
       - name: Download build artifact - fluvio-test
-        if: ${{ false }}
+   #     if: ${{ false }}
         uses: actions/download-artifact@v2
         with:
           name: fluvio-test-${{ matrix.rust-target }}
           path: ~/bin
 
       - name: Set up Fluvio binaries from build
-        if: ${{ false }}
+    #    if: ${{ false }}
         run: |
           chmod +x ~/bin/fluvio-test
           echo "~/bin" >> $GITHUB_PATH

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9]
         binary: [dev]
     env:
       K3D_VERSION: v4.4.8
@@ -209,7 +209,7 @@ jobs:
       - name: Upload diagnostics
         uses: actions/upload-artifact@v2
         timeout-minutes: 5
-        if: ${{ !success() }}
+        if: failure()
         with:
           name: hourly-longevity-${{ matrix.run }}.diag
           path: diagnostics*.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,12 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bencher"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,7 +1693,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "structopt",
- "sysinfo 0.22.5",
+ "sysinfo 0.23.0",
  "tar",
  "tempdir",
  "tempfile",
@@ -2159,7 +2153,6 @@ name = "fluvio-test"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "bencher",
  "bytes 1.1.0",
  "crc",
  "crossbeam-channel",
@@ -2183,11 +2176,11 @@ dependencies = [
  "prettytable-rs",
  "rand 0.8.4",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_yaml",
+ "signal-hook",
  "structopt",
- "syn",
+ "sysinfo 0.23.0",
  "tokio",
  "tracing",
 ]
@@ -4261,15 +4254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,6 +4648,21 @@ name = "sysinfo"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1bfab07306a27332451a662ca9c8156e3a9986f82660ba9c8e744fe8455d43"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e757000a4bed2b1be9be65a3f418b9696adf30bb419214c73997422de73a591"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "futures",
  "futures-lite",
  "hdrhistogram",
+ "indicatif",
  "inventory",
  "md-5",
  "nix",

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -56,7 +56,7 @@ duct = { version = "0.13", default-features = false, optional = true }
 prettytable-rs = { version = "0.8.0", default-features = false, optional = true }
 flate2 = { version = "1", default-features = false, optional = true }
 tar = { version = "0.4", default-features = false, optional = true }
-sysinfo = { version = "0.22.5", default-features = false, optional = true }
+sysinfo = { version = "0.23.0", default-features = false, optional = true }
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio", default-features = false }

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -4,7 +4,7 @@ use std::fs::{copy, write};
 use structopt::StructOpt;
 use serde::Serialize;
 use duct::cmd;
-use sysinfo::{System, SystemExt, NetworkExt, ProcessExt, DiskExt};
+use sysinfo::{System, SystemExt, NetworkExt, ProcessExt, DiskExt, PidExt};
 use which::which;
 
 use fluvio::config::ConfigFile;
@@ -339,7 +339,7 @@ impl ProcessInfo {
 
         for (pid, process) in sys.processes() {
             processes.push(ProcessInfo {
-                pid: *pid as u32,
+                pid: pid.as_u32(),
                 name: process.name().to_string(),
                 disk_usage: format!("{:?}", process.disk_usage()),
             });

--- a/crates/fluvio-test-derive/src/lib.rs
+++ b/crates/fluvio-test-derive/src/lib.rs
@@ -161,7 +161,7 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
 
                     // Disconnect test driver to cluster before starting test
                     test_driver_setup.disconnect();
-                });
+                },"topic setup");
 
                 let _ = topic_setup_wait.join().expect("Topic setup wait failed");
 
@@ -176,6 +176,7 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
                     Ok(fork::Fork::Parent(child_pid)) => child_pid,
                     Ok(fork::Fork::Child) => {
                         #user_test_fn_iden(test_driver, test_case);
+                        println!("finished test");
                         std::process::exit(0);
                     }
                     Err(_) => panic!("Test fork failed"),
@@ -185,7 +186,7 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
                     let pid = nix::unistd::Pid::from_raw(test_process.clone());
                     match nix::sys::wait::waitpid(pid, None) {
                         Ok(status) => {
-                            tracing::debug!("[main] Test exited with status {:?}", status);
+                            println!("[main] Test exited with status {:?}", status);
 
                             // Send something through the channel to signal test completion
                             test_end.send(()).unwrap();

--- a/crates/fluvio-test-derive/src/lib.rs
+++ b/crates/fluvio-test-derive/src/lib.rs
@@ -167,65 +167,10 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 println!("starting test in fork");
 
+                use std::panic::AssertUnwindSafe;
                 #user_test_fn_iden(test_driver, test_case);
-                /*
-                let child_process = match fork::fork {
-                    Ok(fork::Fork::Parent(child_pid)) => child_pid,
-                    Ok(fork::Fork::Child) => {
-                        use std::panic::AssertUnwindSafe;
-                        use std::process::exit;
 
-                        println!("forked test process");
-                        /*
-                        let status = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                            #user_test_fn_iden(test_driver, test_case);
-                        }));
-                        */
-
-                       // #user_test_fn_iden(test_driver, test_case);
-
-                        /*
-
-                        match status {
-                            Ok(_) => {
-                                println!("test passed");
-                                true
-                            }
-                            Err(e) => {
-                                println!("test failed");
-                                println!("{:?}", e);
-                                false
-                            }
-                        }
-                        */
-                    }
-                    Err(err) =>  {
-                        tracing::error!("Failed to fork test process: {}", err);
-                        return Err(TestResult {
-                            success: false,
-                            duration: std::time::Duration::new(0, 0),
-                            ..std::default::Default::default()
-                        })
-                    }
-                };
-
-                let pid = nix::unistd::Pid::from_raw(child_process);
-                */
-
-                /*
-                let status = match nix::sys::wait::waitpid(pid, None) {
-                    Ok(status) => {
-                        tracing::debug!("[fork] Child exited with status {:?}", status);
-                        status
-                    }
-                    Err(err) => panic!("[fork] waitpid() failed: {}", err),
-                };
-                */
-
-
-                println!("finished test");
-
-                 Ok(TestResult {
+                Ok(TestResult {
                     success: true,
                     duration: std::time::Duration::new(0, 0),
                     ..std::default::Default::default()

--- a/crates/fluvio-test-derive/src/lib.rs
+++ b/crates/fluvio-test-derive/src/lib.rs
@@ -164,8 +164,6 @@ pub fn fluvio_test(args: TokenStream, input: TokenStream) -> TokenStream {
                     })
                 };
 
-                println!("starting test in fork");
-
                 #user_test_fn_iden(test_driver, test_case);
 
                 Ok(TestResult {

--- a/crates/fluvio-test-util/test_meta/fork.rs
+++ b/crates/fluvio-test-util/test_meta/fork.rs
@@ -8,7 +8,7 @@ macro_rules! async_process {
             Ok(fork::Fork::Parent(child_pid)) => child_pid,
             Ok(fork::Fork::Child) => {
                 fluvio_future::task::run_block_on($child);
-                println!("finished child process: {}", $msg);
+                tracing::debug!("finished child process: {}", $msg);
                 std::process::exit(0);
             }
             Err(_) => panic!("Fork failed"),
@@ -44,7 +44,7 @@ macro_rules! fork_and_wait {
         let pid = nix::unistd::Pid::from_raw(child_process);
         match nix::sys::wait::waitpid(pid, None) {
             Ok(status) => {
-                println!("[fork] Child exited with status {:?}", status);
+                tracing::debug!("[fork] Child exited with status {:?}", status);
                 status
             }
             Err(err) => panic!("[fork] waitpid() failed: {}", err),

--- a/crates/fluvio-test-util/test_meta/fork.rs
+++ b/crates/fluvio-test-util/test_meta/fork.rs
@@ -3,11 +3,12 @@
 // User responsible for running .join()
 #[macro_export]
 macro_rules! async_process {
-    ($child:expr) => {{
+    ($child:expr,$msg:expr) => {{
         let child_process = match fork::fork() {
             Ok(fork::Fork::Parent(child_pid)) => child_pid,
             Ok(fork::Fork::Child) => {
                 fluvio_future::task::run_block_on($child);
+                println!("finished child process: {}", $msg);
                 std::process::exit(0);
             }
             Err(_) => panic!("Fork failed"),

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -31,6 +31,7 @@ nix = "0.23"
 crossbeam-channel = "0.5"
 sysinfo = { version = "0.23.0" }
 signal-hook = "0.3.13"
+indicatif = "0.16.2"
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio" }

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -16,22 +16,21 @@ futures-lite = "1.11.0"
 futures = "0.3"
 structopt = "0.3.5"
 async-trait = "0.1.21"
-syn = { version = "1.0", features = ["full"]}
 rand = "0.8"
 md-5 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
-serde_bytes = "0.11.5"
 inventory = "0.1"
 tokio = { version = "1.4", features = ["macros"] }
-bencher = "0.1"
 prettytable-rs = "0.8"
 hdrhistogram = "7.3.0"
 crc = "2.0"
 fork = "0.1"
 nix = "0.23"
 crossbeam-channel = "0.5"
+sysinfo = { version = "0.23.0" }
+signal-hook = "0.3.13"
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio" }

--- a/crates/fluvio-test/src/lib.rs
+++ b/crates/fluvio-test/src/lib.rs
@@ -23,3 +23,15 @@ pub fn get_binary(bin_name: &str) -> Result<Command, IoError> {
         Ok(Command::new(bin_dir.into_os_string()))
     }
 }
+
+/*
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test() {
+        assert!(1 == 0);
+    }
+}
+
+*/

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -156,7 +156,7 @@ fn run_test(
                     cluster_cleanup(environment);
                     println!("{}", test_result);
                     println!("trying to kill all");
-                    kill(Pid::from_raw(0), Signal::SIGKILL).expect("Unable to kill test process");
+                  //  kill(Pid::from_raw(0), Signal::SIGKILL).expect("Unable to kill test process");
                 }
             };
             0

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -15,8 +15,7 @@ use fluvio_test_util::test_meta::environment::{EnvDetail, EnvironmentSetup};
 use fluvio_test_util::setup::TestCluster;
 use fluvio_test_util::test_runner::test_driver::{TestDriver};
 use fluvio_test_util::test_runner::test_meta::FluvioTestMeta;
-use fluvio_test_util::test_meta::test_timer::TestTimer;
-use fluvio_test_util::{async_process, fork_and_wait};
+use fluvio_test_util::{async_process};
 
 // This is important for `inventory` crate
 #[allow(unused_imports)]
@@ -60,47 +59,7 @@ fn main() {
         exit(-1);
     }
 
-    let _panic_timer = TestTimer::start();
-
-    /*
-    std::panic::set_hook(Box::new(move |panic_info| {
-        println!("panic hook triggered");
-
-        let current_pid = get_current_pid().expect("Unable to get current pid");
-        println!("current test pid: {}", current_pid);
-        let sys = System::new();
-        let processes = sys.processes();
-        // get this process
-        let current_process = processes.get(&current_pid).expect("Unable to get current process");
-        let g_id = current_process.gid;
-        for (pid, process) in sys.processes() {
-            if pid != &current_pid && pid != &root_pid && process.gid == g_id {
-                println!("pid {} name {}", pid, process.name());
-                process.kill();
-            }
-        }
-
-        process::exit(1);
-    }));
-    */
-
-    let _setup_status = fork_and_wait! {
-        fluvio_future::task::run_block_on(async {
-            let test_case = TestCase::new(option.environment.clone(), test_opt.clone());
-            let test_cluster_opts = TestCluster::new(option.environment.clone());
-            let mut setup_driver = TestDriver::new(Some(test_cluster_opts));
-            // Connect test driver to cluster before starting test
-            setup_driver.connect().await.expect("Unable to connect to cluster");
-
-            // Create topic before starting test
-            setup_driver.create_topic(&test_case.environment)
-                .await
-                .expect("Unable to create default topic");
-
-            // Disconnect test driver to cluster before starting test
-            setup_driver.disconnect();
-        })
-    };
+    
 
     let test_result = run_test(option.environment.clone(), test_opt, test_meta);
 

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -161,7 +161,7 @@ fn run_test(
             ..std::default::Default::default()
         }
     } else if ok {
-        println!("Test passed, killing child processes");
+        println!("Test passed");
         TestResult {
             success: true,
             duration: start.elapsed().unwrap(),

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -156,7 +156,7 @@ fn run_test(
                     cluster_cleanup(environment);
                     println!("{}", test_result);
                     println!("trying to kill all");
-                  //  kill(Pid::from_raw(0), Signal::SIGKILL).expect("Unable to kill test process");
+                    kill(Pid::from_raw(0), Signal::SIGINT).expect("Unable to kill test process");
                 }
             };
             0

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,9 +45,11 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
+                    /*
                     if consumer_id == 1 {
                         panic!("fake test");
                     }
+                    */
 
 
                     if let Some(Ok(record_raw)) = stream_next {

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,11 +45,11 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
-                    /*
+
                     if consumer_id == 1 {
                         panic!("fake test");
                     }
-                    */
+
 
 
                     if let Some(Ok(record_raw)) = stream_next {

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,6 +45,11 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
+                    #[allow(clippy::eq_op)]
+                    if 1 == 1 {
+                        panic!("fake test");
+                    }
+
                     if let Some(Ok(record_raw)) = stream_next {
                         records_recvd += 1;
 
@@ -71,7 +76,7 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
                             assert!(test_record.validate_crc());
                         });
 
-                        /* 
+
                         if let Err(err) = result {
                             let elapsed_time = start_consume.elapsed().unwrap().as_secs();
                             println!(
@@ -80,8 +85,10 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
                                 );
 
                             panic!("Consumer {consumer_id} failed to consume record: {:?}", err);
-                        }*/
-                        panic!("fake test");
+                        }
+
+
+
 
 
                     //    let elapsed_time = now.elapsed().unwrap().as_secs();

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -32,9 +32,6 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
     let start_consume = SystemTime::now();
 
     'consumer_loop: loop {
-        // Take a timestamp before record consumed
-        // let now = SystemTime::now();
-
         select! {
 
                 _ = &mut test_timer => {
@@ -50,8 +47,6 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
                         panic!("fake test");
                     }
                     */
-
-
 
                     if let Some(Ok(record_raw)) = stream_next {
                         records_recvd += 1;

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,10 +45,11 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
-
+                    /* 
                     if consumer_id == 1 {
                         panic!("fake test");
                     }
+                    */
 
 
 
@@ -88,9 +89,6 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                             panic!("Consumer {consumer_id} failed to consume record: {:?}", err);
                         }
-
-
-
 
 
                     //    let elapsed_time = now.elapsed().unwrap().as_secs();

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,7 +45,7 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
-                    /* 
+                    /*
                     if consumer_id == 1 {
                         panic!("fake test");
                     }

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,12 +45,12 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
-                    /*
+
                     #[allow(clippy::eq_op)]
                     if 1 == 1 {
                         panic!("fake test");
                     }
-                    */
+
 
                     if let Some(Ok(record_raw)) = stream_next {
                         records_recvd += 1;

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,9 +45,7 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
-
-                    #[allow(clippy::eq_op)]
-                    if 1 == 1 {
+                    if consumer_id == 1 {
                         panic!("fake test");
                     }
 

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -71,6 +71,7 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
                             assert!(test_record.validate_crc());
                         });
 
+                        /* 
                         if let Err(err) = result {
                             let elapsed_time = start_consume.elapsed().unwrap().as_secs();
                             println!(
@@ -79,7 +80,8 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
                                 );
 
                             panic!("Consumer {consumer_id} failed to consume record: {:?}", err);
-                        }
+                        }*/
+                        panic!("fake test");
 
 
                     //    let elapsed_time = now.elapsed().unwrap().as_secs();

--- a/crates/fluvio-test/src/tests/longevity/consumer.rs
+++ b/crates/fluvio-test/src/tests/longevity/consumer.rs
@@ -45,10 +45,12 @@ pub async fn consumer_stream(test_driver: TestDriver, option: LongevityTestCase,
 
                 stream_next = stream.next() => {
 
+                    /*
                     #[allow(clippy::eq_op)]
                     if 1 == 1 {
                         panic!("fake test");
                     }
+                    */
 
                     if let Some(Ok(record_raw)) = stream_next {
                         records_recvd += 1;

--- a/crates/fluvio-test/src/tests/longevity/mod.rs
+++ b/crates/fluvio-test/src/tests/longevity/mod.rs
@@ -73,7 +73,7 @@ impl TestOption for LongevityTestOption {
 }
 
 #[fluvio_test(topic = "longevity")]
-pub fn longevity(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+pub fn longevity(test_driver: FluvioTestDriver, test_case: TestCase) {
     let option: LongevityTestCase = test_case.into();
 
     println!("Starting Longevity Test");
@@ -90,10 +90,12 @@ pub fn longevity(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         println!("Starting Consumer #{}", i);
         let consumer = async_process!(
             async {
+                println!("try connectiong");
                 test_driver
                     .connect()
                     .await
                     .expect("Connecting to cluster failed");
+                println!("connected");
                 consumer::consumer_stream(test_driver.clone(), option.clone(), i).await
             },
             format!("consumer-{}", i)

--- a/crates/fluvio-test/src/tests/longevity/mod.rs
+++ b/crates/fluvio-test/src/tests/longevity/mod.rs
@@ -88,13 +88,16 @@ pub fn longevity(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
     let mut consumer_wait = Vec::new();
     for i in 0..option.option.consumers {
         println!("Starting Consumer #{}", i);
-        let consumer = async_process!(async {
-            test_driver
-                .connect()
-                .await
-                .expect("Connecting to cluster failed");
-            consumer::consumer_stream(test_driver.clone(), option.clone(), i).await
-        });
+        let consumer = async_process!(
+            async {
+                test_driver
+                    .connect()
+                    .await
+                    .expect("Connecting to cluster failed");
+                consumer::consumer_stream(test_driver.clone(), option.clone(), i).await
+            },
+            format!("consumer-{}", i)
+        );
 
         consumer_wait.push(consumer);
     }
@@ -102,13 +105,16 @@ pub fn longevity(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
     let mut producer_wait = Vec::new();
     for i in 0..option.option.producers {
         println!("Starting Producer #{}", i);
-        let producer = async_process!(async {
-            test_driver
-                .connect()
-                .await
-                .expect("Connecting to cluster failed");
-            producer::producer(test_driver, option, i).await
-        });
+        let producer = async_process!(
+            async {
+                test_driver
+                    .connect()
+                    .await
+                    .expect("Connecting to cluster failed");
+                producer::producer(test_driver, option, i).await
+            },
+            format!("producer-{}", i)
+        );
 
         producer_wait.push(producer);
     }

--- a/crates/fluvio-test/src/tests/longevity/mod.rs
+++ b/crates/fluvio-test/src/tests/longevity/mod.rs
@@ -86,19 +86,19 @@ pub fn longevity(test_driver: FluvioTestDriver, test_case: TestCase) {
     }
 
     let mut consumer_wait = Vec::new();
-    for i in 0..option.option.consumers {
-        println!("Starting Consumer #{}", i);
+    for consumer_id in 0..option.option.consumers {
+        println!("Starting Consumer #{}", consumer_id);
         let consumer = async_process!(
             async {
-                println!("try connectiong");
+                println!("try connecting consumer: {consumer_id}");
                 test_driver
                     .connect()
                     .await
                     .expect("Connecting to cluster failed");
-                println!("connected");
-                consumer::consumer_stream(test_driver.clone(), option.clone(), i).await
+                println!("consumer connected: {consumer_id}");
+                consumer::consumer_stream(test_driver.clone(), option.clone(), consumer_id).await
             },
-            format!("consumer-{}", i)
+            format!("consumer-{}", consumer_id)
         );
 
         consumer_wait.push(consumer);

--- a/crates/fluvio-test/src/tests/self_test/mod.rs
+++ b/crates/fluvio-test/src/tests/self_test/mod.rs
@@ -54,14 +54,17 @@ pub fn self_check(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
 
     println!("Starting Fluvio Test Self-Check");
 
-    let another_process = async_process!(async {
-        // Sleep for a moment to help (visually) validate global test timer
-        std::thread::sleep(std::time::Duration::from_secs(3));
+    let another_process = async_process!(
+        async {
+            // Sleep for a moment to help (visually) validate global test timer
+            std::thread::sleep(std::time::Duration::from_secs(3));
 
-        if self_test_case.option.force_panic {
-            panic!("Intentionally panicking inside another process");
-        }
-    });
+            if self_test_case.option.force_panic {
+                panic!("Intentionally panicking inside another process");
+            }
+        },
+        "sleep"
+    );
 
     another_process.join().unwrap();
 }

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -8,8 +8,13 @@ use std::any::Any;
 use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
+use std::fs::File;
+use std::io::Read;
+use std::collections::BTreeMap;
 
 use structopt::StructOpt;
+use tracing::debug;
+use serde::{Deserialize};
 
 use fluvio_test_derive::fluvio_test;
 use fluvio_test_util::test_meta::environment::{EnvironmentSetup};
@@ -23,12 +28,6 @@ use fluvio::metadata::{
     connector::{ManagedConnectorSpec, SecretString},
 };
 use fluvio_future::timer::sleep;
-
-use tracing::debug;
-use std::fs::File;
-use std::io::Read;
-use std::collections::BTreeMap;
-use serde::{Deserialize};
 
 #[derive(Debug, Clone)]
 pub struct SmokeTestCase {

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -93,135 +93,144 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
     let smoke_test_case: SmokeTestCase = test_case.into();
 
     // If connector tests requested
-    let maybe_connector = if let Some(ref connector_config) =
-        smoke_test_case.option.connector_config
-    {
-        let connector_process = async_process!(async {
-            test_driver
-                .connect()
-                .await
-                .expect("Connecting to cluster failed");
+    let maybe_connector =
+        if let Some(ref connector_config) = smoke_test_case.option.connector_config {
+            let connector_process = async_process!(
+                async {
+                    test_driver
+                        .connect()
+                        .await
+                        .expect("Connecting to cluster failed");
 
-            // Add a connector CRD
-            let admin = test_driver.client().admin().await;
-            // Create a managed connector
-            let config = ConnectorConfig::from_file(&connector_config).unwrap();
-            let spec: ManagedConnectorSpec = config.clone().into();
-            let name = spec.name.clone();
+                    // Add a connector CRD
+                    let admin = test_driver.client().admin().await;
+                    // Create a managed connector
+                    let config = ConnectorConfig::from_file(&connector_config).unwrap();
+                    let spec: ManagedConnectorSpec = config.clone().into();
+                    let name = spec.name.clone();
 
-            debug!("creating managed_connector: {}, spec: {:#?}", name, spec);
+                    debug!("creating managed_connector: {}, spec: {:#?}", name, spec);
 
-            // If the managed connector wants its topic created, don't fail if it already exists
-            if config.create_topic {
-                println!("Attempt to create connector's topic");
-                let topic_spec: TopicSpec =
-                    ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
-                debug!("topic spec: {:?}", topic_spec);
-                admin
-                    .create(config.topic.clone(), false, topic_spec)
-                    .await
-                    .unwrap_or(());
-            }
+                    // If the managed connector wants its topic created, don't fail if it already exists
+                    if config.create_topic {
+                        println!("Attempt to create connector's topic");
+                        let topic_spec: TopicSpec =
+                            ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false)).into();
+                        debug!("topic spec: {:?}", topic_spec);
+                        admin
+                            .create(config.topic.clone(), false, topic_spec)
+                            .await
+                            .unwrap_or(());
+                    }
 
-            // If the connector already exists, don't fail
-            println!("Attempt to create connector");
-            admin
-                .create(name.to_string(), false, spec)
-                .await
-                .unwrap_or(());
+                    // If the connector already exists, don't fail
+                    println!("Attempt to create connector");
+                    admin
+                        .create(name.to_string(), false, spec)
+                        .await
+                        .unwrap_or(());
 
-            // Build a new SmokeTestCase so we can use the consumer verify
-            // Ending after a static number of records received
-            let new_smoke_test_case = SmokeTestCase {
-                environment: EnvironmentSetup {
-                    topic_name: Some(config.topic.clone()),
-                    tls: smoke_test_case.environment.tls,
-                    tls_user: smoke_test_case.environment.tls_user(),
-                    spu: smoke_test_case.environment.spu,
-                    replication: smoke_test_case.environment.replication,
-                    partition: smoke_test_case.environment.partition,
-                    ..Default::default()
+                    // Build a new SmokeTestCase so we can use the consumer verify
+                    // Ending after a static number of records received
+                    let new_smoke_test_case = SmokeTestCase {
+                        environment: EnvironmentSetup {
+                            topic_name: Some(config.topic.clone()),
+                            tls: smoke_test_case.environment.tls,
+                            tls_user: smoke_test_case.environment.tls_user(),
+                            spu: smoke_test_case.environment.spu,
+                            replication: smoke_test_case.environment.replication,
+                            partition: smoke_test_case.environment.partition,
+                            ..Default::default()
+                        },
+                        option: SmokeTestOption {
+                            skip_consumer_validate: true,
+                            producer_iteration: 10,
+                            connector_config: smoke_test_case.option.connector_config.clone(),
+                            ..Default::default()
+                        },
+                    };
+
+                    // Verify that connector is creating data
+                    let start_offset =
+                        offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
+                    let start = start_offset.get(&config.topic.clone()).expect("offsets");
+
+                    println!("Verify connector is creating data: (start: {})", start);
+
+                    const CI_TIME: u64 = 90;
+                    const DEV_TIME: u64 = 10;
+
+                    let wait_sec = if std::env::var("CI").is_ok() {
+                        CI_TIME
+                    } else {
+                        DEV_TIME
+                    };
+
+                    println!("Waiting {} seconds to let connector write", &wait_sec);
+                    sleep(Duration::from_secs(wait_sec)).await;
+
+                    let check_offset =
+                        offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
+                    let check = check_offset.get(&config.topic.clone()).expect("offsets");
+
+                    if check > start {
+                        println!("Connector is receiving data: (check: {})", check)
+                    } else {
+                        panic!("Connector not receiving data")
+                    };
+
+                    println!("Run consume test against connector topic");
+                    validate_consume_message_api(
+                        test_driver,
+                        start_offset,
+                        &new_smoke_test_case.clone(),
+                    )
+                    .await;
                 },
-                option: SmokeTestOption {
-                    skip_consumer_validate: true,
-                    producer_iteration: 10,
-                    connector_config: smoke_test_case.option.connector_config.clone(),
-                    ..Default::default()
-                },
-            };
+                "connector"
+            );
 
-            // Verify that connector is creating data
-            let start_offset =
-                offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
-            let start = start_offset.get(&config.topic.clone()).expect("offsets");
+            Some(connector_process)
 
-            println!("Verify connector is creating data: (start: {})", start);
-
-            const CI_TIME: u64 = 90;
-            const DEV_TIME: u64 = 10;
-
-            let wait_sec = if std::env::var("CI").is_ok() {
-                CI_TIME
-            } else {
-                DEV_TIME
-            };
-
-            println!("Waiting {} seconds to let connector write", &wait_sec);
-            sleep(Duration::from_secs(wait_sec)).await;
-
-            let check_offset =
-                offsets::find_offsets(&test_driver, &new_smoke_test_case.clone()).await;
-            let check = check_offset.get(&config.topic.clone()).expect("offsets");
-
-            if check > start {
-                println!("Connector is receiving data: (check: {})", check)
-            } else {
-                panic!("Connector not receiving data")
-            };
-
-            println!("Run consume test against connector topic");
-            validate_consume_message_api(test_driver, start_offset, &new_smoke_test_case.clone())
-                .await;
-        });
-
-        Some(connector_process)
-
-        // Wait a few seconds to allow the connector a chance to deploy and store data
-    } else {
-        None
-    };
+            // Wait a few seconds to allow the connector a chance to deploy and store data
+        } else {
+            None
+        };
 
     // TableFormat test
     let maybe_table_format =
         if let Some(ref table_format_config) = smoke_test_case.option.table_format_config {
-            let table_format_process = async_process!(async {
-                let config = TableFormatConfig::from_file(table_format_config)
-                    .expect("TableFormat config load failed");
-                let table_format_spec: TableFormatSpec = config.into();
-                let name = table_format_spec.name.clone();
+            let table_format_process = async_process!(
+                async {
+                    let config = TableFormatConfig::from_file(table_format_config)
+                        .expect("TableFormat config load failed");
+                    let table_format_spec: TableFormatSpec = config.into();
+                    let name = table_format_spec.name.clone();
 
-                test_driver
-                    .connect()
-                    .await
-                    .expect("Connecting to cluster failed");
+                    test_driver
+                        .connect()
+                        .await
+                        .expect("Connecting to cluster failed");
 
-                let admin = test_driver.client().admin().await;
+                    let admin = test_driver.client().admin().await;
 
-                admin
-                    .create(name.clone(), false, table_format_spec)
-                    .await
-                    .expect("TableFormat create failed");
-                println!("tableformat \"{}\" created", &name);
+                    admin
+                        .create(name.clone(), false, table_format_spec)
+                        .await
+                        .expect("TableFormat create failed");
+                    println!("tableformat \"{}\" created", &name);
 
-                // Wait a moment then delete
-                sleep(Duration::from_secs(5)).await;
+                    // Wait a moment then delete
+                    sleep(Duration::from_secs(5)).await;
 
-                admin
-                    .delete::<TableFormatSpec, _>(name.clone())
-                    .await
-                    .expect("TableFormat delete failed");
-                println!("tableformat \"{}\" deleted", &name);
-            });
+                    admin
+                        .delete::<TableFormatSpec, _>(name.clone())
+                        .await
+                        .expect("TableFormat delete failed");
+                    println!("tableformat \"{}\" deleted", &name);
+                },
+                "tableformat"
+            );
 
             Some(table_format_process)
             // Create a managed connector
@@ -230,37 +239,47 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         };
 
     // We're going to handle the `--consumer-wait` flag in this process
-    let producer_wait = async_process!(async {
-        let mut test_driver_consumer_wait = test_driver.clone();
+    let producer_wait = async_process!(
+        async {
+            let mut test_driver_consumer_wait = test_driver.clone();
 
-        test_driver
-            .connect()
-            .await
-            .expect("Connecting to cluster failed");
-        println!("About to start producer test");
-
-        let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
-
-        // If we've passed in `--consumer-wait` then we should start the consumer after the producer
-        if smoke_test_case.option.consumer_wait {
-            test_driver_consumer_wait
-                .connect()
-                .await
-                .expect("Connecting to cluster failed");
-            validate_consume_message_api(test_driver_consumer_wait, start_offset, &smoke_test_case)
-                .await;
-        }
-    });
-
-    // By default, we should run the consumer and producer at the same time
-    if !smoke_test_case.option.consumer_wait {
-        let consumer_wait = async_process!(async {
             test_driver
                 .connect()
                 .await
                 .expect("Connecting to cluster failed");
-            consume::validate_consume_message(test_driver, &smoke_test_case).await;
-        });
+            println!("About to start producer test");
+
+            let start_offset = produce::produce_message(test_driver, &smoke_test_case).await;
+
+            // If we've passed in `--consumer-wait` then we should start the consumer after the producer
+            if smoke_test_case.option.consumer_wait {
+                test_driver_consumer_wait
+                    .connect()
+                    .await
+                    .expect("Connecting to cluster failed");
+                validate_consume_message_api(
+                    test_driver_consumer_wait,
+                    start_offset,
+                    &smoke_test_case,
+                )
+                .await;
+            }
+        },
+        "producer"
+    );
+
+    // By default, we should run the consumer and producer at the same time
+    if !smoke_test_case.option.consumer_wait {
+        let consumer_wait = async_process!(
+            async {
+                test_driver
+                    .connect()
+                    .await
+                    .expect("Connecting to cluster failed");
+                consume::validate_consume_message(test_driver, &smoke_test_case).await;
+            },
+            "consumer validation"
+        );
 
         let _ = consumer_wait.join();
     }


### PR DESCRIPTION
resolves #2110 

Use the signal to pass test status from child test wrapper to parent test runner.
Kill all child test processes if the test failed or time out.
Fix concurrent group name for CI jobs

