### PR TITLE
[Merged by Bors] - Update ManagedConnectors crd key name

### DIFF
--- a/k8-util/helm/fluvio-sys/templates/crd_managed_connector.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_managed_connector.yaml
@@ -35,7 +35,7 @@ spec:
                   type: string
                   minimum: 2
                   maximum: 100
-                connectorVersion:
+                version:
                   type: string
                   minimum: 2
                   maximum: 100


### PR DESCRIPTION
We were not storing the version and so we were always pulling latest. Restores the ability to do local connector development for official containers

Fixes #2123 