### PR TITLE
[Merged by Bors] - feat: translate _ in connector parameters keys to -

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix connector crd to store version ([#2123](https://github.com/infinyon/fluvio/issues/2123))
 * Remove max version requirements ([#2106](https://github.com/infinyon/fluvio/issues/2106))
 * Optimize memory allocation  ([#2069](https://github.com/infinyon/fluvio/pull/2133))
+* Translate `_` with `-` in connector parameters ([#2149](https://github.com/infinyon/fluvio/issues/2149))
   
 ## Platform Version 0.9.17 - 2022-01-12
 * Change default values of TopicProducerConfig ([#2069](https://github.com/infinyon/fluvio/issues/2069))

--- a/crates/fluvio-sc/src/k8/controllers/managed_connector_deployment.rs
+++ b/crates/fluvio-sc/src/k8/controllers/managed_connector_deployment.rs
@@ -225,7 +225,7 @@ impl ManagedConnectorDeploymentController {
         let parameters: Vec<String> = parameters
             .keys()
             .zip(parameters.values())
-            .flat_map(|(key, value)| [format!("--{}={}", key.clone(), value.clone())])
+            .flat_map(|(key, value)| [format!("--{}={}", key.replace("_", "-"), value)])
             .collect::<Vec<_>>();
 
         // Prefixing the args with a "--" passed to the container is needed for an unclear reason.


### PR DESCRIPTION
Also remove the `.clone()` calls in that line

Fixes #2149 