### PR TITLE
[Merged by Bors] - disable fluvio update command when using version channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.20 - UNRELEASED
 * Add `connector update -c config` to update the running configuration of a given existing managed connector ([#2188](https://github.com/infinyon/fluvio/pull/2188))
 * Handle large number of produce and consumers ([#2116](https://github.com/infinyon/fluvio/issues/2116))
+* Disable `fluvio update` when using pinned version channel ([#2155](https://github.com/infinyon/fluvio/issues/2155))
 
 ## Platform Version 0.9.19 - 2022-02-10
 * Add WASI support to SmartEngine ([#1874](https://github.com/infinyon/fluvio/issues/1874))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "assert_cmd",
  "cfg-if",
  "color-eyre",
+ "colored",
  "dirs 4.0.0",
  "fluvio-channel",
  "fluvio-cli-common",

--- a/crates/fluvio-channel-cli/Cargo.toml
+++ b/crates/fluvio-channel-cli/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 default = ["fluvio-future", "fluvio-types"]
 
 [dependencies]
+colored = "2"
 color-eyre = { version = "0.5.5", default-features = false }
 structopt = { version = "0.3.16", default-features = false }
 tracing = "0.1.19"

--- a/crates/fluvio-channel-cli/src/bin/main.rs
+++ b/crates/fluvio-channel-cli/src/bin/main.rs
@@ -293,20 +293,17 @@ fn main() -> Result<()> {
         )
     };
 
-    match channel_cli.command {
-        RootCmd::Other(args) => {
-            if args.contains(&"update".to_string())
-                && fluvio_channel::is_pinned_version_channel(channel_name.as_str())
-            {
-                println!(
+    if let RootCmd::Other(args) = channel_cli.command {
+        if args.contains(&"update".to_string())
+            && fluvio_channel::is_pinned_version_channel(channel_name.as_str())
+        {
+            println!(
                     "{}\n{}\n",
                     "Unsupported Feature: The `fluvio update` command is not supported when using a pinned version channel. To use a different version run:".yellow(),
                     "  fluvio version create X.Y.Z\n  fluvio version switch X.Y.Z".italic().yellow()
                 );
-                std::process::exit(1);
-            }
+            std::process::exit(1);
         }
-        _ => (),
     }
 
     // Set env vars

--- a/crates/fluvio-channel-cli/src/bin/main.rs
+++ b/crates/fluvio-channel-cli/src/bin/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::str::FromStr;
 use color_eyre::eyre::{Result, eyre};
+use colored::Colorize;
 use structopt::StructOpt;
 use structopt::clap::AppSettings;
 
@@ -173,7 +174,6 @@ fn main() -> Result<()> {
     // If we're in frontend mode, we want to pass the help text request
 
     let fluvio_channel_root = Root::from_args_safe();
-    //println!("{:#?}", fluvio_channel_root);
 
     let channel_cli = if let Ok(channel_cli) = fluvio_channel_root {
         match channel_cli.command {
@@ -214,42 +214,18 @@ fn main() -> Result<()> {
             args.remove(0);
         }
 
-        //print_help(is_frontend)?;
-        //std::process::exit(0);
         Root {
             command: RootCmd::Other(args),
             ..Default::default()
         }
     };
 
-    // Only if we use `version` subcommand with args
-    // Otherwise pass through to fluvio binary
-
-    // Pick a fluvio binary
-
-    // open a config file
-    // if one doesn't exist, we'll eventually create it before exec
-    // (TODO: Make that location overridable (env var / optional flag))
-    // initialize with stable, latest, dev channels
-    let channel_config_path = FluvioChannelConfig::default_config_location();
-    let _channel = if FluvioChannelConfig::exists(&channel_config_path) {
-        //println!("Config file exists @ {:#?}", &channel_config_path);
-        FluvioChannelConfig::from_file(channel_config_path)?
-    } else {
-        // Default to stable channel behavior
-        FluvioChannelConfig::default()
-    };
-
-    // //
-
     // Check on channel via channel config file
     let (channel_name, channel) = if is_frontend && !&channel_cli.skip_channel_check() {
-        // Look for channel config
-        // TODO: Let this be configurable
+        // TODO: Let this be configurable, make the location overridable (env var / optional flag))
         let channel_config_path = FluvioChannelConfig::default_config_location();
 
         let maybe_channel_config = if FluvioChannelConfig::exists(&channel_config_path) {
-            //println!("Config file exists @ {:#?}", &channel_config_path);
             Some(FluvioChannelConfig::from_file(channel_config_path)?)
         } else {
             // If the channel config doesn't exist, we will create one and initialize with defaults
@@ -316,6 +292,22 @@ fn main() -> Result<()> {
             FluvioChannelInfo::dev_channel(),
         )
     };
+
+    match channel_cli.command {
+        RootCmd::Other(args) => {
+            if args.contains(&"update".to_string())
+                && fluvio_channel::is_pinned_version_channel(channel_name.as_str())
+            {
+                println!(
+                    "{}\n{}\n",
+                    "Unsupported Feature: The `fluvio update` command is not supported when using a pinned version channel. To use a different version run:".yellow(),
+                    "  fluvio version create X.Y.Z\n  fluvio version switch X.Y.Z".italic().yellow()
+                );
+                std::process::exit(1);
+            }
+        }
+        _ => (),
+    }
 
     // Set env vars
     env::set_var(FLUVIO_RELEASE_CHANNEL, channel_name.clone());

--- a/crates/fluvio-channel-cli/tests/pinned_version_channel.rs
+++ b/crates/fluvio-channel-cli/tests/pinned_version_channel.rs
@@ -1,0 +1,31 @@
+#[test]
+fn test_pinned_version_channelissue() {
+    use assert_cmd::prelude::*;
+    use predicates::prelude::*;
+    use std::process::Command;
+
+    // Note: this could be brittle if in the future this version is no longer a resolvable version
+    let pinned_channel = String::from("0.9.18");
+
+    let mut cmd = Command::cargo_bin("fluvio-channel").expect("fluvio-channel binary");
+    // forces it to use the default channel config location because if not it will fall-back to dev channel
+    // TODO: when passing a non-default channel config location is supported then switch to test specific config file
+    // rather than using default channel config
+    cmd.env("FLUVIO_FRONTEND", "true");
+    cmd.arg("version").arg("create").arg(&pinned_channel);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("fluvio-channel").expect("fluvio-channel binary");
+    cmd.env("FLUVIO_FRONTEND", "true");
+    cmd.arg("version").arg("switch").arg(&pinned_channel);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(&pinned_channel));
+
+    let mut cmd = Command::cargo_bin("fluvio-channel").expect("fluvio-channel binary");
+    cmd.env("FLUVIO_FRONTEND", "true");
+    cmd.arg("update");
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("Unsupported Feature"));
+}

--- a/crates/fluvio-channel/src/lib.rs
+++ b/crates/fluvio-channel/src/lib.rs
@@ -380,3 +380,32 @@ pub fn is_fluvio_bin_in_std_dir(fluvio_bin: &Path) -> bool {
     // Verify if fluvio_bin is in the same directory as {home_dir/CLI_CONFIG_PATH}
     fluvio_bin.starts_with(fluvio_home_dir)
 }
+
+/// Determine if provided channel name is a pinned version channel
+pub fn is_pinned_version_channel(channel_name: &str) -> bool {
+    match channel_name {
+        "stable" | "latest" | "dev" => false,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_is_pinned_version_channel() {
+        let test_cases = [
+            ("stable", false),
+            ("latest", false),
+            ("dev", false),
+            ("X.Y.Z", true),
+            ("f.l.u.v.i.o", true),
+        ];
+
+        for case in test_cases {
+            assert_eq!(is_pinned_version_channel(case.0), case.1);
+        }
+    }
+}

--- a/crates/fluvio-channel/src/lib.rs
+++ b/crates/fluvio-channel/src/lib.rs
@@ -383,10 +383,7 @@ pub fn is_fluvio_bin_in_std_dir(fluvio_bin: &Path) -> bool {
 
 /// Determine if provided channel name is a pinned version channel
 pub fn is_pinned_version_channel(channel_name: &str) -> bool {
-    match channel_name {
-        "stable" | "latest" | "dev" => false,
-        _ => true,
-    }
+    !matches!(channel_name, "stable" | "latest" | "dev")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This closes #2155 by checking the channel config to see if the active channel is a pinned version channel. If channel is pinned to a version then `fluvio update` is not supported.
