### PR TITLE
[Merged by Bors] - Add `std`, `derive` features of `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,15 +723,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.9"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex",
  "indexmap",
  "lazy_static",
+ "os_str_bytes",
  "textwrap",
 ]
 
@@ -755,15 +755,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -3640,6 +3631,9 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "owo-colors"

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -16,7 +16,7 @@ target = ["fluvio"]
 
 [dependencies]
 tracing = "0.1.19"
-clap = { version = "3.1.8", default-features = false }
+clap = { version = "3.1.8", features = ["std", "derive"], default-features = false }
 comfy-table = "5.0.1"
 serde = { version = "1.0.103", features = ['derive'] }
 serde_json = "1.0.39"


### PR DESCRIPTION
This change fixes the compilation error for `fluvio-extension-common` crate as it requires now these features.