### PR TITLE
[Merged by Bors] - Add fish support to install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.27 - UNRELEASED
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))
 * Make Zig Install more reliable ([#2388](https://github.com/infinyon/fluvio/issues/2388s))
+* Add path setting hint for fish shell in install script ([#2389](https://github.com/infinyon/fluvio/pull/2389))
 
 ## Platform Version 0.9.26 - 2022-05-10
 * Increase default `STORAGE_MAX_BATCH_SIZE` ([#2342](https://github.com/infinyon/fluvio/issues/2342))

--- a/install.sh
+++ b/install.sh
@@ -141,12 +141,12 @@ remind_path() {
     say "💡 You'll need to add '~/.fluvio/bin/' to your PATH variable"
     say "    You can run the following to set your PATH on shell startup:"
     
-    # shellcheck disable=SC2016
-    local bash_hint='echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.bashrc'
-    # shellcheck disable=SC2016
-    local zsh_hint='echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.zshrc'
-    # shellcheck disable=SC2016
-    local fish_hint='fish_add_path "$HOME/.fluvio/bin"'
+    # shellcheck disable=SC2016,SC2155
+    local bash_hint="$(tput bold)"'echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.bashrc'"$(tput sgr0)"
+    # shellcheck disable=SC2016,SC2155
+    local zsh_hint="$(tput bold)"'echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.zshrc'"$(tput sgr0)"
+    # shellcheck disable=SC2016,SC2155
+    local fish_hint="$(tput bold)"'fish_add_path "$HOME/.fluvio/bin"'"$(tput sgr0)"
 
     case "$(basename "${SHELL}")" in
         bash)

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,8 @@ remind_path() {
     say '      For bash: echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.bashrc'
     # shellcheck disable=SC2016
     say '      For zsh : echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.zshrc'
+    # shellcheck disable=SC2016
+    say '      For fish : fish_add_path "$HOME/.fluvio/bin"'
     say ""
     say "    To use Fluvio you'll need to restart your shell or run the following:"
     # shellcheck disable=SC2016

--- a/install.sh
+++ b/install.sh
@@ -140,16 +140,30 @@ verify_checksum() {
 remind_path() {
     say "💡 You'll need to add '~/.fluvio/bin/' to your PATH variable"
     say "    You can run the following to set your PATH on shell startup:"
+    
     # shellcheck disable=SC2016
-    say '      For bash: echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.bashrc'
+    local bash_hint='echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.bashrc'
     # shellcheck disable=SC2016
-    say '      For zsh : echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.zshrc'
+    local zsh_hint='echo '\''export PATH="${HOME}/.fluvio/bin:${PATH}"'\'' >> ~/.zshrc'
     # shellcheck disable=SC2016
-    say '      For fish : fish_add_path "$HOME/.fluvio/bin"'
-    say ""
-    say "    To use Fluvio you'll need to restart your shell or run the following:"
-    # shellcheck disable=SC2016
-    say '      export PATH="${HOME}/.fluvio/bin:${PATH}"'
+    local fish_hint='fish_add_path "$HOME/.fluvio/bin"'
+
+    case "$(basename "${SHELL}")" in
+        bash)
+            say "      ${bash_hint}"
+            ;;
+        zsh)
+            say "      ${zsh_hint}"
+            ;;
+        fish)
+            say "      ${fish_hint}"
+            ;;
+        *)
+            say "      For bash: ${bash_hint}"
+            say "      For zsh : ${zsh_hint}"
+            say "      For fish : ${fish_hint}"
+            ;;
+    esac
 }
 
 ############################################################


### PR DESCRIPTION
I recently installed Fluvio from the online installer, but I felt left out when it came time to adding the bindir to my path.

The first commit is the important one, the others just clean the output up slightly, now there are 3 variants.