### PR TITLE
[Merged by Bors] - Ignore records larger than requested offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/tests/cli/smoke_tests/e2e-basic.bats
+++ b/tests/cli/smoke_tests/e2e-basic.bats
@@ -17,12 +17,19 @@ setup_file() {
     export TOPIC_NAME_2
     debug_msg "Topic name: $TOPIC_NAME_2"
 
+    TOPIC_NAME_3=$(random_string)
+    export TOPIC_NAME_3
+    debug_msg "Topic name: $TOPIC_NAME_3"
+
     MESSAGE="$(random_string 7)"
     export MESSAGE
     debug_msg "$MESSAGE"
 
     MESSAGE_W_HTML_STR='"&"'
     export MESSAGE_W_HTML_STR
+
+    MULTILINE_MESSAGE="$MESSAGE\n$MESSAGE_W_HTML_STR"
+    export MULTILINE_MESSAGE
 }
 
 teardown_file() {
@@ -36,12 +43,15 @@ teardown_file() {
     assert_success
     run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_2"
     assert_success
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_3"
+    assert_success
 }
 
 # Produce message 
 @test "Produce message" {
     run bash -c 'echo "$MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
     run bash -c 'echo "$MESSAGE_W_HTML_STR" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_2"'
+    run bash -c 'echo -e "$MULTILINE_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_3"'
     assert_success
 }
 
@@ -58,7 +68,13 @@ teardown_file() {
 # https://github.com/infinyon/fluvio/issues/1628
 @test "Consume message using format" {
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_2" --format "{{value}}" -B -d
+    assert_output "$MESSAGE_W_HTML_STR"
+    assert_success
+}
 
+# Validate that consume --tail 1, returns only the last record
+@test "Consume with tail" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_3" --tail 1 -d
     assert_output "$MESSAGE_W_HTML_STR"
     assert_success
 }


### PR DESCRIPTION
Fixes #2002 

Currently, when we do a stream request with a given offset to the SPU, in the SPU response we get the batch where the record with that particular offset is. Since SPU does not do any batch manipulation and send the raw bytes of the batch that it gets from the file, we need to handle this on the client side, by skipping the records of the first batch that are greater than the offset that we want.

This PRs do that, it does not change any public API, just change the internal request_stream function to also return the offset of the expected starting offset so we can use that to filter all the records with an offset greater than that.

Added a CLI smoke test for --tail 1