### PR TITLE
[Merged by Bors] - Try to deprecate LSR field typo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/fluvio-cli/src/partition/list.rs
+++ b/crates/fluvio-cli/src/partition/list.rs
@@ -139,7 +139,7 @@ mod display {
                         Cell::new(status.leader.hw.to_string()),
                         Cell::new(status.leader.leo.to_string()),
                         Cell::new(status.leader.leo.to_string()),
-                        Cell::new(status.lsr.to_string()),
+                        Cell::new(status.lrs().to_string()),
                         Cell::new(format!("{:?}", status.replicas)),
                     ])
                 })

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio metadata"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/partition/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/partition/status.rs
@@ -31,6 +31,7 @@ pub struct PartitionStatus {
     pub leader: ReplicaStatus,
     // TODO: Next time we make a breaking protocol change, rename this to `lrs`
     // TODO: There is no such thing as `lsr`, it is a typo
+    #[cfg_attr(feature = "use_serde", serde(alias = "lrs"))]
     pub lsr: u32,
     pub replicas: Vec<ReplicaStatus>,
     #[cfg_attr(
@@ -114,8 +115,12 @@ impl PartitionStatus {
         self.resolution != PartitionResolution::Online
     }
 
-    // TODO: At next breaking change, deprecate this and replace with `fn lrs` to fix typo
+    #[deprecated = "Replaced by lrs()"]
     pub fn lsr(&self) -> u32 {
+        self.lsr
+    }
+
+    pub fn lrs(&self) -> u32 {
         self.lsr
     }
 


### PR DESCRIPTION
This is a PR that we need before fully changing from LSR to LRS https://github.com/infinyon/fluvio/pull/2392

Without actually renaming the field but adding support in advance to using both `lrs` and `lsr` in the deserialization of the status