### PR TITLE
[Merged by Bors] - Fix some typo Event change_listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))
 * Make Zig Install more reliable ([#2388](https://github.com/infinyon/fluvio/issues/2388s))
 * Add path setting hint for fish shell in install script ([#2389](https://github.com/infinyon/fluvio/pull/2389))
+* Fix typo in `change_listener` function in `fluvio_types` crate ([#2382](https://github.com/infinyon/fluvio/pull/2382))
 
 ## Platform Version 0.9.26 - 2022-05-10
 * Increase default `STORAGE_MAX_BATCH_SIZE` ([#2342](https://github.com/infinyon/fluvio/issues/2342))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.11"
+version = "0.12.12"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "event-listener",
  "fluvio-future",

--- a/crates/fluvio-sc/src/stores/spu.rs
+++ b/crates/fluvio-sc/src/stores/spu.rs
@@ -65,7 +65,7 @@ mod health_check {
         }
 
         pub fn listener(&self) -> OffsetChangeListener {
-            self.event.change_listner()
+            self.event.change_listener()
         }
 
         /// update health check

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -189,7 +189,7 @@ mod inner {
             let (mut sink, mut stream) = socket.split();
             let mut api_stream = stream.api_stream::<FollowerPeerRequest, FollowerPeerApiEnum>();
 
-            let mut event_listener = self.group.events.change_listner();
+            let mut event_listener = self.group.events.change_listener();
 
             // starts initial sync
             debug!("performing initial offset sync to leader");

--- a/crates/fluvio-spu/src/replication/leader/spu.rs
+++ b/crates/fluvio-spu/src/replication/leader/spu.rs
@@ -87,7 +87,7 @@ pub struct FollowerSpuPendingUpdates {
 
 impl FollowerSpuPendingUpdates {
     pub fn listener(&self) -> OffsetChangeListener {
-        self.event.change_listner()
+        self.event.change_listener()
     }
 
     ///  add replica to be updated

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -61,7 +61,7 @@ impl StreamFetchHandler {
         if let Some(leader_state) = ctx.leaders_state().get(&replica).await {
             let (stream_id, offset_publisher) =
                 ctx.stream_publishers().create_new_publisher().await;
-            let consumer_offset_listener = offset_publisher.change_listner();
+            let consumer_offset_listener = offset_publisher.change_listener();
 
             spawn(async move {
                 if let Err(err) = StreamFetchHandler::fetch(

--- a/crates/fluvio-spu/src/storage/mod.rs
+++ b/crates/fluvio-spu/src/storage/mod.rs
@@ -79,8 +79,8 @@ where
     /// listen to offset based on isolation
     pub fn offset_listener(&self, isolation: &Isolation) -> OffsetChangeListener {
         match isolation {
-            Isolation::ReadCommitted => self.hw.change_listner(),
-            Isolation::ReadUncommitted => self.leo.change_listner(),
+            Isolation::ReadCommitted => self.hw.change_listener(),
+            Isolation::ReadUncommitted => self.leo.change_listener(),
         }
     }
 

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/event.rs
+++ b/crates/fluvio-types/src/event.rs
@@ -102,7 +102,12 @@ pub mod offsets {
             self.update(self.current_value() + 1);
         }
 
+        #[deprecated = "Replace by change_listener"]
         pub fn change_listner(self: &Arc<Self>) -> OffsetChangeListener {
+            self.change_listener()
+        }
+
+        pub fn change_listener(self: &Arc<Self>) -> OffsetChangeListener {
             OffsetChangeListener::new(self.clone())
         }
     }
@@ -238,7 +243,7 @@ mod test {
     #[fluvio_future::test]
     async fn test_offset_listener_no_wait() {
         let publisher = OffsetPublisher::shared(0);
-        let listener = publisher.change_listner();
+        let listener = publisher.change_listener();
         let status = Arc::new(AtomicBool::new(false));
 
         TestController::start(listener, status.clone());
@@ -265,7 +270,7 @@ mod test {
     #[fluvio_future::test]
     async fn test_offset_listener_wait() {
         let publisher = OffsetPublisher::shared(0);
-        let listener = publisher.change_listner();
+        let listener = publisher.change_listener();
         let status = Arc::new(AtomicBool::new(false));
 
         TestController::start(listener, status.clone());

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.11"
+version = "0.12.12"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -48,7 +48,7 @@ fluvio-future = { version = "0.3.12", features = [
     "openssl_tls",
     "task_unstable",
 ] }
-fluvio-types = { version = "0.3.3", features = [
+fluvio-types = { version = "0.3.7", features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-features = false }

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -359,7 +359,7 @@ where
                 );
 
                 let publisher = OffsetPublisher::shared(0);
-                let mut listener = publisher.change_listner();
+                let mut listener = publisher.change_listener();
 
                 // update stream with received offsets
                 spawn(async move {


### PR DESCRIPTION
Fix typo in `fluvio_types::event::offsets::OffsetPublisher`:

* deprecate `change_listner`
* replace by `change_listener`
