### PR TITLE
[Merged by Bors] - Move stream publishers to connection-level context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.31 - UNRELEASED
+* Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))
 
 ## Platform Version 0.9.30 - 2022-06-29
 * Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -18,7 +18,6 @@ use crate::replication::follower::SharedFollowersState;
 use crate::replication::leader::{
     SharedReplicaLeadersState, ReplicaLeadersState, FollowerNotifier, SharedSpuUpdates,
 };
-use crate::services::public::StreamPublishers;
 use crate::control_plane::{StatusMessageSink, SharedStatusUpdate};
 use fluvio_smartengine::SmartEngine;
 
@@ -44,7 +43,6 @@ pub struct GlobalContext<S> {
     derivedstream_localstore: SharedStreamStreamLocalStore,
     leaders_state: SharedReplicaLeadersState<S>,
     followers_state: SharedFollowersState<S>,
-    stream_publishers: StreamPublishers,
     spu_followers: SharedSpuUpdates,
     status_update: SharedStatusUpdate,
     sm_engine: SmartEngine,
@@ -75,7 +73,6 @@ where
             config: Arc::new(spu_config),
             leaders_state: ReplicaLeadersState::new_shared(),
             followers_state: FollowersState::new_shared(),
-            stream_publishers: StreamPublishers::new(),
             spu_followers: FollowerNotifier::shared(),
             status_update: StatusMessageSink::shared(),
             sm_engine: SmartEngine::default(),
@@ -126,10 +123,6 @@ where
 
     pub fn config_owned(&self) -> SharedSpuConfig {
         self.config.clone()
-    }
-
-    pub fn stream_publishers(&self) -> &StreamPublishers {
-        &self.stream_publishers
     }
 
     pub fn follower_notifier(&self) -> &FollowerNotifier {

--- a/crates/fluvio-spu/src/services/public/conn_context.rs
+++ b/crates/fluvio-spu/src/services/public/conn_context.rs
@@ -1,0 +1,22 @@
+use crate::services::public::StreamPublishers;
+
+#[derive(Debug)]
+pub(crate) struct ConnectionContext {
+    stream_publishers: StreamPublishers,
+}
+
+impl ConnectionContext {
+    pub(crate) fn new() -> Self {
+        Self {
+            stream_publishers: StreamPublishers::new(),
+        }
+    }
+
+    pub(crate) fn stream_publishers(&self) -> &StreamPublishers {
+        &self.stream_publishers
+    }
+
+    pub(crate) fn stream_publishers_mut(&mut self) -> &mut StreamPublishers {
+        &mut self.stream_publishers
+    }
+}

--- a/crates/fluvio-spu/src/services/public/offset_update.rs
+++ b/crates/fluvio-spu/src/services/public/offset_update.rs
@@ -6,16 +6,16 @@ use fluvio_spu_schema::server::update_offset::{
 };
 use dataplane::ErrorCode;
 use dataplane::api::{ResponseMessage, RequestMessage};
-use crate::core::DefaultSharedGlobalContext;
+use crate::services::public::conn_context::ConnectionContext;
 
-#[instrument(skip(ctx, request))]
-pub async fn handle_offset_update(
-    ctx: &DefaultSharedGlobalContext,
+#[instrument(skip(conn_ctx, request))]
+pub(crate) async fn handle_offset_update(
     request: RequestMessage<UpdateOffsetsRequest>,
+    conn_ctx: &mut ConnectionContext,
 ) -> Result<ResponseMessage<UpdateOffsetsResponse>, IoError> {
     debug!("received stream updates");
     let (header, updates) = request.get_header_request();
-    let publishers = ctx.stream_publishers();
+    let publishers = conn_ctx.stream_publishers();
     let mut status_list = vec![];
 
     for update in updates.offsets {


### PR DESCRIPTION
This is the first PR of implementation of dropping a stream's server-side counterpart when a stream on the client-side is dropped.  This is all part of the activities for managing offsets per consumer on the SPU side.

Currently, the lifetime of `StreamPublisher` is equal to the lifetime of Tcp connection between SPU and client. We do not clean up `StreamPublishers` until the connection is dropped. Therefore, there is no need to keep them inside `GlobalContext` and have it multi-threaded, because it is always touched by only one thread (the one that handles connection). 

This PR doesn't add or remove any functional behavior. The `StreamPublishers` will be dropped after disconnect as it does now. The actual drop mechanism will go in another PR.