### PR TITLE
Add generic trait impl for everything that dereferences to `Request`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Platform Version 0.9.28 - UNRELEASED
 
+* Add generic trait impl for everything that dereferences to `Request` ([#2397](https://github.com/infinyon/fluvio/pull/2397))
+
 ## Platform Version 0.9.27 - 2022-05-25
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))
 * Make Zig Install more reliable ([#2388](https://github.com/infinyon/fluvio/issues/2388s))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-sc-schema",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -1604,7 +1604,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1802,7 +1802,7 @@ version = "0.0.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-types",
  "log",
  "tracing",
@@ -1816,7 +1816,7 @@ dependencies = [
  "base64",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -1839,7 +1839,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-socket",
  "fluvio-types",
  "flv-util",
@@ -1929,6 +1929,17 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol"
 version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c875b24392b835610a0e8c620d11e696014bd106f48a9759bbd080bd1f25d4dd"
+dependencies = [
+ "bytes",
+ "fluvio-protocol-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.7.8"
 dependencies = [
  "bytes",
  "fluvio-future",
@@ -1939,21 +1950,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-protocol"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c875b24392b835610a0e8c620d11e696014bd106f48a9759bbd080bd1f25d4dd"
-dependencies = [
- "bytes",
- "fluvio-protocol-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
-]
-
-[[package]]
 name = "fluvio-protocol-derive"
 version = "0.4.2"
 dependencies = [
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "proc-macro2",
  "quote",
  "syn",
@@ -2005,7 +2005,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -2038,7 +2038,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-types",
  "log",
  "paste",
@@ -2054,7 +2054,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-socket",
  "fluvio-types",
  "futures-util",
@@ -2112,7 +2112,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -2146,7 +2146,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-service",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -2176,7 +2176,7 @@ dependencies = [
  "bytes",
  "flate2",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "log",
  "serde",
  "static_assertions",
@@ -2197,7 +2197,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7",
+ "fluvio-protocol 0.7.8",
  "fluvio-socket",
  "fluvio-storage",
  "fluvio-types",
@@ -2266,7 +2266,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future",
- "fluvio-protocol 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol 0.7.7",
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/api/mod.rs
+++ b/crates/fluvio-protocol/src/api/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::fs::File;
 use std::io::{Cursor, Error as IoError, ErrorKind, Read};
 use std::convert::TryFrom;
+use std::ops::Deref;
 use bytes::Buf;
 use tracing::{debug, trace};
 
@@ -76,6 +77,11 @@ pub trait ApiMessage: Sized + Default {
 
         Self::decode_from(&mut src)
     }
+}
+
+impl<T: Request, D: Deref<Target = T> + Debug + Encoder + Decoder> Request for D {
+    const API_KEY: u16 = T::API_KEY;
+    type Response = T::Response;
 }
 
 pub trait ApiKey: Sized + Encoder + Decoder + TryFrom<u16> {}


### PR DESCRIPTION
Added generic impl of `Request` trait for everything that dereferences to `Request`.

Also, impl `Decoder` and `Encoder` for Arc<T: Decoder + Encoder>.

These changes allow using `Arc<any Request>` in retries without cloning the data.

Related to #2361 