### PR TITLE
[Merged by Bors] - feat(connector): deprecate meta flag create_topic

### DIFF
--- a/crates/fluvio-cli/src/connector/create.rs
+++ b/crates/fluvio-cli/src/connector/create.rs
@@ -51,7 +51,7 @@ impl CreateManagedConnectorOpt {
                 Ok(())
             }
             Ok(_) => Ok(()),
-                Err(e) => Err(e),
+            Err(e) => Err(e),
         }?;
 
         admin.create(name.to_string(), false, spec).await?;

--- a/crates/fluvio-cli/src/connector/create.rs
+++ b/crates/fluvio-cli/src/connector/create.rs
@@ -39,21 +39,21 @@ impl CreateManagedConnectorOpt {
         debug!("creating managed_connector: {}, spec: {:#?}", name, spec);
 
         let admin = fluvio.admin().await;
-        if config.create_topic {
-            let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
-            debug!("topic spec: {:?}", replica_spec);
-            match admin
-                .create::<TopicSpec>(config.topic, false, replica_spec.into())
-                .await
-            {
-                Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
-                    //println!("Topic already exists");
-                    Ok(())
-                }
-                Ok(_) => Ok(()),
+
+        let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
+        debug!("topic spec: {:?}", replica_spec);
+        match admin
+            .create::<TopicSpec>(config.topic, false, replica_spec.into())
+            .await
+        {
+            Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
+                //println!("Topic already exists");
+                Ok(())
+            }
+            Ok(_) => Ok(()),
                 Err(e) => Err(e),
-            }?;
-        }
+        }?;
+
         admin.create(name.to_string(), false, spec).await?;
 
         Ok(())

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -94,8 +94,6 @@ pub struct ConnectorConfig {
     pub(crate) topic: String,
     pub(crate) version: Option<String>,
     #[serde(default)]
-    pub(crate) create_topic: bool,
-    #[serde(default)]
     parameters: BTreeMap<String, String>,
     #[serde(default)]
     secrets: BTreeMap<String, SecretString>,

--- a/crates/fluvio-cli/src/connector/update.rs
+++ b/crates/fluvio-cli/src/connector/update.rs
@@ -64,9 +64,7 @@ impl UpdateManagedConnectorOpt {
             .create::<TopicSpec>(config.topic, false, replica_spec.into())
             .await
         {
-            Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
-                Ok(())
-            }
+            Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => Ok(()),
             Ok(_) => {
                 debug!("UpdateManagedConnectorOpt - Created a new topic.");
                 Ok(())

--- a/crates/fluvio-cli/src/connector/update.rs
+++ b/crates/fluvio-cli/src/connector/update.rs
@@ -55,26 +55,24 @@ impl UpdateManagedConnectorOpt {
 
         debug!(?existing_config, "Found connector");
 
-        // create_topic will succeed even if the topic already exists. PR: 1823
+        // topic already exists. original decision PR: 1823
         // A New Topic might have been defined - We will not delete the old one.
-        if config.create_topic {
-            // Check if the topic already exists by trying to create it
-            let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
-            debug!(?replica_spec, "UpdateManagedConnectorOpt topic spec");
-            match admin
-                .create::<TopicSpec>(config.topic, false, replica_spec.into())
-                .await
-            {
-                Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
-                    Ok(())
-                }
-                Ok(_) => {
-                    debug!("UpdateManagedConnectorOpt - Created a new topic.");
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }?;
-        }
+        // Check if the topic already exists by trying to create it
+        let replica_spec = ReplicaSpec::Computed(TopicReplicaParam::new(1, 1, false));
+        debug!(?replica_spec, "UpdateManagedConnectorOpt topic spec");
+        match admin
+            .create::<TopicSpec>(config.topic, false, replica_spec.into())
+            .await
+        {
+            Err(FluvioError::AdminApi(ApiError::Code(ErrorCode::TopicAlreadyExists, _))) => {
+                Ok(())
+            }
+            Ok(_) => {
+                debug!("UpdateManagedConnectorOpt - Created a new topic.");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }?;
 
         admin
             .delete::<ManagedConnectorSpec, _>(&config.name)


### PR DESCRIPTION
Closes #2200
- Deprecate a redundant flag since the topic needs to exist for connectors and it can be safely checked that it exists with create #1823 
