### PR TITLE
[Merged by Bors] - Add `AtMostOnce` and `AtLeastOnce` delivery semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Support async response in multiplexed socket. ([#2488](https://github.com/infinyon/fluvio/pull/2488))
 * Drop write lock before async IO operations. ([#2490](https://github.com/infinyon/fluvio/pull/2490))
 * Add `Clone` trait to `DefaultProduceRequest`. ([#2501](https://github.com/infinyon/fluvio/pull/2501))
+* Add `AtMostOnce` and `AtLeastOnce` delivery semantics. ([#2503](https://github.com/infinyon/fluvio/pull/2503))
 
 ## Platform Version 0.9.31 - 2022-07-13
 * Move stream publishers to connection-level context ([#2452](https://github.com/infinyon/fluvio/pull/2452))

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -48,10 +48,11 @@ strum = { version = "0.24", features = ["derive"], optional = true }
 num-traits = { version = "0.2", optional = true }
 
 # Fluvio dependencies
-fluvio-future = { version = "0.4.0", features = [
+fluvio-future = { version = "0.4.1", features = [
     "task",
     "openssl_tls",
     "task_unstable",
+    "retry"
 ] }
 fluvio-types = { version = "0.3.7", features = [
     "events",

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -100,7 +100,7 @@ pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, RecordKey, ProduceOutput,
-    FutureRecordMetadata, RecordMetadata,
+    FutureRecordMetadata, RecordMetadata, DeliverySemantic, RetryPolicy, RetryStrategy,
 };
 
 pub use consumer::{

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -1,6 +1,9 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::str::FromStr;
 use std::time::Duration;
 
 use derive_builder::Builder;
+use fluvio_future::retry::{ExponentialBackoff, FibonacciBackoff, FixedDelay};
 use dataplane::Isolation;
 
 use fluvio_compression::Compression;
@@ -12,6 +15,11 @@ use crate::stats::ClientStatsDataCollect;
 const DEFAULT_LINGER_MS: u64 = 100;
 const DEFAULT_TIMEOUT_MS: u64 = 1500;
 const DEFAULT_BATCH_SIZE_BYTES: usize = 16_384;
+
+const DEFAULT_RETRIES_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_INITIAL_DELAY: Duration = Duration::from_millis(20);
+const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(200);
+const DEFAULT_MAX_RETRIES: usize = 4;
 
 fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE_BYTES
@@ -38,10 +46,14 @@ fn default_stats_collect() -> ClientStatsDataCollect {
     ClientStatsDataCollect::default()
 }
 
+fn default_delivery() -> DeliverySemantic {
+    DeliverySemantic::default()
+}
+
 /// Options used to adjust the behavior of the Producer.
 /// Create this struct with [`TopicProducerConfigBuilder`].
 ///
-/// Create a producer with a custom config with [`Fluvio::topic_producer_with_config()`].
+/// Create a producer with a custom config with [`crate::Fluvio::topic_producer_with_config()`].
 #[derive(Builder)]
 #[builder(pattern = "owned")]
 pub struct TopicProducerConfig {
@@ -76,6 +88,15 @@ pub struct TopicProducerConfig {
     /// Collect resource and data transfer stats used by Fluvio producer
     #[builder(default = "default_stats_collect()")]
     pub(crate) stats_collect: ClientStatsDataCollect,
+
+    /// Delivery guarantees that producer must respect.
+    /// [`DeliverySemantic::AtMostOnce`] - send records without waiting from response. `Fire and forget`
+    /// approach.
+    /// [`DeliverySemantic::AtLeastOnce`] - send records, wait for the response and retry
+    /// if error occurred. Retry parameters, such as delay, retry strategy, timeout, etc.,
+    /// can be configured in [`RetryPolicy`].
+    #[builder(default = "default_delivery()")]
+    pub(crate) delivery_semantic: DeliverySemantic,
 }
 
 impl Default for TopicProducerConfig {
@@ -90,6 +111,222 @@ impl Default for TopicProducerConfig {
 
             #[cfg(feature = "stats")]
             stats_collect: default_stats_collect(),
+            delivery_semantic: default_delivery(),
         }
+    }
+}
+
+/// Defines guarantees that Producer must follow delivering records to SPU.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum DeliverySemantic {
+    /// Send records without waiting for the response. `Fire and forget` approach.
+    AtMostOnce,
+    /// Send records, wait for the response and retry if an error occurs. Retry parameters,
+    /// such as delay, retry strategy, timeout, etc., can be configured in [`RetryPolicy`].
+    AtLeastOnce(RetryPolicy),
+}
+
+/// Defines parameters of retries in [`DeliverySemantic::AtLeastOnce`] delivery semantic.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RetryPolicy {
+    /// Max amount of retries. If `0`, no retries will be performed.
+    pub max_retries: usize,
+
+    /// Initial delay before the first retry.
+    pub initial_delay: Duration,
+
+    /// The upper limit for delay for [`RetryStrategy::ExponentialBackoff`] and
+    /// [`RetryStrategy::FibonacciBackoff`] retry strategies.
+    pub max_delay: Duration,
+
+    /// Max duration for all retries.
+    pub timeout: Duration,
+
+    /// Defines the strategy of delays distribution.
+    pub strategy: RetryStrategy,
+}
+
+impl Default for DeliverySemantic {
+    fn default() -> Self {
+        Self::AtLeastOnce(RetryPolicy::default())
+    }
+}
+
+impl Display for DeliverySemantic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl FromStr for DeliverySemantic {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "at_most_once" | "at-most-once" | "AtMostOnce" | "atMostOnce" | "atmostonce" => Ok(DeliverySemantic::AtMostOnce),
+            "at_least_once" | "at-least-once" | "AtLeastOnce" | "atLeastOnce" | "atleastonce" => Ok(DeliverySemantic::default()),
+            _ => Err(format!("unrecognized delivery semantic: {}. Supported: at_most_once (AtMostOnce), at_least_once (AtLeastOnce)", s)),
+        }
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: DEFAULT_MAX_RETRIES,
+            initial_delay: DEFAULT_INITIAL_DELAY,
+            max_delay: DEFAULT_MAX_DELAY,
+            timeout: DEFAULT_RETRIES_TIMEOUT,
+            strategy: RetryStrategy::ExponentialBackoff,
+        }
+    }
+}
+
+/// Strategy of delays distribution.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RetryStrategy {
+    /// A retry strategy is driven by a fixed interval between retries.
+    FixedDelay,
+    /// A retry strategy is driven by exponential back-off.
+    /// For example, if you have five retries with initial delay of 10ms, the sequence will be:
+    /// `[10ms, 100ms, 1s, 200s, 200s]`
+    #[default]
+    ExponentialBackoff,
+    /// A retry strategy is driven by the Fibonacci series of intervals between retries.
+    /// For example, if you have five retries with initial delay of 10ms, the sequence will be
+    /// `[10ms, 10ms, 20ms, 30ms, 50ms]`
+    FibonacciBackoff,
+}
+
+#[derive(Debug)]
+enum RetryPolicyIter {
+    FixedDelay(FixedDelay),
+    ExponentialBackoff(ExponentialBackoff),
+    FibonacciBackoff(FibonacciBackoff),
+}
+
+impl Iterator for RetryPolicyIter {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            RetryPolicyIter::FixedDelay(iter) => iter.next(),
+            RetryPolicyIter::ExponentialBackoff(iter) => iter.next(),
+            RetryPolicyIter::FibonacciBackoff(iter) => iter.next(),
+        }
+    }
+}
+
+impl RetryPolicy {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Duration> + Debug + Send {
+        match self.strategy {
+            RetryStrategy::FixedDelay => {
+                RetryPolicyIter::FixedDelay(FixedDelay::new(self.initial_delay))
+            }
+            RetryStrategy::ExponentialBackoff => RetryPolicyIter::ExponentialBackoff(
+                ExponentialBackoff::from_millis(self.initial_delay.as_millis() as u64)
+                    .max_delay(self.max_delay),
+            ),
+            RetryStrategy::FibonacciBackoff => RetryPolicyIter::FibonacciBackoff(
+                FibonacciBackoff::new(self.initial_delay).max_delay(self.max_delay),
+            ),
+        }
+        .take(self.max_retries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retry_policy_fixed_iter() {
+        //given
+        let duration = Duration::from_millis(10);
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_delay: duration,
+            strategy: RetryStrategy::FixedDelay,
+            ..Default::default()
+        };
+
+        //when
+        let iter = policy.iter();
+
+        //then
+        assert_eq!(iter.collect::<Vec<Duration>>(), [duration; 3])
+    }
+
+    #[test]
+    fn test_retry_policy_exponential_iter() {
+        //given
+        let duration = Duration::from_millis(10);
+        let max_duration = Duration::from_millis(2000);
+        let policy = RetryPolicy {
+            max_retries: 5,
+            initial_delay: duration,
+            max_delay: max_duration,
+            strategy: RetryStrategy::ExponentialBackoff,
+            ..Default::default()
+        };
+
+        //when
+        let iter = policy.iter();
+
+        //then
+        assert_eq!(
+            iter.collect::<Vec<Duration>>(),
+            [
+                duration,
+                Duration::from_millis(100),
+                Duration::from_millis(1000),
+                max_duration,
+                max_duration
+            ]
+        )
+    }
+
+    #[test]
+    fn test_retry_policy_fibonacci_iter() {
+        //given
+        let duration = Duration::from_millis(10);
+        let max_duration = Duration::from_millis(30);
+        let policy = RetryPolicy {
+            max_retries: 5,
+            initial_delay: duration,
+            max_delay: max_duration,
+            strategy: RetryStrategy::FibonacciBackoff,
+            ..Default::default()
+        };
+
+        //when
+        let iter = policy.iter();
+
+        //then
+        assert_eq!(
+            iter.collect::<Vec<Duration>>(),
+            [
+                duration,
+                Duration::from_millis(10),
+                Duration::from_millis(20),
+                max_duration,
+                max_duration
+            ]
+        )
+    }
+
+    #[test]
+    fn test_retry_policy_never_retry() {
+        //given
+        let policy = RetryPolicy {
+            max_retries: 0,
+            ..Default::default()
+        };
+
+        //when
+        let iter = policy.iter();
+
+        //then
+        assert_eq!(iter.collect::<Vec<Duration>>(), [])
     }
 }

--- a/crates/fluvio/src/producer/error.rs
+++ b/crates/fluvio/src/producer/error.rs
@@ -1,4 +1,5 @@
 use async_channel::RecvError;
+use fluvio_future::retry::TimeoutError;
 use dataplane::ErrorCode;
 
 use super::record::RecordMetadata;
@@ -22,4 +23,6 @@ pub enum ProducerError {
     SpuErrorCode(#[from] ErrorCode),
     #[error("Invalid configuration in producer: {0}")]
     InvalidConfiguration(String),
+    #[error("the produce request retry timeout limit reached")]
+    ProduceRequestRetryTimeout(#[from] TimeoutError),
 }

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -35,6 +35,7 @@ use crate::stats::{ClientStats, ClientStatsDataCollect, metrics::ClientStatsData
 use self::accumulator::{BatchHandler};
 pub use self::config::{
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducerConfigBuilderError,
+    DeliverySemantic, RetryPolicy, RetryStrategy,
 };
 pub use self::error::ProducerError;
 use self::event::EventHandler;


### PR DESCRIPTION
Added two delivery semantics to Producer:
     1. `AtMostOnce` - we send records and do not wait for a response. To wait for the response, one could use ProduceOutput::wait after sending the record.     
     2. `AtLeastOnce` - we send records, wait for the response and retry if a network error occurs.     
     
The default retry policy:
retries: 4,
max timeout: 300s
delays sequence: 20ms, 400ms, 8s, 160s (Exponential Backoff)

Related #2481