### PR TITLE
chore(typo): Rename partition's `lsr` -> `lrs`

### DIFF
--- a/crates/fluvio-cli/src/client/partition/list.rs
+++ b/crates/fluvio-cli/src/client/partition/list.rs
@@ -96,7 +96,7 @@ mod display {
                 "SIZE",
                 "HW",
                 "LEO",
-                "LRS",
+                "LSR",
                 "FOLLOWER OFFSETS",
             ])
         }

--- a/crates/fluvio-controlplane-metadata/src/partition/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/partition/status.rs
@@ -29,10 +29,8 @@ use super::ElectionScoring;
 pub struct PartitionStatus {
     pub resolution: PartitionResolution,
     pub leader: ReplicaStatus,
-    // TODO: Next time we make a breaking protocol change, rename this to `lrs`
-    // TODO: There is no such thing as `lsr`, it is a typo
-    #[cfg_attr(feature = "use_serde", serde(alias = "lrs"))]
-    pub lsr: u32,
+    #[cfg_attr(feature = "use_serde", serde(alias = "lsr"))]
+    pub lrs: u32,
     pub replicas: Vec<ReplicaStatus>,
     #[cfg_attr(
         feature = "use_serde",
@@ -49,7 +47,7 @@ impl Default for PartitionStatus {
             size: PartitionStatus::SIZE_NOT_SUPPORTED,
             resolution: Default::default(),
             leader: Default::default(),
-            lsr: Default::default(),
+            lrs: Default::default(),
             replicas: Default::default(),
             is_being_deleted: Default::default(),
         }
@@ -117,11 +115,11 @@ impl PartitionStatus {
 
     #[deprecated = "Replaced by lrs()"]
     pub fn lsr(&self) -> u32 {
-        self.lsr
+        self.lrs()
     }
 
     pub fn lrs(&self) -> u32 {
-        self.lsr
+        self.lrs
     }
 
     pub fn replica_iter(&self) -> Iter<ReplicaStatus> {
@@ -211,7 +209,7 @@ impl PartitionStatus {
     /// recalculate lrs which is count of follower whose leo is same as leader
     fn update_lrs(&mut self) {
         let leader_leo = self.leader.leo;
-        self.lsr = self
+        self.lrs = self
             .replicas
             .iter()
             .filter(|re| re.leo != -1 && leader_leo == re.leo)

--- a/k8-util/helm/fluvio-sys/templates/crd_partition.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_partition.yaml
@@ -76,11 +76,11 @@ spec:
         type: boolean
         description: Being deleted
         jsonPath: .status.isBeingDeleted
-      - name: LSR
+      - name: LRS
         type: integer
         format: int32
         description: Live Replicas
-        jsonPath: .status.lsr
+        jsonPath: .status.lrs
       - name: HW
         type: integer
         format: int64


### PR DESCRIPTION
Found old TODO for a typo fix on next minor version bump
Basically this is redoing #1298