### PR TITLE
[Merged by Bors] - Allow exporting profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * CLI: Migrate all fluvio crates to `comfy-table` from `prettytable-rs` ([#2285](https://github.com/infinyon/fluvio/issues/2263))
 * Storage: Enforce size based retention for topic ([#2179](https://github.com/infinyon/fluvio/issues/2179))
 * Don't try to use directories as smartmodule if passed as argument ([#2292](https://github.com/infinyon/fluvio/issues/2292))
+* CLI: Profile export ([#2327](https://github.com/infinyon/fluvio/issues/2327))
 
 ## Platform Version 0.9.23 - 2022-04-13
 * Add `TYPE` column to `fluvio connector list` ([#2218](https://github.com/infinyon/fluvio/issues/2218))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -79,6 +79,12 @@ pub enum CliError {
     TableFormatNotFound(String),
     #[error(transparent)]
     FluvioInstall(#[from] fluvio_cli_common::error::CliError),
+    #[error("Not active profile set in config")]
+    NoActiveProfileInConfig,
+    #[error("Profile not found in config: {0}")]
+    ProfileNotFoundInConfig(String),
+    #[error("Cluster not found in config: {0}")]
+    ClusterNotFoundInConfig(String),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/fluvio-cli/src/profile/export.rs
+++ b/crates/fluvio-cli/src/profile/export.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde::Serialize;
 
 use fluvio::config::{ConfigFile, TlsCerts, TlsPolicy, TlsConfig};
-use fluvio_extension_common::{Terminal, OutputFormat};
+use fluvio_extension_common::Terminal;
 use fluvio_extension_common::output::OutputType;
 
 use crate::Result;
@@ -13,18 +13,25 @@ use crate::error::CliError;
 #[derive(Parser, Debug)]
 pub struct ExportOpt {
     profile_name: Option<String>,
-    #[clap(flatten)]
-    output: OutputFormat,
+    #[clap(
+        default_value_t = OutputType::json,
+        short = 'O',
+        long = "output",
+        value_name = "type",
+        arg_enum,
+        ignore_case = true
+    )]
+    pub output_format: OutputType,
 }
 
 impl ExportOpt {
     pub fn process<O: Terminal>(self, out: Arc<O>) -> Result<()> {
-        let output_format = match self.output.format {
+        let output_format = match self.output_format {
             OutputType::table => {
                 eprintln!("Table format is not supported, using JSON instead");
                 OutputType::json
             }
-            _ => self.output.format,
+            _ => self.output_format,
         };
 
         let config_file = match ConfigFile::load(None) {

--- a/crates/fluvio-cli/src/profile/mod.rs
+++ b/crates/fluvio-cli/src/profile/mod.rs
@@ -75,7 +75,7 @@ pub enum ProfileCmd {
     #[clap(subcommand, name = "sync")]
     Sync(SyncCmd),
 
-    /// Export a profile
+    /// Export a profile for use in other applications
     #[clap(name = "export")]
     Export(ExportOpt),
 }

--- a/crates/fluvio-cli/src/profile/mod.rs
+++ b/crates/fluvio-cli/src/profile/mod.rs
@@ -14,6 +14,7 @@ mod rename;
 mod delete_profile;
 mod delete_cluster;
 mod list;
+mod export;
 
 use crate::Result;
 use crate::common::output::Terminal;
@@ -24,6 +25,7 @@ use crate::profile::switch::SwitchOpt;
 use crate::profile::sync::SyncCmd;
 use crate::profile::list::ListOpt;
 use crate::profile::rename::RenameOpt;
+use crate::profile::export::ExportOpt;
 
 #[derive(Debug, Parser)]
 pub struct ProfileOpt {
@@ -72,6 +74,10 @@ pub enum ProfileCmd {
     /// Sync a profile from a cluster
     #[clap(subcommand, name = "sync")]
     Sync(SyncCmd),
+
+    /// Export a profile
+    #[clap(name = "export")]
+    Export(ExportOpt),
 }
 
 impl ProfileCmd {
@@ -97,6 +103,9 @@ impl ProfileCmd {
             }
             Self::Sync(sync) => {
                 sync.process().await?;
+            }
+            Self::Export(export) => {
+                export.process(out)?;
             }
         }
 

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -355,6 +355,11 @@ impl Config {
         Ok(profile)
     }
 
+    /// Returns a reference to the current Profile if there is one.
+    pub fn profile(&self, profile_name: &str) -> Option<&Profile> {
+        self.profile.get(profile_name)
+    }
+
     /// Returns a mutable reference to the current Profile if there is one.
     pub fn profile_mut(&mut self, profile_name: &str) -> Option<&mut Profile> {
         self.profile.get_mut(profile_name)

--- a/tests/cli/smoke_tests/profile-export.bats
+++ b/tests/cli/smoke_tests/profile-export.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+# Create topic
+@test "Export current profile" {
+    debug_msg "Export current profile"
+    run timeout 15s "$FLUVIO_BIN" profile export
+    debug_msg "status: $status"
+    debug_msg "output: ${lines[@]}"
+    assert_success
+    assert_output --partial 'endpoint'
+    assert_output --partial 'tls'
+}


### PR DESCRIPTION
Resolves https://github.com/infinyon/fluvio/issues/2327

Adds
```
fluvio-profile-export 
Export a profile

USAGE:
    fluvio profile export [OPTIONS] [PROFILE_NAME]

ARGS:
    <PROFILE_NAME>    

OPTIONS:
    -O, --output <type>    [default: json] [possible values: table, yaml, json]
    -h, --help             Print help information
```

Output:
```
{
  "endpoint": "<endpoint>",
  "tls": {
    "policy": "<Verified | Anonymous | Disabled>",
    "domain": "<domain>",
    "key": "<cert pem>",
    "cert": "<cert pem>",
    "ca_cert": "<cert pem>"
  }
}
```