### PR TITLE
[Merged by Bors] - Generic storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes",
  "flate2",

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -27,7 +27,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.3.1", path = "../fluvio-types" }
 fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.6.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 base64 = "0.13.0"
 
 [dev-dependencies]

--- a/crates/fluvio-controlplane-metadata/src/partition/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/partition/status.rs
@@ -55,6 +55,7 @@ impl Default for PartitionStatus {
     }
 }
 
+#[cfg(feature = "use_serde")]
 const fn default_partition_status_size() -> i64 {
     PartitionStatus::SIZE_NOT_SUPPORTED
 }

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/crates/fluvio-dataplane-protocol/src/fetch/response.rs
+++ b/crates/fluvio-dataplane-protocol/src/fetch/response.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
+use crate::batch::BatchRecords;
 use crate::core::Decoder;
 use crate::core::Encoder;
 use crate::derive::FluvioDefault;
@@ -91,7 +92,7 @@ where
     pub records: R,
 }
 
-impl FetchablePartitionResponse<RecordSet> {
+impl<R: BatchRecords> FetchablePartitionResponse<RecordSet<R>> {
     /// offset that will be use for fetching rest of offsets
     /// this will be 1 greater than last offset of previous query
     /// If all records have been read then it will be either HW or LEO

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -26,7 +26,7 @@ paste = "1.0"
 fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
 fluvio-controlplane-metadata = { version = "0.14.0", default-features = false, path = "../fluvio-controlplane-metadata" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -28,7 +28,7 @@ fluvio-future = { version = "0.3.13", features = [
     "openssl_tls",
     "zero_copy",
 ] }
-dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.14.0", optional = true }

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -15,7 +15,7 @@ crate-type = ['lib']
 
 [dependencies]
 eyre = { version = "0.6", default-features = false }
-fluvio-dataplane-protocol = { version = "0.9.0", path = "../fluvio-dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.10.0", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 
 [dev-dependencies]

--- a/crates/fluvio-smartmodule/examples/Cargo.lock
+++ b/crates/fluvio-smartmodule/examples/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,15 +71,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,20 +87,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -147,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.7.1"
+version = "0.7.4"
 dependencies = [
  "bytes",
  "fluvio-protocol-derive",
@@ -156,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -166,12 +139,11 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
  "fluvio-smartmodule-derive",
- "fluvio-spu-schema",
 ]
 
 [[package]]
@@ -181,30 +153,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "fluvio-spu-schema"
-version = "0.9.1"
-dependencies = [
- "bytes",
- "flate2",
- "fluvio-dataplane-protocol",
- "fluvio-protocol",
- "fluvio-types",
- "log",
- "serde",
- "static_assertions",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-types"
-version = "0.3.1"
-dependencies = [
- "thiserror",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -579,16 +527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,26 +574,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -866,12 +784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,16 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
@@ -24,4 +24,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.9", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.10", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -687,6 +687,7 @@ mod test_leader {
     use fluvio_controlplane_metadata::partition::{ReplicaKey, Replica};
     use fluvio_storage::{ReplicaStorage, ReplicaStorageConfig, OffsetInfo, ReplicaSlice};
     use dataplane::{Offset, ErrorCode};
+    use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
     use crate::{
@@ -748,9 +749,9 @@ mod test_leader {
         }
 
         // do dummy implementations of write
-        async fn write_recordset(
+        async fn write_recordset<R: BatchRecords>(
             &mut self,
-            records: &mut dataplane::record::RecordSet,
+            records: &mut dataplane::record::RecordSet<R>,
             update_highwatermark: bool,
         ) -> Result<(), fluvio_storage::StorageError> {
             self.pos.leo = records.last_offset().unwrap();

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -144,7 +144,7 @@ async fn test_stream_fetch_basic() {
             let partition = &response.partition;
             assert_eq!(partition.error_code, ErrorCode::None);
             assert_eq!(partition.high_watermark, 2);
-            assert_eq!(partition.next_offset_for_fetch(), Some(2)); // shoule be same as HW
+            assert_eq!(partition.next_offset_for_fetch(), Some(2)); // should be same as HW
 
             assert_eq!(partition.records.batches.len(), 1);
             let batch = &partition.records.batches[0];

--- a/crates/fluvio-storage/src/lib.rs
+++ b/crates/fluvio-storage/src/lib.rs
@@ -28,6 +28,7 @@ mod inner {
 
     use async_trait::async_trait;
 
+    use dataplane::batch::BatchRecords;
     use dataplane::{ErrorCode, Isolation, Offset, ReplicaKey};
     use dataplane::record::RecordSet;
     use fluvio_controlplane_metadata::partition::Replica;
@@ -181,9 +182,9 @@ mod inner {
         async fn get_partition_size(&self) -> Result<u64, ErrorCode>;
 
         /// write record set
-        async fn write_recordset(
+        async fn write_recordset<R: BatchRecords>(
             &mut self,
-            records: &mut RecordSet,
+            records: &mut RecordSet<R>,
             update_highwatermark: bool,
         ) -> Result<(), StorageError>;
 

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -9,6 +9,7 @@ use std::time::{Instant};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
+use dataplane::batch::BatchRecords;
 use fluvio_future::fs::File;
 use tracing::instrument;
 use tracing::{debug, trace};
@@ -124,7 +125,10 @@ impl MutFileRecords {
     /// try to write batch
     /// if there is enough room, return true, false otherwise
     #[instrument(skip(self,batch),fields(pos=self.get_pos()))]
-    pub async fn write_batch(&mut self, batch: &Batch) -> Result<(bool, usize, u32), StorageError> {
+    pub async fn write_batch<R: BatchRecords>(
+        &mut self,
+        batch: &Batch<R>,
+    ) -> Result<(bool, usize, u32), StorageError> {
         trace!("start sending using batch {:#?}", batch.get_header());
         if batch.base_offset < self.base_offset {
             return Err(StorageError::LogValidation(LogValidationError::BaseOff));

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -55,7 +55,7 @@ fluvio-types = { version = "0.3.0", features = [
 fluvio-sc-schema = { version = "0.12.1", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.9.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"


### PR DESCRIPTION
Use generic `RecordSet<R: BatchRecords>` instead of `RecordSet<MemoryRecords>`.

This is a step towards remove the linking to `MemoryRecords` in storage in order to support compression.