### PR TITLE
[Merged by Bors] - Display multi-word subcommand aliases in CLI help info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Upgrade to Wasmtime 0.37 ([#2400](https://github.com/infinyon/fluvio/pull/2400))
 * Allow Cluster diagnostics to continue even if profile doesn't exist  ([#2400](https://github.com/infinyon/fluvio/pull/2402))
 * Add timeout when creating SPG ([#2364](https://github.com/infinyon/fluvio/issues/2411))
-* Log fluvio version and git rev on client creation ([#2403](https://github.com/infinyon/fluvio/issues/2403)
+* Log fluvio version and git rev on client creation ([#2403](https://github.com/infinyon/fluvio/issues/2403))
+* Display multi-word subcommand aliases in CLI help info ([#2033](https://github.com/infinyon/fluvio/issues/2033))
 
 ## Platform Version 0.9.27 - 2022-05-25
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -160,14 +160,14 @@ mod root {
         ///
         /// Used with the consumer output type `full_table` to
         /// describe how to render JSON data in a tabular form
-        #[clap(subcommand, name = "table-format", aliases = &["tf"])]
+        #[clap(subcommand, name = "table-format", visible_alias = "tf")]
         TableFormat(TableFormatCmd),
 
         /// Create and manage DerivedStreams
         ///
         /// Use topics, SmartModules or other DerivedStreams
         /// to build a customized stream to consume
-        #[clap(subcommand, name = "derived-stream", aliases = &["ds"])]
+        #[clap(subcommand, name = "derived-stream", visible_alias = "ds")]
         DerivedStream(DerivedStreamCmd),
 
         #[clap(external_subcommand)]
@@ -281,7 +281,7 @@ mod root {
         /// Create and manage SmartModules
         ///
         /// SmartModules are compiled WASM modules used to create SmartModules.
-        #[clap(subcommand, name = "smart-module", aliases = &["sm"])]
+        #[clap(subcommand, name = "smart-module", visible_alias = "sm")]
         SmartModule(SmartModuleCmd),
     }
 


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio/issues/2033

Example:
```
Fluvio Command Line Interface

fluvio-cli [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -c, --cluster <host:port>          Address of cluster
        --tls                          Enable TLS
        --enable-client-cert           TLS: use client cert
        --domain <DOMAIN>              Required if client cert is used
        --ca-cert <CA_CERT>            Path to TLS ca cert, required when client cert is enabled
        --client-cert <CLIENT_CERT>    Path to TLS client certificate
        --client-key <CLIENT_KEY>      Path to TLS client private key
    -P, --profile <profile>            
    -h, --help                         Print help information

SUBCOMMANDS:
    consume           Read messages from a topic/partition
    produce           Write messages to a topic/partition
    topic             Manage and view Topics
    partition         Manage and view Partitions
    smart-module      Create and manage SmartModules [aliases: sm]
    profile           Manage Profiles, which describe linked clusters
    cluster           Install or uninstall Fluvio cluster
    install           Install Fluvio plugins
    update            Update the Fluvio CLI
    version           Print Fluvio version information
    completions       Generate command-line completions for Fluvio
    connector         Create and work with Managed Connectors
    table-format      Create a TableFormat display specification [aliases: tf]
    derived-stream    Create and manage DerivedStreams [aliases: ds]
    help              Print this message or the help of the given subcommand(s)
```

This makes use of `clap`s `visible_alias` subcommand feature.