### PR TITLE
[Merged by Bors] - Fix diagnostics run if profile is not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14]
+        run: [r1]
         spu: [2]
         test:
           [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14]
         spu: [2]
         test:
           [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10]
         spu: [2]
         test:
           [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.28 - UNRELEASED
 * Upgrade to Wasmtime 0.37 ([#2400](https://github.com/infinyon/fluvio/pull/2400))
+* Allow Cluster diagnostics to continue even if profile doesn't exist  ([#2400](https://github.com/infinyon/fluvio/pull/2402))
 
 ## Platform Version 0.9.27 - 2022-05-25
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -47,7 +47,13 @@ impl DiagnosticsOpt {
         let temp_dir = tempdir::TempDir::new("fluvio-diagnostics")?;
         let temp_path = temp_dir.path();
 
-        let spu_specs = self.copy_fluvio_specs(temp_path).await?;
+        let spu_specs = match self.copy_fluvio_specs(temp_path).await {
+            Ok(specs) => specs,
+            Err(err) => {
+                eprintln!("error copying fluivo specs: {:#?}", err);
+                vec![]
+            }
+        };
 
         // write internal fluvio cluster internal state
         match profile_ty {
@@ -222,6 +228,8 @@ impl DiagnosticsOpt {
 
     async fn copy_fluvio_specs(&self, dest: &Path) -> Result<Vec<Metadata<SpuSpec>>> {
         use fluvio::Fluvio;
+
+        println!("start copying fluvio specs from...");
         let fluvio = Fluvio::connect().await?;
         let admin = fluvio.admin().await;
 

--- a/crates/fluvio-sc/src/k8/controllers/spu_controller.rs
+++ b/crates/fluvio-sc/src/k8/controllers/spu_controller.rs
@@ -23,6 +23,8 @@ use crate::stores::spg::{SpuGroupSpec};
 
 /// Update SPU from changes in SPU Group and SPU Services
 /// This is only place where we make changes to SPU
+/// For each SPU Group, we create children SPUs so it's 1:M parent-child relationship
+/// For each SPU Service, we create SPUs so it's 1:M parent-child relationship
 pub struct K8SpuController {
     services: StoreContext<SpuServiceSpec>,
     groups: StoreContext<SpuGroupSpec>,

--- a/crates/fluvio-sc/src/k8/controllers/spu_controller.rs
+++ b/crates/fluvio-sc/src/k8/controllers/spu_controller.rs
@@ -23,8 +23,7 @@ use crate::stores::spg::{SpuGroupSpec};
 
 /// Update SPU from changes in SPU Group and SPU Services
 /// This is only place where we make changes to SPU
-/// For each SPU Group, we create children SPUs so it's 1:M parent-child relationship
-/// For each SPU Service, we create SPUs so it's 1:M parent-child relationship
+/// For each SPU Group, we map to children SPUs so it's 1:M parent-child relationship
 pub struct K8SpuController {
     services: StoreContext<SpuServiceSpec>,
     groups: StoreContext<SpuGroupSpec>,


### PR DESCRIPTION
Related to #2320.

Allow diagnostics to continue even if the fluvio profile is not found