### PR TITLE
[Merged by Bors] - Change default max_bytes in consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use `Clap` instead of `StructOpt` for all CLI ([#2166](https://github.com/infinyon/fluvio/issues/2166))
 * Re-enable ZSH completions ([#2283](https://github.com/infinyon/fluvio/issues/2283))
 * Disable versions from displaying in CLI subcommands ([#1805](https://github.com/infinyon/fluvio/issues/1805))
+* Increase default `MAX_FETCH_BYTES` in fluvio client ([#2259](https://github.com/infinyon/fluvio/issues/2259))
 
 ## Platform Version 0.9.22 - 2022-03-25
 * Add topic level compression configuration ([#2249](https://github.com/infinyon/fluvio/issues/2249))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-sc-schema",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -1630,7 +1630,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1828,7 +1828,7 @@ version = "0.0.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-types",
  "log",
  "tracing",
@@ -1842,7 +1842,7 @@ dependencies = [
  "base64",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1864,7 +1864,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-socket",
  "flv-util",
  "futures-util",
@@ -1956,9 +1956,20 @@ version = "0.7.4"
 dependencies = [
  "bytes",
  "fluvio-future",
- "fluvio-protocol-derive",
+ "fluvio-protocol-derive 0.4.1",
  "futures",
  "tokio-util 0.7.1",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6880961c231604fd52fac7800c7c4c18c2c49b0ec0a614cd1cf806efb4c61e9"
+dependencies = [
+ "bytes",
+ "fluvio-protocol-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -1966,12 +1977,24 @@ dependencies = [
 name = "fluvio-protocol-derive"
 version = "0.4.1"
 dependencies = [
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "proc-macro2",
  "quote",
  "syn",
  "tracing",
  "trybuild",
+]
+
+[[package]]
+name = "fluvio-protocol-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2b322665711776c5edbe78187389f72e5cf183598a1bfc59723cab97156659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
 ]
 
 [[package]]
@@ -2006,7 +2029,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -2039,7 +2062,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-types",
  "log",
  "paste",
@@ -2055,7 +2078,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-socket",
  "fluvio-types",
  "futures-util",
@@ -2113,7 +2136,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -2147,7 +2170,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-service",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -2177,7 +2200,7 @@ dependencies = [
  "bytes",
  "flate2",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "log",
  "serde",
  "static_assertions",
@@ -2198,7 +2221,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.4",
  "fluvio-socket",
  "fluvio-storage",
  "fluvio-types",
@@ -2266,6 +2289,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
+ "fluvio-protocol 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",
@@ -2355,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "event-listener",
  "fluvio-future",

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -49,3 +49,4 @@ dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane
 # Fluvio test framework Attribute macro
 fluvio-test-derive = { path = "../fluvio-test-derive" }
 fluvio-test-util = { path = "../fluvio-test-util" }
+fluvio-protocol = "0.7.4"

--- a/crates/fluvio-test/src/tests/batching/mod.rs
+++ b/crates/fluvio-test/src/tests/batching/mod.rs
@@ -5,6 +5,11 @@ use futures_lite::StreamExt;
 use tracing::debug;
 
 use fluvio::{Offset, TopicProducer, TopicProducerConfigBuilder, FluvioAdmin};
+use fluvio::dataplane::batch::Batch;
+use fluvio::dataplane::batch::RawRecords;
+
+use dataplane::core::Encoder;
+
 use fluvio_controlplane_metadata::partition::PartitionSpec;
 use clap::Parser;
 
@@ -117,7 +122,7 @@ pub async fn batching(
 
         let config = TopicProducerConfigBuilder::default()
             .linger(Duration::from_millis(600000))
-            .batch_size(17)
+            .batch_size(17 + Batch::<RawRecords>::default().write_size(0))
             .build()
             .expect("failed to build config");
 

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -1,5 +1,8 @@
 pub const PRODUCT_NAME: &str = "fluvio";
 
+// Fluvio
+pub const FLUVIO_MAX_SIZE_TOPIC_NAME: u8 = 255;
+
 // SPU/SC Server Path
 pub const SERVER_CONFIG_BASE_PATH: &str = "/etc";
 pub const SERVER_CONFIG_DIR: &str = "fluvio";

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -49,7 +49,7 @@ fluvio-future = { version = "0.3.12", features = [
     "openssl_tls",
     "task_unstable",
 ] }
-fluvio-types = { version = "0.3.0", features = [
+fluvio-types = { version = "0.3.3", features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-features = false }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -576,10 +576,19 @@ mod publish_stream {
 /// MAX FETCH BYTES
 static MAX_FETCH_BYTES: Lazy<i32> = Lazy::new(|| {
     use std::env;
+    use fluvio_protocol::Encoder;
+    use crate::dataplane::fetch::FetchResponse;
+    use crate::dataplane::fetch::FetchableTopicResponse;
+    use crate::dataplane::fetch::FetchablePartitionResponse;
+    use crate::dataplane::batch::MemoryRecords;
     let var_value = env::var("FLV_CLIENT_MAX_FETCH_BYTES").unwrap_or_default();
-    let max_bytes: i32 = var_value
-        .parse()
-        .unwrap_or_else(|_| STORAGE_MAX_BATCH_SIZE.try_into().unwrap_or(1048588));
+    let max_bytes: i32 = var_value.parse().unwrap_or_else(|_| {
+        FetchResponse::<MemoryRecords>::default().write_size(0) as i32
+            + FetchableTopicResponse::<MemoryRecords>::default().write_size(0) as i32
+            + FetchablePartitionResponse::<MemoryRecords>::default().write_size(0) as i32
+            + 64 // using max size of topic name
+            + STORAGE_MAX_BATCH_SIZE.try_into().unwrap_or(1048588)
+    });
     max_bytes
 });
 

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -7,6 +7,7 @@ use futures_util::future::{Either, err, join_all};
 use futures_util::stream::{StreamExt, once, iter};
 use futures_util::FutureExt;
 
+use fluvio_types::defaults::STORAGE_MAX_BATCH_SIZE;
 use fluvio_spu_schema::server::stream_fetch::{
     DefaultStreamFetchRequest, DefaultStreamFetchResponse, GZIP_WASM_API, SMART_MODULE_API,
     LegacySmartModulePayload, SmartModuleWasmCompressed, WASM_MODULE_API, WASM_MODULE_V2_API,
@@ -576,7 +577,9 @@ mod publish_stream {
 static MAX_FETCH_BYTES: Lazy<i32> = Lazy::new(|| {
     use std::env;
     let var_value = env::var("FLV_CLIENT_MAX_FETCH_BYTES").unwrap_or_default();
-    let max_bytes: i32 = var_value.parse().unwrap_or(1000000);
+    let max_bytes: i32 = var_value
+        .parse()
+        .unwrap_or_else(|_| STORAGE_MAX_BATCH_SIZE.try_into().unwrap_or(1048588));
     max_bytes
 });
 

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -7,7 +7,7 @@ use futures_util::future::{Either, err, join_all};
 use futures_util::stream::{StreamExt, once, iter};
 use futures_util::FutureExt;
 
-use fluvio_types::defaults::STORAGE_MAX_BATCH_SIZE;
+use fluvio_types::defaults::{STORAGE_MAX_BATCH_SIZE, FLUVIO_MAX_SIZE_TOPIC_NAME};
 use fluvio_spu_schema::server::stream_fetch::{
     DefaultStreamFetchRequest, DefaultStreamFetchResponse, GZIP_WASM_API, SMART_MODULE_API,
     LegacySmartModulePayload, SmartModuleWasmCompressed, WASM_MODULE_API, WASM_MODULE_V2_API,
@@ -586,7 +586,7 @@ static MAX_FETCH_BYTES: Lazy<i32> = Lazy::new(|| {
         FetchResponse::<MemoryRecords>::default().write_size(0) as i32
             + FetchableTopicResponse::<MemoryRecords>::default().write_size(0) as i32
             + FetchablePartitionResponse::<MemoryRecords>::default().write_size(0) as i32
-            + 64 // using max size of topic name
+            + FLUVIO_MAX_SIZE_TOPIC_NAME as i32 // using max size of topic name
             + STORAGE_MAX_BATCH_SIZE.try_into().unwrap_or(1048588)
     });
     max_bytes

--- a/tests/cli/smoke_tests/consume-batch-size.bats
+++ b/tests/cli/smoke_tests/consume-batch-size.bats
@@ -27,7 +27,7 @@ teardown_file() {
 
 @test "Produce message with batch large" {
     run bash -c "yes abc |head -c 1500000 > $TOPIC_NAME.txt"
-    run bash -c 'timeout 25s "$FLUVIO_BIN" produce "$TOPIC_NAME" --batch-size 1048588 --file $TOPIC_NAME.txt --linger 5s'
+    run bash -c 'timeout 50s "$FLUVIO_BIN" produce "$TOPIC_NAME" --batch-size 1048588 --file $TOPIC_NAME.txt --linger 5s'
     assert_success
 }
 

--- a/tests/cli/smoke_tests/consume-batch-size.bats
+++ b/tests/cli/smoke_tests/consume-batch-size.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup_file() {
+    TOPIC_NAME=$(random_string)
+    export TOPIC_NAME
+    debug_msg "Topic name: $TOPIC_NAME"
+}
+
+teardown_file() {
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    run rm $TOPIC_NAME.txt
+}
+
+# Create topic
+@test "Create topics for test" {
+    debug_msg "topic: $TOPIC_NAME"
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+}
+
+@test "Produce message with batch large" {
+    run bash -c "yes abc |head -c 1500000 > $TOPIC_NAME.txt"
+    run bash -c 'timeout 25s "$FLUVIO_BIN" produce "$TOPIC_NAME" --batch-size 1048588 --file $TOPIC_NAME.txt --linger 5s'
+    assert_success
+}
+
+# Consume message and compare message
+@test "Consume message" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME" -B -d
+    assert_output --partial "abc"
+    assert_success
+}
+
+

--- a/tests/cli/smoke_tests/produce-error.bats
+++ b/tests/cli/smoke_tests/produce-error.bats
@@ -33,7 +33,7 @@ teardown_file() {
     run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME_2" --compression-type snappy
 }
 
-# This should faild due to batch too big
+# This should fail due to batch too big
 @test "Produce message with SPU error code" {
     run bash -c "yes a | tr -d "\n" |head -c 10000000 > $TOPIC_NAME.txt"
     run bash -c 'timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME" --batch-size 50000000 --raw --file $TOPIC_NAME.txt'


### PR DESCRIPTION
This changes `MAX_FETCH_BYTES` to be the same value of `STORAGE_MAX_BATCH_SIZE` + the size of the other felds in a `FetchableTopicResponse` in order to be able to receive responses with at least a batch of that size.


Fixes #2259 