### PR TITLE
[Merged by Bors] - Detect smart module type on SmartEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `fluvio connector config <connector-name>`  ([#2464](https://github.com/infinyon/fluvio/pull/2464))
 * Add performance counters to producer ([#2424](https://github.com/infinyon/fluvio/issues/2424))
 * Upgrade to fluvio-future 0.4.0 ([#2470](https://github.com/infinyon/fluvio/pull/2470))
+* Add support to detecting smartmodule type from WASM payload on SPU  ([#2457](https://github.com/infinyon/fluvio/issues/2457))
 
 ## Platform Version 0.9.30 - 2022-06-29
 * Improve CLI error output when log_dir isn't writable ([#2425](https://github.com/infinyon/fluvio/pull/2425))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.13.1"
+version = "0.13.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1863,6 +1863,7 @@ dependencies = [
  "fluvio-package-index",
  "fluvio-sc-schema",
  "fluvio-socket",
+ "fluvio-spu-schema",
  "fluvio-types",
  "futures",
  "handlebars",
@@ -2382,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.11"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "fluvio-types",
  "futures-util",
  "nix",
+ "thiserror",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -27,6 +27,7 @@ consumer = [
     "fluvio-types",
     "fluvio-future",
     "fluvio-sc-schema",
+    "fluvio-spu-schema",
 ]
 k8s = [
     "k8-client",
@@ -89,6 +90,8 @@ fluvio-cli-common = { path = "../fluvio-cli-common" }
 fluvio-types = { path = "../fluvio-types", optional = true }
 fluvio-future = { version = "0.4.0", features = ["fs", "io", "subscriber", "native2_tls"], optional = true }
 fluvio-sc-schema = { path = "../fluvio-sc-schema", features = ["use_serde"], optional = true }
+fluvio-spu-schema = { path = "../fluvio-spu-schema", optional = true }
+
 indicatif = "0.16.2"
 
 [dev-dependencies]

--- a/crates/fluvio-dataplane-protocol/src/error_code.rs
+++ b/crates/fluvio-dataplane-protocol/src/error_code.rs
@@ -135,7 +135,7 @@ pub enum ErrorCode {
     #[error("SmartModule {name} was not found")]
     SmartModuleNotFound { name: String },
     #[fluvio(tag = 6002)]
-    #[error("SmartModule is invalid")]
+    #[error("SmartModule is invalid: {error}")]
     SmartModuleInvalid { error: String, name: Option<String> },
     #[fluvio(tag = 6003)]
     #[error("SmartModule is not a valid '{kind}' SmartModule due to {error}. Are you missing a #[smartmodule({kind})] attribute?")]

--- a/crates/fluvio-dataplane-protocol/src/smartmodule.rs
+++ b/crates/fluvio-dataplane-protocol/src/smartmodule.rs
@@ -199,6 +199,8 @@ mod encoding {
         FilterMap,
         #[fluvio(min_version = 16)]
         Join,
+        #[fluvio(min_version = 17)]
+        Generic,
     }
 
     impl Default for SmartModuleKind {

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -33,7 +33,7 @@ dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package
 ] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.17.0", optional = true }
 flate2 = { version = "1.0", optional = true }
-fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]
 fluvio-types = { path = "../fluvio-types" }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -34,6 +34,7 @@ dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", package
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", version = "0.17.0", optional = true }
 flate2 = { version = "1.0", optional = true }
 fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema" }
+thiserror = "1.0.31"
 
 [dev-dependencies]
 fluvio-types = { path = "../fluvio-types" }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.2.11"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
@@ -48,14 +48,13 @@ impl SmartModuleAggregate {
         let aggregate_fn: AggregateFnKind = if let Ok(agg_fn) = base
             .instance
             .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(AGGREGATE_FN_NAME))
         {
             AggregateFnKind::New(agg_fn)
         } else {
             let agg_fn: OldAggregateFn = base
                 .instance
                 .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(AGGREGATE_FN_NAME))?;
+                .map_err(|err| Error::NotNamedExport(AGGREGATE_FN_NAME, err))?;
             AggregateFnKind::Old(agg_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
@@ -48,14 +48,14 @@ impl SmartModuleAggregate {
         let aggregate_fn: AggregateFnKind = if let Ok(agg_fn) = base
             .instance
             .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)
-            .map_err(|_err| Error::NamedExport(AGGREGATE_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(AGGREGATE_FN_NAME))
         {
             AggregateFnKind::New(agg_fn)
         } else {
             let agg_fn: OldAggregateFn = base
                 .instance
                 .get_typed_func(&mut base.store, AGGREGATE_FN_NAME)
-                .map_err(|_err| Error::NamedExport(AGGREGATE_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(AGGREGATE_FN_NAME))?;
             AggregateFnKind::Old(agg_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/array_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/array_map.rs
@@ -8,6 +8,7 @@ use dataplane::smartmodule::{
 use crate::{
     WasmSlice,
     smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
+    error::Error,
 };
 
 const ARRAY_MAP_FN_NAME: &str = "array_map";
@@ -37,17 +38,19 @@ impl SmartModuleArrayMap {
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
         let map_fn = if let Ok(array_map_fn) = base
             .instance
             .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
+            .map_err(|_err| Error::NamedExport(ARRAY_MAP_FN_NAME))
         {
             ArrayMapFnKind::New(array_map_fn)
         } else {
             let array_map_fn = base
                 .instance
-                .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)?;
+                .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
+                .map_err(|_err| Error::NamedExport(ARRAY_MAP_FN_NAME))?;
             ArrayMapFnKind::Old(array_map_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/array_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/array_map.rs
@@ -43,14 +43,14 @@ impl SmartModuleArrayMap {
         let map_fn = if let Ok(array_map_fn) = base
             .instance
             .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
-            .map_err(|_err| Error::NamedExport(ARRAY_MAP_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(ARRAY_MAP_FN_NAME))
         {
             ArrayMapFnKind::New(array_map_fn)
         } else {
             let array_map_fn = base
                 .instance
                 .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
-                .map_err(|_err| Error::NamedExport(ARRAY_MAP_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(ARRAY_MAP_FN_NAME))?;
             ArrayMapFnKind::Old(array_map_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/array_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/array_map.rs
@@ -43,14 +43,13 @@ impl SmartModuleArrayMap {
         let map_fn = if let Ok(array_map_fn) = base
             .instance
             .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(ARRAY_MAP_FN_NAME))
         {
             ArrayMapFnKind::New(array_map_fn)
         } else {
             let array_map_fn = base
                 .instance
                 .get_typed_func(&mut base.store, ARRAY_MAP_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(ARRAY_MAP_FN_NAME))?;
+                .map_err(|err| Error::NotNamedExport(ARRAY_MAP_FN_NAME, err))?;
             ArrayMapFnKind::Old(array_map_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/error.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/error.rs
@@ -1,7 +1,7 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Failed to get valid exports for {0}.")]
-    NotNamedExport(&'static str),
+    #[error("Failed to get valid exports for {0}: {1}")]
+    NotNamedExport(&'static str, anyhow::Error),
     #[error("Failed to get valid exports for any kind of smartmodule.")]
     NotValidExports,
     #[error("Failed to instantiate: {0}")]

--- a/crates/fluvio-smartengine/src/smartmodule/error.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/error.rs
@@ -1,0 +1,9 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to get valid exports for {0}.")]
+    NamedExport(&'static str),
+    #[error("Failed to get valid exports for any kind of smartmodule.")]
+    AnyExports,
+    #[error("Failed to instantiate: {0}")]
+    Instantiate(anyhow::Error),
+}

--- a/crates/fluvio-smartengine/src/smartmodule/error.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/error.rs
@@ -1,9 +1,9 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Failed to get valid exports for {0}.")]
-    NamedExport(&'static str),
+    NotNamedExport(&'static str),
     #[error("Failed to get valid exports for any kind of smartmodule.")]
-    AnyExports,
+    NotValidExports,
     #[error("Failed to instantiate: {0}")]
     Instantiate(anyhow::Error),
 }

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -43,14 +43,14 @@ impl SmartModuleFilter {
         let filter_fn = if let Ok(filt_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_FN_NAME)
-            .map_err(|_err| Error::NamedExport("filter"))
+            .map_err(|_err| Error::NotNamedExport("filter"))
         {
             FilterFnKind::New(filt_fn)
         } else {
             let filt_fn: OldFilterFn = base
                 .instance
                 .get_typed_func(&mut base.store, FILTER_FN_NAME)
-                .map_err(|_err| Error::NamedExport("filter"))?;
+                .map_err(|_err| Error::NotNamedExport("filter"))?;
             FilterFnKind::Old(filt_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -43,14 +43,13 @@ impl SmartModuleFilter {
         let filter_fn = if let Ok(filt_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport("filter"))
         {
             FilterFnKind::New(filt_fn)
         } else {
             let filt_fn: OldFilterFn = base
                 .instance
                 .get_typed_func(&mut base.store, FILTER_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport("filter"))?;
+                .map_err(|err| Error::NotNamedExport("filter", err))?;
             FilterFnKind::Old(filt_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -44,14 +44,14 @@ impl SmartModuleFilterMap {
         let filter_map_fn = if let Ok(fmap_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
-            .map_err(|_err| Error::NamedExport(FILTER_MAP_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(FILTER_MAP_FN_NAME))
         {
             FilterMapFnKind::New(fmap_fn)
         } else {
             let fmap_fn: OldFilterMapFn = base
                 .instance
                 .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
-                .map_err(|_err| Error::NamedExport(FILTER_MAP_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(FILTER_MAP_FN_NAME))?;
             FilterMapFnKind::Old(fmap_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -44,14 +44,13 @@ impl SmartModuleFilterMap {
         let filter_map_fn = if let Ok(fmap_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(FILTER_MAP_FN_NAME))
         {
             FilterMapFnKind::New(fmap_fn)
         } else {
             let fmap_fn: OldFilterMapFn = base
                 .instance
                 .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(FILTER_MAP_FN_NAME))?;
+                .map_err(|err| Error::NotNamedExport(FILTER_MAP_FN_NAME, err))?;
             FilterMapFnKind::Old(fmap_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -8,6 +8,7 @@ use crate::{
     smartmodule::{
         SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
+    error::Error,
 };
 
 const FILTER_MAP_FN_NAME: &str = "filter_map";
@@ -38,17 +39,19 @@ impl SmartModuleFilterMap {
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
         let filter_map_fn = if let Ok(fmap_fn) = base
             .instance
             .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
+            .map_err(|_err| Error::NamedExport(FILTER_MAP_FN_NAME))
         {
             FilterMapFnKind::New(fmap_fn)
         } else {
             let fmap_fn: OldFilterMapFn = base
                 .instance
-                .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)?;
+                .get_typed_func(&mut base.store, FILTER_MAP_FN_NAME)
+                .map_err(|_err| Error::NamedExport(FILTER_MAP_FN_NAME))?;
             FilterMapFnKind::Old(fmap_fn)
         };
 

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -46,14 +46,14 @@ impl SmartModuleJoin {
         let join_fn = if let Ok(join_fn) = base
             .instance
             .get_typed_func(&mut base.store, JOIN_FN_NAME)
-            .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))
         {
             JoinFnKind::New(join_fn)
         } else {
             let join_fn = base
                 .instance
                 .get_typed_func(&mut base.store, JOIN_FN_NAME)
-                .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))?;
             JoinFnKind::Old(join_fn)
         };
         Ok(Self { base, join_fn })

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -9,6 +9,7 @@ use crate::{
     WasmSlice,
     smartmodule::{
         SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
+        error::Error,
     },
 };
 
@@ -40,17 +41,21 @@ impl SmartModuleJoin {
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let join_fn =
-            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
-                JoinFnKind::New(join_fn)
-            } else {
-                let join_fn = base
-                    .instance
-                    .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
-                JoinFnKind::Old(join_fn)
-            };
+        let join_fn = if let Ok(join_fn) = base
+            .instance
+            .get_typed_func(&mut base.store, JOIN_FN_NAME)
+            .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))
+        {
+            JoinFnKind::New(join_fn)
+        } else {
+            let join_fn = base
+                .instance
+                .get_typed_func(&mut base.store, JOIN_FN_NAME)
+                .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))?;
+            JoinFnKind::Old(join_fn)
+        };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -43,19 +43,16 @@ impl SmartModuleJoin {
         version: i16,
     ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let join_fn = if let Ok(join_fn) = base
-            .instance
-            .get_typed_func(&mut base.store, JOIN_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))
-        {
-            JoinFnKind::New(join_fn)
-        } else {
-            let join_fn = base
-                .instance
-                .get_typed_func(&mut base.store, JOIN_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))?;
-            JoinFnKind::Old(join_fn)
-        };
+        let join_fn =
+            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
+                JoinFnKind::New(join_fn)
+            } else {
+                let join_fn = base
+                    .instance
+                    .get_typed_func(&mut base.store, JOIN_FN_NAME)
+                    .map_err(|err| Error::NotNamedExport(JOIN_FN_NAME, err))?;
+                JoinFnKind::Old(join_fn)
+            };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -9,6 +9,7 @@ use crate::{
     WasmSlice,
     smartmodule::{
         SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
+        error::Error,
     },
 };
 
@@ -40,17 +41,21 @@ impl SmartModuleJoinStream {
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let join_fn =
-            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
-                JoinFnKind::New(join_fn)
-            } else {
-                let join_fn = base
-                    .instance
-                    .get_typed_func(&mut base.store, JOIN_FN_NAME)?;
-                JoinFnKind::Old(join_fn)
-            };
+        let join_fn = if let Ok(join_fn) = base
+            .instance
+            .get_typed_func(&mut base.store, JOIN_FN_NAME)
+            .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))
+        {
+            JoinFnKind::New(join_fn)
+        } else {
+            let join_fn = base
+                .instance
+                .get_typed_func(&mut base.store, JOIN_FN_NAME)
+                .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))?;
+            JoinFnKind::Old(join_fn)
+        };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -46,14 +46,14 @@ impl SmartModuleJoinStream {
         let join_fn = if let Ok(join_fn) = base
             .instance
             .get_typed_func(&mut base.store, JOIN_FN_NAME)
-            .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))
         {
             JoinFnKind::New(join_fn)
         } else {
             let join_fn = base
                 .instance
                 .get_typed_func(&mut base.store, JOIN_FN_NAME)
-                .map_err(|_err| Error::NamedExport(JOIN_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))?;
             JoinFnKind::Old(join_fn)
         };
         Ok(Self { base, join_fn })

--- a/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join_stream.rs
@@ -43,19 +43,16 @@ impl SmartModuleJoinStream {
         version: i16,
     ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let join_fn = if let Ok(join_fn) = base
-            .instance
-            .get_typed_func(&mut base.store, JOIN_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))
-        {
-            JoinFnKind::New(join_fn)
-        } else {
-            let join_fn = base
-                .instance
-                .get_typed_func(&mut base.store, JOIN_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(JOIN_FN_NAME))?;
-            JoinFnKind::Old(join_fn)
-        };
+        let join_fn =
+            if let Ok(join_fn) = base.instance.get_typed_func(&mut base.store, JOIN_FN_NAME) {
+                JoinFnKind::New(join_fn)
+            } else {
+                let join_fn = base
+                    .instance
+                    .get_typed_func(&mut base.store, JOIN_FN_NAME)
+                    .map_err(|err| Error::NotNamedExport(JOIN_FN_NAME, err))?;
+                JoinFnKind::Old(join_fn)
+            };
         Ok(Self { base, join_fn })
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -40,17 +40,14 @@ impl SmartModuleMap {
         version: i16,
     ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let map_fn = if let Ok(map_fn) = base
-            .instance
-            .get_typed_func(&mut base.store, MAP_FN_NAME)
-            .map_err(|_err| Error::NotNamedExport(MAP_FN_NAME))
+        let map_fn = if let Ok(map_fn) = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)
         {
             MapFnKind::New(map_fn)
         } else {
             let map_fn: OldMapFn = base
                 .instance
                 .get_typed_func(&mut base.store, MAP_FN_NAME)
-                .map_err(|_err| Error::NotNamedExport(MAP_FN_NAME))?;
+                .map_err(|err| Error::NotNamedExport(MAP_FN_NAME, err))?;
             MapFnKind::Old(map_fn)
         };
         Ok(Self { base, map_fn })

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -43,14 +43,14 @@ impl SmartModuleMap {
         let map_fn = if let Ok(map_fn) = base
             .instance
             .get_typed_func(&mut base.store, MAP_FN_NAME)
-            .map_err(|_err| Error::NamedExport(MAP_FN_NAME))
+            .map_err(|_err| Error::NotNamedExport(MAP_FN_NAME))
         {
             MapFnKind::New(map_fn)
         } else {
             let map_fn: OldMapFn = base
                 .instance
                 .get_typed_func(&mut base.store, MAP_FN_NAME)
-                .map_err(|_err| Error::NamedExport(MAP_FN_NAME))?;
+                .map_err(|_err| Error::NotNamedExport(MAP_FN_NAME))?;
             MapFnKind::Old(map_fn)
         };
         Ok(Self { base, map_fn })

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -8,6 +8,7 @@ use crate::{
     smartmodule::{
         SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
     },
+    error::Error,
 };
 
 const MAP_FN_NAME: &str = "map";
@@ -37,13 +38,19 @@ impl SmartModuleMap {
         module: &SmartModuleWithEngine,
         params: SmartModuleExtraParams,
         version: i16,
-    ) -> Result<Self> {
+    ) -> Result<Self, Error> {
         let mut base = SmartModuleContext::new(module, params, version)?;
-        let map_fn = if let Ok(map_fn) = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)
+        let map_fn = if let Ok(map_fn) = base
+            .instance
+            .get_typed_func(&mut base.store, MAP_FN_NAME)
+            .map_err(|_err| Error::NamedExport(MAP_FN_NAME))
         {
             MapFnKind::New(map_fn)
         } else {
-            let map_fn: OldMapFn = base.instance.get_typed_func(&mut base.store, MAP_FN_NAME)?;
+            let map_fn: OldMapFn = base
+                .instance
+                .get_typed_func(&mut base.store, MAP_FN_NAME)
+                .map_err(|_err| Error::NamedExport(MAP_FN_NAME))?;
             MapFnKind::Old(map_fn)
         };
         Ok(Self { base, map_fn })

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -273,7 +273,9 @@ impl SmartModuleWithEngine {
             return Ok(Box::new(join_stream));
         }
 
-        Err(Error::msg("Unable to initialize generic smartmodule"))
+        Err(Error::msg(
+            "Unable to initialize smartmodule. Make sure that the wasm module includes the correct imports.",
+        ))
     }
 }
 

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -116,7 +116,7 @@ impl SmartEngine {
                 version,
             )?),
             SmartModuleKind::Generic(context) => {
-                smartmodule.create_smartmodule(smart_payload.params, version, context)?
+                smartmodule.create_generic_smartmodule(smart_payload.params, version, context)?
             }
         };
         Ok(smartmodule_instance)
@@ -239,7 +239,9 @@ impl SmartModuleWithEngine {
         Ok(aggregate)
     }
 
-    fn create_smartmodule(
+    /// Create smartmodule without knowing its type. This function will try to initialize the smartmodule as each one of
+    /// the available smartmodules until there is success or all the kinds of smartmodules is tried.
+    fn create_generic_smartmodule(
         &self,
         params: SmartModuleExtraParams,
         version: i16,

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -258,25 +258,25 @@ impl SmartModuleWithEngine {
     ) -> Result<Box<dyn SmartModuleInstance>, error::Error> {
         match self.create_filter(params.clone(), version) {
             Ok(filter) => return Ok(Box::new(filter)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
         match self.create_map(params.clone(), version) {
             Ok(map) => return Ok(Box::new(map)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
         match self.create_filter_map(params.clone(), version) {
             Ok(filter_map) => return Ok(Box::new(filter_map)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
         match self.create_array_map(params.clone(), version) {
             Ok(array_map) => return Ok(Box::new(array_map)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
@@ -286,19 +286,19 @@ impl SmartModuleWithEngine {
         };
         match self.create_aggregate(params.clone(), accumulator, version) {
             Ok(aggregate) => return Ok(Box::new(aggregate)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
         match self.create_join(params.clone(), version) {
             Ok(join) => return Ok(Box::new(join)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 
         match self.create_join_stream(params, version) {
             Ok(join_stream) => return Ok(Box::new(join_stream)),
-            Err(error::Error::NotNamedExport(_)) => {}
+            Err(error::Error::NotNamedExport(_, _)) => {}
             Err(any_other_error) => return Err(any_other_error),
         }
 

--- a/crates/fluvio-smartmodule/examples/Cargo.lock
+++ b/crates/fluvio-smartmodule/examples/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -146,6 +146,22 @@ pub enum SmartModuleKind {
     Generic(SmartModuleContextData),
 }
 
+impl std::fmt::Display for SmartModuleKind {
+    fn fmt(&self, out: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let name = match self {
+            SmartModuleKind::Filter => "filter",
+            SmartModuleKind::Map => "map",
+            SmartModuleKind::ArrayMap => "array_map",
+            SmartModuleKind::Aggregate { .. } => "aggregate",
+            SmartModuleKind::FilterMap => "filter_map",
+            SmartModuleKind::Join(..) => "join",
+            SmartModuleKind::JoinStream { .. } => "join_stream",
+            SmartModuleKind::Generic(..) => "smartmodule",
+        };
+        out.write_str(name)
+    }
+}
+
 #[derive(Debug, Clone, Encoder, Decoder)]
 pub enum SmartModuleContextData {
     None,

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -43,6 +43,8 @@ pub const ARRAY_MAP_WASM_API: i16 = 15;
 // version for persistent SmartModule
 pub const SMART_MODULE_API: i16 = 16;
 
+pub const GENERIC_SMARTMODULE_API: i16 = 17;
+
 /// Fetch records continuously
 /// Output will be send back as stream
 #[derive(Decoder, Encoder, Default, Debug)]
@@ -140,6 +142,27 @@ pub enum SmartModuleKind {
         topic: String,
         derivedstream: String,
     },
+    #[fluvio(min_version = GENERIC_SMARTMODULE_API)]
+    Generic(SmartModuleContextData),
+}
+
+#[derive(Debug, Clone, Encoder, Decoder)]
+pub enum SmartModuleContextData {
+    None,
+    Aggregate {
+        accumulator: Vec<u8>,
+    },
+    Join(String),
+    JoinStream {
+        topic: String,
+        derivedstream: String,
+    },
+}
+
+impl Default for SmartModuleContextData {
+    fn default() -> Self {
+        Self::None
+    }
 }
 
 impl Default for SmartModuleKind {

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -1834,7 +1834,7 @@ async fn test_stream_fetch_invalid_wasm_module(
     assert_eq!(
         response.partition.error_code,
         ErrorCode::SmartModuleInvalidExports {
-            kind: "Filter".to_owned(),
+            kind: "filter".to_owned(),
             error: "failed to parse WebAssembly module".to_owned()
         }
     );
@@ -2424,7 +2424,7 @@ async fn test_stream_fetch_invalid_smartmodule(
 
     match response.partition.error_code {
         ErrorCode::SmartModuleInvalidExports { error: _, kind } => {
-            assert_eq!(kind, "Filter");
+            assert_eq!(kind, "filter");
         }
         _ => panic!("expected an InvalidSmartModule error"),
     }

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -24,7 +24,9 @@ use dataplane::{
 };
 use dataplane::fixture::{create_batch, TEST_RECORD};
 use fluvio_spu_schema::server::{
-    stream_fetch::{SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind},
+    stream_fetch::{
+        SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind, SmartModuleContextData,
+    },
     update_offset::{UpdateOffsetsRequest, OffsetUpdate},
 };
 use fluvio_spu_schema::server::stream_fetch::SmartModuleWasmCompressed;
@@ -405,6 +407,17 @@ async fn test_stream_fetch_filter_predefined() {
     .await;
 }
 
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_filter_generic() {
+    predefined_test(
+        "test_stream_fetch_filter_generic",
+        FLUVIO_WASM_FILTER,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
+        test_stream_fetch_filter,
+    )
+    .await;
+}
+
 async fn test_stream_fetch_filter(
     ctx: Arc<GlobalContext<FileReplica>>,
     test_path: PathBuf,
@@ -596,6 +609,17 @@ async fn test_stream_fetch_filter_individual_predefined() {
     .await;
 }
 
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_filter_individual_generic() {
+    predefined_test(
+        "test_stream_fetch_filter_individual_generic",
+        FLUVIO_WASM_FILTER_ODD,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
+        test_stream_fetch_filter_individual,
+    )
+    .await;
+}
+
 async fn test_stream_fetch_filter_individual(
     ctx: Arc<GlobalContext<FileReplica>>,
     test_path: PathBuf,
@@ -714,6 +738,17 @@ async fn test_stream_filter_error_fetch_predefined() {
         "test_stream_filter_error_fetch_predefined",
         FLUVIO_WASM_FILTER_ODD,
         SmartModuleKind::Filter,
+        test_stream_filter_error_fetch,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_filter_error_fetch_generic() {
+    predefined_test(
+        "test_stream_filter_error_fetch_generic",
+        FLUVIO_WASM_FILTER_ODD,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
         test_stream_filter_error_fetch,
     )
     .await;
@@ -848,6 +883,17 @@ async fn test_stream_filter_max_predefined() {
         "test_stream_filter_max_predefined",
         FLUVIO_WASM_FILTER,
         SmartModuleKind::Filter,
+        test_stream_filter_max,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_filter_max_generic() {
+    predefined_test(
+        "test_stream_filter_max_generic",
+        FLUVIO_WASM_FILTER,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
         test_stream_filter_max,
     )
     .await;
@@ -1161,6 +1207,17 @@ async fn test_stream_fetch_map_error_predefined() {
     .await;
 }
 
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_map_error_generic() {
+    predefined_test(
+        "test_stream_fetch_map_error_generic",
+        FLUVIO_WASM_MAP_DOUBLE,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
+        test_stream_fetch_map_error,
+    )
+    .await;
+}
+
 async fn test_stream_fetch_map_error(
     ctx: Arc<GlobalContext<FileReplica>>,
     test_path: PathBuf,
@@ -1295,6 +1352,19 @@ async fn test_stream_aggregate_fetch_single_batch_predefined() {
         SmartModuleKind::Aggregate {
             accumulator: Vec::from("A"),
         },
+        test_stream_aggregate_fetch_single_batch,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_aggregate_fetch_single_batch_generic() {
+    predefined_test(
+        "test_stream_aggregate_fetch_single_batch_generic",
+        FLUVIO_WASM_AGGREGATE,
+        SmartModuleKind::Generic(SmartModuleContextData::Aggregate {
+            accumulator: Vec::from("A"),
+        }),
         test_stream_aggregate_fetch_single_batch,
     )
     .await;
@@ -1441,6 +1511,18 @@ async fn test_stream_aggregate_fetch_multiple_batch_predefined() {
         SmartModuleKind::Aggregate {
             accumulator: Vec::from("A"),
         },
+        test_stream_aggregate_fetch_multiple_batch,
+    )
+    .await;
+}
+#[fluvio_future::test(ignore)]
+async fn test_stream_aggregate_fetch_multiple_batch_generic() {
+    predefined_test(
+        "test_stream_aggregate_fetch_multiple_batch_generic",
+        FLUVIO_WASM_AGGREGATE,
+        SmartModuleKind::Generic(SmartModuleContextData::Aggregate {
+            accumulator: Vec::from("A"),
+        }),
         test_stream_aggregate_fetch_multiple_batch,
     )
     .await;
@@ -1796,6 +1878,17 @@ async fn test_stream_fetch_array_map_predefined() {
     .await;
 }
 
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_array_map_generic() {
+    predefined_test(
+        "test_stream_fetch_array_map_generic",
+        FLUVIO_WASM_ARRAY_MAP_ARRAY,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
+        test_stream_fetch_array_map,
+    )
+    .await;
+}
+
 async fn test_stream_fetch_array_map(
     ctx: Arc<GlobalContext<FileReplica>>,
     test_path: PathBuf,
@@ -1913,6 +2006,17 @@ async fn test_stream_fetch_filter_map_predefined() {
         "test_stream_fetch_filter_map_predefined",
         FLUVIO_WASM_FILTER_MAP,
         SmartModuleKind::FilterMap,
+        test_stream_fetch_filter_map,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_filter_map_generic() {
+    predefined_test(
+        "test_stream_fetch_filter_map_generic",
+        FLUVIO_WASM_FILTER_MAP,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
         test_stream_fetch_filter_map,
     )
     .await;
@@ -2037,6 +2141,17 @@ async fn test_stream_fetch_filter_with_params_predefined() {
         "test_stream_fetch_filter_with_params_predefined",
         FLUVIO_WASM_FILTER_WITH_PARAMETERS,
         SmartModuleKind::Filter,
+        test_stream_fetch_filter_with_params,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_filter_with_params_generic() {
+    predefined_test(
+        "test_stream_fetch_filter_with_params_generic",
+        FLUVIO_WASM_FILTER_WITH_PARAMETERS,
+        SmartModuleKind::Generic(SmartModuleContextData::None),
         test_stream_fetch_filter_with_params,
     )
     .await;
@@ -2549,6 +2664,28 @@ async fn test_stream_fetch_join_adhoc() {
         "test_stream_fetch_join_legacy",
         FLUVIO_WASM_JOIN,
         SmartModuleKind::Join(JOIN_RIGHT_TOPIC.into()),
+        test_stream_fetch_join,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_join_predefined() {
+    predefined_test(
+        "test_stream_fetch_join_predefenided",
+        FLUVIO_WASM_JOIN,
+        SmartModuleKind::Join(JOIN_RIGHT_TOPIC.into()),
+        test_stream_fetch_join,
+    )
+    .await;
+}
+
+#[fluvio_future::test(ignore)]
+async fn test_stream_fetch_join_generic() {
+    predefined_test(
+        "test_stream_fetch_join_generic",
+        FLUVIO_WASM_JOIN,
+        SmartModuleKind::Generic(SmartModuleContextData::Join(JOIN_RIGHT_TOPIC.into())),
         test_stream_fetch_join,
     )
     .await;

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -196,9 +196,16 @@ impl SmartModuleContext {
                     error = err.to_string().as_str(),
                     "Error Instantiating SmartModule"
                 );
-                ErrorCode::SmartModuleInvalidExports {
-                    kind: format!("{:?}", kind),
-                    error: err.to_string(),
+                if let SmartModuleKind::Generic(_) = kind {
+                    ErrorCode::SmartModuleInvalid {
+                        error: err.to_string(),
+                        name: None,
+                    }
+                } else {
+                    ErrorCode::SmartModuleInvalidExports {
+                        kind: format!("{}", kind),
+                        error: err.to_string(),
+                    }
                 }
             })
     }

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -9,6 +9,7 @@ use fluvio::{
 use fluvio_smartengine::SmartModuleInstance;
 use fluvio_spu_schema::server::stream_fetch::{
     SmartModuleInvocationWasm, LegacySmartModulePayload, SmartModuleWasmCompressed,
+    SmartModuleContextData,
 };
 use futures_util::{StreamExt, stream::BoxStream};
 
@@ -69,7 +70,8 @@ impl SmartModuleContext {
         // check for right consumer stream exists, this only happens for join type
         let right_consumer_stream = match invocation.kind {
             // for join, create consumer stream
-            SmartModuleKind::Join(ref topic) => {
+            SmartModuleKind::Join(ref topic)
+            | SmartModuleKind::Generic(SmartModuleContextData::Join(ref topic)) => {
                 let consumer = ctx.leaders().partition_consumer(topic.to_owned(), 0).await;
 
                 Some(

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -86,7 +86,11 @@ impl SmartModuleContext {
             SmartModuleKind::JoinStream {
                 topic: ref _topic,
                 derivedstream: ref derivedstream_name,
-            } => {
+            }
+            | SmartModuleKind::Generic(SmartModuleContextData::JoinStream {
+                topic: ref _topic,
+                derivedstream: ref derivedstream_name,
+            }) => {
                 // first ensure derivedstream exists
                 if let Some(derivedstream) = ctx.derivedstream_store().spec(derivedstream_name) {
                     // find input which has topic

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -66,7 +66,7 @@ fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
-fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.2.0" }
+fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.3.0" }
 
 [target.'cfg(unix)'.dependencies]
 fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema", features = [

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.13.1"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -69,14 +69,14 @@ dirs = "4.0.0"
 fluvio-smartengine = { path = "../fluvio-smartengine/", optional = true, version = "0.2.0" }
 
 [target.'cfg(unix)'.dependencies]
-fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema", features = [
+fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema", features = [
     "file",
 ] }
 [target.'cfg(windows)'.dependencies]
-fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-fluvio-spu-schema = { version = "0.9.0", path = "../fluvio-spu-schema" }
+fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema" }
 
 [dev-dependencies]
 async-std = { version = "1.6.4", default-features = false }

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -215,7 +215,7 @@ impl InnerTopicProducer {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "smartengine")] {
-        use fluvio_spu_schema::server::stream_fetch::{SmartModuleWasmCompressed, SmartModuleKind, LegacySmartModulePayload};
+        use fluvio_spu_schema::server::stream_fetch::{SmartModuleWasmCompressed, SmartModuleContextData, SmartModuleKind, LegacySmartModulePayload};
         use std::collections::BTreeMap;
         use fluvio_smartengine::SmartEngine;
 
@@ -299,6 +299,22 @@ cfg_if::cfg_if! {
                 let smart_payload = LegacySmartModulePayload {
                     wasm: SmartModuleWasmCompressed::Raw(map.into()),
                     kind: SmartModuleKind::Aggregate { accumulator },
+                    params: params.into(),
+                };
+                self.init_engine(smart_payload)?;
+                Ok(self)
+            }
+
+            /// Use generic smartmodule (the type is detected in smartengine)
+            pub fn with_smartmodule<T: Into<Vec<u8>>>(
+                mut self,
+                smartmodule: T,
+                params: BTreeMap<String, String>,
+                context: SmartModuleContextData,
+            ) -> Result<Self, FluvioError> {
+                let smart_payload = LegacySmartModulePayload {
+                    wasm: SmartModuleWasmCompressed::Raw(smartmodule.into()),
+                    kind: SmartModuleKind::Generic ( context ),
                     params: params.into(),
                 };
                 self.init_engine(smart_payload)?;


### PR DESCRIPTION
Fixes #2457 

This PR adds a way to defer to the SPU the smarmodule type resolution.

We can use now in CLI and API a generic --smartmodule type and the SPU will try to detect the smart module type by trying to initialize the smart module engine with each one of them until there is success

example:


`fluvio consume numbers --smartmodule double -B` Where double is https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartmodule/examples/map_double. Should return a stream with the numbers of `number` topic multiplied by 2