### PR TITLE
Add SmartModule config to connector top level configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Upgrade to fluvio-future 0.4.0 ([#2470](https://github.com/infinyon/fluvio/pull/2470))
 * Add support to detecting smartmodule type from WASM payload on SPU  ([#2457](https://github.com/infinyon/fluvio/issues/2457))
 * Require `version` field in connector yaml. ([#2472](https://github.com/infinyon/fluvio/pull/2472))
+* Add support to SmartModule parameters in Connectors ([#2455](https://github.com/infinyon/fluvio/issues/2455))
+* Move smartmodule configuration to top level config ([#2471](https://github.com/infinyon/fluvio/issues/2471))
 
 ## Platform Version 0.9.30 - 2022-06-29
 * Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -350,7 +350,7 @@ impl From<ManagedConnectorSpec> for ConnectorConfig {
             ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters
             .remove("filter-map")
-            .or(parameters.remove("filter_map"))
+            .or_else(|| parameters.remove("filter_map"))
         {
             (Some(smartmodule_name), Some(SmartModuleType::FilterMap))
         } else {
@@ -362,7 +362,7 @@ impl From<ManagedConnectorSpec> for ConnectorConfig {
                 ManagedConnectorParameterValueInner::String(agrgate_initial_value),
             )) = parameters
                 .remove("aggregate-initial-value")
-                .or(parameters.remove("aggregate_initial_value"))
+                .or_else(|| parameters.remove("aggregate_initial_value"))
             {
                 Some(agrgate_initial_value)
             } else {

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -321,33 +321,33 @@ impl From<ManagedConnectorSpec> for ConnectorConfig {
             None
         };
 
-        let (smartmodule_name, smartmodule_type) = if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        let (smartmodule_name, smartmodule_type) = if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("smartmodule-name")
         {
             (Some(smartmodule_name), None)
-        } else if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        } else if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("filter")
         {
             (Some(smartmodule_name), Some(SmartModuleType::Filter))
-        } else if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        } else if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("map")
         {
             (Some(smartmodule_name), Some(SmartModuleType::Map))
-        } else if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        } else if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("aggregate")
         {
             (Some(smartmodule_name), Some(SmartModuleType::Aggregate))
-        } else if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        } else if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("array_map")
         {
             (Some(smartmodule_name), Some(SmartModuleType::ArrayMap))
-        } else if let Some(ManageConnectorParameterValue(
-            ManageConnectorParameterValueInner::String(smartmodule_name),
+        } else if let Some(ManagedConnectorParameterValue(
+            ManagedConnectorParameterValueInner::String(smartmodule_name),
         )) = parameters.remove("filter_map")
         {
             (Some(smartmodule_name), Some(SmartModuleType::FilterMap))
@@ -356,8 +356,8 @@ impl From<ManagedConnectorSpec> for ConnectorConfig {
         };
 
         let smartmodule = if let Some(smartmodule_name) = smartmodule_name {
-            let aggregate_initial_value = if let Some(ManageConnectorParameterValue(
-                ManageConnectorParameterValueInner::String(agrgate_initial_value),
+            let aggregate_initial_value = if let Some(ManagedConnectorParameterValue(
+                ManagedConnectorParameterValueInner::String(agrgate_initial_value),
             )) = parameters.remove("aggregate-initial-value")
             {
                 Some(agrgate_initial_value)
@@ -365,8 +365,8 @@ impl From<ManagedConnectorSpec> for ConnectorConfig {
                 None
             };
 
-            let smartmodule_parameters = if let Some(ManageConnectorParameterValue(
-                ManageConnectorParameterValueInner::Map(map),
+            let smartmodule_parameters = if let Some(ManagedConnectorParameterValue(
+                ManagedConnectorParameterValueInner::Map(map),
             )) = parameters.remove("smartmodule-parameters")
             {
                 Some(map)

--- a/crates/fluvio-cli/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-cli/test-data/connectors/full-config.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 name: my-test-mqtt
 type: mqtt
 topic: my-mqtt
@@ -19,6 +19,7 @@ parameters:
   - -10
   - -10.0
 
+
 secrets:
   foo: bar
 producer:
@@ -27,3 +28,11 @@ producer:
   compression: gzip
 consumer:
   partition: 10
+smartmodule:
+  name: myaggregate
+  type: aggregate
+  aggregate_initial_value: something
+  parameters:
+    key_1: value_1
+    key_2: value_2
+    key_3: 10

--- a/crates/fluvio-cli/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-cli/test-data/connectors/full-config.yaml
@@ -1,6 +1,6 @@
-version: 0.2.0
+version: 0.3.0
 name: my-test-mqtt
-type: mqtt
+type: mqtt-source
 topic: my-mqtt
 create_topic: false
 direction: source
@@ -18,7 +18,6 @@ parameters:
   param_6:
   - -10
   - -10.0
-
 
 secrets:
   foo: bar


### PR DESCRIPTION
Adds a `smartmodule` top level config:

```yaml
...
smartmodule: # optional
  name: some-name # required
  type: aggregate # optional (valid values: filter, map, filter_map, aggregate, array_map)
  aggregate_initial_value: 1 # optional
  parameters: # optional
    key: value
    foo: bar
...
```

Also changed struct name from `ManageConnectorParameterValue` to `ManagedConnectorParameterValue`

Closes #2471
Closes #2455 