### PR TITLE
[Merged by Bors] - fix hourly failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,7 +602,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
+        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [3]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,7 +602,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
-        run: [r1,r2,r3,r4,r5,r6,r7,r8,r9,r10]
+        run: [r1]
         test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean]
         k8: [k3d, minikube]
         spu: [3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Platform Version 0.9.28 - UNRELEASED
 * Upgrade to Wasmtime 0.37 ([#2400](https://github.com/infinyon/fluvio/pull/2400))
 * Allow Cluster diagnostics to continue even if profile doesn't exist  ([#2400](https://github.com/infinyon/fluvio/pull/2402))
+* Add timeout when creating SPG ([#2364](https://github.com/infinyon/fluvio/issues/2411))
 
 ## Platform Version 0.9.27 - 2022-05-25
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.12"
+version = "0.12.14"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.14"
+version = "0.12.13"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -66,7 +66,7 @@ fluvio-extension-common = { path = "../fluvio-extension-common", optional = true
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = [
     "k8",
 ] }
-fluvio-sc-schema = { path = "../fluvio-sc-schema", default-features = false, optional = true }
+fluvio-sc-schema = { path = "../fluvio-sc-schema", default-features = false}
 flv-util = "0.5.2"
 k8-config = { version = "2.0.0" }
 k8-client = { version = "6.0.0" }

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -11,6 +11,7 @@ use std::time::SystemTime;
 use derive_builder::Builder;
 use fluvio::FluvioAdmin;
 use fluvio_controlplane_metadata::spg::SpuConfig;
+use fluvio_sc_schema::objects::CommonCreateRequest;
 use k8_client::SharedK8Client;
 use k8_client::load_and_share;
 use tracing::{warn, debug, instrument};
@@ -1149,7 +1150,16 @@ impl ClusterInstaller {
                 spu_config: self.config.spu_config.clone(),
             };
 
-            admin.create(spg_name.clone(), false, spu_spec).await?;
+            admin
+                .create_with_config(
+                    CommonCreateRequest {
+                        name: spg_name.clone(),
+                        timeout: Some(*MAX_PROVISION_TIME_SEC as u32 * 1000),
+                        ..Default::default()
+                    },
+                    spu_spec,
+                )
+                .await?;
             pb.set_message(format!("🤖 Spu Group {} started", spg_name));
         } else {
             pb.set_message("SPU Group Exists,skipping");

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"

--- a/crates/fluvio-sc-schema/src/objects/create.rs
+++ b/crates/fluvio-sc-schema/src/objects/create.rs
@@ -25,11 +25,13 @@ pub struct CreateRequest<S: CreatableAdminSpec> {
 pub struct CommonCreateRequest {
     pub name: String,
     pub dry_run: bool,
+    #[fluvio(min_version = 7)]
+    pub timeout: Option<u32>, // timeout in milliseconds
 }
 
 impl Request for ObjectApiCreateRequest {
     const API_KEY: u16 = AdminPublicApiKey::Create as u16;
-    const DEFAULT_API_VERSION: i16 = 6;
+    const DEFAULT_API_VERSION: i16 = 7;
     type Response = Status;
 }
 

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.14"
+version = "0.12.13"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -54,7 +54,9 @@ fluvio-types = { version = "0.3.7", features = [
 fluvio-sc-schema = { version = "0.14.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
-dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = ["memory_batch"], package = "fluvio-dataplane-protocol" }
+dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = [
+    "memory_batch",
+], package = "fluvio-dataplane-protocol" }
 fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.12"
+version = "0.12.14"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -51,7 +51,7 @@ fluvio-future = { version = "0.3.12", features = [
 fluvio-types = { version = "0.3.7", features = [
     "events",
 ], path = "../fluvio-types" }
-fluvio-sc-schema = { version = "0.13.0", path = "../fluvio-sc-schema", default-features = false }
+fluvio-sc-schema = { version = "0.14.0", path = "../fluvio-sc-schema", default-features = false }
 fluvio-socket = { path = "../fluvio-socket", version = "0.11.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = ["memory_batch"], package = "fluvio-dataplane-protocol" }

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -151,9 +151,26 @@ impl FluvioAdmin {
         S: CreatableAdminSpec + Sync + Send,
         ObjectApiCreateRequest: From<(CommonCreateRequest, S)>,
     {
-        let common_request = CommonCreateRequest { name, dry_run };
+        let common_request = CommonCreateRequest {
+            name,
+            dry_run,
+            ..Default::default()
+        };
 
-        let create_request: ObjectApiCreateRequest = (common_request, spec).into();
+        self.create_with_config(common_request, spec).await
+    }
+
+    #[instrument(skip(self, config, spec))]
+    pub async fn create_with_config<S>(
+        &self,
+        config: CommonCreateRequest,
+        spec: S,
+    ) -> Result<(), FluvioError>
+    where
+        S: CreatableAdminSpec + Sync + Send,
+        ObjectApiCreateRequest: From<(CommonCreateRequest, S)>,
+    {
+        let create_request: ObjectApiCreateRequest = (config, spec).into();
 
         debug!("sending create request: {:#?}", create_request);
 


### PR DESCRIPTION
resolves #2411.

Add timeout (ms) in create time to override default SPG timeout which was set to 2 minute which is too low. 
This bump up `fluvio_sc_schema` since this changes API signature of the CommonCreateRequest