### PR TITLE
[Merged by Bors] - update k3d to use v5.4.1 for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.events.input.verbose }}
-  K3D_VERSION: v4.4.8
+  K3D_VERSION: v5.4.1
   BATS_VERSION: 1.2.1
   TLS_ARGS: --tls --domain fluvio.local --server-key ./tls/certs/server.key --server-cert ./tls/certs/server.crt --ca-cert ./tls/certs/ca.crt --client-cert ./tls/certs/client-root.crt --client-key ./tls/certs/client-root.key
   AUTH_FILE: crates/fluvio-sc/test-data/auth_config/policy.json

--- a/k8-util/cluster/reset-k3d.sh
+++ b/k8-util/cluster/reset-k3d.sh
@@ -3,4 +3,4 @@
 # this defaults to docker and assume you have have sudo access
 set -e
 k3d cluster delete fluvio
-k3d cluster create fluvio  --no-lb --no-hostip --no-rollback
+k3d cluster create fluvio


### PR DESCRIPTION
Also remove other options.
Hopefully this will increase reliability of cluster creation