### PR TITLE
Support configuring compression level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.27 - UNRELEASED
+* Support configuring gzip compression level ([#2248](https://github.com/infinyon/fluvio/issues/2248))
 
 ## Platform Version 0.9.26 - 2022-05-10
 * Increase default `STORAGE_MAX_BATCH_SIZE` ([#2342](https://github.com/infinyon/fluvio/issues/2342))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.11"
+version = "0.13.0"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "lz4_flex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/crates/fluvio-cli/src/produce/mod.rs
+++ b/crates/fluvio-cli/src/produce/mod.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use humantime::parse_duration;
 
 use fluvio::{
-    Compression, Fluvio, FluvioError, TopicProducer, TopicProducerConfigBuilder, RecordKey,
-    ProduceOutput,
+    Compression, CompressionLevel, Fluvio, FluvioError, TopicProducer, TopicProducerConfigBuilder,
+    RecordKey, ProduceOutput,
 };
 use fluvio::dataplane::Isolation;
 use fluvio_types::print_cli_ok;
@@ -53,6 +53,12 @@ pub struct ProduceOpt {
     #[clap(long)]
     pub compression: Option<Compression>,
 
+    /// Level of compression to use when sending records.
+    /// Supported levels: 0 (compression algorithm's default level) or 1-9.
+    /// Only Gzip supports setting a compression level.
+    #[clap(long)]
+    pub compression_level: Option<CompressionLevel>,
+
     /// Path to a file to produce to the topic. If absent, producer will read stdin.
     #[clap(short, long)]
     pub file: Option<PathBuf>,
@@ -93,6 +99,13 @@ impl ProduceOpt {
         // Compression
         let config_builder = if let Some(compression) = self.compression {
             config_builder.compression(compression)
+        } else {
+            config_builder
+        };
+
+        // Compression level
+        let config_builder = if let Some(compression_level) = self.compression_level {
+            config_builder.compression_level(compression_level)
         } else {
             config_builder
         };

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-compression"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-compression/src/error.rs
+++ b/crates/fluvio-compression/src/error.rs
@@ -6,8 +6,8 @@ pub enum CompressionError {
     IoError(#[from] std::io::Error),
     #[error("unknown compression format: {0}")]
     UnknownCompressionFormat(String),
-    #[error("unknown compression level: {0}")]
-    UnknownCompressionLevel(String),
+    #[error("unknown GZIP compression level: {0}")]
+    UnknownGzipLevel(String),
     #[error("error flushing Snap encoder: {0}")]
     SnapError(#[from] Box<IntoInnerError<FrameEncoder<Vec<u8>>>>),
     #[error("error flushing Snap encoder: {0}")]

--- a/crates/fluvio-compression/src/error.rs
+++ b/crates/fluvio-compression/src/error.rs
@@ -6,6 +6,8 @@ pub enum CompressionError {
     IoError(#[from] std::io::Error),
     #[error("unknown compression format: {0}")]
     UnknownCompressionFormat(String),
+    #[error("unknown compression level: {0}")]
+    UnknownCompressionLevel(String),
     #[error("error flushing Snap encoder: {0}")]
     SnapError(#[from] Box<IntoInnerError<FrameEncoder<Vec<u8>>>>),
     #[error("error flushing Snap encoder: {0}")]

--- a/crates/fluvio-compression/src/gzip.rs
+++ b/crates/fluvio-compression/src/gzip.rs
@@ -1,13 +1,14 @@
 use std::io::{Read, Write};
 
-use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 
+use crate::CompressionLevel;
 use crate::error::CompressionError;
 
-pub fn compress(src: &[u8]) -> Result<Vec<u8>, CompressionError> {
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+pub fn compress(src: &[u8], level: CompressionLevel) -> Result<Vec<u8>, CompressionError> {
+    let flate2_level: flate2::Compression = level.try_into()?;
+    let mut encoder = GzEncoder::new(Vec::new(), flate2_level);
     encoder.write_all(src)?;
     Ok(encoder.finish()?)
 }
@@ -26,12 +27,30 @@ mod tests {
     #[test]
     fn test_compress_decompress() {
         let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let compressed = compress(text.as_bytes()).unwrap();
+        let compressed = compress(text.as_bytes(), CompressionLevel::default()).unwrap();
 
         assert!(compressed.len() < text.as_bytes().len());
 
         let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
 
+        assert_eq!(uncompressed, text);
+    }
+
+    #[test]
+    fn test_compression_level1() {
+        let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let compressed = compress(text.as_bytes(), CompressionLevel::Level1).unwrap();
+        assert!(compressed.len() < text.as_bytes().len());
+        let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
+        assert_eq!(uncompressed, text);
+    }
+
+    #[test]
+    fn test_compression_level9() {
+        let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let compressed = compress(text.as_bytes(), CompressionLevel::Level9).unwrap();
+        assert!(compressed.len() < text.as_bytes().len());
+        let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
         assert_eq!(uncompressed, text);
     }
 }

--- a/crates/fluvio-compression/src/gzip.rs
+++ b/crates/fluvio-compression/src/gzip.rs
@@ -7,7 +7,7 @@ use crate::GzipLevel;
 use crate::error::CompressionError;
 
 pub fn compress(src: &[u8], level: GzipLevel) -> Result<Vec<u8>, CompressionError> {
-    let flate2_level: flate2::Compression = level.try_into()?;
+    let flate2_level: flate2::Compression = level.into();
     let mut encoder = GzEncoder::new(Vec::new(), flate2_level);
     encoder.write_all(src)?;
     Ok(encoder.finish()?)

--- a/crates/fluvio-compression/src/gzip.rs
+++ b/crates/fluvio-compression/src/gzip.rs
@@ -3,10 +3,10 @@ use std::io::{Read, Write};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 
-use crate::CompressionLevel;
+use crate::GzipLevel;
 use crate::error::CompressionError;
 
-pub fn compress(src: &[u8], level: CompressionLevel) -> Result<Vec<u8>, CompressionError> {
+pub fn compress(src: &[u8], level: GzipLevel) -> Result<Vec<u8>, CompressionError> {
     let flate2_level: flate2::Compression = level.try_into()?;
     let mut encoder = GzEncoder::new(Vec::new(), flate2_level);
     encoder.write_all(src)?;
@@ -27,7 +27,7 @@ mod tests {
     #[test]
     fn test_compress_decompress() {
         let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let compressed = compress(text.as_bytes(), CompressionLevel::default()).unwrap();
+        let compressed = compress(text.as_bytes(), GzipLevel::default()).unwrap();
 
         assert!(compressed.len() < text.as_bytes().len());
 
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn test_compression_level1() {
         let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let compressed = compress(text.as_bytes(), CompressionLevel::Level1).unwrap();
+        let compressed = compress(text.as_bytes(), GzipLevel::Level1).unwrap();
         assert!(compressed.len() < text.as_bytes().len());
         let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
         assert_eq!(uncompressed, text);
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn test_compression_level9() {
         let text = "FLUVIO_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let compressed = compress(text.as_bytes(), CompressionLevel::Level9).unwrap();
+        let compressed = compress(text.as_bytes(), GzipLevel::Level9).unwrap();
         assert!(compressed.len() < text.as_bytes().len());
         let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
         assert_eq!(uncompressed, text);

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -31,7 +31,7 @@ impl TryFrom<u8> for Compression {
     fn try_from(v: u8) -> Result<Self, CompressionError> {
         match v {
             0 => Ok(Compression::None),
-            1 => Ok(Compression::Gzip(GzipLevel::default())),
+            1 => Ok(Compression::Gzip(Default::default())),
             2 => Ok(Compression::Snappy),
             3 => Ok(Compression::Lz4),
             _ => Err(CompressionError::UnknownCompressionFormat(format!(
@@ -60,7 +60,7 @@ impl FromStr for Compression {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "none" => Ok(Compression::None),
-            "gzip" => Ok(Compression::Gzip(GzipLevel::default())),
+            "gzip" => Ok(Compression::Gzip(Default::default())),
             "snappy" => Ok(Compression::Snappy),
             "lz4" => Ok(Compression::Lz4),
             _ => Err(CompressionError::UnknownCompressionFormat(s.into())),

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -172,20 +172,13 @@ impl TryFrom<i8> for GzipLevel {
     }
 }
 
-impl TryFrom<GzipLevel> for flate2::Compression {
-    type Error = CompressionError;
-
-    fn try_from(level: GzipLevel) -> Result<Self, Self::Error> {
+impl From<GzipLevel> for flate2::Compression {
+    fn from(level: GzipLevel) -> Self {
         let int_level = level as u32;
-        match int_level {
-            int_level if int_level == 0 => Ok(flate2::Compression::default()),
-            int_level if int_level >= 1 && int_level <= 9 => {
-                Ok(flate2::Compression::new(int_level))
-            }
-            _ => Err(CompressionError::UnknownGzipLevel(format!(
-                "Gzip supports compression levels 1..9, supplied level: {int_level}"
-            ))),
+        if int_level < 1 || int_level > 9 {
+            panic!("Invalid GzipLevel discriminant: {int_level}")
         }
+        flate2::Compression::new(int_level)
     }
 }
 

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -26,9 +26,9 @@ impl Default for Compression {
     }
 }
 
-impl TryFrom<i8> for Compression {
+impl TryFrom<u8> for Compression {
     type Error = CompressionError;
-    fn try_from(v: i8) -> Result<Self, CompressionError> {
+    fn try_from(v: u8) -> Result<Self, CompressionError> {
         match v {
             0 => Ok(Compression::None),
             1 => Ok(Compression::Gzip(GzipLevel::default())),
@@ -149,7 +149,7 @@ impl Default for GzipLevel {
     }
 }
 
-impl TryFrom<i8> for CompressionLevel {
+impl TryFrom<i8> for GzipLevel {
     type Error = CompressionError;
 
     fn try_from(v: i8) -> Result<Self, CompressionError> {

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -186,18 +186,6 @@ impl TryFrom<CompressionLevel> for flate2::Compression {
 
 impl std::fmt::Display for CompressionLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use CompressionLevel::*;
-        match *self {
-            Default => write!(f, "0"),
-            Level1 => write!(f, "1"),
-            Level2 => write!(f, "2"),
-            Level3 => write!(f, "3"),
-            Level4 => write!(f, "4"),
-            Level5 => write!(f, "5"),
-            Level6 => write!(f, "6"),
-            Level7 => write!(f, "7"),
-            Level8 => write!(f, "8"),
-            Level9 => write!(f, "9"),
-        }
+        write!(f, "{}", *self as u8)
     }
 }

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -174,10 +174,17 @@ impl TryFrom<i8> for GzipLevel {
 
 impl From<GzipLevel> for flate2::Compression {
     fn from(level: GzipLevel) -> Self {
-        let int_level = level as u32;
-        if int_level < 1 || int_level > 9 {
-            panic!("Invalid GzipLevel discriminant: {int_level}")
-        }
+        let int_level = match level {
+            GzipLevel::Level1 => 1,
+            GzipLevel::Level2 => 2,
+            GzipLevel::Level3 => 3,
+            GzipLevel::Level4 => 4,
+            GzipLevel::Level5 => 5,
+            GzipLevel::Level6 => 6,
+            GzipLevel::Level7 => 7,
+            GzipLevel::Level8 => 8,
+            GzipLevel::Level9 => 9,
+        };
         flate2::Compression::new(int_level)
     }
 }

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -27,7 +27,7 @@ flv-util = { version = "0.5.0" }
 fluvio-types = { version = "0.3.1", path = "../fluvio-types" }
 fluvio-stream-model = { path = "../fluvio-stream-model", version = "0.6.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.12.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 base64 = "0.13.0"
 
 [dev-dependencies]

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -28,7 +28,7 @@ eyre = { version = "0.6", default-features = false }
 thiserror = "1"
 
 # Fluvio dependencies
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2.0", path = "../fluvio-compression" }
 fluvio-future = { version = "0.3.1" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7", features = [
     "derive",

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-dataplane-protocol"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "data plane protocol"

--- a/crates/fluvio-dataplane-protocol/src/batch.rs
+++ b/crates/fluvio-dataplane-protocol/src/batch.rs
@@ -21,9 +21,7 @@ use crate::Size;
 use crate::record::ConsumerRecord;
 use crate::record::Record;
 
-pub const COMPRESSION_CODEC_MASK: i16 = 0b0000111;
-pub const COMPRESSION_LEVEL_MASK: i16 = 0b1111000;
-pub const COMPRESSION_LEVEL_SHIFT: i8 = 3;
+pub const COMPRESSION_CODEC_MASK: i16 = 0x07;
 pub const NO_TIMESTAMP: i64 = -1;
 
 pub trait BatchRecords: Default + Debug + Encoder + Decoder + Send + Sync {
@@ -78,6 +76,7 @@ pub struct Batch<R = MemoryRecords> {
     pub base_offset: Offset,
     pub batch_len: i32, // only for decoding
     pub header: BatchHeader,
+    compression_level: CompressionLevel,
     records: R,
 }
 
@@ -147,8 +146,8 @@ impl<R> Batch<R> {
         self.get_header().get_compression()
     }
 
-    pub fn get_compression_level(&self) -> Result<CompressionLevel, CompressionError> {
-        self.get_header().get_compression_level()
+    pub fn get_compression_level(&self) -> CompressionLevel {
+        self.compression_level
     }
 
     /// decode from buf stored in the file
@@ -173,6 +172,7 @@ impl TryFrom<Batch<RawRecords>> for Batch {
             base_offset: batch.base_offset,
             batch_len: (BATCH_HEADER_SIZE + records.write_size(0)) as i32,
             header: batch.header,
+            compression_level: Default::default(),
             records,
         })
     }
@@ -185,7 +185,7 @@ impl TryFrom<Batch> for Batch<RawRecords> {
         f.records.encode(&mut buf, 0)?;
 
         let compression = f.get_compression()?;
-        let compression_level = f.get_compression_level()?;
+        let compression_level = f.get_compression_level();
         let compressed_records = compression.compress(&buf, compression_level)?;
         let records = RawRecords(compressed_records);
 
@@ -193,6 +193,7 @@ impl TryFrom<Batch> for Batch<RawRecords> {
             base_offset: f.base_offset,
             batch_len: f.batch_len,
             header: f.header,
+            compression_level,
             records,
         })
     }
@@ -400,16 +401,6 @@ impl BatchHeader {
     fn set_max_time_stamp(&mut self, timestamp: Timestamp) {
         self.max_time_stamp = timestamp;
     }
-
-    fn get_compression_level(&self) -> Result<CompressionLevel, CompressionError> {
-        let level_bits = (self.attributes & COMPRESSION_LEVEL_MASK) >> COMPRESSION_LEVEL_SHIFT;
-        CompressionLevel::try_from(level_bits as i8)
-    }
-
-    pub fn set_compression_level(&mut self, level: CompressionLevel) {
-        let level_bits = ((level as i16) << COMPRESSION_LEVEL_SHIFT) & COMPRESSION_LEVEL_MASK;
-        self.attributes = (self.attributes & !COMPRESSION_LEVEL_MASK) | level_bits;
-    }
 }
 
 impl Default for BatchHeader {
@@ -550,7 +541,7 @@ pub mod memory {
             header.set_max_time_stamp(max_time_stamp);
 
             header.set_compression(compression);
-            header.set_compression_level(compression_level);
+            batch.compression_level = compression_level;
 
             *batch.mut_records() = records;
 
@@ -869,25 +860,6 @@ mod test {
             (200..250).contains(&records_delta[2]),
             "records_delta[2]: {}",
             records_delta[2]
-        );
-    }
-
-    #[test]
-    fn test_encode_decode_compression_config_in_batch_header() {
-        let mut header = BatchHeader::default();
-        header.set_compression(Compression::Gzip);
-        assert_eq!(header.get_compression().unwrap(), Compression::Gzip);
-        header.set_compression(Compression::Snappy);
-        assert_eq!(header.get_compression().unwrap(), Compression::Snappy);
-        header.set_compression_level(CompressionLevel::Level1);
-        assert_eq!(
-            header.get_compression_level().unwrap(),
-            CompressionLevel::Level1
-        );
-        header.set_compression_level(CompressionLevel::Level9);
-        assert_eq!(
-            header.get_compression_level().unwrap(),
-            CompressionLevel::Level9
         );
     }
 }

--- a/crates/fluvio-dataplane-protocol/src/batch.rs
+++ b/crates/fluvio-dataplane-protocol/src/batch.rs
@@ -20,7 +20,7 @@ use crate::Size;
 use crate::record::ConsumerRecord;
 use crate::record::Record;
 
-pub const COMPRESSION_CODEC_MASK: u16 = 0x07;
+pub const COMPRESSION_CODEC_MASK: i16 = 0x07;
 pub const NO_TIMESTAMP: i64 = -1;
 
 pub trait BatchRecords: Default + Debug + Encoder + Decoder + Send + Sync {
@@ -360,7 +360,7 @@ pub struct BatchHeader {
     pub partition_leader_epoch: i32,
     pub magic: i8,
     pub crc: u32,
-    pub attributes: u16,
+    pub attributes: i16,
     /// Indicates the count from the beginning of the batch to the end
     ///
     /// Adding this to the base_offset will give the offset of the last record in this batch
@@ -379,7 +379,7 @@ impl BatchHeader {
     }
 
     pub fn set_compression(&mut self, compression: Compression) {
-        let compression_bits = u8::from(compression) as u16 & COMPRESSION_CODEC_MASK;
+        let compression_bits = u8::from(compression) as i16 & COMPRESSION_CODEC_MASK;
         self.attributes = (self.attributes & !COMPRESSION_CODEC_MASK) | compression_bits;
     }
 
@@ -415,7 +415,7 @@ pub const BATCH_HEADER_SIZE: usize =
           size_of::<i32>()      // partition leader epoch
         + size_of::<u8>()       // magic
         + size_of::<i32>()      // crc
-        + size_of::<u16>()      // u16
+        + size_of::<i16>()      // attributes
         + size_of::<i32>()      // last offset delta
         + size_of::<i64>()      // first_timestamp
         + size_of::<i64>()      // max_time_stamp

--- a/crates/fluvio-dataplane-protocol/src/batch.rs
+++ b/crates/fluvio-dataplane-protocol/src/batch.rs
@@ -20,7 +20,7 @@ use crate::Size;
 use crate::record::ConsumerRecord;
 use crate::record::Record;
 
-pub const COMPRESSION_CODEC_MASK: i16 = 0x07;
+pub const COMPRESSION_CODEC_MASK: u16 = 0x07;
 pub const NO_TIMESTAMP: i64 = -1;
 
 pub trait BatchRecords: Default + Debug + Encoder + Decoder + Send + Sync {
@@ -360,7 +360,7 @@ pub struct BatchHeader {
     pub partition_leader_epoch: i32,
     pub magic: i8,
     pub crc: u32,
-    pub attributes: i16,
+    pub attributes: u16,
     /// Indicates the count from the beginning of the batch to the end
     ///
     /// Adding this to the base_offset will give the offset of the last record in this batch
@@ -375,11 +375,11 @@ pub struct BatchHeader {
 impl BatchHeader {
     fn get_compression(&self) -> Result<Compression, CompressionError> {
         let compression_bits = self.attributes & COMPRESSION_CODEC_MASK;
-        Compression::try_from(compression_bits as i8)
+        Compression::try_from(compression_bits as u8)
     }
 
     pub fn set_compression(&mut self, compression: Compression) {
-        let compression_bits = compression as i16 & COMPRESSION_CODEC_MASK;
+        let compression_bits = u8::from(compression) as u16 & COMPRESSION_CODEC_MASK;
         self.attributes = (self.attributes & !COMPRESSION_CODEC_MASK) | compression_bits;
     }
 
@@ -411,16 +411,18 @@ impl Default for BatchHeader {
     }
 }
 
-pub const BATCH_HEADER_SIZE: usize = size_of::<i32>()     // partition leader epoch
+pub const BATCH_HEADER_SIZE: usize =
+          size_of::<i32>()      // partition leader epoch
         + size_of::<u8>()       // magic
-        + size_of::<i32>()      //crc
-        + size_of::<i16>()      // i16
+        + size_of::<i32>()      // crc
+        + size_of::<u16>()      // u16
         + size_of::<i32>()      // last offset delta
         + size_of::<i64>()      // first_timestamp
         + size_of::<i64>()      // max_time_stamp
-        + size_of::<i64>()      //producer id
+        + size_of::<i64>()      // producer id
         + size_of::<i16>()      // produce_epoch
-        + size_of::<i32>(); // first sequence
+        + size_of::<i32>()      // first sequence
+        ;
 
 #[cfg(feature = "memory_batch")]
 pub mod memory {

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -26,5 +26,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "1.0.0", features = ["serde"] }
 
-fluvio = { version = "0.12.0", path = "../fluvio", optional = true }
+fluvio = { version = "0.13.0", path = "../fluvio", optional = true }
 fluvio-package-index = { version = "0.6", path = "../fluvio-package-index" }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -26,7 +26,7 @@ paste = "1.0"
 fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
 fluvio-controlplane-metadata = { version = "0.15.0", default-features = false, path = "../fluvio-controlplane-metadata" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.12.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 
 [dev-dependencies]
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -28,7 +28,7 @@ fluvio-future = { version = "0.3.13", features = [
     "openssl_tls",
     "zero_copy",
 ] }
-dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
+dataplane = { version = "0.12.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.15.0", optional = true }

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ['lib']
 
 [dependencies]
 eyre = { version = ">=0.6.8", default-features = false, features=["auto-install"] }
-fluvio-dataplane-protocol = { version = "0.11.0", path = "../fluvio-dataplane-protocol", default-features = false }
+fluvio-dataplane-protocol = { version = "0.12.0", path = "../fluvio-dataplane-protocol", default-features = false }
 fluvio-smartmodule-derive = { version = "0.2.0", path = "../fluvio-smartmodule-derive" }
 
 [dev-dependencies]

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -24,4 +24,4 @@ static_assertions = "1.1.0"
 
 # Fluvio dependencies
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.11", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.12", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -46,7 +46,7 @@ fluvio-types = { features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-storage = { path = "../fluvio-storage" }
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2.0", path = "../fluvio-compression" }
 fluvio-controlplane = { path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata" }
 fluvio-spu-schema = { path = "../fluvio-spu-schema", features = [

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -154,9 +154,7 @@ fn validate_records<R: BatchRecords>(
         match compression {
             CompressionAlgorithm::Any => true,
             CompressionAlgorithm::None => batch_compression == Compression::None,
-            CompressionAlgorithm::Gzip => {
-                batch_compression == Compression::Gzip(GzipLevel::default())
-            }
+            CompressionAlgorithm::Gzip => matches!(batch_compression, Compression::Gzip(_)),
             CompressionAlgorithm::Snappy => batch_compression == Compression::Snappy,
             CompressionAlgorithm::Lz4 => batch_compression == Compression::Lz4,
         }

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind};
 
 use dataplane::batch::BatchRecords;
-use fluvio::{Compression, GzipLevel};
+use fluvio::Compression;
 use fluvio_controlplane_metadata::topic::CompressionAlgorithm;
 use fluvio_storage::StorageError;
 use tracing::{debug, trace, error};

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind};
 
 use dataplane::batch::BatchRecords;
-use fluvio::{Compression};
+use fluvio::{Compression, GzipLevel};
 use fluvio_controlplane_metadata::topic::CompressionAlgorithm;
 use fluvio_storage::StorageError;
 use tracing::{debug, trace, error};
@@ -154,7 +154,9 @@ fn validate_records<R: BatchRecords>(
         match compression {
             CompressionAlgorithm::Any => true,
             CompressionAlgorithm::None => batch_compression == Compression::None,
-            CompressionAlgorithm::Gzip => batch_compression == Compression::Gzip,
+            CompressionAlgorithm::Gzip => {
+                batch_compression == Compression::Gzip(GzipLevel::default())
+            }
             CompressionAlgorithm::Snappy => batch_compression == Compression::Snappy,
             CompressionAlgorithm::Lz4 => batch_compression == Compression::Lz4,
         }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -55,7 +55,7 @@ fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-f
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = ["memory_batch"], package = "fluvio-dataplane-protocol" }
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2.0", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -54,7 +54,7 @@ fluvio-types = { version = "0.3.3", features = [
 fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = ["memory_batch"], package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.12.0", path = "../fluvio-dataplane-protocol", features = ["memory_batch"], package = "fluvio-dataplane-protocol" }
 fluvio-compression = { version = "0.2.0", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.11"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -110,6 +110,7 @@ pub use crate::admin::FluvioAdmin;
 pub use crate::fluvio::Fluvio;
 
 pub use fluvio_compression::Compression;
+pub use fluvio_compression::CompressionLevel;
 
 pub(crate) mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -110,7 +110,7 @@ pub use crate::admin::FluvioAdmin;
 pub use crate::fluvio::Fluvio;
 
 pub use fluvio_compression::Compression;
-pub use fluvio_compression::CompressionLevel;
+pub use fluvio_compression::GzipLevel;
 
 pub(crate) mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use derive_builder::Builder;
 use dataplane::Isolation;
 
-use fluvio_compression::{Compression, CompressionLevel};
+use fluvio_compression::Compression;
 
 use crate::producer::partitioning::{Partitioner, SiphashRoundRobinPartitioner};
 
@@ -54,12 +54,6 @@ pub struct TopicProducerConfig {
     #[builder(setter(into, strip_option), default)]
     pub(crate) compression: Option<Compression>,
 
-    /// Compression level used by Fluvio producer to compress data.
-    /// Supported levels: 0 (compression algorithm's default level) or 1-9.
-    /// Only Gzip supports setting a compression level.
-    #[builder(setter(into, strip_option), default)]
-    pub(crate) compression_level: Option<CompressionLevel>,
-
     /// Max time duration that the server is allowed to process the batch.
     #[builder(default = "default_timeout()")]
     pub(crate) timeout: Duration,
@@ -81,7 +75,6 @@ impl Default for TopicProducerConfig {
             compression: None,
             timeout: default_timeout(),
             isolation: default_isolation(),
-            compression_level: None,
         }
     }
 }

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use derive_builder::Builder;
 use dataplane::Isolation;
 
-use fluvio_compression::Compression;
+use fluvio_compression::{Compression, CompressionLevel};
 
 use crate::producer::partitioning::{Partitioner, SiphashRoundRobinPartitioner};
 
@@ -64,6 +64,11 @@ pub struct TopicProducerConfig {
     /// [`Isolation::ReadUncommitted`] just waits for the leader to accept the message.
     #[builder(default = "default_isolation()")]
     pub(crate) isolation: Isolation,
+    /// Compression level used by Fluvio producer to compress data.
+    /// If there is a topic level compression and it is not compatible with this setting, the producer
+    /// initialization will fail.
+    #[builder(setter(into, strip_option), default)]
+    pub(crate) compression_level: Option<CompressionLevel>,
 }
 
 impl Default for TopicProducerConfig {
@@ -75,6 +80,7 @@ impl Default for TopicProducerConfig {
             compression: None,
             timeout: default_timeout(),
             isolation: default_isolation(),
+            compression_level: None,
         }
     }
 }

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -49,10 +49,16 @@ pub struct TopicProducerConfig {
     pub(crate) partitioner: Box<dyn Partitioner + Send + Sync>,
 
     /// Compression algorithm used by Fluvio producer to compress data.
-    /// If there is a topic level compression and it is not compatible with this setting, the producer
-    /// initialization will fail.
+    /// If there is a topic level compression and it is not compatible with this setting,
+    /// the producer initialization will fail.
     #[builder(setter(into, strip_option), default)]
     pub(crate) compression: Option<Compression>,
+
+    /// Compression level used by Fluvio producer to compress data.
+    /// Supported levels: 0 (compression algorithm's default level) or 1-9.
+    /// Only Gzip supports setting a compression level.
+    #[builder(setter(into, strip_option), default)]
+    pub(crate) compression_level: Option<CompressionLevel>,
 
     /// Max time duration that the server is allowed to process the batch.
     #[builder(default = "default_timeout()")]
@@ -64,11 +70,6 @@ pub struct TopicProducerConfig {
     /// [`Isolation::ReadUncommitted`] just waits for the leader to accept the message.
     #[builder(default = "default_isolation()")]
     pub(crate) isolation: Isolation,
-    /// Compression level used by Fluvio producer to compress data.
-    /// If there is a topic level compression and it is not compatible with this setting, the producer
-    /// initialization will fail.
-    #[builder(setter(into, strip_option), default)]
-    pub(crate) compression_level: Option<CompressionLevel>,
 }
 
 impl Default for TopicProducerConfig {

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -6,7 +6,7 @@ use async_lock::RwLock;
 use dataplane::ReplicaKey;
 use dataplane::record::Record;
 
-use fluvio_compression::{Compression, GzipLevel};
+use fluvio_compression::Compression;
 use fluvio_sc_schema::topic::CompressionAlgorithm;
 #[cfg(feature = "smartengine")]
 use fluvio_smartengine::SmartModuleInstance;
@@ -297,7 +297,7 @@ impl TopicProducer {
             match topic_spec.get_compression_type() {
                 CompressionAlgorithm::Any => config.compression.unwrap_or_default(),
                 CompressionAlgorithm::Gzip => match config.compression {
-                    None => Compression::Gzip(GzipLevel::default()),
+                    None => Compression::Gzip(Default::default()),
                     Some(Compression::Gzip(level)) => Compression::Gzip(level),
                     Some(compression_config) => return Err(FluvioError::Producer(ProducerError::InvalidConfiguration(
                         format!("Compression in the producer ({}) does not match with topic level compression (gzip)",

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -323,8 +323,12 @@ impl TopicProducer {
                 },
             };
 
-        let record_accumulator =
-            RecordAccumulator::new(config.batch_size, partition_count, compression);
+        let record_accumulator = RecordAccumulator::new(
+            config.batch_size,
+            partition_count,
+            compression,
+            config.compression_level.unwrap_or_default(),
+        );
         let producer_pool = ProducerPool::shared(
             config.clone(),
             topic.clone(),


### PR DESCRIPTION
Fixes #2248.

Of the currently used compression libraries, I found only Gzip supports setting a compression level. It allows levels 1..9. Snappy doesn't support any levels, and LZ4 generally does support them, but the Rust wrapper doesn't. This may be for a good reason, because almost all the levels LZ4 supports use the HC variant, which is much slower than the main variant.

The proposed code supports levels 1..9, plus "0" which means the undelying algorithm's default level.

Since Fluvio encodes the compression format + level in a bitfield of the batch header, I'm not sure if supporting this many levels is necessary, since it uses additional 4 bits. Maybe we could support only two or three levels (max ratio, max compression, balanced).