### PR TITLE
remove log from hourly cluster start

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Start Fluvio Cluster
         run: |
           fluvio version
-          RUST_LOG=fluvio=debug fluvio cluster start
+          fluvio cluster start
 
       # Disabled for now bc data load is unstable in CI
       #- name: Look for longevity data


### PR DESCRIPTION
with log, hourly tests without failure.  Unto log to see if it can reproduce failure. If so, this could be due to (1) k8 client (2) OpenSSL since some of the log indicate TLS could be issue