### PR TITLE
[Merged by Bors] - Add custom deserializer for connector yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Display multi-word subcommand aliases in CLI help info ([#2033](https://github.com/infinyon/fluvio/issues/2033))
 * Add filter-map support to SmartProducer ([#2418](https://github.com/infinyon/fluvio/issues/2418))
 * Fix `wasi` functions binding relying on order ([#2428](https://github.com/infinyon/fluvio/pull/2428))
+* Add top level `producer` and `consumer` entries to connector yaml configurations. ([#2426](https://github.com/infinyon/fluvio/issues/2426))
+* Allow string, dictionaries and lists as options to `paramaters` section in connector yaml. ([#2426](https://github.com/infinyon/fluvio/issues/2426))
 
 ## Platform Version 0.9.27 - 2022-05-25
 * Support installing clusters on Google Kubernetes Engine ([#2364](https://github.com/infinyon/fluvio/issues/2364))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "home",
  "http-types",
  "humantime",
+ "humantime-serde",
  "indicatif",
  "k8-client",
  "k8-config",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -67,6 +67,7 @@ crossterm = { version = "0.23.0", features = ['event-stream']}
 tui = { version = "0.17.0", default-features = false, features = ['crossterm'] }
 futures = "0.3"
 humantime = "2.1.0"
+humantime-serde = "1.1.1"
 bytesize = { version = "1.1.0", features = ['serde'] }
 
 # Fluvio dependencies

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -193,7 +193,7 @@ impl ConnectorConfig {
             if let Some(batch_size_string) = &producer.batch_size_string {
                 let batch_size = batch_size_string
                     .parse::<ByteSize>()
-                    .map_err(|e| CliError::Other(e))?;
+                    .map_err(CliError::Other)?;
                 producer.batch_size = Some(batch_size);
             }
         }

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -116,16 +116,34 @@ fn config_test() {
     let connector_cfg = ConnectorConfig::from_file("test-data/test-config.yaml")
         .expect("Failed to load test config");
     let expected_params = BTreeMap::from([
-        ("param_1".to_string(), YamlParameter{ context: vec!["mqtt.hsl.fi".to_string()] }),
-        ("param_2".to_string(), YamlParameter{ context: vec!["foo:bar".to_string(), "bar:foo".to_string()] }),
-        ("param_3".to_string(), YamlParameter{ context: vec!["baz".to_string()] })
+        (
+            "param_1".to_string(),
+            YamlParameter {
+                context: vec!["mqtt.hsl.fi".to_string()],
+            },
+        ),
+        (
+            "param_2".to_string(),
+            YamlParameter {
+                context: vec!["foo:bar".to_string(), "bar:foo".to_string()],
+            },
+        ),
+        (
+            "param_3".to_string(),
+            YamlParameter {
+                context: vec!["baz".to_string()],
+            },
+        ),
     ]);
     assert_eq!(connector_cfg.parameters, expected_params);
     let out: ManagedConnectorSpec = connector_cfg.into();
     let expected_params = BTreeMap::from([
         ("consumer-partition".to_string(), vec!["10".to_string()]),
         ("param_1".to_string(), vec!["mqtt.hsl.fi".to_string()]),
-        ("param_2".to_string(), vec!["foo:bar".to_string(), "bar:foo".to_string()]),
+        (
+            "param_2".to_string(),
+            vec!["foo:bar".to_string(), "bar:foo".to_string()],
+        ),
         ("param_3".to_string(), vec!["baz".to_string()]),
         ("producer-batch-size".to_string(), vec!["44".to_string()]),
         ("producer-compression".to_string(), vec!["Gzip".to_string()]),

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -318,8 +318,8 @@ fn error_yaml_tests() {
     #[cfg(unix)]
     assert_eq!("ConnectorConfig(Message(\"unknown variant `gzipaoeu`, expected one of `none`, `gzip`, `snappy`, `lz4`\", Some(Pos { marker: Marker { index: 123, line: 8, col: 15 }, path: \"producer.compression\" })))", format!("{:?}", connector_cfg));
 
-    #[cfg(unix)]
     let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-batchsize.yaml")
         .expect_err("This yaml should error");
+    #[cfg(unix)]
     assert_eq!("Other(\"couldn't parse \\\"aoeu\\\" into a known SI unit, couldn't parse unit of \\\"aoeu\\\"\")", format!("{:?}", connector_cfg));
 }

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -311,11 +311,14 @@ fn simple_yaml_test() {
 fn error_yaml_tests() {
     let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-linger.yaml")
         .expect_err("This yaml should error");
+    #[cfg(unix)]
     assert_eq!("ConnectorConfig(Message(\"invalid value: string \\\"1\\\", expected a duration\", Some(Pos { marker: Marker { index: 118, line: 8, col: 10 }, path: \"producer.linger\" })))", format!("{:?}", connector_cfg));
     let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-compression.yaml")
         .expect_err("This yaml should error");
+    #[cfg(unix)]
     assert_eq!("ConnectorConfig(Message(\"unknown variant `gzipaoeu`, expected one of `none`, `gzip`, `snappy`, `lz4`\", Some(Pos { marker: Marker { index: 123, line: 8, col: 15 }, path: \"producer.compression\" })))", format!("{:?}", connector_cfg));
 
+    #[cfg(unix)]
     let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-batchsize.yaml")
         .expect_err("This yaml should error");
     assert_eq!("Other(\"couldn't parse \\\"aoeu\\\" into a known SI unit, couldn't parse unit of \\\"aoeu\\\"\")", format!("{:?}", connector_cfg));

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 use clap::Parser;
 
-use serde::{
-    Deserializer,
-    Deserialize,
-};
+use serde::{Deserializer, Deserialize};
 use serde::de::{self, Visitor, SeqAccess};
 use std::fmt;
 use std::collections::BTreeMap;
@@ -12,10 +9,7 @@ use std::path::PathBuf;
 use std::fs::File;
 use std::io::Read;
 
-use fluvio::{
-    Fluvio,
-    Compression,
-};
+use fluvio::{Fluvio, Compression};
 use fluvio::metadata::connector::{ManagedConnectorSpec, SecretString};
 use fluvio_extension_common::Terminal;
 use fluvio_extension_common::COMMAND_TEMPLATE;
@@ -129,7 +123,7 @@ fn config_test() {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConsumerParameters {
     #[serde(default)]
-    partition: Option<i32>
+    partition: Option<i32>,
 }
 use std::time::Duration;
 
@@ -142,7 +136,6 @@ pub struct ProducerParameters {
 
     batch_size: Option<usize>,
 }
-
 
 impl ConnectorConfig {
     pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, CliError> {
@@ -210,8 +203,7 @@ impl<'de> Deserialize<'de> for YamlParameter {
 
 struct YamlParameterVisitor;
 
-impl<'de> Visitor<'de> for YamlParameterVisitor
-{
+impl<'de> Visitor<'de> for YamlParameterVisitor {
     type Value = YamlParameter;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -222,15 +214,17 @@ impl<'de> Visitor<'de> for YamlParameterVisitor
     where
         E: de::Error,
     {
-        Ok(YamlParameter{ context: vec![value.to_string()] })
+        Ok(YamlParameter {
+            context: vec![value.to_string()],
+        })
     }
 
     fn visit_seq<A>(self, seq: A) -> Result<YamlParameter, A::Error>
-        where A: SeqAccess<'de>,
+    where
+        A: SeqAccess<'de>,
     {
-        Ok(YamlParameter{ context: vec![] })
+        Ok(YamlParameter { context: vec![] })
 
-       //Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
+        //Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
     }
-
 }

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -113,7 +113,6 @@ pub struct ConnectorConfig {
     consumer: Option<ConsumerParameters>,
 }
 
-
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConsumerParameters {
     #[serde(default)]
@@ -255,7 +254,6 @@ impl<'de> Visitor<'de> for YamlParameterVisitor {
     }
 }
 
-
 #[test]
 fn full_yaml_test() {
     let connector_cfg = ConnectorConfig::from_file("test-data/connectors/full-config.yaml")
@@ -311,11 +309,14 @@ fn simple_yaml_test() {
 
 #[test]
 fn error_yaml_tests() {
-    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-linger.yaml").expect_err("This yaml should error");
+    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-linger.yaml")
+        .expect_err("This yaml should error");
     assert_eq!("ConnectorConfig(Message(\"invalid value: string \\\"1\\\", expected a duration\", Some(Pos { marker: Marker { index: 118, line: 8, col: 10 }, path: \"producer.linger\" })))", format!("{:?}", connector_cfg));
-    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-compression.yaml").expect_err("This yaml should error");
+    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-compression.yaml")
+        .expect_err("This yaml should error");
     assert_eq!("ConnectorConfig(Message(\"unknown variant `gzipaoeu`, expected one of `none`, `gzip`, `snappy`, `lz4`\", Some(Pos { marker: Marker { index: 123, line: 8, col: 15 }, path: \"producer.compression\" })))", format!("{:?}", connector_cfg));
 
-    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-batchsize.yaml").expect_err("This yaml should error");
+    let connector_cfg = ConnectorConfig::from_file("test-data/connectors/error-batchsize.yaml")
+        .expect_err("This yaml should error");
     assert_eq!("Other(\"couldn't parse \\\"aoeu\\\" into a known SI unit, couldn't parse unit of \\\"aoeu\\\"\")", format!("{:?}", connector_cfg));
 }

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -115,9 +115,23 @@ pub struct ConnectorConfig {
 fn config_test() {
     let connector_cfg = ConnectorConfig::from_file("test-data/test-config.yaml")
         .expect("Failed to load test config");
-    println!("{:#?}", connector_cfg);
+    let expected_params = BTreeMap::from([
+        ("param_1".to_string(), YamlParameter{ context: vec!["mqtt.hsl.fi".to_string()] }),
+        ("param_2".to_string(), YamlParameter{ context: vec!["foo:bar".to_string(), "bar:foo".to_string()] }),
+        ("param_3".to_string(), YamlParameter{ context: vec!["baz".to_string()] })
+    ]);
+    assert_eq!(connector_cfg.parameters, expected_params);
     let out: ManagedConnectorSpec = connector_cfg.into();
-    println!("{:#?}", out);
+    let expected_params = BTreeMap::from([
+        ("consumer-partition".to_string(), vec!["10".to_string()]),
+        ("param_1".to_string(), vec!["mqtt.hsl.fi".to_string()]),
+        ("param_2".to_string(), vec!["foo:bar".to_string(), "bar:foo".to_string()]),
+        ("param_3".to_string(), vec!["baz".to_string()]),
+        ("producer-batch-size".to_string(), vec!["44".to_string()]),
+        ("producer-compression".to_string(), vec!["Gzip".to_string()]),
+        ("producer-linger".to_string(), vec!["1ms".to_string()]),
+    ]);
+    assert_eq!(out.parameters, expected_params);
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -188,7 +202,7 @@ impl From<ConnectorConfig> for ManagedConnectorSpec {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct YamlParameter {
     context: Vec<String>,
 }

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::fs::File;
 use std::io::Read;
+use std::time::Duration;
+use bytesize::ByteSize;
 
 use fluvio::{Fluvio, Compression};
 use fluvio::metadata::connector::{ManagedConnectorSpec, SecretString};
@@ -157,7 +159,6 @@ pub struct ConsumerParameters {
     #[serde(default)]
     partition: Option<i32>,
 }
-use std::time::Duration;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ProducerParameters {
@@ -166,7 +167,7 @@ pub struct ProducerParameters {
 
     compression: Option<Compression>,
 
-    batch_size: Option<usize>,
+    batch_size: Option<ByteSize>,
 }
 
 impl ConnectorConfig {

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -1,13 +1,21 @@
 use std::sync::Arc;
 use clap::Parser;
 
-use serde::Deserialize;
+use serde::{
+    Deserializer,
+    Deserialize,
+};
+use serde::de::{self, Visitor, SeqAccess};
+use std::fmt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::fs::File;
 use std::io::Read;
 
-use fluvio::Fluvio;
+use fluvio::{
+    Fluvio,
+    Compression,
+};
 use fluvio::metadata::connector::{ManagedConnectorSpec, SecretString};
 use fluvio_extension_common::Terminal;
 use fluvio_extension_common::COMMAND_TEMPLATE;
@@ -101,8 +109,91 @@ pub struct ConnectorConfig {
 
     #[serde(default)]
     secrets: BTreeMap<String, SecretString>,
+
+    #[serde(default)]
+    producer: Option<ProducerParameters>,
+
+    #[serde(default)]
+    consumer: Option<ConsumerParameters>,
 }
-use serde::{Deserializer};
+
+#[test]
+fn config_test() {
+    let connector_cfg = ConnectorConfig::from_file("test-data/test-config.yaml")
+        .expect("Failed to load test config");
+    println!("{:?}", connector_cfg);
+    let out: ManagedConnectorSpec = connector_cfg.into();
+    println!("{:?}", out);
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConsumerParameters {
+    #[serde(default)]
+    partition: Option<i32>
+}
+use std::time::Duration;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProducerParameters {
+    #[serde(with = "humantime_serde")]
+    linger: Option<Duration>,
+
+    compression: Option<Compression>,
+
+    batch_size: Option<usize>,
+}
+
+
+impl ConnectorConfig {
+    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, CliError> {
+        let mut file = File::open(path.into())?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let connector_config: Self = serde_yaml::from_str(&contents)?;
+        Ok(connector_config)
+    }
+}
+
+impl From<ConnectorConfig> for ManagedConnectorSpec {
+    fn from(config: ConnectorConfig) -> ManagedConnectorSpec {
+        let mut parameters = BTreeMap::new();
+        for (key, value) in config.parameters.iter() {
+            parameters.insert(key.clone(), value.context.clone());
+        }
+
+        // Producer arguments are prefixed with `producer`
+        if let Some(producer) = config.producer {
+            if let Some(linger) = producer.linger {
+                let linger = humantime::format_duration(linger).to_string();
+                parameters.insert("producer-linger".to_string(), vec![linger]);
+            }
+            if let Some(compression) = producer.compression {
+                let compression = format!("{:?}", compression);
+                parameters.insert("producer-compression".to_string(), vec![compression]);
+            }
+            if let Some(batch_size) = producer.batch_size {
+                let batch_size = format!("{}", batch_size);
+                parameters.insert("producer-batch-size".to_string(), vec![batch_size]);
+            }
+        }
+
+        // Consumer arguments are prefixed with `consumer`.
+        if let Some(consumer) = config.consumer {
+            if let Some(partition) = consumer.partition {
+                let partition = format!("{}", partition);
+                parameters.insert("consumer-partition".to_string(), vec![partition]);
+            }
+        }
+        ManagedConnectorSpec {
+            name: config.name,
+            type_: config.type_,
+            topic: config.topic,
+            parameters,
+            secrets: config.secrets,
+            version: config.version,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct YamlParameter {
@@ -113,14 +204,12 @@ impl<'de> Deserialize<'de> for YamlParameter {
     where
         D: Deserializer<'de>,
     {
-		deserializer.deserialize_any(YamlParameterVisitor)
+        deserializer.deserialize_any(YamlParameterVisitor)
     }
 }
-use serde::de::{self, Visitor, SeqAccess};
 
 struct YamlParameterVisitor;
 
-    use std::fmt;
 impl<'de> Visitor<'de> for YamlParameterVisitor
 {
     type Value = YamlParameter;
@@ -139,53 +228,9 @@ impl<'de> Visitor<'de> for YamlParameterVisitor
     fn visit_seq<A>(self, seq: A) -> Result<YamlParameter, A::Error>
         where A: SeqAccess<'de>,
     {
-        Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
+        Ok(YamlParameter{ context: vec![] })
+
+       //Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
     }
 
-}
-
-use std::str::FromStr;
-impl FromStr for YamlParameter {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(YamlParameter {
-            context: vec![s.to_string()],
-        })
-    }
-}
-
-impl ConnectorConfig {
-    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, CliError> {
-        let mut file = File::open(path.into())?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        let connector_config: Self = serde_yaml::from_str(&contents)?;
-        Ok(connector_config)
-    }
-}
-
-impl From<ConnectorConfig> for ManagedConnectorSpec {
-    fn from(config: ConnectorConfig) -> ManagedConnectorSpec {
-        let mut parameters = BTreeMap::new();
-        for (key, value) in config.parameters.iter() {
-            parameters.insert(key.clone(), value.context.clone());
-        }
-        ManagedConnectorSpec {
-            name: config.name,
-            type_: config.type_,
-            topic: config.topic,
-            parameters,
-            secrets: config.secrets,
-            version: config.version,
-        }
-    }
-}
-
-#[test]
-fn config_test() {
-    let out: ManagedConnectorSpec = ConnectorConfig::from_file("test-data/test-config.yaml")
-        .expect("Failed to load test config")
-        .into();
-    println!("{:?}", out);
 }

--- a/crates/fluvio-cli/test-data/connectors/error-batchsize.yaml
+++ b/crates/fluvio-cli/test-data/connectors/error-batchsize.yaml
@@ -1,0 +1,8 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+direction: source
+producer:
+  batch-size: 1aoeu

--- a/crates/fluvio-cli/test-data/connectors/error-compression.yaml
+++ b/crates/fluvio-cli/test-data/connectors/error-compression.yaml
@@ -1,0 +1,8 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+direction: source
+producer:
+  compression: gzipaoeu

--- a/crates/fluvio-cli/test-data/connectors/error-linger.yaml
+++ b/crates/fluvio-cli/test-data/connectors/error-linger.yaml
@@ -1,0 +1,8 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+direction: source
+producer:
+  linger: 1

--- a/crates/fluvio-cli/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-cli/test-data/connectors/full-config.yaml
@@ -15,7 +15,7 @@ secrets:
   foo: bar
 producer:
   linger: 1ms
-  batch_size: '44 MB'
+  batch-size: '44 MB'
   compression: gzip
 consumer:
   partition: 10

--- a/crates/fluvio-cli/test-data/connectors/simple.yaml
+++ b/crates/fluvio-cli/test-data/connectors/simple.yaml
@@ -1,0 +1,5 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false

--- a/crates/fluvio-cli/test-data/test-config.yaml
+++ b/crates/fluvio-cli/test-data/test-config.yaml
@@ -6,14 +6,16 @@ create_topic: false
 direction: source
 parameters:
   param_1: "mqtt.hsl.fi"
-  header:
-    "auth: foo" # This is broken
+  param_2:
+    foo: bar
+    bar: foo
+  param_3:
+    - "baz"
 secrets:
   foo: bar
 producer:
   linger: 1ms
   batch_size: 44
   compression: gzip
-
 consumer:
   partition: 10

--- a/crates/fluvio-cli/test-data/test-config.yaml
+++ b/crates/fluvio-cli/test-data/test-config.yaml
@@ -15,7 +15,7 @@ secrets:
   foo: bar
 producer:
   linger: 1ms
-  batch_size: 44
+  batch_size: '44 MB'
   compression: gzip
 consumer:
   partition: 10

--- a/crates/fluvio-cli/test-data/test-config.yaml
+++ b/crates/fluvio-cli/test-data/test-config.yaml
@@ -5,8 +5,10 @@ topic: my-mqtt
 create_topic: false
 direction: source
 parameters:
-  mqtt-url: "mqtt.hsl.fi"
-  mqtt-topic: "/hfp/v2/journey/#"
-  fluvio-topic: "my-mqtt"
+  param_1: "mqtt.hsl.fi"
+  header:
+    - "auth: foo"
+  test:
+     auth: "foo"
 secrets:
   foo: bar

--- a/crates/fluvio-cli/test-data/test-config.yaml
+++ b/crates/fluvio-cli/test-data/test-config.yaml
@@ -7,8 +7,13 @@ direction: source
 parameters:
   param_1: "mqtt.hsl.fi"
   header:
-    - "auth: foo"
-  test:
-     auth: "foo"
+    "auth: foo" # This is broken
 secrets:
   foo: bar
+producer:
+  linger: 1ms
+  batch_size: 44
+  compression: gzip
+
+consumer:
+  partition: 10

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.15.4"
+version = "0.16.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/connector/k8/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/connector/k8/spec.rs
@@ -42,7 +42,7 @@ pub struct K8ManagedConnectorSpec {
     #[cfg_attr(feature = "use_serde", serde(rename = "type"))]
     pub type_: String, // syslog, github star, slack
     pub topic: String,
-    pub parameters: BTreeMap<String, String>,
+    pub parameters: BTreeMap<String, Vec<String>>,
     pub secrets: BTreeMap<String, SecretString>,
 }
 mod convert {

--- a/crates/fluvio-controlplane-metadata/src/connector/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/connector/spec.rs
@@ -22,7 +22,7 @@ pub struct ManagedConnectorSpec {
     pub type_: String, // syslog, github star, slack
 
     pub topic: String,
-    pub parameters: BTreeMap<String, String>,
+    pub parameters: BTreeMap<String, Vec<String>>,
     pub secrets: BTreeMap<String, SecretString>,
 }
 

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"
@@ -24,7 +24,7 @@ paste = "1.0"
 
 # Fluvio dependencies
 fluvio-types = { version = "0.3.0", path = "../fluvio-types" }
-fluvio-controlplane-metadata = { version = "0.15.0", default-features = false, path = "../fluvio-controlplane-metadata" }
+fluvio-controlplane-metadata = { version = "0.16.0", default-features = false, path = "../fluvio-controlplane-metadata" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol" }
 

--- a/crates/fluvio-sc/src/k8/controllers/managed_connector_deployment.rs
+++ b/crates/fluvio-sc/src/k8/controllers/managed_connector_deployment.rs
@@ -225,7 +225,13 @@ impl ManagedConnectorDeploymentController {
         let parameters: Vec<String> = parameters
             .keys()
             .zip(parameters.values())
-            .flat_map(|(key, value)| [format!("--{}={}", key.replace('_', "-"), value)])
+            .flat_map(|(key, values)| {
+                let mut args = Vec::new();
+                for value in values.iter() {
+                    args.push(format!("--{}={}", key.replace('_', "-"), value))
+                }
+                args
+            })
             .collect::<Vec<_>>();
 
         // Prefixing the args with a "--" passed to the container is needed for an unclear reason.

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -31,7 +31,7 @@ fluvio-future = { version = "0.3.13", features = [
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane-protocol", features = [
     "file",
 ] }
-fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.15.0", optional = true }
+fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.16.0", optional = true }
 flate2 = { version = "1.0", optional = true }
 fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
 

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -315,7 +315,7 @@ pub struct ConnectorConfig {
     #[serde(default)]
     pub(crate) create_topic: bool,
     #[serde(default)]
-    parameters: BTreeMap<String, String>,
+    parameters: BTreeMap<String, Vec<String>>,
     #[serde(default)]
     secrets: BTreeMap<String, SecretString>,
 }
@@ -347,7 +347,7 @@ impl From<ConnectorConfig> for ManagedConnectorSpec {
             name: config.name,
             type_: config.type_,
             topic: config.topic,
-            parameters: todo!(), //config.parameters,
+            parameters: config.parameters,
             secrets: config.secrets,
             version: config.version,
         }

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -347,7 +347,7 @@ impl From<ConnectorConfig> for ManagedConnectorSpec {
             name: config.name,
             type_: config.type_,
             topic: config.topic,
-            parameters: config.parameters,
+            parameters: todo!(), //config.parameters,
             secrets: config.secrets,
             version: config.version,
         }


### PR DESCRIPTION
* Closes #2421
* Closes #2410.

This enables the connectors yamls to be thusly:
```yaml
version: 0.1.0
name: my-test-mqtt
type: mqtt
topic: my-mqtt
create_topic: false
direction: source
parameters:
  param_1: "mqtt.hsl.fi"
  param_2:
    foo: bar
    bar: foo
  param_3:
    - "baz"
secrets:
  foo: bar
producer:
  linger: 1ms
  batch_size: 44
  compression: gzip
consumer:
  partition: 10
```