### PR TITLE
[Merged by Bors] - Keep serving incoming requests even if socket closed to write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.32 - UNRELEASED
 * Restrict usage of `--initial`, `--extra-params` and `--join-topic` in `fluvio consume`. Those options only should be accepted when using specific smartmodules. ([#2476](https://github.com/infinyon/fluvio/pull/2476))
+* Keep serving incoming requests even if socket closed to write. ([#2484](https://github.com/infinyon/fluvio/pull/2484))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))


### PR DESCRIPTION
This change is needed for `at most once` delivery semantic. The client can send a batch and close the socket without waiting for a response. If the server can't write response it should continue to handle incoming requests that are received and waiting to be served.

Related #2481