### PR TITLE
[Merged by Bors] - Do not allow --initial when we are not using aggregate smartmodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Platform Version 0.9.32 - UNRELEASED
+* Restrict usage of `--initial`, `--extra-params` and `--join-topic` in `fluvio consume`. Those options only should be accepted when using specific smartmodules. ([#2476](https://github.com/infinyon/fluvio/pull/2476))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))

--- a/crates/fluvio-cli/src/consume/mod.rs
+++ b/crates/fluvio-cli/src/consume/mod.rs
@@ -158,29 +158,40 @@ pub struct ConsumeOpt {
     pub array_map: Option<String>,
 
     /// Path to a SmartModule join wasm filee
-    #[clap(long, group("smartmodule_group"))]
+    #[clap(long, group("smartmodule_group"), group("join_group"))]
     pub join: Option<String>,
 
     /// Path to a WASM file for aggregation
-    #[clap(long, group("smartmodule_group"))]
+    #[clap(long, group("smartmodule_group"), group("aggregate_group"))]
     pub aggregate: Option<String>,
 
     /// Path or name to WASM module. This support any of the other
     /// smartmodule types: filter, map, array_map, aggregate, join and filter_map
-    #[clap(long, group("smartmodule_group"))]
+    #[clap(
+        long,
+        group("smartmodule_group"),
+        group("aggregate_group"),
+        group("join_group")
+    )]
     pub smartmodule: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, requires = "join_group")]
     pub join_topic: Option<String>,
 
     /// (Optional) Path to a file to use as an initial accumulator value with --aggregate
-    #[clap(long)]
+    #[clap(long, requires = "aggregate_group")]
     pub initial: Option<String>,
 
     /// (Optional) Extra input parameters passed to the smartmodule module.
     /// They should be passed using key=value format
     /// Eg. fluvio consume topic-name --filter filter.wasm -e foo=bar -e key=value -e one=1
-    #[clap(short = 'e', long= "extra-params", parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[clap(
+        short = 'e',
+        requires = "smartmodule_group",
+        long= "extra-params",
+        parse(try_from_str = parse_key_val),
+        number_of_values = 1
+    )]
     pub extra_params: Option<Vec<(String, String)>>,
 
     /// Isolation level that consumer must respect.


### PR DESCRIPTION
I noticed that in `fluvio consume` we can use `--initial` and `--join-topic` when we are not using their respective smart modules. This fixes that, now if we use `--initial` without using --aggregate or --smartmodule the CLI will fail with the right description.

The same applies to `--extra-params`