### PR TITLE
[Merged by Bors] - docs: specify installation for rust

### DIFF
--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -8,13 +8,10 @@
 //! reading a previously-stored message from that same Fluvio cluster. Let's get started
 //! with a quick example where we produce and consume some messages.
 //!
-//! # Prerequisites
+//! # Examples
 //!
-//! Add `fluvio` crate to the project's `Cargo.toml` file
-//!
-//! ```ignore
-//! fluvio = "0.12"
-//! ```
+//! Fluvio's documentation provide a set of examples for Rust.
+//! You can visit the examples page [following this link](https://www.fluvio.io/api/official/rust/examples/).
 //!
 //! # Fluvio Echo
 //!

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -10,7 +10,11 @@
 //!
 //! # Prerequisites
 //!
-//! [Install Fluvio](#installation)
+//! Add `fluvio` crate to the project's `Cargo.toml` file
+//!
+//! ```ignore
+//! fluvio = "0.12"
+//! ```
 //!
 //! # Fluvio Echo
 //!


### PR DESCRIPTION
Provides a `Cargo.toml` example on how to install `fluvio` on Rust projects.

---

Currently when reading documentation on https://docs.rs/fluvio/latest/fluvio/ an installation link points to a section that is not available. To avoid having this link, the content is replaced with the installation guide on: https://www.fluvio.io/api/official/rust/installation/.