### PR TITLE
[Merged by Bors] - Add type column to `fluvio connector list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.23 - UNRELEASED
+* Add `TYPE` column to `fluvio connector list` ([#2218](https://github.com/infinyon/fluvio/issues/2218))
 
 ## Platform Version 0.9.22 - 2022-03-25
 * Add topic level compression configuration ([#2249](https://github.com/infinyon/fluvio/issues/2249))

--- a/crates/fluvio-cli/src/connector/list.rs
+++ b/crates/fluvio-cli/src/connector/list.rs
@@ -84,7 +84,7 @@ mod output {
     impl TableOutputHandler for ListManagedConnectors {
         /// table header implementation
         fn header(&self) -> Row {
-            row!["NAME", "VERSION", "STATUS",]
+            row!["NAME", "TYPE", "VERSION", "STATUS",]
         }
 
         /// return errors in string format
@@ -100,6 +100,7 @@ mod output {
                     let spec = &r.spec;
                     Row::new(vec![
                         Cell::new_align(&r.name, Alignment::LEFT),
+                        Cell::new_align(&spec.type_.to_string(), Alignment::LEFT),
                         Cell::new_align(&spec.version(), Alignment::LEFT),
                         Cell::new_align(&r.status.to_string(), Alignment::RIGHT),
                     ])


### PR DESCRIPTION
Hey,

Here comes another PR for adding a `TYPE` header to the `fluvio connector list` command

This resolves #2218