### PR TITLE
[Merged by Bors] - Add `wasi` support to smartengine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.19 - UNRELEASED
+* Add WASI support to SmartEngine ([#1874](https://github.com/infinyon/fluvio/issues/1874))
 
 ## Platform Version 0.9.18 - 2022-01-31
 * Show Platform version for fluvio run ([#2104](https://github.com/infinyon/fluvio/issues/2104))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +561,72 @@ name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
+name = "cap-fs-ext"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68548ec86cd6e80bd3a82f6e1f9fdf7f0855d82fca10a4351734e0b458768e1a"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "winapi",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4885ffa2fcd32e04f2e2828537d760cba3aae7f3642e72195272b856ae7d71"
+dependencies = [
+ "ambient-authority",
+ "errno",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.31.3",
+ "winapi",
+ "winapi-util",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f7d4fff11afb2e0ff27ff4c761fe6fbf2b592bdd4e3b65eb264b8da7631286"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "cap-std"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3500cb800c41283d7ba1e541609c041378410494cfdc43232220d63d240e5d"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "rustix 0.31.3",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a837533cbe6037743926538ab7ec292026b99e0823967bef984778dd92e40c9c"
+dependencies = [
+ "cap-primitives",
+ "once_cell",
+ "rustix 0.31.3",
+ "winx",
+]
 
 [[package]]
 name = "cargo-lock"
@@ -1298,6 +1370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2058,7 @@ dependencies = [
  "nix",
  "tracing",
  "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -2362,6 +2445,17 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c496df0e588acbc672c912b4eb48ca7912164e89498ffad89969492f8e958f"
+dependencies = [
+ "io-lifetimes",
+ "rustix 0.32.1",
+ "winapi",
 ]
 
 [[package]]
@@ -2904,6 +2998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9132d2d6504f4e348b8e16787f01613b4d0e587458641a40e727304416ac8d"
+dependencies = [
+ "io-lifetimes",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +3015,12 @@ checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "isahc"
@@ -3129,6 +3239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3301,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-uninit"
@@ -4135,8 +4257,24 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
+ "itoa 1.0.1",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.36",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.0.37",
  "winapi",
 ]
 
@@ -4379,6 +4517,15 @@ checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]
@@ -4681,6 +4828,22 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-interface"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56154c0a9e540ca0e204475913b1fccee114865b647d2019191fade73a8e4b56"
+dependencies = [
+ "atty",
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "io-lifetimes",
+ "rustix 0.31.3",
+ "winapi",
+ "winx",
 ]
 
 [[package]]
@@ -5190,6 +5353,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi-cap-std-sync"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11be3f8de85a747166e53b0bec8ae65945df476ba1048bbfca35292ad398b161"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-lifetimes",
+ "lazy_static",
+ "rustix 0.31.3",
+ "system-interface",
+ "tracing",
+ "wasi-common",
+ "winapi",
+]
+
+[[package]]
+name = "wasi-common"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e3aed634c018892c52a25239f3f23b97d5a70c9790e6a9299cb32d30fc5542"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cap-rand",
+ "cap-std",
+ "rustix 0.31.3",
+ "thiserror",
+ "tracing",
+ "wiggle",
+ "winapi",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,7 +5534,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.31.3",
  "serde",
  "sha2 0.9.9",
  "toml",
@@ -5389,7 +5591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "044d9108ee9851547d8bc4e700be4479fde51efff3a81b1bc43219fc7e3310b0"
 dependencies = [
  "cc",
- "rustix",
+ "rustix 0.31.3",
  "winapi",
 ]
 
@@ -5406,7 +5608,7 @@ dependencies = [
  "gimli",
  "object",
  "region",
- "rustix",
+ "rustix 0.31.3",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -5434,7 +5636,7 @@ dependencies = [
  "more-asserts",
  "rand 0.8.4",
  "region",
- "rustix",
+ "rustix 0.31.3",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -5454,6 +5656,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-wasi"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33235c2f566f307802eefde34366660d81a6c159da4e96e92be168c019bf2685"
+dependencies = [
+ "anyhow",
+ "wasi-cap-std-sync",
+ "wasi-common",
+ "wasmtime",
+ "wiggle",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wast"
 version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,7 +5694,7 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
 dependencies = [
- "wast",
+ "wast 39.0.0",
 ]
 
 [[package]]
@@ -5504,6 +5728,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiggle"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8d701567bd2e7f303248d4f92f5a22145b282234a28bd82d62fd9ef6dc215c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "thiserror",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87f4a07fca63f501eda1bb964ed1350195e02e340bc54ee53ee0d3fdef1f1bf"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93dd9ccf857924ed83c5d6365ea77cda1ed15bbf352dce54912432708091663"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,6 +5799,29 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winx"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54de2ce52a3e5839e129c7859e2b1f581769bbef57c0a2a09a12a5a3a5b3c2a"
+dependencies = [
+ "bitflags",
+ "io-lifetimes",
+ "winapi",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror",
+ "wast 35.0.2",
+]
 
 [[package]]
 name = "wyz"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ FLUVIO_BIN?=$(if $(TARGET),./target/$(TARGET)/$(BUILD_PROFILE)/fluvio,./target/$
 RELEASE_FLAG=$(if $(RELEASE),--release,)
 TARGET_FLAG=$(if $(TARGET),--target $(TARGET),)
 VERBOSE_FLAG=$(if $(VERBOSE),--verbose,)
+DEBUG_SMARTMODULE_FLAG=$(if $(DEBUG_SMARTMODULE),--features wasi,)
 
 BUILD_FLAGS = $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -13,9 +13,11 @@ description = "The offical Fluvio SmartEngine"
 
 [features]
 smartmodule = ["fluvio-controlplane-metadata", "flate2"]
+wasi = ["wasmtime-wasi"]
 
 [dependencies]
 wasmtime = "0.33"
+wasmtime-wasi = {version="0.33", optional = true}
 nix = "0.23"
 tracing = "0.1.27"
 anyhow = "1.0.38"

--- a/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
@@ -6,7 +6,7 @@ use wasmtime::{AsContextMut, Trap, TypedFunc};
 
 use crate::{
     WasmSlice,
-    smartmodule::{SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
 };
 use dataplane::smartmodule::{
     SmartModuleAggregateInput, SmartModuleInput, SmartModuleOutput, SmartModuleInternalError,
@@ -38,13 +38,12 @@ impl AggregateFnKind {
 
 impl SmartModuleAggregate {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         accumulator: Vec<u8>,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let aggregate_fn: AggregateFnKind = if let Ok(agg_fn) = base
             .instance
             .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)

--- a/crates/fluvio-smartengine/src/smartmodule/array_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/array_map.rs
@@ -7,7 +7,7 @@ use dataplane::smartmodule::{
 };
 use crate::{
     WasmSlice,
-    smartmodule::{SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
 };
 
 const ARRAY_MAP_FN_NAME: &str = "array_map";
@@ -34,12 +34,11 @@ impl ArrayMapFnKind {
 
 impl SmartModuleArrayMap {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let map_fn = if let Ok(array_map_fn) = base
             .instance
             .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -7,7 +7,7 @@ use dataplane::smartmodule::{
 };
 use crate::{
     WasmSlice,
-    smartmodule::{SmartModuleWithEngine, SmartEngine, SmartModuleContext, SmartModuleInstance},
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
 };
 
 const FILTER_FN_NAME: &str = "filter";
@@ -35,12 +35,11 @@ impl FilterFnKind {
 
 impl SmartModuleFilter {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let filter_fn = if let Ok(filt_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_FN_NAME)

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -6,8 +6,7 @@ use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInt
 use crate::{
     WasmSlice,
     smartmodule::{
-        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-        SmartModuleExtraParams,
+        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
 };
 
@@ -36,12 +35,11 @@ impl FilterMapFnKind {
 
 impl SmartModuleFilterMap {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let filter_map_fn = if let Ok(fmap_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -8,8 +8,7 @@ use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInt
 use crate::{
     WasmSlice,
     smartmodule::{
-        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-        SmartModuleExtraParams,
+        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
 };
 
@@ -38,12 +37,11 @@ impl JoinFnKind {
 
 impl SmartModuleJoin {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let join_fn =
             if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
                 JoinFnKind::New(join_fn)

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -8,8 +8,7 @@ use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInt
 use crate::{
     WasmSlice,
     smartmodule::{
-        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-        SmartModuleExtraParams,
+        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
 };
 
@@ -38,12 +37,11 @@ impl JoinFnKind {
 
 impl SmartModuleJoinStream {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let join_fn =
             if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
                 JoinFnKind::New(join_fn)

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -6,8 +6,7 @@ use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInt
 use crate::{
     WasmSlice,
     smartmodule::{
-        SmartEngine, SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance,
-        SmartModuleExtraParams,
+        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
 };
 
@@ -35,12 +34,11 @@ impl MapFnKind {
 
 impl SmartModuleMap {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut base = SmartModuleContext::new(engine, module, params, version)?;
+        let mut base = SmartModuleContext::new(module, params, version)?;
         let map_fn = if let Ok(map_fn) = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)
         {
             MapFnKind::New(map_fn)

--- a/crates/fluvio-smartengine/src/smartmodule/memory.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/memory.rs
@@ -10,8 +10,8 @@ const MEMORY: &str = "memory";
 
 /// Copy a byte array into an instance's linear memory
 /// and return the offset relative to the module's memory.
-pub fn copy_memory_to_instance(
-    store: &mut Store<()>,
+pub fn copy_memory_to_instance<T>(
+    store: &mut Store<T>,
     instance: &Instance,
     bytes: &[u8],
 ) -> Result<isize, Error> {

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -156,7 +156,7 @@ impl SmartEngine {
         let host_fn_import = module
             .imports()
             .next()
-            .ok_or(Error::msg("At least one import is required"))?;
+            .ok_or_else(|| Error::msg("At least one import is required"))?;
         linker.func_wrap(
             host_fn_import.module(),
             host_fn_import.name().unwrap_or(""),

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -6,7 +6,7 @@ use dataplane::record::Record;
 use dataplane::smartmodule::SmartModuleExtraParams;
 use tracing::{debug, instrument, trace};
 use anyhow::{Error, Result};
-use wasmtime::{Memory, Store, Engine, Module, Func, Caller, Extern, Trap, Instance};
+use wasmtime::{Memory, Engine, Module, Caller, Extern, Trap, Instance, IntoFunc, Store};
 
 use crate::smartmodule::filter::SmartModuleFilter;
 use crate::smartmodule::map::SmartModuleMap;
@@ -32,8 +32,15 @@ pub mod file_batch;
 pub mod join_stream;
 
 pub type WasmSlice = (i32, i32, u32);
+
 #[cfg(feature = "smartmodule")]
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleSpec};
+
+#[cfg(feature = "wasi")]
+type State = wasmtime_wasi::WasiCtx;
+
+#[cfg(not(feature = "wasi"))]
+type State = ();
 
 use self::join_stream::SmartModuleJoinStream;
 
@@ -111,6 +118,54 @@ impl SmartEngine {
     }
 }
 
+#[cfg(not(feature = "wasi"))]
+impl SmartEngine {
+    fn new_store(&self) -> Store<State> {
+        Store::new(&self.0, ())
+    }
+
+    fn instantiate<Params, Args>(
+        &self,
+        store: &mut wasmtime::Store<State>,
+        module: &Module,
+        host_fn: impl IntoFunc<State, Params, Args>,
+    ) -> Result<Instance, Error> {
+        let func = wasmtime::Func::wrap(&mut *store, host_fn);
+        Instance::new(store, module, &[func.into()])
+    }
+}
+
+#[cfg(feature = "wasi")]
+impl SmartEngine {
+    fn new_store(&self) -> Store<State> {
+        let wasi = wasmtime_wasi::WasiCtxBuilder::new()
+            .inherit_stderr()
+            .inherit_stdout()
+            .build();
+        Store::new(&self.0, wasi)
+    }
+
+    fn instantiate<Params, Args>(
+        &self,
+        store: &mut wasmtime::Store<State>,
+        module: &Module,
+        host_fn: impl IntoFunc<State, Params, Args>,
+    ) -> Result<Instance, Error> {
+        let mut linker = wasmtime::Linker::new(&self.0);
+        wasmtime_wasi::add_to_linker(&mut linker, |c| c)?;
+        let host_fn_import = module
+            .imports()
+            .next()
+            .ok_or(Error::msg("At least one import is required"))?;
+        linker.func_wrap(
+            host_fn_import.module(),
+            host_fn_import.name().unwrap_or(""),
+            host_fn,
+        )?;
+        linker.instantiate(store, module)
+    }
+}
+
 impl Debug for SmartEngine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SmartModuleEngine")
@@ -128,12 +183,12 @@ impl SmartModuleWithEngine {
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<SmartModuleFilter> {
-        let filter = SmartModuleFilter::new(&self.engine, self, params, version)?;
+        let filter = SmartModuleFilter::new(self, params, version)?;
         Ok(filter)
     }
 
     fn create_map(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleMap> {
-        let map = SmartModuleMap::new(&self.engine, self, params, version)?;
+        let map = SmartModuleMap::new(self, params, version)?;
         Ok(map)
     }
 
@@ -142,7 +197,7 @@ impl SmartModuleWithEngine {
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<SmartModuleFilterMap> {
-        let filter_map = SmartModuleFilterMap::new(&self.engine, self, params, version)?;
+        let filter_map = SmartModuleFilterMap::new(self, params, version)?;
         Ok(filter_map)
     }
 
@@ -151,12 +206,12 @@ impl SmartModuleWithEngine {
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<SmartModuleArrayMap> {
-        let map = SmartModuleArrayMap::new(&self.engine, self, params, version)?;
+        let map = SmartModuleArrayMap::new(self, params, version)?;
         Ok(map)
     }
 
     fn create_join(&self, params: SmartModuleExtraParams, version: i16) -> Result<SmartModuleJoin> {
-        let join = SmartModuleJoin::new(&self.engine, self, params, version)?;
+        let join = SmartModuleJoin::new(self, params, version)?;
         Ok(join)
     }
 
@@ -165,7 +220,7 @@ impl SmartModuleWithEngine {
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<SmartModuleJoinStream> {
-        let join = SmartModuleJoinStream::new(&self.engine, self, params, version)?;
+        let join = SmartModuleJoinStream::new(self, params, version)?;
         Ok(join)
     }
 
@@ -175,14 +230,13 @@ impl SmartModuleWithEngine {
         accumulator: Vec<u8>,
         version: i16,
     ) -> Result<SmartModuleAggregate> {
-        let aggregate =
-            SmartModuleAggregate::new(&self.engine, self, params, accumulator, version)?;
+        let aggregate = SmartModuleAggregate::new(self, params, accumulator, version)?;
         Ok(aggregate)
     }
 }
 
 pub struct SmartModuleContext {
-    store: Store<()>,
+    store: Store<State>,
     instance: Instance,
     records_cb: Arc<RecordsCallBack>,
     params: SmartModuleExtraParams,
@@ -191,30 +245,28 @@ pub struct SmartModuleContext {
 
 impl SmartModuleContext {
     pub fn new(
-        engine: &SmartEngine,
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
     ) -> Result<Self> {
-        let mut store = Store::new(&engine.0, ());
+        let mut store = module.engine.new_store();
         let cb = Arc::new(RecordsCallBack::new());
         let records_cb = cb.clone();
-        let copy_records = Func::wrap(
-            &mut store,
-            move |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
-                debug!(len, "callback from wasm filter");
-                let memory = match caller.get_export("memory") {
-                    Some(Extern::Memory(mem)) => mem,
-                    _ => return Err(Trap::new("failed to find host memory")),
-                };
+        let copy_records_fn = move |mut caller: Caller<'_, State>, ptr: i32, len: i32| {
+            debug!(len, "callback from wasm filter");
+            let memory = match caller.get_export("memory") {
+                Some(Extern::Memory(mem)) => mem,
+                _ => return Err(Trap::new("failed to find host memory")),
+            };
 
-                let records = RecordsMemory { ptr, len, memory };
-                cb.set(records);
-                Ok(())
-            },
-        );
+            let records = RecordsMemory { ptr, len, memory };
+            cb.set(records);
+            Ok(())
+        };
 
-        let instance = Instance::new(&mut store, &module.module, &[copy_records.into()])?;
+        let instance = module
+            .engine
+            .instantiate(&mut store, &module.module, copy_records_fn)?;
         Ok(Self {
             store,
             instance,
@@ -370,7 +422,7 @@ pub struct RecordsMemory {
 }
 
 impl RecordsMemory {
-    fn copy_memory_from(&self, store: &mut Store<()>) -> Result<Vec<u8>> {
+    fn copy_memory_from(&self, store: &mut Store<State>) -> Result<Vec<u8>> {
         let mut bytes = vec![0u8; self.len as u32 as usize];
         self.memory.read(store, self.ptr as usize, &mut bytes)?;
         Ok(bytes)

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -8,7 +8,7 @@ build-cli-minimal: install_rustup_target
 
 
 build-cluster: install_rustup_target
-	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
+	cargo build --bin fluvio-run --features wasi $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
 
 build-test:	install_rustup_target 
 	cargo build --bin fluvio-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -8,7 +8,7 @@ build-cli-minimal: install_rustup_target
 
 
 build-cluster: install_rustup_target
-	cargo build --bin fluvio-run --features wasi $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)
+	cargo build --bin fluvio-run $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG) $(DEBUG_SMARTMODULE_FLAG)
 
 build-test:	install_rustup_target 
 	cargo build --bin fluvio-test $(RELEASE_FLAG) $(TARGET_FLAG) $(VERBOSE_FLAG)

--- a/makefiles/check.mk
+++ b/makefiles/check.mk
@@ -44,4 +44,4 @@ run-client-doc-test: install_rustup_target
 
 
 fluvio_run_bin: install_rustup_target
-	cargo build --bin fluvio-run $(RELEASE_FLAG) --target $(TARGET)
+	cargo build --bin fluvio-run --features wasi $(RELEASE_FLAG) --target $(TARGET)

--- a/makefiles/check.mk
+++ b/makefiles/check.mk
@@ -44,4 +44,4 @@ run-client-doc-test: install_rustup_target
 
 
 fluvio_run_bin: install_rustup_target
-	cargo build --bin fluvio-run --features wasi $(RELEASE_FLAG) --target $(TARGET)
+	cargo build --bin fluvio-run $(RELEASE_FLAG) --target $(TARGET) $(DEBUG_SMARTMODULE_FLAG)


### PR DESCRIPTION
Added `WASI` support to `smartengine` that allows user's code to have access to `stdout` and `stderr` for debug purposes. 
It's guarded by feature `wasi` and disabled by default.
User's code has to be compiled against `wasm32-wasi` target.

Fixes #1874