### PR TITLE
[Merged by Bors] - Move to dataplane-protocol convertion from MemoryRecords to RawRecords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol 0.7.6",
  "fluvio-socket",
+ "fluvio-types",
  "flv-util",
  "futures-util",
  "once_cell",
@@ -2343,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "event-listener",
  "fluvio-future",

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"
@@ -27,7 +27,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.3.1", path = "../fluvio-types" }
 fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.6.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 base64 = "0.13.0"
 
 [dev-dependencies]

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -33,6 +33,7 @@ fluvio-protocol = { path = "../fluvio-protocol", version = "0.7", features = [
     "api",
 ] }
 flv-util = { version = "0.5.0" }
+fluvio-types = { version = "0.3.5", path = "../fluvio-types" }
 
 [dev-dependencies]
 fluvio-dataplane-protocol = { path = ".", features = ["file"]}

--- a/crates/fluvio-dataplane-protocol/src/batch.rs
+++ b/crates/fluvio-dataplane-protocol/src/batch.rs
@@ -173,7 +173,12 @@ impl TryFrom<Batch> for Batch<RawRecords> {
     fn try_from(f: Batch) -> Result<Self, Self::Error> {
         let mut buf = Vec::new();
         f.records.encode(&mut buf, 0)?;
-        let records = RawRecords(buf);
+
+        let compression = f.get_compression()?;
+
+        let compressed_records = compression.compress(&buf)?;
+        let records = RawRecords(compressed_records);
+
         Ok(Batch {
             base_offset: f.base_offset,
             batch_len: f.batch_len,

--- a/crates/fluvio-dataplane-protocol/src/record.rs
+++ b/crates/fluvio-dataplane-protocol/src/record.rs
@@ -22,7 +22,9 @@ use crate::core::Version;
 
 use crate::batch::Batch;
 use crate::Offset;
+
 use fluvio_compression::CompressionError;
+use fluvio_types::Timestamp;
 
 /// maximum text to display
 static MAX_STRING_DISPLAY: Lazy<usize> = Lazy::new(|| {
@@ -345,7 +347,7 @@ impl<R: BatchRecords> Encoder for RecordSet<R> {
 pub struct RecordHeader {
     attributes: i8,
     #[varint]
-    timestamp_delta: i64,
+    timestamp_delta: Timestamp,
     #[varint]
     offset_delta: Offset,
 }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"
@@ -26,7 +26,7 @@ paste = "1.0"
 fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
 fluvio-controlplane-metadata = { version = "0.15.0", default-features = false, path = "../fluvio-controlplane-metadata" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -28,7 +28,7 @@ fluvio-future = { version = "0.3.13", features = [
     "openssl_tls",
     "zero_copy",
 ] }
-dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.15.0", optional = true }

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -15,7 +15,7 @@ crate-type = ['lib']
 
 [dependencies]
 eyre = { version = ">=0.6.8", default-features = false, features=["auto-install"] }
-fluvio-dataplane-protocol = { version = "0.10.0", path = "../fluvio-dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.11.0", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 
 [dev-dependencies]

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
@@ -24,4 +24,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.10", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.11", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/lib.rs
+++ b/crates/fluvio-types/src/lib.rs
@@ -34,3 +34,6 @@ pub type IgnoreRackAssignment = bool;
 // AuthToken
 pub type TokenName = String;
 pub type TokenSecret = String;
+
+// Time
+pub type Timestamp = i64;

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -55,7 +55,7 @@ fluvio-types = { version = "0.3.3", features = [
 fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.10.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use async_lock::{Mutex, RwLock};
 use dataplane::ReplicaKey;
+use dataplane::batch::{Batch, MemoryRecords};
 use dataplane::produce::{DefaultPartitionRequest, DefaultTopicRequest, DefaultProduceRequest};
 use fluvio_future::timer::sleep;
 use fluvio_types::SpuId;
@@ -200,9 +201,11 @@ impl PartitionProducer {
 
         for p_batch in batches_ready {
             let notify = p_batch.notify.clone();
-            let batch = p_batch.try_into()?;
+            let batch: Batch<MemoryRecords> = p_batch.into();
 
-            partition_request.records.batches.push(batch);
+            let raw_batch = batch.try_into()?;
+
+            partition_request.records.batches.push(raw_batch);
 
             batch_notifiers.push(notify);
         }


### PR DESCRIPTION
This moves the conversion from RawRecords to MemoryRecords to the fluvio-dataplane-protocol.

Also creates a type alias for Timestamp and set default to NO_TIMESTAMP in batch headers

This is part of #2288