### PR TITLE
[Merged by Bors] - Support `ReadCommitted` isolation in SPU for Produce requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Platform Version 0.9.25 - UNRELEASED
 * Set timestamp in Records while producing. ([#2288](https://github.com/infinyon/fluvio/issues/2288))
-
+* Support `ReadCommitted` isolation in SPU for Produce requests [#2336](https://github.com/infinyon/fluvio/pull/2336)
 
 ## Platform Version 0.9.24 - 2022-04-21
 * CLI: Migrate all fluvio crates to `comfy-table` from `prettytable-rs` ([#2285](https://github.com/infinyon/fluvio/issues/2263))

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -35,6 +35,9 @@ pub enum ErrorCode {
     #[fluvio(tag = 6)]
     #[error("the given SPU is not the leader for the partition")]
     NotLeaderForPartition,
+    #[fluvio(tag = 7)]
+    #[error("the request timed out.")]
+    RequestTimedOut,
     #[fluvio(tag = 10)]
     #[error("the message is too large to send")]
     MessageTooLarge,
@@ -255,6 +258,7 @@ mod test {
         assert_tag!(ErrorCode::None, 0, 0);
         assert_tag!(ErrorCode::OffsetOutOfRange, 1, 0);
         assert_tag!(ErrorCode::NotLeaderForPartition, 6, 0);
+        assert_tag!(ErrorCode::RequestTimedOut, 7, 0);
         assert_tag!(ErrorCode::MessageTooLarge, 10, 0);
         assert_tag!(ErrorCode::PermissionDenied, 13, 0);
         assert_tag!(ErrorCode::StorageError, 56, 0);

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -253,7 +253,7 @@ mod test {
                 fluvio_protocol::Encoder::encode(&$variant, &mut data, $version)
                     .expect(&format!("Failed to encode {}", stringify!($variant)));
                 assert_eq!(
-                    data,
+                    data[..2],
                     ($tag as i16).to_be_bytes(),
                     "Data check failed for {}",
                     stringify!($variant)
@@ -277,7 +277,14 @@ mod test {
         assert_tag!(ErrorCode::None, 0, 0);
         assert_tag!(ErrorCode::OffsetOutOfRange, 1, 0);
         assert_tag!(ErrorCode::NotLeaderForPartition, 6, 0);
-        assert_tag!(ErrorCode::RequestTimedOut, 7, 0);
+        assert_tag!(
+            ErrorCode::RequestTimedOut {
+                kind: RequestKind::Produce,
+                timeout_ms: 1
+            },
+            7,
+            0
+        );
         assert_tag!(ErrorCode::MessageTooLarge, 10, 0);
         assert_tag!(ErrorCode::PermissionDenied, 13, 0);
         assert_tag!(ErrorCode::StorageError, 56, 0);

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -4,6 +4,7 @@
 //! Error code definitions described here.
 //!
 
+use std::fmt::{Display, Formatter};
 use flv_util::string_helper::upper_cammel_case_to_sentence;
 use fluvio_protocol::{Encoder, Decoder};
 use crate::smartmodule::SmartModuleRuntimeError;
@@ -36,8 +37,8 @@ pub enum ErrorCode {
     #[error("the given SPU is not the leader for the partition")]
     NotLeaderForPartition,
     #[fluvio(tag = 7)]
-    #[error("the request timed out.")]
-    RequestTimedOut,
+    #[error("the request '{kind}' exceeded the timeout {timeout_ms} ms")]
+    RequestTimedOut { timeout_ms: i32, kind: RequestKind },
     #[fluvio(tag = 10)]
     #[error("the message is too large to send")]
     MessageTooLarge,
@@ -213,6 +214,24 @@ pub enum LegacySmartModuleError {
 impl Default for LegacySmartModuleError {
     fn default() -> Self {
         Self::Runtime(Default::default())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Encoder, Decoder)]
+#[non_exhaustive]
+pub enum RequestKind {
+    Produce,
+}
+
+impl Default for RequestKind {
+    fn default() -> Self {
+        RequestKind::Produce
+    }
+}
+
+impl Display for RequestKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -315,8 +315,8 @@ where
         &self,
         records: &mut RecordSet<R>,
         notifiers: &FollowerNotifier,
-    ) -> Result<i64, StorageError> {
-        let base_offset = self
+    ) -> Result<(Offset, Offset), StorageError> {
+        let offsets = self
             .storage
             .write_record_set(records, self.in_sync_replica == 1)
             .await?;
@@ -324,7 +324,7 @@ where
         self.notify_followers(notifiers).await;
         self.update_status().await;
 
-        Ok(base_offset)
+        Ok(offsets)
     }
 
     async fn notify_followers(&self, notifier: &FollowerNotifier) {

--- a/crates/fluvio-spu/src/replication/mod.rs
+++ b/crates/fluvio-spu/src/replication/mod.rs
@@ -2,5 +2,4 @@ pub(crate) mod follower;
 pub(crate) mod leader;
 
 #[cfg(test)]
-#[cfg(target_os = "linux")]
-mod test;
+pub(crate) mod test;

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -7,7 +7,7 @@ use fluvio_storage::StorageError;
 use tracing::{debug, trace, error};
 use tracing::instrument;
 
-use dataplane::{ErrorCode, Isolation, Offset};
+use dataplane::{ErrorCode, Isolation, Offset, RequestKind};
 use dataplane::produce::{
     ProduceResponse, TopicProduceResponse, PartitionProduceResponse, PartitionProduceData,
     DefaultProduceRequest, DefaultTopicRequest,
@@ -222,7 +222,10 @@ async fn wait_for_acks(
                     },
                     _ = timer => {
                         debug!(?partition.replica_id, "response timeout exceeded");
-                        partition.error_code = ErrorCode::RequestTimedOut;
+                        partition.error_code = ErrorCode::RequestTimedOut {
+                            kind: RequestKind::Produce,
+                            timeout_ms
+                        };
                     },
                 }
             }

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -1,13 +1,13 @@
 use std::io::{Error, ErrorKind};
 
 use dataplane::batch::BatchRecords;
-use fluvio::Compression;
+use fluvio::{Compression};
 use fluvio_controlplane_metadata::topic::CompressionAlgorithm;
 use fluvio_storage::StorageError;
 use tracing::{debug, trace, error};
 use tracing::instrument;
 
-use dataplane::ErrorCode;
+use dataplane::{ErrorCode, Isolation, Offset};
 use dataplane::produce::{
     ProduceResponse, TopicProduceResponse, PartitionProduceResponse, PartitionProduceData,
     DefaultProduceRequest, DefaultTopicRequest,
@@ -16,8 +16,26 @@ use dataplane::api::RequestMessage;
 use dataplane::api::ResponseMessage;
 use dataplane::record::RecordSet;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
+use tokio::select;
+use std::time::Duration;
+use fluvio_future::timer::sleep;
 
 use crate::core::DefaultSharedGlobalContext;
+
+const MAX_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct TopicWriteResult {
+    topic: String,
+    partitions: Vec<PartitionWriteResult>,
+}
+
+#[derive(Default)]
+struct PartitionWriteResult {
+    replica_id: ReplicaKey,
+    base_offset: Offset,
+    leo: Offset,
+    error_code: ErrorCode,
+}
 
 #[instrument(
     skip(request,ctx),
@@ -33,12 +51,20 @@ pub async fn handle_produce_request(
     let (header, produce_request) = request.get_header_request();
     trace!("Handling ProduceRequest: {:#?}", produce_request);
 
-    let mut response = ProduceResponse::default();
+    let isolation = produce_request.isolation();
+    let mut topic_results = Vec::with_capacity(produce_request.topics.len());
     for topic_request in produce_request.topics.into_iter() {
-        let topic_response = handle_produce_topic(&ctx, topic_request).await?;
-        response.responses.push(topic_response);
+        let topic_result = handle_produce_topic(&ctx, topic_request).await;
+        topic_results.push(topic_result);
     }
-
+    wait_for_acks(
+        isolation,
+        produce_request.timeout_ms,
+        &mut topic_results,
+        &ctx,
+    )
+    .await;
+    let response = into_response(topic_results);
     trace!("Returning ProduceResponse: {:#?}", &response);
     Ok(RequestMessage::<DefaultProduceRequest>::response_with_header(&header, response))
 }
@@ -50,23 +76,22 @@ pub async fn handle_produce_request(
 async fn handle_produce_topic(
     ctx: &DefaultSharedGlobalContext,
     topic_request: DefaultTopicRequest,
-) -> Result<TopicProduceResponse, Error> {
+) -> TopicWriteResult {
     trace!("Handling produce request for topic:");
-    let topic = &topic_request.name;
 
-    let mut topic_response = TopicProduceResponse {
-        name: topic.to_owned(),
-        ..Default::default()
+    let mut topic_result = TopicWriteResult {
+        topic: topic_request.name,
+        partitions: vec![],
     };
-
     for partition_request in topic_request.partitions.into_iter() {
-        let replica_id = ReplicaKey::new(topic.to_string(), partition_request.partition_index);
-        let partition_response =
-            handle_produce_partition(ctx, replica_id, partition_request).await?;
-        topic_response.partitions.push(partition_response);
+        let replica_id = ReplicaKey::new(
+            topic_result.topic.clone(),
+            partition_request.partition_index,
+        );
+        let partition_response = handle_produce_partition(ctx, replica_id, partition_request).await;
+        topic_result.partitions.push(partition_response);
     }
-
-    Ok(topic_response)
+    topic_result
 }
 
 #[instrument(
@@ -77,20 +102,14 @@ async fn handle_produce_partition<R: BatchRecords>(
     ctx: &DefaultSharedGlobalContext,
     replica_id: ReplicaKey,
     partition_request: PartitionProduceData<RecordSet<R>>,
-) -> Result<PartitionProduceResponse, Error> {
+) -> PartitionWriteResult {
     trace!("Handling produce request for partition:");
-
-    let mut partition_response = PartitionProduceResponse {
-        partition_index: replica_id.partition,
-        ..Default::default()
-    };
 
     let leader_state = match ctx.leaders_state().get(&replica_id).await {
         Some(leader_state) => leader_state,
         None => {
             debug!(%replica_id, "Replica not found");
-            partition_response.error_code = ErrorCode::NotLeaderForPartition;
-            return Ok(partition_response);
+            return PartitionWriteResult::error(replica_id, ErrorCode::NotLeaderForPartition);
         }
     };
 
@@ -98,16 +117,14 @@ async fn handle_produce_partition<R: BatchRecords>(
         Some(replica_metadata) => replica_metadata,
         None => {
             error!(%replica_id, "Replica not found");
-            partition_response.error_code = ErrorCode::TopicNotFound;
-            return Ok(partition_response);
+            return PartitionWriteResult::error(replica_id, ErrorCode::TopicNotFound);
         }
     };
 
     let mut records = partition_request.records;
     if validate_records(&records, replica_metadata.compression_type).is_err() {
         error!(%replica_id, "Compression in batch not supported by this topic");
-        partition_response.error_code = ErrorCode::CompressionError;
-        return Ok(partition_response);
+        return PartitionWriteResult::error(replica_id, ErrorCode::CompressionError);
     }
 
     let write_result = leader_state
@@ -115,21 +132,16 @@ async fn handle_produce_partition<R: BatchRecords>(
         .await;
 
     match write_result {
-        Ok(base_offset) => {
-            partition_response.error_code = ErrorCode::None;
-            partition_response.base_offset = base_offset;
-        }
+        Ok((base_offset, leo)) => PartitionWriteResult::ok(replica_id, base_offset, leo),
         Err(err @ StorageError::BatchTooBig(_)) => {
             error!(%replica_id, "Batch is too big: {:#?}", err);
-            partition_response.error_code = ErrorCode::MessageTooLarge
+            PartitionWriteResult::error(replica_id, ErrorCode::MessageTooLarge)
         }
         Err(err) => {
             error!(%replica_id, "Error writing to replica: {:#?}", err);
-            partition_response.error_code = ErrorCode::StorageError;
+            PartitionWriteResult::error(replica_id, ErrorCode::StorageError)
         }
     }
-
-    Ok(partition_response)
 }
 
 fn validate_records<R: BatchRecords>(
@@ -156,5 +168,119 @@ fn validate_records<R: BatchRecords>(
             ErrorKind::Other,
             "Compression not supported by topic",
         ))
+    }
+}
+/// For isolation = ReadCommitted wait until the replica's `hw` includes written records offsets or
+/// until `timeout_ms` passes. In case of timeout, the partition response returns `RequestTimedOut`
+/// error code. The timeout is not shared between partitions.
+///
+/// For isolation = ReadUncommitted - it's no op.
+async fn wait_for_acks(
+    isolation: Isolation,
+    timeout_ms: i32,
+    results: &mut [TopicWriteResult],
+    ctx: &DefaultSharedGlobalContext,
+) {
+    trace!(?isolation, "waiting for acks");
+    match &isolation {
+        Isolation::ReadCommitted => {
+            for partition in results.iter_mut().flat_map(|r| r.partitions.iter_mut()) {
+                if partition.error_code != ErrorCode::None {
+                    trace!(?partition.replica_id, %partition.error_code, "partition result with error, skip waiting");
+                    continue;
+                }
+                let leader_state = match ctx.leaders_state().get(&partition.replica_id).await {
+                    Some(leader_state) => leader_state,
+                    None => {
+                        debug!(%partition.replica_id, "Replica not found");
+                        partition.error_code = ErrorCode::NotLeaderForPartition;
+                        continue;
+                    }
+                };
+                let leo = partition.leo;
+                if leader_state.hw().ge(&leo) {
+                    trace!(?partition.replica_id, %leo, "batch already committed, skip waiting");
+                    continue;
+                }
+
+                let mut listener = leader_state.offset_listener(&isolation);
+                let wait_future = async {
+                    loop {
+                        let hw = listener.listen().await;
+                        if hw.ge(&leo) {
+                            break;
+                        }
+                    }
+                };
+                let timeout = u64::try_from(timeout_ms)
+                    .map(Duration::from_millis)
+                    .unwrap_or(MAX_TIMEOUT);
+                let timer = sleep(timeout);
+                select! {
+                    _ = wait_future => {
+                        trace!(?partition.replica_id, "waiting for acks completed");
+                    },
+                    _ = timer => {
+                        debug!(?partition.replica_id, "response timeout exceeded");
+                        partition.error_code = ErrorCode::RequestTimedOut;
+                    },
+                }
+            }
+        }
+        Isolation::ReadUncommitted => {}
+    };
+}
+
+impl From<TopicWriteResult> for TopicProduceResponse {
+    fn from(write_result: TopicWriteResult) -> Self {
+        Self {
+            name: write_result.topic,
+            partitions: write_result
+                .partitions
+                .into_iter()
+                .map(PartitionProduceResponse::from)
+                .collect(),
+        }
+    }
+}
+
+impl PartitionWriteResult {
+    fn error(replica_id: ReplicaKey, error_code: ErrorCode) -> Self {
+        Self {
+            replica_id,
+            error_code,
+            ..Default::default()
+        }
+    }
+
+    fn ok(replica_id: ReplicaKey, base_offset: Offset, leo: Offset) -> Self {
+        Self {
+            replica_id,
+            base_offset,
+            leo,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<PartitionWriteResult> for PartitionProduceResponse {
+    fn from(write_result: PartitionWriteResult) -> Self {
+        Self {
+            partition_index: write_result.replica_id.partition,
+            error_code: write_result.error_code,
+            base_offset: write_result.base_offset,
+            ..Default::default()
+        }
+    }
+}
+
+fn into_response(topic_results: Vec<TopicWriteResult>) -> ProduceResponse {
+    let responses = topic_results
+        .into_iter()
+        .map(TopicProduceResponse::from)
+        .collect();
+    ProduceResponse {
+        responses,
+        ..Default::default()
     }
 }

--- a/crates/fluvio-spu/src/storage/mod.rs
+++ b/crates/fluvio-spu/src/storage/mod.rs
@@ -131,7 +131,7 @@ where
         &self,
         records: &mut RecordSet<R>,
         hw_update: bool,
-    ) -> Result<i64, StorageError> {
+    ) -> Result<(Offset, Offset), StorageError> {
         debug!(
             replica = %self.id,
             leo = self.leo(),
@@ -146,7 +146,7 @@ where
         let base_offset = writer.get_leo();
 
         let now = Instant::now();
-        let _offset_updates = writer.write_recordset(records, hw_update).await?;
+        writer.write_recordset(records, hw_update).await?;
         debug!(write_time_ms = %now.elapsed().as_millis());
 
         let leo = writer.get_leo();
@@ -158,7 +158,7 @@ where
             self.hw.update(hw);
         }
 
-        Ok(base_offset)
+        Ok((base_offset, leo))
     }
 
     /// perform permanent remove


### PR DESCRIPTION
The produce handler uses the `acks` field from `ProduceRequest` to determine which isolation will be taken. 
In case of `ReadCommitted` isolation, it waits until the replica's `hw` includes records from the requests before returning the response. Awaiting is limited by the `timeout_ms` field of the request. For now, the timeout is not shared between partitions, it is counted separately for each partition. 

For `ReadUncommitted` there is no waiting.

Related #2302
