### PR TITLE
[Merged by Bors] - Fix panic in 'fluvio connector logs'

### DIFF
--- a/crates/fluvio-cli/src/connector/logs.rs
+++ b/crates/fluvio-cli/src/connector/logs.rs
@@ -36,9 +36,11 @@ impl LogsManagedConnectorOpt {
             .stdout;
 
         let pods = String::from_utf8_lossy(&pods);
-        let pod = pods
-            .split(' ')
-            .find(|pod_name| self.is_matching_connector_name(pod_name));
+        let pod = if !pods.is_empty() {
+            pods.split(' ').find(|pod_name| self.is_matching_connector_name(pod_name))
+        } else {
+            None
+        };
 
         if let Some(pod) = pod {
             println!();
@@ -60,7 +62,7 @@ impl LogsManagedConnectorOpt {
     fn is_matching_connector_name(&self, pod_name: &str) -> bool {
         const GENERATED_STRING_SIZE: usize = 17;
 
-        let connector_name = &pod_name[..pod_name.len() - GENERATED_STRING_SIZE];
+        let connector_name = &pod_name[..pod_name.len() - pod_name.len().min(GENERATED_STRING_SIZE)];
         connector_name == self.name
     }
 }

--- a/crates/fluvio-cli/src/connector/logs.rs
+++ b/crates/fluvio-cli/src/connector/logs.rs
@@ -37,7 +37,8 @@ impl LogsManagedConnectorOpt {
 
         let pods = String::from_utf8_lossy(&pods);
         let pod = if !pods.is_empty() {
-            pods.split(' ').find(|pod_name| self.is_matching_connector_name(pod_name))
+            pods.split(' ')
+                .find(|pod_name| self.is_matching_connector_name(pod_name))
         } else {
             None
         };
@@ -62,7 +63,8 @@ impl LogsManagedConnectorOpt {
     fn is_matching_connector_name(&self, pod_name: &str) -> bool {
         const GENERATED_STRING_SIZE: usize = 17;
 
-        let connector_name = &pod_name[..pod_name.len() - pod_name.len().min(GENERATED_STRING_SIZE)];
+        let connector_name =
+            &pod_name[..pod_name.len() - pod_name.len().min(GENERATED_STRING_SIZE)];
         connector_name == self.name
     }
 }


### PR DESCRIPTION
If cluster has no installed connectors, `fluvio connector logs <name>` will panic on line 63 with:

* Attempt to subtract with overflow in debug build, i.e. `0usize - 17usize` = overflow panic.
* Byte index 18446744073709551599 is out of bounds of '' in release build, i.e. overflow check is skipped, but slice boundaries check is still there.
 
This happens because `pod_name` will contain an empty string in case of missing connectors. So, this PR:

* Makes `is_matching_connector_name` safe to work with any input string.
* Skips search if `kubectl` returned empty string to begin with.