### PR TITLE
[Merged by Bors] - Add specific log_dir creation error

### DIFF
--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -236,7 +236,7 @@ jobs:
           log_dir="/obviously/not/a/writable/path"
           stderr="$(mktemp)"
           echo "Starting cluster with '--log-dir=${log_dir}'"
-          fluvio cluster start --local --develop --log-dir "${log_dir}" 2>$stderr
+          fluvio cluster start --local --develop --skip-checks --log-dir "${log_dir}" 2>$stderr
           [ $? -eq 0 ] && { echo "Expected nonzero exit code, got $?"; exit 2; }
           grep -qF "${log_dir}" $stderr || { echo "Expected to find '${log_dir}' in stderr"; exit 3; }
 

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -233,6 +233,7 @@ jobs:
       - name: Start local fluvio cluster with bad --log-dir
         timeout-minutes: 1
         run: |
+          set +e
           log_dir="/obviously/not/a/writable/path"
           stderr="$(mktemp)"
           echo "Starting cluster with '--log-dir=${log_dir}'"

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -237,7 +237,7 @@ jobs:
           log_dir="/obviously/not/a/writable/path"
           stderr="$(mktemp)"
           echo "Starting cluster with '--log-dir=${log_dir}'"
-          fluvio cluster start --local --develop --skip-checks --log-dir "${log_dir}" 2>$stderr
+          fluvio cluster start --local --develop --skip-checks --log-dir "${log_dir}" 2> >(tee $stderr >&2)
           [ $? -eq 0 ] && { echo "Expected nonzero exit code, got $?"; exit 2; }
           grep -qF "${log_dir}" $stderr || { echo "Expected to find '${log_dir}' in stderr"; exit 3; }
 

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -189,6 +189,56 @@ jobs:
           name: local-${{ matrix.run }}-${{ matrix.test }}-diag
           path: diagnostics*.gz
 
+  verify_cli_errors:
+    name: Verify error message output under CLI error condition
+    needs:
+      - build_primary_binaries
+      - config
+    runs-on: ${{ matrix.os }}
+    env:
+      UNINSTALL: noclean
+      FLUVIO_BIN: ~/bin/fluvio
+      TEST_BIN: ~/bin/fluvio-test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-12]
+        rust-target: [x86_64-apple-darwin]
+        run: [r1]
+        spu: [1]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v2
+        with:
+          name: fluvio-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Download artifact - fluvio-run
+        uses: actions/download-artifact@v2
+        with:
+          name: fluvio-run-${{ matrix.rust-target }}
+          path: ~/.fluvio/extensions
+      - run: chmod +x ~/.fluvio/extensions/fluvio-run
+      - name: Download artifact - fluvio-test
+        uses: actions/download-artifact@v2
+        with:
+          name: fluvio-test-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Set up Fluvio binaries
+        run: |
+          chmod +x ~/bin/fluvio ~/bin/fluvio-test ~/.fluvio/extensions/fluvio-run
+          echo "~/bin" >> $GITHUB_PATH
+          echo "DEFAULT_SPU=${{ matrix.spu }}" | tee -a $GITHUB_ENV
+          echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
+      - name: Start local fluvio cluster with bad --log-dir
+        timeout-minutes: 1
+        run: |
+          log_dir="/obviously/not/a/writable/path"
+          stderr="$(mktemp)"
+          echo "Starting cluster with '--log-dir=${log_dir}'"
+          fluvio cluster start --local --develop --log-dir "${log_dir}" 2>$stderr
+          [ $? -eq 0 ] && { echo "Expected nonzero exit code, got $?"; exit 2; }
+          grep -qF "${log_dir}" $stderr || { echo "Expected to find '${log_dir}' in stderr"; exit 3; }
 
  # same as in ci.yaml except no aa64
   build_image:

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -239,7 +239,7 @@ jobs:
           brew install kind
           kind create cluster --config k8-util/cluster/kind.yaml
       - name: Start local fluvio cluster with bad --log-dir
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: |
           set +e
           log_dir="/obviously/not/a/writable/path"

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -230,6 +230,14 @@ jobs:
           echo "~/bin" >> $GITHUB_PATH
           echo "DEFAULT_SPU=${{ matrix.spu }}" | tee -a $GITHUB_ENV
           echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
+      - name: Print version
+        run: fluvio version
+      - name: Set up Docker for Mac
+        uses: docker-practice/actions-setup-docker@master
+      - name: Install and start Kind
+        run: |
+          brew install kind
+          kind create cluster --config k8-util/cluster/kind.yaml
       - name: Start local fluvio cluster with bad --log-dir
         timeout-minutes: 1
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.30 - UNRELEASED
+* Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))
 
 ## Platform Version 0.9.29 - 2022-06-27 
 * Revert 0.9.28 updates to Connector yaml config ([#2436](https://github.com/infinyon/fluvio/pull/2436))

--- a/crates/fluvio-cluster/src/error.rs
+++ b/crates/fluvio-cluster/src/error.rs
@@ -93,6 +93,12 @@ pub enum K8InstallError {
 /// Errors that may occur while trying to install Fluvio locally
 #[derive(thiserror::Error, Debug)]
 pub enum LocalInstallError {
+    /// An IO error occured during log dir creation
+    #[error("An error occurred creating the cluster log directory {path:?}")]
+    LogDirectoryError {
+        path: std::path::PathBuf,
+        source: IoError,
+    },
     /// An IO error occurred, such as opening a file or running a command.
     #[error(transparent)]
     IoError(#[from] IoError),

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -395,7 +395,12 @@ impl LocalInstaller {
         debug!("using log dir: {}", self.config.log_dir.display());
         pb.set_message("Creating log directory");
         if !self.config.log_dir.exists() {
-            create_dir_all(&self.config.log_dir).map_err(LocalInstallError::IoError)?;
+            create_dir_all(&self.config.log_dir).map_err(|e| {
+                LocalInstallError::LogDirectoryError {
+                    path: self.config.log_dir.clone(),
+                    source: e,
+                }
+            })?;
         }
 
         pb.set_message("Sync files");

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -385,13 +385,6 @@ impl LocalInstaller {
 
         let pb = self.pb_factory.create();
 
-        let client = load_and_share()?;
-
-        pb.set_message("Ensure CRDs are installed");
-        // before we do let's try make sure SPU are installed.
-        check_crd(client.clone()).await?;
-        pb.set_message("CRD Checked");
-
         debug!("using log dir: {}", self.config.log_dir.display());
         pb.set_message("Creating log directory");
         if !self.config.log_dir.exists() {
@@ -402,6 +395,13 @@ impl LocalInstaller {
                 }
             })?;
         }
+
+        let client = load_and_share()?;
+
+        pb.set_message("Ensure CRDs are installed");
+        // before we do let's try make sure SPU are installed.
+        check_crd(client.clone()).await?;
+        pb.set_message("CRD Checked");
 
         pb.set_message("Sync files");
         // ensure we sync files before we launch servers


### PR DESCRIPTION
Previous implementation simply prints:
	0: Fluvio cluster error
	1: Permission denied (os error 13)

...which gives no information regarding which operation caused the
error, or even to which path the error relates.

This commit adds an interstitial error to the chain, which prints:
	1: An error occurred creating the cluster log directory "/usr/local/var/log/fluvio"