### PR TITLE
Force 1 fetch stream per consumer and replica

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.17"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4391dfc45967422482f128c2e3c44f0aded28ac64f3d9cf50a2a476ef37fee0"
+checksum = "cc6a89ad97db849764e15c37fa98146599d97e1e5c10460ec3b73d67277b8de9"
 dependencies = [
  "async-fs",
  "async-io",
@@ -1928,17 +1928,6 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affa551e5cb1ef263ecaa47cdf36ba013872574fa3de1ff8660dd3ddcde89810"
-dependencies = [
- "bytes",
- "fluvio-protocol-derive 0.4.1",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-protocol"
 version = "0.7.7"
 dependencies = [
  "bytes",
@@ -1950,14 +1939,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-protocol-derive"
-version = "0.4.1"
+name = "fluvio-protocol"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2b322665711776c5edbe78187389f72e5cf183598a1bfc59723cab97156659"
+checksum = "c875b24392b835610a0e8c620d11e696014bd106f48a9759bbd080bd1f25d4dd"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "bytes",
+ "fluvio-protocol-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -1971,6 +1959,18 @@ dependencies = [
  "syn",
  "tracing",
  "trybuild",
+]
+
+[[package]]
+name = "fluvio-protocol-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e1b0457e0fd958a6a8f54a508fda58ba169ba667d3fe26367fa50eee4d733b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
 ]
 
 [[package]]
@@ -2266,7 +2266,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.6",
+ "fluvio-protocol 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",
@@ -2706,16 +2706,16 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d6a30320f094710245150395bc763ad23128d6a1ebbad7594dc4164b62c56b"
+checksum = "d113a9853e5accd30f43003560b5563ffbb007e3f325e8b103fa0d0029c6e6df"
 dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -3067,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "ittapi-rs"
@@ -3214,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
@@ -3661,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "owo-colors"
@@ -3929,11 +3929,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3969,12 +3969,6 @@ checksum = "871372391786ccec00d3c5d3d6608905b3d4db263639cfe075d3b60a736d115a"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -4092,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -4104,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -4282,18 +4276,18 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4526,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4590,12 +4584,12 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca642ba17f8b2995138b1d7711829c92e98c0a25ea019de790f4f09279c4e296"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "windows-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4701,13 +4695,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4724,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf915673a340ee41f2fc24ad1286c75ea92026f04b65a0d0e5132d80b95fc61"
+checksum = "56b1e20ee77901236c389ff74618a899ff5fd34719a7ff0fd1d64f0acca5179a"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4965,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5157,6 +5151,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"
@@ -5893,18 +5893,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.1+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.1+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -107,6 +107,9 @@ pub enum ErrorCode {
     #[fluvio(tag = 3002)]
     #[error("the fetch session was not found")]
     FetchSessionNotFoud,
+    #[fluvio(tag = 3003)]
+    #[error("the fetch session already exists for customer_id {0}")]
+    FetchSessionAlreadyExists(u32),
 
     // Legacy SmartModule errors
     #[deprecated(since = "0.9.13")]

--- a/crates/fluvio-protocol/src/api/mod.rs
+++ b/crates/fluvio-protocol/src/api/mod.rs
@@ -8,9 +8,11 @@ use tracing::{debug, trace};
 
 mod request;
 mod response;
+mod session;
 
 pub use self::response::*;
 pub use self::request::*;
+pub use self::session::*;
 use crate::{Encoder, Decoder};
 
 pub const MAX_BYTES: i32 = 52428800;

--- a/crates/fluvio-protocol/src/api/session.rs
+++ b/crates/fluvio-protocol/src/api/session.rs
@@ -1,0 +1,18 @@
+use std::marker::PhantomData;
+use super::Request;
+use crate::Encoder;
+use crate::Decoder;
+
+pub const CLOSE_SESSION_API_KEY: u16 = 10_000;
+
+#[derive(Debug, Encoder, Decoder, Default)]
+pub struct CloseSessionRequest {
+    pub session_id: i32,
+}
+
+impl Request for CloseSessionRequest {
+    const API_KEY: u16 = CLOSE_SESSION_API_KEY;
+    type Response = CloseSessionResponse;
+}
+
+pub type CloseSessionResponse = PhantomData<bool>;

--- a/crates/fluvio-socket/src/multiplexing.rs
+++ b/crates/fluvio-socket/src/multiplexing.rs
@@ -281,10 +281,11 @@ pub struct AsyncResponse<R> {
 impl<R> PinnedDrop for AsyncResponse<R> {
     fn drop(self: Pin<&mut Self>) {
         let session_id = self.correlation_id;
-        run_block_on(async {
+        let sink = self.sink.clone();
+        run_block_on(async move {
             //stream dropped, notify spu
             let request = RequestMessage::new_request(CloseSessionRequest { session_id });
-            match self.sink.send_request(&request).await {
+            match sink.send_request(&request).await {
                 Ok(_) => {
                     trace!(%session_id, "close session request sent");
                 }

--- a/crates/fluvio-socket/src/test_request.rs
+++ b/crates/fluvio-socket/src/test_request.rs
@@ -5,7 +5,9 @@ use std::io::Error as IoError;
 
 use tracing::{debug};
 
-use fluvio_protocol::api::{api_decode, ApiMessage, Request, RequestHeader, RequestMessage};
+use fluvio_protocol::api::{
+    api_decode, ApiMessage, CloseSessionRequest, Request, RequestHeader, RequestMessage,
+};
 use fluvio_protocol::bytes::Buf;
 use fluvio_protocol::derive::{Decoder, Encoder};
 
@@ -15,6 +17,8 @@ use fluvio_protocol::derive::{Decoder, Encoder};
 pub enum TestKafkaApiEnum {
     Echo = 1000,
     Status = 1001,
+
+    CloseSessionRequest = 10_000,
 }
 
 impl Default for TestKafkaApiEnum {
@@ -65,6 +69,7 @@ pub struct AsyncStatusResponse {
 pub enum TestApiRequest {
     EchoRequest(RequestMessage<EchoRequest>),
     AsyncStatusRequest(RequestMessage<AsyncStatusRequest>),
+    CloseSessionRequest(RequestMessage<CloseSessionRequest>),
     Noop(bool),
 }
 
@@ -90,6 +95,9 @@ impl ApiMessage for TestApiRequest {
             TestKafkaApiEnum::Echo => api_decode!(TestApiRequest, EchoRequest, src, header),
             TestKafkaApiEnum::Status => {
                 api_decode!(TestApiRequest, AsyncStatusRequest, src, header)
+            }
+            TestKafkaApiEnum::CloseSessionRequest => {
+                api_decode!(TestApiRequest, CloseSessionRequest, src, header)
             }
         }
     }

--- a/crates/fluvio-spu-schema/src/server/api.rs
+++ b/crates/fluvio-spu-schema/src/server/api.rs
@@ -16,6 +16,7 @@ use dataplane::api::RequestMessage;
 use dataplane::produce::DefaultProduceRequest;
 
 use dataplane::fetch::FileFetchRequest;
+use fluvio_protocol::api::CloseSessionRequest;
 
 use crate::ApiVersionsRequest;
 use super::SpuServerApiKey;
@@ -36,6 +37,7 @@ pub enum SpuServerRequest {
     FetchOffsetsRequest(RequestMessage<FetchOffsetsRequest>),
     FileStreamFetchRequest(RequestMessage<FileStreamFetchRequest>),
     UpdateOffsetsRequest(RequestMessage<UpdateOffsetsRequest>),
+    CloseSessionRequest(RequestMessage<CloseSessionRequest>),
 }
 
 impl fmt::Display for SpuServerRequest {
@@ -47,6 +49,7 @@ impl fmt::Display for SpuServerRequest {
             Self::FetchOffsetsRequest(_) => write!(f, "FetchOffsetsRequest"),
             Self::FileStreamFetchRequest(_) => write!(f, "FileStreamFetchRequest"),
             Self::UpdateOffsetsRequest(_) => write!(f, "UpdateOffsetsRequest"),
+            Self::CloseSessionRequest(_) => write!(f, "CloseSessionRequest"),
         }
     }
 }
@@ -79,6 +82,9 @@ impl ApiMessage for SpuServerRequest {
             SpuServerApiKey::FetchOffsets => api_decode!(Self, FetchOffsetsRequest, src, header),
             SpuServerApiKey::StreamFetch => api_decode!(Self, FileStreamFetchRequest, src, header),
             SpuServerApiKey::UpdateOffsets => api_decode!(Self, UpdateOffsetsRequest, src, header),
+            SpuServerApiKey::CloseSessionRequest => {
+                api_decode!(Self, CloseSessionRequest, src, header)
+            }
         }
     }
 }

--- a/crates/fluvio-spu-schema/src/server/api_key.rs
+++ b/crates/fluvio-spu-schema/src/server/api_key.rs
@@ -6,6 +6,12 @@ static_assertions::const_assert_eq!(
     SpuServerApiKey::ApiVersion as u16,
 );
 
+// Make sure that the CloseSessionRequest variant matches fluvio_protocol's CLOSE_SESSION_API_KEY
+static_assertions::const_assert_eq!(
+    fluvio_protocol::api::CLOSE_SESSION_API_KEY,
+    SpuServerApiKey::CloseSessionRequest as u16,
+);
+
 /// Api Key for Spu Server API
 #[repr(u16)]
 #[derive(PartialEq, Debug, Encoder, Decoder, Clone, Copy)]
@@ -20,6 +26,7 @@ pub enum SpuServerApiKey {
     FetchOffsets = 1002,
     StreamFetch = 1003,
     UpdateOffsets = 1005,
+    CloseSessionRequest = 10_000,
 }
 
 impl Default for SpuServerApiKey {

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -43,6 +43,9 @@ pub const ARRAY_MAP_WASM_API: i16 = 15;
 // version for persistent SmartModule
 pub const SMART_MODULE_API: i16 = 16;
 
+// version for supplied consumer ID's
+pub const CONSUMER_ID_API: i16 = 17;
+
 /// Fetch records continuously
 /// Output will be send back as stream
 #[derive(Decoder, Encoder, Default, Debug)]
@@ -66,6 +69,8 @@ where
     pub smartmodule: Option<SmartModuleInvocation>,
     #[fluvio(min_version = 16)]
     pub derivedstream: Option<DerivedStreamInvocation>,
+    #[fluvio(min_version = 17)]
+    pub consumer_id: u32,
     pub data: PhantomData<R>,
 }
 
@@ -74,7 +79,7 @@ where
     R: Debug + Decoder + Encoder,
 {
     const API_KEY: u16 = SpuServerApiKey::StreamFetch as u16;
-    const DEFAULT_API_VERSION: i16 = SMART_MODULE_API;
+    const DEFAULT_API_VERSION: i16 = CONSUMER_ID_API;
     type Response = StreamFetchResponse<R>;
 }
 

--- a/crates/fluvio-spu/src/services/public/drop_stream.rs
+++ b/crates/fluvio-spu/src/services/public/drop_stream.rs
@@ -1,0 +1,26 @@
+use std::io::Error as IoError;
+
+use tracing::{instrument, trace, debug};
+
+use dataplane::api::RequestMessage;
+use fluvio_protocol::api::CloseSessionRequest;
+
+use crate::core::DefaultSharedGlobalContext;
+
+#[instrument(skip(req_msg, ctx))]
+pub async fn handle_drop_stream_request(
+    req_msg: RequestMessage<CloseSessionRequest>,
+    ctx: DefaultSharedGlobalContext,
+) -> Result<(), IoError> {
+    let request = req_msg.request();
+    let session_id = request.session_id;
+    trace!(%session_id, "handling drop stream request");
+
+    let publishers = ctx.stream_publishers();
+    match publishers.remove_publisher(session_id).await {
+        None => debug!(%session_id, "stream publisher not found"),
+        Some(_) => trace!(%session_id, "stream publisher stopped"),
+    }
+
+    Ok(())
+}

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -4,6 +4,7 @@ mod fetch_handler;
 mod offset_request;
 mod offset_update;
 mod stream_fetch;
+mod drop_stream;
 
 #[cfg(test)]
 mod tests;
@@ -25,6 +26,7 @@ use self::produce_handler::handle_produce_request;
 use self::fetch_handler::handle_fetch_request;
 use self::offset_request::handle_offset_request;
 use self::offset_update::handle_offset_update;
+use self::drop_stream::handle_drop_stream_request;
 use self::stream_fetch::StreamFetchHandler;
 pub use stream_fetch::publishers::StreamPublishers;
 
@@ -119,6 +121,9 @@ impl FluvioService for PublicService {
                             shared_sink,
                             "UpdateOffsetsRequest"
                         ),
+                        SpuServerRequest::CloseSessionRequest(request) => {
+                            handle_drop_stream_request(request, context.clone()).await?
+                        }
                     }
                 }
                 Some(Err(e)) => {

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -2017,6 +2017,8 @@ async fn test_stream_fetch_filter_with_params(
         ..Default::default()
     };
 
+    drop(stream);
+
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
         .await


### PR DESCRIPTION
This PR adds extra information to stream publishers, allowing validation if there are no duplicated streams per consumer and replica.
Also, deleting of finished streams moved up to prevent dangled streams publishers. A stream dangled due to early returns if errors occur.

This is a draft version to validate the idea.

Fixes #2367