### PR TITLE
[Merged by Bors] - Add timestamp to `fluvio consume --format`

### DIFF
--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -82,7 +82,7 @@ pub struct ConsumeOpt {
     /// Provide a template string to print records with a custom format.
     /// See --help for details.
     ///
-    /// Template strings may include the variables {{key}}, {{value}}, {{offset}}, {{partition}} and {{timestamp}}
+    /// Template strings may include the variables {{key}}, {{value}}, {{offset}}, {{partition}} and {{time}}
     /// which will have each record's contents substituted in their place.
     /// Note that timestamp is displayed using RFC3339, is always UTC and ignores system timezone.
     ///
@@ -607,7 +607,7 @@ impl ConsumeOpt {
                     "value": value,
                     "offset": record.offset(),
                     "partition": record.partition(),
-                    "timestamp": timestamp_rfc3339,
+                    "time": timestamp_rfc3339,
                 });
                 templates.render(USER_TEMPLATE, &object).ok()
             }

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -4,11 +4,13 @@
 //! CLI command for Consume operation
 //!
 
+use std::time::UNIX_EPOCH;
 use std::{io::Error as IoError, path::PathBuf};
 use std::io::{self, ErrorKind, Read, Stdout};
 use std::collections::{BTreeMap};
 use flate2::Compression;
 use flate2::bufread::GzEncoder;
+use fluvio::dataplane::batch::NO_TIMESTAMP;
 use fluvio::metadata::tableformat::{TableFormatSpec};
 use tracing::{debug, trace, instrument};
 use clap::{Parser, ArgEnum};
@@ -80,8 +82,10 @@ pub struct ConsumeOpt {
     /// Provide a template string to print records with a custom format.
     /// See --help for details.
     ///
-    /// Template strings may include the variables {{key}}, {{value}}, {{offset}} and {{partition}}
+    /// Template strings may include the variables {{key}}, {{value}}, {{offset}}, {{partition}} and {{timestamp}}
     /// which will have each record's contents substituted in their place.
+    /// Note that timestamp is displayed using RFC3339, is always UTC and ignores system timezone.
+    ///
     /// For example, the following template string:
     ///
     /// Offset {{offset}} has key {{key}} and value {{value}}
@@ -584,11 +588,26 @@ impl ConsumeOpt {
             }
             (_, Some(templates)) => {
                 let value = String::from_utf8_lossy(record.value()).to_string();
+                let timestamp_rfc3339 = if record.timestamp() == NO_TIMESTAMP {
+                    "NA".to_string()
+                } else {
+                    format!(
+                        "{}",
+                        humantime::format_rfc3339_millis(
+                            UNIX_EPOCH
+                                + std::time::Duration::from_millis(
+                                    record.timestamp().try_into().unwrap_or_default()
+                                )
+                        )
+                    )
+                };
+
                 let object = serde_json::json!({
                     "key": formatted_key,
                     "value": value,
                     "offset": record.offset(),
                     "partition": record.partition(),
+                    "timestamp": timestamp_rfc3339,
                 });
                 templates.render(USER_TEMPLATE, &object).ok()
             }

--- a/tests/cli/smoke_tests/e2e-basic.bats
+++ b/tests/cli/smoke_tests/e2e-basic.bats
@@ -9,6 +9,9 @@ load "$TEST_HELPER_DIR"/bats-support/load.bash
 load "$TEST_HELPER_DIR"/bats-assert/load.bash
 
 setup_file() {
+    CURRENT_DATE=$(date +%Y-%m)
+    export CURRENT_DATE
+
     TOPIC_NAME=$(random_string)
     export TOPIC_NAME
     debug_msg "Topic name: $TOPIC_NAME"
@@ -128,6 +131,13 @@ teardown_file() {
     assert_output "$MESSAGE_W_HTML_STR"
     assert_success
 }
+
+@test "Consume message display timestamp using format" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_2" --format "{{timestamp}}" -B -d
+    assert_output --partial "$CURRENT_DATE"
+    assert_success
+}
+
 
 # Validate that consume --tail 1, returns only the last record
 @test "Consume with tail" {

--- a/tests/cli/smoke_tests/e2e-basic.bats
+++ b/tests/cli/smoke_tests/e2e-basic.bats
@@ -133,7 +133,7 @@ teardown_file() {
 }
 
 @test "Consume message display timestamp using format" {
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_2" --format "{{timestamp}}" -B -d
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_2" --format "{{time}}" -B -d
     assert_output --partial "$CURRENT_DATE"
     assert_success
 }


### PR DESCRIPTION
This PRs adds `{{time}}` to --format that will display the timestamp with RFC3339 format, and NA in case of no timestamp in record


``` fluvio consume topic --format "{{timestamp}}"
2022-05-03T19:12:56.980Z
2022-05-03T19:13:00.481Z
```