### PR TITLE
[Merged by Bors] - fix(cli): #2207 connector delete error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for partial CA Intermediate Trust Anchors ([#2232](https://github.com/infinyon/fluvio/pull/2232))
 * Fix Installer problem with self-signed certs ([#2216](https://github.com/infinyon/fluvio/issues/2216))
 * Report SPU error codes to FutureRecordMetadata ([#2228](https://github.com/infinyon/fluvio/issues/2228))
+* Fix Connector delete error message ([#2207](https://github.com/infinyon/fluvio/issues/2207))
 
 ## Platform Version 0.9.20 - 2022-02-10
 * Add `connector update -c config` to update the running configuration of a given existing managed connector ([#2188](https://github.com/infinyon/fluvio/pull/2188))

--- a/crates/fluvio-cli/src/connector/delete.rs
+++ b/crates/fluvio-cli/src/connector/delete.rs
@@ -36,7 +36,8 @@ impl DeleteManagedConnectorOpt {
                 FluvioError::AdminApi(ApiError::Code(ErrorCode::ManagedConnectorNotFound, _)) => {
                     CliError::InvalidConnector(format!("{} not found", &self.name))
                 }
-                _ => CliError::Other(format!("{:?}", e)),
+                // Raise a bug for any Unhandled error.
+                _ => CliError::Unhandled(format!("{:?}", e)),
             })?;
 
         Ok(())

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -71,6 +71,8 @@ pub enum CliError {
     InvalidArg(String),
     #[error("Unknown error: {0}")]
     Other(String),
+    #[error("BUG! Report me - Unhandled error: {0}")]
+    Unhandled(String),
     #[error("Unexpected Infallible error")]
     Infallible(#[from] Infallible),
     #[error("Dataplane error: {0}")]


### PR DESCRIPTION
Fixes #2207
Proposes a precedent for #2240

By default CLIError::Unhandled intent is a "I'm a BUG - I should be fixed" in a predictable easily automation-parseable form -

All CLI is mapped out in contextual presentable form whilst library will still do #[from]

Any Unhandled errors can be quickly fixed by identifying straight from the report which one needs to be matched instead of go with status quo bad presentation. e.g. if CI screams suddenly 100 unhandled errors they can be mapped much faster.

This way when someone adds CLI test cases for any negative tests they can identify all errors that need proper user visible contextual presentation vs library presentation.

e.g. when this would be now Unhandled - 
```
$ ./target/debug/fluvio connector delete foobar
Error: 
   0: BUG! Report me - Unhandled error: AdminApi(Code(ManagedConnectorNotFound, Some("not found")))
```

But as a mapped error now for connector not found:
```
$ ./target/debug/fluvio connector delete fffd
Error:
   0: Invalid connector: fffd not found
```
