### PR TITLE
[Merged by Bors] - feat: improve display representation of fluvio_storage::error::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/fluvio-storage/src/error.rs
+++ b/crates/fluvio-storage/src/error.rs
@@ -13,11 +13,11 @@ pub enum StorageError {
 
     #[error(transparent)]
     Io(#[from] IoError),
-    #[error("Offset error")]
+    #[error("Offset error: {0}")]
     Offset(#[from] OffsetError),
-    #[error("Log validation error")]
+    #[error("Log validation error: {0}")]
     LogValidation(#[from] LogValidationError),
-    #[error("Zero-copy send file error")]
+    #[error("Zero-copy send file error: {0}")]
     SendFile(#[from] SendFileError),
     #[error("Batch exceeded maximum bytes: {0}")]
     BatchTooBig(usize),


### PR DESCRIPTION
Currently, a log using this error does not provide enough information:

eg:
```
2022-02-09T16:28:55.185966Z ERROR sc_dispatch_loop{socket=17}:handle_update_replica_request{sc_sink=fd(17)}: fluvio_spu::control_plane::dispatcher: error storage Log validation error
```