### PR TITLE
[Merged by Bors] - Align connector names on left (#2146)

### DIFF
--- a/crates/fluvio-cli/src/connector/list.rs
+++ b/crates/fluvio-cli/src/connector/list.rs
@@ -99,7 +99,7 @@ mod output {
                 .map(|r| {
                     let _spec = &r.spec;
                     Row::new(vec![
-                        Cell::new_align(&r.name, Alignment::RIGHT),
+                        Cell::new_align(&r.name, Alignment::LEFT),
                         Cell::new_align(&r.status.to_string(), Alignment::RIGHT),
                     ])
                 })


### PR DESCRIPTION
Resolves #2146

Aligns the connector name to the left when running the connector list command.