### PR TITLE
[Merged by Bors] - make store timeout configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ env:
   TLS_ARGS: --tls --domain fluvio.local --server-key ./tls/certs/server.key --server-cert ./tls/certs/server.crt --ca-cert ./tls/certs/ca.crt --client-cert ./tls/certs/client-root.crt --client-key ./tls/certs/client-root.key
   AUTH_FILE: crates/fluvio-sc/test-data/auth_config/policy.json
   X509_SCOPE_FILE: crates/fluvio-sc/test-data/auth_config/scopes.json
+  MAX_PROVISION_TIME_SEC: 600
 
 jobs:
   # this job set up dynamic configuration shared among jobs
@@ -492,15 +493,11 @@ jobs:
           ./k8-util/cluster/reset-k3d.sh
       - name: Start fluvio cluster
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         if: matrix.test != 'smoke-test-tls'
         run: fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
       - name: Start fluvio cluster TLS
         if: matrix.test == 'smoke-test-tls'
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         # note that Local config doesn't not support auth and scopes in the argument for now
         run: >
           AUTH_POLICY=${{ env.AUTH_FILE }}
@@ -682,21 +679,15 @@ jobs:
       - name: Start fluvio cluster
         if: matrix.test == 'smoke-test-k8'
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         run: |
           fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
       - name: Start fluvio cluster TLS
         timeout-minutes: 10
-        env:
-            FLV_DISPATCHER_WAIT: 600
         if: matrix.test == 'smoke-test-k8-tls'
         run: |
           fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}
       - name: Start fluvio cluster TLS with root
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         if: matrix.test == 'smoke-test-k8-tls-root-unclean'
         run: |
           make smoke-test-k8-tls-policy-setup
@@ -766,7 +757,6 @@ jobs:
         timeout-minutes: 5
         env:
           TEST_DATA_BYTES: 10000
-          FLV_DISPATCHER_WAIT: 300
         run: |
           date
           k3d image import -k /tmp/infinyon-fluvio.tar -c fluvio
@@ -809,8 +799,6 @@ jobs:
           ./k8-util/cluster/reset-k3d.sh
       - name: Install stable CLI and start Fluvio cluster
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
           ~/.fluvio/bin/fluvio cluster start
@@ -890,8 +878,6 @@ jobs:
           echo "~/bin" >> $GITHUB_PATH
       - name: Start cluster
         timeout-minutes: 10
-        env:
-          FLV_DISPATCHER_WAIT: 600
         run: fluvio cluster start --develop
       - name: Run CLI smoke tests
         timeout-minutes: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.21 - UNRELEASED
+* Make store time out configurable ([#2116](https://github.com/infinyon/fluvio/issues/2212))
 
 ## Platform Version 0.9.20 - 2022-02-10
 * Add `connector update -c config` to update the running configuration of a given existing managed connector ([#2188](https://github.com/infinyon/fluvio/pull/2188))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-channel",
  "async-rwlock",

--- a/crates/fluvio-cluster/src/start/mod.rs
+++ b/crates/fluvio-cluster/src/start/mod.rs
@@ -8,9 +8,9 @@ mod constants {
 
     use once_cell::sync::Lazy;
 
-    /// maximum time waiting for network check, DNS or network
-    pub static MAX_SC_NETWORK_LOOP: Lazy<u16> = Lazy::new(|| {
-        let var_value = env::var("FLV_CLUSTER_MAX_SC_NETWORK_LOOP").unwrap_or_default();
+    /// maximum time waiting for SC and SPU to provision
+    pub static MAX_PROVISION_TIME_SEC: Lazy<u16> = Lazy::new(|| {
+        let var_value = env::var("FLV_CLUSTER_PROVISION_TIMEOUT").unwrap_or_default();
         var_value.parse().unwrap_or(300)
     });
 }

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2021"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-stream-dispatcher/src/store/mod.rs
+++ b/crates/fluvio-stream-dispatcher/src/store/mod.rs
@@ -49,6 +49,7 @@ mod context {
         store: Arc<LocalStore<S, MetaContext>>,
         sender: Sender<WSAction<S, MetaContext>>,
         receiver: Receiver<WSAction<S, MetaContext>>,
+        wait_time: u64,
     }
 
     impl<S, MetaContext> StoreContext<S, MetaContext>
@@ -68,7 +69,13 @@ mod context {
                 store,
                 sender,
                 receiver,
+                wait_time: *MAX_WAIT_TIME,
             }
+        }
+
+        /// set wait time out in seconds
+        pub fn set_wait_time(&mut self, wait_time: u64) {
+            self.wait_time = wait_time;
         }
 
         pub async fn send(
@@ -171,7 +178,7 @@ mod context {
                 Ok(_) => {
                     // wait for object created in the store
 
-                    let mut timer = sleep(Duration::from_secs(*MAX_WAIT_TIME));
+                    let mut timer = sleep(Duration::from_secs(self.wait_time));
                     let mut spec_listener = self.change_listener();
                     loop {
                         // check if we can find old object


### PR DESCRIPTION
resolves #2212

* instead of loop, specify timeout for cluster provision
* allow store time out to be configurable
* specify global provisional timeout for CI