### PR TITLE
Fix some typos

### DIFF
--- a/crates/fluvio-controlplane/src/requests/register_spu.rs
+++ b/crates/fluvio-controlplane/src/requests/register_spu.rs
@@ -73,7 +73,7 @@ impl RegisterSpuResponse {
 
     pub fn failed_registration() -> Self {
         RegisterSpuResponse {
-            error_code: ErrorCode::SpuRegisterationFailed,
+            error_code: ErrorCode::SpuRegistrationFailed,
             error_message: None,
         }
     }

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -61,7 +61,7 @@ pub enum ErrorCode {
     SpuError,
     #[fluvio(tag = 1001)]
     #[error("failed to register an SPU")]
-    SpuRegisterationFailed,
+    SpuRegistrationFailed,
     #[fluvio(tag = 1002)]
     #[error("the SPU is offline")]
     SpuOffline,
@@ -106,7 +106,7 @@ pub enum ErrorCode {
     // Stream Fetch error
     #[fluvio(tag = 3002)]
     #[error("the fetch session was not found")]
-    FetchSessionNotFoud,
+    FetchSessionNotFound,
 
     // Legacy SmartModule errors
     #[deprecated(since = "0.9.13")]
@@ -291,7 +291,7 @@ mod test {
 
         // Spu errors
         assert_tag!(ErrorCode::SpuError, 1000, 0);
-        assert_tag!(ErrorCode::SpuRegisterationFailed, 1001, 0);
+        assert_tag!(ErrorCode::SpuRegistrationFailed, 1001, 0);
         assert_tag!(ErrorCode::SpuOffline, 1002, 0);
         assert_tag!(ErrorCode::SpuNotFound, 1003, 0);
         assert_tag!(ErrorCode::SpuAlreadyExists, 1004, 0);
@@ -309,7 +309,7 @@ mod test {
         assert_tag!(ErrorCode::PartitionNotLeader, 3001, 0);
 
         // Stream Fetch error
-        assert_tag!(ErrorCode::FetchSessionNotFoud, 3002, 0);
+        assert_tag!(ErrorCode::FetchSessionNotFound, 3002, 0);
     }
 
     #[test]

--- a/crates/fluvio-sc/src/cli.rs
+++ b/crates/fluvio-sc/src/cli.rs
@@ -211,7 +211,7 @@ impl TlsConfig {
             info!("using tls anonymous access");
             TlsAcceptor::builder().map_err(|err| err.into_io_error())?
         })
-        .with_certifiate_and_key_from_pem_files(server_crt_path, server_key_path)
+        .with_certificate_and_key_from_pem_files(server_crt_path, server_key_path)
         .map_err(|err| err.into_io_error())?;
 
         Ok(builder.build())

--- a/crates/fluvio-sc/src/controllers/partitions/Test.MD
+++ b/crates/fluvio-sc/src/controllers/partitions/Test.MD
@@ -38,7 +38,7 @@
   - Statu's Replica should have value of leader
 
 * Follower up:
-  - Partition with 2 replicas.
+  - Partition with 2 replicas. 
   - Shutdown all SPU. This should set partition status to ElectionNoLeaderFounded
   - Bring up follower SPU.
   - It should do election (doesn't)

--- a/crates/fluvio-sc/src/k8/controllers/mod.rs
+++ b/crates/fluvio-sc/src/k8/controllers/mod.rs
@@ -97,7 +97,7 @@ mod k8_operator {
                 global_ctx.spgs().clone(),
             );
         });
-        whitelist!(config, "k8_managed_connector_delpoyment", {
+        whitelist!(config, "k8_managed_connector_deployment", {
             ManagedConnectorDeploymentController::start(
                 global_ctx.managed_connectors().clone(),
                 managed_connector_deployments_ctx,

--- a/crates/fluvio-sc/src/k8/objects/spu_k8_config.rs
+++ b/crates/fluvio-sc/src/k8/objects/spu_k8_config.rs
@@ -217,7 +217,7 @@ mod extended {
                                     .with_context(ctx),
                             )
                         }
-                        Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
+                        Err(err) => Err(K8ConvertError::KeyConversionError(IoError::new(
                             ErrorKind::InvalidData,
                             format!("error converting metadata: {:#?}", err),
                         ))),

--- a/crates/fluvio-sc/src/stores/spu.rs
+++ b/crates/fluvio-sc/src/stores/spu.rs
@@ -65,7 +65,7 @@ mod health_check {
         }
 
         pub fn listener(&self) -> OffsetChangeListener {
-            self.event.change_listner()
+            self.event.change_listener()
         }
 
         /// update health check

--- a/crates/fluvio-spu/src/config/cli.rs
+++ b/crates/fluvio-spu/src/config/cli.rs
@@ -168,7 +168,7 @@ impl SpuOpt {
         } else {
             TlsAcceptor::builder().map_err(|err| err.into_io_error())?
         })
-        .with_certifiate_and_key_from_pem_files(server_crt_path, server_key_path)
+        .with_certificate_and_key_from_pem_files(server_crt_path, server_key_path)
         .map_err(|err| err.into_io_error())?;
 
         Ok(Some(builder.build()))

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -189,7 +189,7 @@ mod inner {
             let (mut sink, mut stream) = socket.split();
             let mut api_stream = stream.api_stream::<FollowerPeerRequest, FollowerPeerApiEnum>();
 
-            let mut event_listener = self.group.events.change_listner();
+            let mut event_listener = self.group.events.change_listener();
 
             // starts initial sync
             debug!("performing initial offset sync to leader");

--- a/crates/fluvio-spu/src/replication/leader/spu.rs
+++ b/crates/fluvio-spu/src/replication/leader/spu.rs
@@ -87,7 +87,7 @@ pub struct FollowerSpuPendingUpdates {
 
 impl FollowerSpuPendingUpdates {
     pub fn listener(&self) -> OffsetChangeListener {
-        self.event.change_listner()
+        self.event.change_listener()
     }
 
     ///  add replica to be updated

--- a/crates/fluvio-spu/src/services/public/offset_update.rs
+++ b/crates/fluvio-spu/src/services/public/offset_update.rs
@@ -40,7 +40,7 @@ pub async fn handle_offset_update(
                 );
                 OffsetUpdateStatus {
                     session_id: update.session_id,
-                    error: ErrorCode::FetchSessionNotFoud,
+                    error: ErrorCode::FetchSessionNotFound,
                 }
             }
         };

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -61,7 +61,7 @@ impl StreamFetchHandler {
         if let Some(leader_state) = ctx.leaders_state().get(&replica).await {
             let (stream_id, offset_publisher) =
                 ctx.stream_publishers().create_new_publisher().await;
-            let consumer_offset_listener = offset_publisher.change_listner();
+            let consumer_offset_listener = offset_publisher.change_listener();
 
             spawn(async move {
                 if let Err(err) = StreamFetchHandler::fetch(

--- a/crates/fluvio-spu/src/storage/mod.rs
+++ b/crates/fluvio-spu/src/storage/mod.rs
@@ -79,8 +79,8 @@ where
     /// listen to offset based on isolation
     pub fn offset_listener(&self, isolation: &Isolation) -> OffsetChangeListener {
         match isolation {
-            Isolation::ReadCommitted => self.hw.change_listner(),
-            Isolation::ReadUncommitted => self.leo.change_listner(),
+            Isolation::ReadCommitted => self.hw.change_listener(),
+            Isolation::ReadUncommitted => self.leo.change_listener(),
         }
     }
 

--- a/crates/fluvio-stream-dispatcher/src/dispatcher/k8_dispatcher.rs
+++ b/crates/fluvio-stream-dispatcher/src/dispatcher/k8_dispatcher.rs
@@ -379,7 +379,9 @@ mod convert {
                         debug!("skipping: {} {}", S::LABEL, obj.metadata.name);
                         continue;
                     }
-                    K8ConvertError::KeyConvertionError(err) => return Err(err.into()),
+                    #[allow(deprecated)]
+                    K8ConvertError::KeyConversionError(err)
+                    | K8ConvertError::KeyConvertionError(err) => return Err(err.into()),
                     K8ConvertError::Other(err) => return Err(err.into()),
                 },
             };

--- a/crates/fluvio-stream-dispatcher/src/dispatcher/k8_ws_service.rs
+++ b/crates/fluvio-stream-dispatcher/src/dispatcher/k8_ws_service.rs
@@ -134,11 +134,11 @@ where
     }
 
     pub async fn delete(&self, meta: K8MetaItem) -> Result<(), C::MetadataClientError> {
-        use k8_metadata_client::k8_types::options::{DeleteOptions, PropogationPolicy};
+        use k8_metadata_client::k8_types::options::{DeleteOptions, PropagationPolicy};
 
         let options = if S::DELETE_WAIT_DEPENDENTS {
             Some(DeleteOptions {
-                propagation_policy: Some(PropogationPolicy::Foreground),
+                propagation_policy: Some(PropagationPolicy::Foreground),
                 ..Default::default()
             })
         } else {

--- a/crates/fluvio-stream-model/src/store/k8.rs
+++ b/crates/fluvio-stream-model/src/store/k8.rs
@@ -148,7 +148,10 @@ where
     /// skip, this object, it is not considered valid object  
     Skip(K8Obj<S>),
     /// Converting error
+    #[deprecated = "Replace by KeyConversionError"]
     KeyConvertionError(IoError),
+    /// Converting error
+    KeyConversionError(IoError),
     Other(IoError),
 }
 
@@ -192,13 +195,13 @@ where
                     Ok(MetadataStoreObject::new(key, local_spec, local_status)
                         .with_context(MetadataContext::new(ctx_item, owner)))
                 }
-                Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
+                Err(err) => Err(K8ConvertError::KeyConversionError(IoError::new(
                     ErrorKind::InvalidData,
                     format!("error converting metadata: {:#?}", err),
                 ))),
             }
         }
-        Err(err) => Err(K8ConvertError::KeyConvertionError(IoError::new(
+        Err(err) => Err(K8ConvertError::KeyConversionError(IoError::new(
             ErrorKind::InvalidData,
             format!("error converting key: {:#?}", err),
         ))),

--- a/crates/fluvio-types/src/event.rs
+++ b/crates/fluvio-types/src/event.rs
@@ -102,7 +102,12 @@ pub mod offsets {
             self.update(self.current_value() + 1);
         }
 
+        #[deprecated = "Replace by change_listener"]
         pub fn change_listner(self: &Arc<Self>) -> OffsetChangeListener {
+            self.change_listener()
+        }
+
+        pub fn change_listener(self: &Arc<Self>) -> OffsetChangeListener {
             OffsetChangeListener::new(self.clone())
         }
     }
@@ -238,7 +243,7 @@ mod test {
     #[fluvio_future::test]
     async fn test_offset_listener_no_wait() {
         let publisher = OffsetPublisher::shared(0);
-        let listener = publisher.change_listner();
+        let listener = publisher.change_listener();
         let status = Arc::new(AtomicBool::new(false));
 
         TestController::start(listener, status.clone());
@@ -265,7 +270,7 @@ mod test {
     #[fluvio_future::test]
     async fn test_offset_listener_wait() {
         let publisher = OffsetPublisher::shared(0);
-        let listener = publisher.change_listner();
+        let listener = publisher.change_listener();
         let status = Arc::new(AtomicBool::new(false));
 
         TestController::start(listener, status.clone());

--- a/crates/fluvio/src/config/tls.rs
+++ b/crates/fluvio/src/config/tls.rs
@@ -203,7 +203,7 @@ cfg_if::cfg_if! {
                         info!("Using anonymous TLS");
                         let builder = TlsConnector::builder()
                                 .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))?
-                                .with_hostname_vertification_disabled()
+                                .with_hostname_verification_disabled()
                                 .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))?;
 
                         let connector: TlsAnonymousConnector = builder.build().into();

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -359,7 +359,7 @@ where
                 );
 
                 let publisher = OffsetPublisher::shared(0);
-                let mut listener = publisher.change_listner();
+                let mut listener = publisher.change_listener();
 
                 // update stream with received offsets
                 spawn(async move {

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -43,7 +43,7 @@ mod context {
             &0
         }
 
-        /// always return true, this should be changed
+        /// always return tru, this should be changed
         fn is_newer(&self, _another: &Self) -> bool {
             true
         }


### PR DESCRIPTION
While looking at the code, I saw some typos, this PR is just to correct them.
I didn't see any rules about deprecations, so here are the choices I made:

- I corrected typos in the comments, including in the changelog.
- for the code, I tried to preserve the api by using `#[deprecated]`
- for `crates/fluvio-cli/src/topic/create.rs` I did not put the `#[deprecated]` because the `CreateTopicOpt` is created by the clap parser
- for `crates/fluvio-dataplane-protocol/src/error_code.rs` because two variants can't share the same tag (derive Encoder/Decoder)
- Be careful with `crates/fluvio-sc/src/k8/controllers/mod.rs`, I don't know the consequences of the correction

Also I don't know if I should rename `crates/fluvio-protocol/src/core/varint.rs` to `variant.rs`?
