### PR TITLE
[Merged by Bors] - docs: clarify that `send()` does not `flush()` automatically in producer documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -96,7 +96,10 @@ pub mod config;
 use tracing::instrument;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
-pub use producer::{TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, RecordKey};
+pub use producer::{
+    TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, RecordKey, ProduceOutput,
+    FutureRecordMetadata, RecordMetadata,
+};
 
 pub use consumer::{
     PartitionConsumer, ConsumerConfig, MultiplePartitionConsumer, PartitionSelectionStrategy,

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -37,7 +37,7 @@ pub use self::error::ProducerError;
 use self::event::EventHandler;
 pub use self::output::ProduceOutput;
 use self::partition_producer::PartitionProducer;
-pub use self::record::FutureRecordMetadata;
+pub use self::record::{FutureRecordMetadata, RecordMetadata};
 
 use crate::error::Result;
 
@@ -309,6 +309,17 @@ impl TopicProducer {
         })
     }
 
+    /// Send all the queued records in the producer batches.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fluvio::{TopicProducer, FluvioError};
+    /// # async fn example(producer: &TopicProducer) -> Result<(), FluvioError> {
+    /// producer.send("Key", "Value").await?;
+    /// producer.flush().await?;
+    /// # Ok(())
+    /// # }
     pub async fn flush(&self) -> Result<(), FluvioError> {
         self.inner.flush().await
     }
@@ -316,6 +327,10 @@ impl TopicProducer {
     /// Sends a key/value record to this producer's Topic.
     ///
     /// The partition that the record will be sent to is derived from the Key.
+    ///
+    ///  Depending on the producer configuration, a `send` call will not send immediately
+    ///  the record to the SPU. Instead, it could add the record to a batch.
+    ///  `TopicProducer::flush` is used to immediately send all the queued records in the producer batches.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Fixes #2191