### PR TITLE
Drop write lock before async IO operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/crates/fluvio-storage/src/cleaner.rs
+++ b/crates/fluvio-storage/src/cleaner.rs
@@ -116,13 +116,14 @@ impl Cleaner {
             Duration::from_secs(self.replica_config.retention_seconds.get() as u64);
         let read = self.segments.read().await;
         let expired_segments = read.find_expired_segments(&retention_secs);
+        let total = read.len();
+        drop(read);
         debug!(
             seconds = retention_secs.as_secs(),
-            total = read.len(),
+            total = total,
             expired = expired_segments.len(),
             "expired segments"
         );
-        drop(read);
         if !expired_segments.is_empty() {
             self.segments.remove_segments(&expired_segments).await;
             let read = self.segments.read().await;

--- a/crates/fluvio-storage/src/segments.rs
+++ b/crates/fluvio-storage/src/segments.rs
@@ -148,6 +148,7 @@ impl SharedSegments {
         let mut write = self.write().await;
 
         if let Some((old_segment, min_offset)) = write.remove_segment(base_offset) {
+            drop(write);
             self.min_offset.store(min_offset, MEM_ORDER);
             if let Err(err) = old_segment.remove().await {
                 error!("failed to remove segment: {:#?}", err);


### PR DESCRIPTION
Write lock guard shouldn't outlive `await` on async IO operations because under high load awaiting time could be significant, and during all that time, the lock guard won't be dropped and will prevent the system from any progress. 