### PR TITLE
[Merged by Bors] - Add timestamp to `ConsumerRecord`

### DIFF
--- a/crates/fluvio-dataplane-protocol/src/record.rs
+++ b/crates/fluvio-dataplane-protocol/src/record.rs
@@ -711,6 +711,46 @@ mod test {
         );
         assert!(decoded.key.is_none());
     }
+
+    #[test]
+    fn test_consumer_record_no_timestamp() {
+        let record = ConsumerRecord::<Record<RecordData>> {
+            timestamp_base: NO_TIMESTAMP,
+            offset: 0,
+            partition: 0,
+            record: Default::default(),
+        };
+
+        assert_eq!(record.timestamp(), NO_TIMESTAMP);
+        let record = ConsumerRecord::<Record<RecordData>> {
+            timestamp_base: 0,
+            offset: 0,
+            partition: 0,
+            record: Default::default(),
+        };
+        assert_eq!(record.timestamp(), NO_TIMESTAMP);
+    }
+
+    #[test]
+    fn test_consumer_record_timestamp() {
+        let record = ConsumerRecord::<Record<RecordData>> {
+            timestamp_base: 1_000_000_000,
+            offset: 0,
+            partition: 0,
+            record: Default::default(),
+        };
+
+        assert_eq!(record.timestamp(), 1_000_000_000);
+        let mut memory_record = Record::<RecordData>::default();
+        memory_record.preamble.timestamp_delta = 800;
+        let record = ConsumerRecord::<Record<RecordData>> {
+            timestamp_base: 1_000_000_000,
+            record: memory_record,
+            offset: 0,
+            partition: 0,
+        };
+        assert_eq!(record.timestamp(), 1_000_000_800);
+    }
 }
 
 #[cfg(feature = "file")]

--- a/crates/fluvio-dataplane-protocol/src/record.rs
+++ b/crates/fluvio-dataplane-protocol/src/record.rs
@@ -14,6 +14,7 @@ use bytes::BufMut;
 
 use crate::batch::BatchRecords;
 use crate::batch::MemoryRecords;
+use crate::batch::NO_TIMESTAMP;
 use crate::batch::RawRecords;
 use crate::core::{Encoder, Decoder};
 use crate::core::DecoderVarInt;
@@ -526,6 +527,8 @@ pub struct ConsumerRecord<B = DefaultRecord> {
     pub partition: i32,
     /// The Record contents
     pub record: B,
+    /// Timestamp base of batch in which the records is present
+    pub(crate) timestamp_base: Timestamp,
 }
 
 impl<B> ConsumerRecord<B> {
@@ -559,6 +562,14 @@ impl ConsumerRecord<DefaultRecord> {
     /// Returns the contents of this Record's value
     pub fn value(&self) -> &[u8] {
         self.record.value().as_ref()
+    }
+    /// Return the timestamp of the Record
+    pub fn timestamp(&self) -> Timestamp {
+        if self.timestamp_base <= 0 {
+            NO_TIMESTAMP
+        } else {
+            self.timestamp_base + self.record.timestamp_delta()
+        }
     }
 }
 


### PR DESCRIPTION
This PRs adds timestamp() to ConsumerRecord API. This is the last protocol-related change needed to add timestamp formatting to CLI.

Part of #2288 