### PR TITLE
[Merged by Bors] - add compression support to fluvio produce cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -830,13 +830,10 @@ jobs:
     needs: build_image
     #if: ${{ false }}
     runs-on: ${{ matrix.os }}
-    env:
-      FLV_CLIENT_DEFAULT_COMPRESSION_CODEC: ${{ matrix.compression }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        compression: [none, gzip, snappy, lz4]
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.rust }}

--- a/tests/cli/smoke_tests/e2e-basic.bats
+++ b/tests/cli/smoke_tests/e2e-basic.bats
@@ -21,6 +21,18 @@ setup_file() {
     export TOPIC_NAME_3
     debug_msg "Topic name: $TOPIC_NAME_3"
 
+    TOPIC_NAME_4=$(random_string)
+    export TOPIC_NAME_4
+    debug_msg "Topic name: $TOPIC_NAME_4"
+
+    TOPIC_NAME_5=$(random_string)
+    export TOPIC_NAME_5
+    debug_msg "Topic name: $TOPIC_NAME_5"
+
+    TOPIC_NAME_6=$(random_string)
+    export TOPIC_NAME_6
+    debug_msg "Topic name: $TOPIC_NAME_6"
+
     MESSAGE="$(random_string 7)"
     export MESSAGE
     debug_msg "$MESSAGE"
@@ -30,6 +42,15 @@ setup_file() {
 
     MULTILINE_MESSAGE="$MESSAGE\n$MESSAGE_W_HTML_STR"
     export MULTILINE_MESSAGE
+
+    GZIP_MESSAGE="$MESSAGE-GZIP"
+    export GZIP_MESSAGE
+
+    SNAPPY_MESSAGE="$MESSAGE-SNAPPY"
+    export SNAPPY_MESSAGE
+
+    LZ4_MESSAGE="$MESSAGE-LZ4"
+    export LZ4_MESSAGE
 }
 
 teardown_file() {
@@ -45,6 +66,12 @@ teardown_file() {
     assert_success
     run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_3"
     assert_success
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_4"
+    assert_success
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_5"
+    assert_success
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_6"
+    assert_success
 }
 
 # Produce message 
@@ -52,6 +79,9 @@ teardown_file() {
     run bash -c 'echo "$MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
     run bash -c 'echo "$MESSAGE_W_HTML_STR" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_2"'
     run bash -c 'echo -e "$MULTILINE_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_3"'
+    run bash -c 'echo -e "$GZIP_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_4" --compression gzip'
+    run bash -c 'echo -e "$SNAPPY_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_5" --compression snappy'
+    run bash -c 'echo -e "$LZ4_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_6" --compression lz4'
     assert_success
 }
 
@@ -78,3 +108,25 @@ teardown_file() {
     assert_output "$MESSAGE_W_HTML_STR"
     assert_success
 }
+
+@test "Consume gzip message" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_4" -B -d
+
+    assert_output --partial "$GZIP_MESSAGE"
+    assert_success
+}
+
+@test "Consume snappy message" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_5" -B -d
+
+    assert_output --partial "$SNAPPY_MESSAGE"
+    assert_success
+}
+
+@test "Consume lz4 message" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_6" -B -d
+
+    assert_output --partial "$LZ4_MESSAGE"
+    assert_success
+}
+

--- a/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
+++ b/tests/cli/smoke_tests/e2e-smartmodule-basic.bats
@@ -73,7 +73,7 @@ setup_file() {
 
     TEST_MESSAGE="$(random_string 10)aaa"
     export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME" --compression gzip'
     assert_success
 
     # Consume from topic and verify we should have 2 entries
@@ -179,7 +179,7 @@ setup_file() {
 
     TEST_MESSAGE="100"
     export TEST_MESSAGE
-    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME" --compression snappy'
     assert_success
 
     # Consume from topic and verify we should have 2 entries
@@ -226,7 +226,7 @@ setup_file() {
     export SECOND_MESSAGE
     THIRD_MESSAGE='"Cranberry"'
     export THIRD_MESSAGE
-    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
+    run bash -c 'echo "$FULL_TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME" --compression lz4'
     assert_success
 
     # Consume from topic and verify we should have the json message


### PR DESCRIPTION
Closes #2245

adds a `--compression` flag to `fluvio produce` command. Supported values are `none`, `gzip`, `snap` and `lz4`