### PR TITLE
Add error message on 'fluvio connector logs <name>' when request connector is undefined

### DIFF
--- a/crates/fluvio-cli/src/connector/logs.rs
+++ b/crates/fluvio-cli/src/connector/logs.rs
@@ -36,7 +36,9 @@ impl LogsManagedConnectorOpt {
             .stdout;
 
         let pods = String::from_utf8_lossy(&pods);
-        let pod = pods.split(' ').find(|pod| pod.starts_with(&self.name));
+        let pod = pods
+            .split(' ')
+            .find(|pod_name| self.is_matching_connector_name(pod_name));
 
         if let Some(pod) = pod {
             println!();
@@ -53,5 +55,12 @@ impl LogsManagedConnectorOpt {
                 self.name
             )))
         }
+    }
+
+    fn is_matching_connector_name(&self, pod_name: &str) -> bool {
+        const GENERATED_STRING_SIZE: usize = 17;
+
+        let connector_name = &pod_name[..pod_name.len() - GENERATED_STRING_SIZE];
+        connector_name == self.name
     }
 }

--- a/crates/fluvio-cli/src/connector/logs.rs
+++ b/crates/fluvio-cli/src/connector/logs.rs
@@ -46,7 +46,12 @@ impl LogsManagedConnectorOpt {
                 vec!["logs", pod]
             };
             Command::new("kubectl").args(args).spawn()?.wait()?;
+            Ok(())
+        } else {
+            Err(CliError::InvalidArg(format!(
+                "Connector {} does not exist",
+                self.name
+            )))
         }
-        Ok(())
     }
 }

--- a/crates/fluvio-cli/src/connector/logs.rs
+++ b/crates/fluvio-cli/src/connector/logs.rs
@@ -25,9 +25,16 @@ pub struct LogsManagedConnectorOpt {
 impl LogsManagedConnectorOpt {
     pub async fn process(self) -> Result<(), CliError> {
         let pods = Command::new("kubectl")
-            .args(["get", "pods", "-o=jsonpath='{.items[*].metadata.name}"])
+            .args([
+                "get",
+                "pods",
+                "--selector",
+                "app=fluvio-connector",
+                "-o=jsonpath={.items[*].metadata.name}",
+            ])
             .output()?
             .stdout;
+
         let pods = String::from_utf8_lossy(&pods);
         let pod = pods.split(' ').find(|pod| pod.starts_with(&self.name));
 


### PR DESCRIPTION
- An error message was missing when requesting logs from an undefined connector.

```bash
$ fluvio connector logs test-undefined
Error: 
   0: Invalid argument: Connector test-undefined does not exist
```
- Fix bug where we could see logs of all pods not only connectors
- Fix bug where we could match with the wrong pod

Fixes #2161 