### PR TITLE
[Merged by Bors] - Fix #2432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.30 - UNRELEASED
 * Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))
+* Fix bug in `last_partition_offset` update when handling smartmodules on SPU ([#2432](https://github.com/infinyon/fluvio/pull/2432))
 
 ## Platform Version 0.9.29 - 2022-06-27 
 * Revert 0.9.28 updates to Connector yaml config ([#2436](https://github.com/infinyon/fluvio/pull/2436))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -385,7 +385,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -2330,6 +2329,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-rwlock",
+ "async-std",
  "async-trait",
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,6 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-rwlock",
- "async-std",
  "async-trait",
  "bytes",
  "cfg-if",

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -80,4 +80,3 @@ dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane
 serde_json = "1"
 flate2 = "1.0.22"
 portpicker = "0.1.1"
-async-std = {version = "1.12.0", features=["unstable"] }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -80,3 +80,4 @@ dataplane = { path = "../fluvio-dataplane-protocol", package = "fluvio-dataplane
 serde_json = "1"
 flate2 = "1.0.22"
 portpicker = "0.1.1"
+async-std = {version = "1.12.0", features=["unstable"] }

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -307,7 +307,6 @@ impl StreamFetchHandler {
                         "Consumer offset updated and is behind, need to send records",
                     );
                     let (offset, wait) = self.send_back_records(consumer_offset_update, smartmodule_instance.as_mut(), join_record.as_ref()).await?;
-                    // NOTE: last_partition_offset should not be changed to a smaller value here:
                     last_partition_offset = offset;
                     if wait {
                         last_known_consumer_offset = None;

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -501,7 +501,7 @@ impl StreamFetchHandler {
     async fn send_processed_response(
         &self,
         file_partition_response: FilePartitionResponse,
-        mut next_offset: Offset,
+        next_offset: Offset,
         batch: Batch,
         smartmodule_error: Option<SmartModuleRuntimeError>,
     ) -> Result<(Offset, bool), StreamFetchError> {
@@ -521,10 +521,12 @@ impl StreamFetchHandler {
             return Ok((next_offset, false));
         }
 
-        if has_records {
+        let next_filter_offset = if has_records {
             trace!(?batch, "SmartModule batch:");
-            next_offset = batch.get_last_offset() + 1;
-        }
+            batch.get_last_offset() + 1
+        } else {
+            next_offset
+        };
 
         debug!(
             next_offset,
@@ -541,7 +543,7 @@ impl StreamFetchHandler {
             high_watermark: file_partition_response.high_watermark,
             log_start_offset: file_partition_response.log_start_offset,
             records: records.try_into()?,
-            next_filter_offset: next_offset,
+            next_filter_offset,
             // we mark last offset in the response that we should sync up
             ..Default::default()
         };

--- a/crates/fluvio-spu/src/services/public/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/stream_fetch.rs
@@ -307,6 +307,7 @@ impl StreamFetchHandler {
                         "Consumer offset updated and is behind, need to send records",
                     );
                     let (offset, wait) = self.send_back_records(consumer_offset_update, smartmodule_instance.as_mut(), join_record.as_ref()).await?;
+                    // NOTE: last_partition_offset should not be changed to a smaller value here:
                     last_partition_offset = offset;
                     if wait {
                         last_known_consumer_offset = None;

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -1116,11 +1116,7 @@ async fn test_stream_fetch_map(
         .await
         .expect("send offset");
 
-    let response = async_std::future::timeout(std::time::Duration::from_secs(3), stream.next())
-        .await
-        .expect("timeout")
-        .expect("third")
-        .expect("response");
+    let response = stream.next().await.expect("third").expect("response");
 
     assert_eq!(response.partition.records.batches.len(), 1);
     let records = response.partition.records.batches[0]

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -1122,6 +1122,12 @@ async fn test_stream_fetch_map(
         .expect("third")
         .expect("response");
 
+    assert_eq!(response.partition.records.batches.len(), 1);
+    let records = response.partition.records.batches[0]
+        .memory_records()
+        .expect("records");
+    assert_eq!(records.len(), 20);
+
     server_end_event.notify();
     debug!("terminated controller");
 }

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -991,6 +991,142 @@ async fn test_stream_filter_max(
 const FLUVIO_WASM_MAP_DOUBLE: &str = "fluvio_wasm_map_double";
 
 #[fluvio_future::test(ignore)]
+async fn test_stream_fetch_map_adhoc() {
+    adhoc_test(
+        "test_stream_fetch_map_error_adhoc",
+        FLUVIO_WASM_MAP_DOUBLE,
+        SmartModuleKind::Map,
+        test_stream_fetch_map,
+    )
+    .await;
+}
+
+async fn test_stream_fetch_map(
+    ctx: Arc<GlobalContext<FileReplica>>,
+    test_path: PathBuf,
+    wasm_payload: Option<LegacySmartModulePayload>,
+    smartmodule: Option<SmartModuleInvocation>,
+) {
+    ensure_clean_dir(&test_path);
+
+    let port = portpicker::pick_unused_port().expect("No free ports left");
+
+    let addr = format!("127.0.0.1:{}", port);
+
+    let server_end_event = create_public_server(addr.to_owned(), ctx.clone()).run();
+
+    // wait for stream controller async to start
+    sleep(Duration::from_millis(100)).await;
+
+    let client_socket =
+        MultiplexerSocket::new(FluvioSocket::connect(&addr).await.expect("connect"));
+
+    // perform for two versions
+
+    let topic = "test_map_error";
+    let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
+    let test_id = test.id.clone();
+    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+        .await
+        .expect("replica");
+    ctx.leaders_state().insert(test_id, replica.clone()).await;
+
+    let stream_request = DefaultStreamFetchRequest {
+        topic: topic.to_owned(),
+        partition: 0,
+        fetch_offset: 0,
+        isolation: Isolation::ReadUncommitted,
+        max_bytes: 300,
+        wasm_module: Vec::new(),
+        wasm_payload,
+        smartmodule,
+        ..Default::default()
+    };
+
+    let mut stream = client_socket
+        .create_stream(RequestMessage::new_request(stream_request), 11)
+        .await
+        .expect("create stream");
+
+    for _ in 0..10 {
+        let mut records = BatchProducer::builder()
+            .records(20_u16)
+            .record_generator(Arc::new(|i, _| Record::new(i.to_string())))
+            .build()
+            .expect("batch")
+            .records();
+
+        replica
+            .write_record_set(&mut records, ctx.follower_notifier())
+            .await
+            .expect("write");
+    }
+
+    debug!("first map fetch");
+
+    let response = stream.next().await.expect("first").expect("response");
+    let stream_id = response.stream_id;
+
+    assert_eq!(response.partition.records.batches.len(), 1);
+    let records = response.partition.records.batches[0]
+        .memory_records()
+        .expect("records");
+    assert_eq!(records.len(), 20);
+    assert_eq!(records[0].value.as_ref(), "0".as_bytes());
+    assert_eq!(records[1].value.as_ref(), "2".as_bytes());
+    let partition = &response.partition;
+    assert_eq!(partition.error_code, ErrorCode::None);
+    assert_eq!(partition.high_watermark, 200);
+    assert_eq!(partition.next_filter_offset, 20);
+    assert_eq!(partition.next_offset_for_fetch(), Some(20));
+
+    // consumer can send back to same offset to read back again
+    debug!("send back offset ack to SPU");
+    client_socket
+        .send_and_receive(RequestMessage::new_request(UpdateOffsetsRequest {
+            offsets: vec![OffsetUpdate {
+                offset: 20,
+                session_id: stream_id,
+            }],
+        }))
+        .await
+        .expect("send offset");
+
+    let response = stream.next().await.expect("second").expect("response");
+    assert_eq!(response.partition.records.batches.len(), 1);
+    let records = response.partition.records.batches[0]
+        .memory_records()
+        .expect("records");
+    assert_eq!(records.len(), 20);
+    assert_eq!(records[0].value.as_ref(), "0".as_bytes());
+    assert_eq!(records[1].value.as_ref(), "2".as_bytes());
+    let partition = &response.partition;
+    assert_eq!(partition.error_code, ErrorCode::None);
+    assert_eq!(partition.high_watermark, 200);
+    assert_eq!(partition.next_filter_offset, 40);
+    assert_eq!(partition.next_offset_for_fetch(), Some(40));
+
+    client_socket
+        .send_and_receive(RequestMessage::new_request(UpdateOffsetsRequest {
+            offsets: vec![OffsetUpdate {
+                offset: 40,
+                session_id: stream_id,
+            }],
+        }))
+        .await
+        .expect("send offset");
+
+    let response = async_std::future::timeout(std::time::Duration::from_secs(3), stream.next())
+        .await
+        .expect("timeout")
+        .expect("third")
+        .expect("response");
+
+    server_end_event.notify();
+    debug!("terminated controller");
+}
+
+#[fluvio_future::test(ignore)]
 async fn test_stream_fetch_map_error_legacy() {
     legacy_test(
         "test_stream_fetch_map_error_legacy",
@@ -1004,7 +1140,7 @@ async fn test_stream_fetch_map_error_legacy() {
 #[fluvio_future::test(ignore)]
 async fn test_stream_fetch_map_error_adhoc() {
     adhoc_test(
-        "test_stream_fetch_map_error_legacy",
+        "test_stream_fetch_map_error_adhoc",
         FLUVIO_WASM_MAP_DOUBLE,
         SmartModuleKind::Map,
         test_stream_fetch_map_error,
@@ -1015,7 +1151,7 @@ async fn test_stream_fetch_map_error_adhoc() {
 #[fluvio_future::test(ignore)]
 async fn test_stream_fetch_map_error_predefined() {
     predefined_test(
-        "test_stream_fetch_map_error_legacy",
+        "test_stream_fetch_map_error_predefined",
         FLUVIO_WASM_MAP_DOUBLE,
         SmartModuleKind::Map,
         test_stream_fetch_map_error,


### PR DESCRIPTION
Update return value of `send_processed_response` in SPU. It should return last_partition_offset instead of `next_filter_offset`.

Fixes #2432