### PR TITLE
[Merged by Bors] - Fix issue with producer when sending more than one batch per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.30 - UNRELEASED
 * Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))
+* Fix issue in producer when sending more than one batch in a request ([#2443](//github.com/infinyon/fluvio/issues/2443))
 
 ## Platform Version 0.9.29 - 2022-06-27 
 * Revert 0.9.28 updates to Connector yaml config ([#2436](https://github.com/infinyon/fluvio/pull/2436))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-test/src/tests/producer_fail/mod.rs
+++ b/crates/fluvio-test/src/tests/producer_fail/mod.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use fluvio::{RecordKey, TopicProducer, FluvioAdmin, FluvioError};
+use fluvio::{RecordKey, TopicProducer, TopicProducerConfigBuilder, FluvioAdmin, FluvioError};
 use fluvio_controlplane_metadata::partition::PartitionSpec;
 use clap::Parser;
 
@@ -47,7 +47,14 @@ pub async fn produce_batch(
     println!("Starting produce_batch test");
 
     let topic_name = test_case.environment.base_topic_name();
-    let producer: TopicProducer = test_driver.create_producer(&topic_name).await;
+    let config = TopicProducerConfigBuilder::default()
+        .linger(std::time::Duration::from_millis(10))
+        .build()
+        .expect("failed to build config");
+
+    let producer: TopicProducer = test_driver
+        .create_producer_with_config(&topic_name, config)
+        .await;
 
     println!("Created producer");
 

--- a/crates/fluvio-test/src/tests/producer_fail/mod.rs
+++ b/crates/fluvio-test/src/tests/producer_fail/mod.rs
@@ -81,7 +81,7 @@ pub async fn produce_batch(
     let value = "a".repeat(5000);
     let result: Result<_, FluvioError> = (|| async move {
         let mut results = Vec::new();
-        for i in 0..1000 {
+        for _ in 0..1000 {
             let result = producer.send(RecordKey::NULL, value.clone()).await?;
             results.push(result);
         }

--- a/crates/fluvio-test/src/tests/producer_fail/mod.rs
+++ b/crates/fluvio-test/src/tests/producer_fail/mod.rs
@@ -78,10 +78,11 @@ pub async fn produce_batch(
 
     println!("Got cluster manager");
 
+    let value = "a".repeat(5000);
     let result: Result<_, FluvioError> = (|| async move {
         let mut results = Vec::new();
         for i in 0..1000 {
-            let result = producer.send(RecordKey::NULL, i.to_string()).await?;
+            let result = producer.send(RecordKey::NULL, value.clone()).await?;
             results.push(result);
         }
         println!("Send 1000");

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.12.13"
+version = "0.12.14"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]


### PR DESCRIPTION
Fixes #2443 

 The producer only sends back the base offset of the first batch. Therefore batch metadata is not resolved for the batches that are after the first one.

With this change, we put each batch in its own PartitionProduceResponse, so SPU returns back the base offset of each batch