### PR TITLE
[Merged by Bors] - Make produce request cloneable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Keep serving incoming requests even if socket closed to write. ([#2484](https://github.com/infinyon/fluvio/pull/2484))
 * Support async response in multiplexed socket. ([#2488](https://github.com/infinyon/fluvio/pull/2488))
 * Drop write lock before async IO operations. ([#2490](https://github.com/infinyon/fluvio/pull/2490))
+* Add `Clone` trait to `DefaultProduceRequest`. ([#2482](https://github.com/infinyon/fluvio/pull/2482))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Keep serving incoming requests even if socket closed to write. ([#2484](https://github.com/infinyon/fluvio/pull/2484))
 * Support async response in multiplexed socket. ([#2488](https://github.com/infinyon/fluvio/pull/2488))
 * Drop write lock before async IO operations. ([#2490](https://github.com/infinyon/fluvio/pull/2490))
-* Add `Clone` trait to `DefaultProduceRequest`. ([#2482](https://github.com/infinyon/fluvio/pull/2482))
+* Add `Clone` trait to `DefaultProduceRequest`. ([#2501](https://github.com/infinyon/fluvio/pull/2501))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-sc-schema",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -1790,7 +1790,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-socket",
  "fluvio-types",
  "flv-tls-proxy",
@@ -1992,7 +1992,7 @@ version = "0.0.0"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-types",
  "log",
  "tracing",
@@ -2007,7 +2007,7 @@ dependencies = [
  "bytes",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
@@ -2031,7 +2031,7 @@ dependencies = [
  "fluvio-compression",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-socket",
  "fluvio-types",
  "flv-util",
@@ -2144,6 +2144,17 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol"
 version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d93e55fab0af4f137b3b643a6968cc56c0aebc0708c286abe749ceafb66fc67"
+dependencies = [
+ "bytes",
+ "fluvio-protocol-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.7.9"
 dependencies = [
  "bytes",
  "fluvio-future 0.4.1",
@@ -2154,21 +2165,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-protocol"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d93e55fab0af4f137b3b643a6968cc56c0aebc0708c286abe749ceafb66fc67"
-dependencies = [
- "bytes",
- "fluvio-protocol-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
-]
-
-[[package]]
 name = "fluvio-protocol-derive"
 version = "0.4.2"
 dependencies = [
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "proc-macro2",
  "quote",
  "syn",
@@ -2220,7 +2220,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-sc-schema",
  "fluvio-service",
  "fluvio-socket",
@@ -2252,7 +2252,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-types",
  "log",
  "paste",
@@ -2268,7 +2268,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-socket",
  "fluvio-types",
  "futures-util",
@@ -2329,7 +2329,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -2363,7 +2363,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-service",
  "fluvio-smartengine",
  "fluvio-socket",
@@ -2393,7 +2393,7 @@ dependencies = [
  "bytes",
  "flate2",
  "fluvio-dataplane-protocol",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "log",
  "serde",
  "static_assertions",
@@ -2414,7 +2414,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8",
+ "fluvio-protocol 0.7.9",
  "fluvio-socket",
  "fluvio-storage",
  "fluvio-types",
@@ -2484,7 +2484,7 @@ dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-protocol 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-protocol 0.7.8",
  "fluvio-test-derive 0.0.0",
  "fluvio-test-util",
  "fluvio-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ dependencies = [
 name = "fluvio-compression"
 version = "0.1.1"
 dependencies = [
+ "bytes",
  "flate2",
  "lz4_flex",
  "serde",

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-compression"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -18,3 +18,4 @@ flate2 = { version = "1.0.20"}
 snap = { version = "1" }
 lz4_flex = { version = "0.9", default-features = false, features = ["safe-decode", "safe-encode", "frame"] }
 thiserror = "1.0.30"
+bytes = { version = "1.1.0"}

--- a/crates/fluvio-compression/src/error.rs
+++ b/crates/fluvio-compression/src/error.rs
@@ -1,3 +1,5 @@
+use bytes::buf::Writer;
+use bytes::BytesMut;
 use snap::write::{IntoInnerError, FrameEncoder};
 
 #[derive(thiserror::Error, Debug)]
@@ -7,7 +9,7 @@ pub enum CompressionError {
     #[error("unknown compression format: {0}")]
     UnknownCompressionFormat(String),
     #[error("error flushing Snap encoder: {0}")]
-    SnapError(#[from] Box<IntoInnerError<FrameEncoder<Vec<u8>>>>),
+    SnapError(#[from] Box<IntoInnerError<FrameEncoder<Writer<BytesMut>>>>),
     #[error("error flushing Snap encoder: {0}")]
     Lz4Error(#[from] lz4_flex::frame::Error),
     #[error("Unreachable error")]

--- a/crates/fluvio-compression/src/gzip.rs
+++ b/crates/fluvio-compression/src/gzip.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use flate2::Compression;
 use flate2::read::GzDecoder;
@@ -6,10 +7,10 @@ use flate2::write::GzEncoder;
 
 use crate::error::CompressionError;
 
-pub fn compress(src: &[u8]) -> Result<Vec<u8>, CompressionError> {
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+pub fn compress(src: &[u8]) -> Result<Bytes, CompressionError> {
+    let mut encoder = GzEncoder::new(BytesMut::new().writer(), Compression::default());
     encoder.write_all(src)?;
-    Ok(encoder.finish()?)
+    Ok(encoder.finish()?.into_inner().freeze())
 }
 
 pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
@@ -21,6 +22,7 @@ pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Buf;
     use super::*;
 
     #[test]
@@ -30,7 +32,7 @@ mod tests {
 
         assert!(compressed.len() < text.as_bytes().len());
 
-        let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
+        let uncompressed = String::from_utf8(uncompress(compressed.reader()).unwrap()).unwrap();
 
         assert_eq!(uncompressed, text);
     }

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use bytes::Bytes;
 
 mod error;
 
@@ -58,9 +59,9 @@ impl FromStr for Compression {
 
 impl Compression {
     /// Compress the given data, returning the compressed data
-    pub fn compress(&self, src: &[u8]) -> Result<Vec<u8>, CompressionError> {
+    pub fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
         match *self {
-            Compression::None => Ok(src.to_vec()),
+            Compression::None => Ok(Bytes::copy_from_slice(src)),
             Compression::Gzip => gzip::compress(src),
             Compression::Snappy => snappy::compress(src),
             Compression::Lz4 => lz4::compress(src),

--- a/crates/fluvio-compression/src/lz4.rs
+++ b/crates/fluvio-compression/src/lz4.rs
@@ -1,13 +1,14 @@
 use std::io::{Read, Write};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::error::CompressionError;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 
-pub fn compress(src: &[u8]) -> Result<Vec<u8>, CompressionError> {
-    let buf = Vec::with_capacity(src.len());
-    let mut encoder = FrameEncoder::new(buf);
+pub fn compress(src: &[u8]) -> Result<Bytes, CompressionError> {
+    let buf = BytesMut::with_capacity(src.len());
+    let mut encoder = FrameEncoder::new(buf.writer());
     encoder.write_all(src)?;
-    Ok(encoder.finish()?)
+    Ok(encoder.finish()?.into_inner().freeze())
 }
 
 pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
@@ -19,6 +20,7 @@ pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Buf;
     use super::*;
 
     #[test]
@@ -28,7 +30,7 @@ mod tests {
 
         assert!(compressed.len() < text.as_bytes().len());
 
-        let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
+        let uncompressed = String::from_utf8(uncompress(compressed.reader()).unwrap()).unwrap();
 
         assert_eq!(uncompressed, text);
     }

--- a/crates/fluvio-compression/src/snappy.rs
+++ b/crates/fluvio-compression/src/snappy.rs
@@ -1,13 +1,17 @@
 use std::io::{Read, Write};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::error::CompressionError;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 
-pub fn compress(src: &[u8]) -> Result<Vec<u8>, CompressionError> {
-    let buf = Vec::with_capacity(src.len());
-    let mut encoder = FrameEncoder::new(buf);
+pub fn compress(src: &[u8]) -> Result<Bytes, CompressionError> {
+    let buf = BytesMut::with_capacity(src.len());
+    let mut encoder = FrameEncoder::new(buf.writer());
     encoder.write_all(src)?;
-    Ok(encoder.into_inner().map_err(Box::new)?)
+    Ok(encoder
+        .into_inner()
+        .map(|w| w.into_inner().freeze())
+        .map_err(Box::new)?)
 }
 
 pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
@@ -19,6 +23,7 @@ pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>, CompressionError> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Buf;
     use super::*;
 
     #[test]
@@ -28,7 +33,7 @@ mod tests {
 
         assert!(compressed.len() < text.as_bytes().len());
 
-        let uncompressed = String::from_utf8(uncompress(compressed.as_slice()).unwrap()).unwrap();
+        let uncompressed = String::from_utf8(uncompress(compressed.reader()).unwrap()).unwrap();
 
         assert_eq!(uncompressed, text);
     }

--- a/crates/fluvio-dataplane-protocol/Cargo.toml
+++ b/crates/fluvio-dataplane-protocol/Cargo.toml
@@ -28,7 +28,7 @@ eyre = { version = "0.6", default-features = false }
 thiserror = "1"
 
 # Fluvio dependencies
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2", path = "../fluvio-compression" }
 fluvio-future = { version = "0.4.0" }
 fluvio-protocol = { path = "../fluvio-protocol", version = "0.7", features = [
     "derive",

--- a/crates/fluvio-dataplane-protocol/src/batch.rs
+++ b/crates/fluvio-dataplane-protocol/src/batch.rs
@@ -184,7 +184,7 @@ impl TryFrom<Batch> for Batch<RawRecords> {
         let compression = f.get_compression()?;
         let compressed_records = compression.compress(&buf)?;
         let compressed_records_len = compressed_records.len() as i32;
-        let records = RawRecords(Bytes::from(compressed_records));
+        let records = RawRecords(compressed_records);
 
         Ok(Batch {
             base_offset: f.base_offset,

--- a/crates/fluvio-dataplane-protocol/src/record.rs
+++ b/crates/fluvio-dataplane-protocol/src/record.rs
@@ -344,6 +344,14 @@ impl<R: BatchRecords> Encoder for RecordSet<R> {
     }
 }
 
+impl<R: Clone> Clone for RecordSet<R> {
+    fn clone(&self) -> Self {
+        Self {
+            batches: self.batches.clone(),
+        }
+    }
+}
+
 #[derive(Decoder, Default, Encoder, Debug, Clone)]
 pub struct RecordHeader {
     attributes: i8,

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/api/request.rs
+++ b/crates/fluvio-protocol/src/api/request.rs
@@ -171,6 +171,15 @@ where
     }
 }
 
+impl<R: Clone> Clone for RequestMessage<R> {
+    fn clone(&self) -> Self {
+        Self {
+            header: self.header.clone(),
+            request: self.request.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -46,7 +46,7 @@ fluvio-types = { features = [
     "events",
 ], path = "../fluvio-types" }
 fluvio-storage = { path = "../fluvio-storage" }
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2", path = "../fluvio-compression" }
 fluvio-controlplane = { path = "../fluvio-controlplane" }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata" }
 fluvio-spu-schema = { path = "../fluvio-spu-schema", features = [

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -62,7 +62,7 @@ fluvio-protocol = { path = "../fluvio-protocol", version = "0.7" }
 dataplane = { version = "0.11.0", path = "../fluvio-dataplane-protocol", features = [
     "memory_batch",
 ], package = "fluvio-dataplane-protocol" }
-fluvio-compression = { version = "0.1.0", path = "../fluvio-compression" }
+fluvio-compression = { version = "0.2", path = "../fluvio-compression" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"


### PR DESCRIPTION
This is needed for being able to retry produce requests if an error occurs.

Related #2481