### PR TITLE
[Merged by Bors] - Support async response in socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Rename `--smartmodule` option in `fluvio consume` to `--smart-module`. `--smartmodule is still an alias for backward compatibility. ([#2485](https://github.com/infinyon/fluvio/issues/2485))
 * Measure latency for stats using macro. ([#2483](https://github.com/infinyon/fluvio/pull/2483))
 * Keep serving incoming requests even if socket closed to write. ([#2484](https://github.com/infinyon/fluvio/pull/2484))
+* Support async response in multiplexed socket. ([#2488](https://github.com/infinyon/fluvio/pull/2488))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.13.0"
+version = "0.12.1"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.13.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/multiplexing.rs
+++ b/crates/fluvio-socket/src/multiplexing.rs
@@ -484,7 +484,7 @@ impl MultiPlexingResponseDispatcher {
                     trace!("found stream");
                     // sender was dropped before response arrives
                     if queue_sender.is_closed() {
-                        debug!("attempt to send data to closed socket: {}", correlation_id);
+                        debug!(correlation_id, "attempt to send data to closed socket");
                         Ok(())
                     } else {
                         queue_sender.send(Some(msg)).await.map_err(|err| {
@@ -503,8 +503,8 @@ impl MultiPlexingResponseDispatcher {
         } else {
             // sender was dropped and unregistered before response arrives
             debug!(
-                "no socket receiver founded for id: {}, abandoning sending",
-                correlation_id
+                correlation_id,
+                "no socket receiver founded, abandoning sending",
             );
             Ok(())
         }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -57,7 +57,7 @@ fluvio-types = { version = "0.3.7", features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-sc-schema = { version = "0.14.0", path = "../fluvio-sc-schema", default-features = false }
-fluvio-socket = { path = "../fluvio-socket", version = "0.12.0" }
+fluvio-socket = { path = "../fluvio-socket", version = "0.13.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = [
     "memory_batch",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -57,7 +57,7 @@ fluvio-types = { version = "0.3.7", features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-sc-schema = { version = "0.14.0", path = "../fluvio-sc-schema", default-features = false }
-fluvio-socket = { path = "../fluvio-socket", version = "0.13.0" }
+fluvio-socket = { path = "../fluvio-socket", version = "0.12.1" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = [
     "memory_batch",

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -401,7 +401,7 @@ where
                 }
 
                 let response_publisher = publisher.clone();
-                let update_stream = stream.map(move |item| {
+                let update_stream = StreamExt::map(stream, move |item| {
                     item.map(|response| {
                         if let Some(last_offset) = response.partition.next_offset_for_fetch() {
                             debug!(last_offset, stream_id, "received last offset from spu");


### PR DESCRIPTION
Added an ability to receive a response asynchronously. We re-use the current functionality of `AsyncResponse` and streaming, just saying that `AsyncResponse` is now also a Future that can resolve to one result instead of a sequence of results for the streaming case.

Related #2481