### PR TITLE
[Merged by Bors] - Improve error reporting in `SmartModule` runtime errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -14,7 +14,7 @@ description = "Fluvio SmartModule WASM library"
 crate-type = ['lib']
 
 [dependencies]
-eyre = { version = "0.6", default-features = false }
+eyre = { version = "0.6", default-features = false, features=["auto-install"] }
 fluvio-dataplane-protocol = { version = "0.10.0", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -14,7 +14,7 @@ description = "Fluvio SmartModule WASM library"
 crate-type = ['lib']
 
 [dependencies]
-eyre = { version = "0.6", default-features = false, features=["auto-install"] }
+eyre = { version = ">=0.6.8", default-features = false, features=["auto-install"] }
 fluvio-dataplane-protocol = { version = "0.10.0", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 

--- a/crates/fluvio-smartmodule/examples/Cargo.lock
+++ b/crates/fluvio-smartmodule/examples/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "eyre"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "bytes",
  "fluvio-protocol-derive",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",


### PR DESCRIPTION
Currently, error reporting from user-defined `SmartModule` has two issues:
1. Conversion from any error to `eyre::Report` compiles but panics at runtime.
2. Panics lead to non-informative `wasm trap: wasm unreachable instruction executed`.

This PR fixes the first issue by enabling the feature `auto-install` on `eyre`. This feature enables support for the conversion of the most commonly used errors. Example of the error output after the fix:
```
Error:
   0: Dataplane error: SmartModule runtime error invalid type: integer `1`, expected a string at line 1 column 8

      SmartModule Info:
          Type: Filter
          Offset: 2
          Key: NULL
          Value: {"key":1}
   1: SmartModule runtime error invalid type: integer `1`, expected a string at line 1 column 8

      SmartModule Info:
          Type: Filter
          Offset: 2
          Key: NULL
          Value: {"key":1}
```

The second issue can't be fixed at this moment due to `wasm32-unknown-unknown` and `wasm32-wasi` targets do not support `panic=unwind`, only `panic=abort`. We can't catch panic. When it occurs, the execution just stopped and `wasmtime` engine just returns `Trap` with the message `wasm `unreachable` instruction executed`. So, there is no way to somehow enrich the current error reporting in case of panics.

Closes #2286 