### PR TITLE
[Merged by Bors] - #2427 allowing delete of multiple connectors, smart modules and topics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Platform Version 0.9.33 - UNRELEASED
 * Added `DeliverySemantic` to `fluvio-cli`. ([#2508](https://github.com/infinyon/fluvio/pull/2508))
+* CLI: Added ability to delete multiple connectors, smart modules and topics with one command. ([#2518](https://github.com/infinyon/fluvio/pull/2518))
 
 ## Platform Version 0.9.32 - 2022-07-26
 * Restrict usage of `--initial`, `--extra-params` and `--join-topic` in `fluvio consume`. Those options only should be accepted when using specific smartmodules. ([#2476](https://github.com/infinyon/fluvio/pull/2476))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Platform Version 0.9.33 - UNRELEASED
 * Added `DeliverySemantic` to `fluvio-cli`. ([#2508](https://github.com/infinyon/fluvio/pull/2508))
-* CLI: Added ability to delete multiple connectors, smart modules and topics with one command. ([#2518](https://github.com/infinyon/fluvio/pull/2518))
+* CLI: Added ability to delete multiple connectors, smart modules and topics with one command. ([#2427](https://github.com/infinyon/fluvio/issues/2427))
 
 ## Platform Version 0.9.32 - 2022-07-26
 * Restrict usage of `--initial`, `--extra-params` and `--join-topic` in `fluvio consume`. Those options only should be accepted when using specific smartmodules. ([#2476](https://github.com/infinyon/fluvio/pull/2476))

--- a/crates/fluvio-cli/src/bin/main.rs
+++ b/crates/fluvio-cli/src/bin/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     // If the CLI comes back with an error, attempt to handle it
     if let Err(e) = run_block_on(root.process()) {
         let user_error = e.get_user_error()?;
-        println!("{}", user_error);
+        eprintln!("{}", user_error);
         std::process::exit(1);
     }
 

--- a/crates/fluvio-cli/src/bin/main.rs
+++ b/crates/fluvio-cli/src/bin/main.rs
@@ -13,7 +13,8 @@ fn main() -> Result<()> {
 
     // If the CLI comes back with an error, attempt to handle it
     if let Err(e) = run_block_on(root.process()) {
-        e.print()?;
+        let user_error = e.get_user_error()?;
+        println!("{}", user_error);
         std::process::exit(1);
     }
 

--- a/crates/fluvio-cli/src/connector/delete.rs
+++ b/crates/fluvio-cli/src/connector/delete.rs
@@ -33,7 +33,11 @@ impl DeleteManagedConnectorOpt {
                 let error = CliError::from(error);
                 err_happened = true;
                 if self.continue_on_error {
-                    println!("connector \"{}\" delete failed with: {}", name, error);
+                    let user_error = match error.get_user_error() {
+                        Ok(usr_err) => usr_err,
+                        Err(err) => format!("{}", err),
+                    };
+                    println!("connector \"{}\" delete failed with: {}", name, user_error);
                 } else {
                     return Err(error);
                 }
@@ -42,7 +46,7 @@ impl DeleteManagedConnectorOpt {
             }
         }
         if err_happened {
-            Err(CliError::Other(
+            Err(CliError::CollectedError(
                 "Failed deleting connector(s). Check previous errors.".to_string(),
             ))
         } else {

--- a/crates/fluvio-cli/src/connector/delete.rs
+++ b/crates/fluvio-cli/src/connector/delete.rs
@@ -34,7 +34,7 @@ impl DeleteManagedConnectorOpt {
                 err_happened = true;
                 if self.continue_on_error {
                     let user_error = match error.get_user_error() {
-                        Ok(usr_err) => usr_err,
+                        Ok(usr_err) => usr_err.to_string(),
                         Err(err) => format!("{}", err),
                     };
                     println!("connector \"{}\" delete failed with: {}", name, user_error);

--- a/crates/fluvio-cli/src/connector/delete.rs
+++ b/crates/fluvio-cli/src/connector/delete.rs
@@ -28,7 +28,7 @@ impl DeleteManagedConnectorOpt {
         let admin = fluvio.admin().await;
         let mut err_happened = false;
         for name in self.names.iter() {
-            debug!("deleting connector: {}", name);
+            debug!(name, "deleting connector" );
             if let Err(error) = admin.delete::<ManagedConnectorSpec, _>(name).await {
                 let error = CliError::from(error);
                 err_happened = true;

--- a/crates/fluvio-cli/src/connector/delete.rs
+++ b/crates/fluvio-cli/src/connector/delete.rs
@@ -28,7 +28,7 @@ impl DeleteManagedConnectorOpt {
         let admin = fluvio.admin().await;
         let mut err_happened = false;
         for name in self.names.iter() {
-            debug!(name, "deleting connector" );
+            debug!(name, "deleting connector");
             if let Err(error) = admin.delete::<ManagedConnectorSpec, _>(name).await {
                 let error = CliError::from(error);
                 err_happened = true;

--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -50,7 +50,7 @@ pub enum ManagedConnectorCmd {
     )]
     Update(UpdateManagedConnectorOpt),
 
-    /// Delete a Managed Connector
+    /// Delete one or more Managed Connectors with the given name(s)
     #[clap(
         name = "delete",
         help_template = COMMAND_TEMPLATE,

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -124,42 +124,42 @@ impl CliError {
     /// Sometimes, specific errors require specific user-facing error messages.
     /// Here is where we define those messages, as well as the exit code that the
     /// program should return when exiting after those errors.
-    pub fn get_user_error(self) -> Result<String> {
+    pub fn get_user_error(self) -> Result<&'static str> {
         match &self {
             Self::ClientError(FluvioError::AdminApi(api)) => match api {
                 ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
-                    Ok("Topic already exists".to_string())
+                    Ok("Topic already exists")
                 }
                 ApiError::Code(ErrorCode::ManagedConnectorAlreadyExists, _) => {
-                    Ok("Connector already exists".to_string())
+                    Ok("Connector already exists")
                 }
-                ApiError::Code(ErrorCode::TopicNotFound, _) => Ok("Topic not found".to_string()),
-                ApiError::Code(ErrorCode::SmartModuleNotFound{ name: _ }, _) => Ok("Smart Module not found".to_string()),
+                ApiError::Code(ErrorCode::TopicNotFound, _) => Ok("Topic not found"),
+                ApiError::Code(ErrorCode::SmartModuleNotFound{ name: _ }, _) => Ok("Smart Module not found"),
                 ApiError::Code(ErrorCode::ManagedConnectorNotFound, _) => {
-                    Ok("Connector not found".to_string())
+                    Ok("Connector not found")
                 }
                 ApiError::Code(ErrorCode::TopicInvalidName, _) => {
-                    Ok("Invalid topic name: topic name may only include lowercase letters (a-z), numbers (0-9), and hyphens (-).".to_string())
+                    Ok("Invalid topic name: topic name may only include lowercase letters (a-z), numbers (0-9), and hyphens (-).")
                 }
                 ApiError::Code(ErrorCode::TableFormatAlreadyExists, _) => {
-                    Ok("TableFormat already exists".to_string())
+                    Ok("TableFormat already exists")
                 }
                 ApiError::Code(ErrorCode::TableFormatNotFound, _) => {
-                    Ok("TableFormat not found".to_string())
+                    Ok("TableFormat not found")
                 }
                 _ => Err(self),
             },
             Self::ClientError(FluvioError::Socket(SocketError::Io(io)))
                 if io.kind() == ErrorKind::TimedOut =>
             {
-                Ok("Network connection timed out while waiting for response".to_string())
+                Ok("Network connection timed out while waiting for response")
             }
             #[cfg(feature = "k8s")]
             Self::ClusterCliError(ClusterCliError::TargetError(TargetError::ClientError(
                 FluvioError::Socket(SocketError::Io(io)),
             ))) => match io.kind() {
                 ErrorKind::ConnectionRefused => {
-                    Ok("Failed to connect to cluster, make sure you have started or connected to your cluster".to_string())
+                    Ok("Failed to connect to cluster, make sure you have started or connected to your cluster")
                 }
                 _ => Err(self),
             },

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -71,6 +71,8 @@ pub enum CliError {
     InvalidArg(String),
     #[error("Unknown error: {0}")]
     Other(String),
+    #[error("{0}")]
+    CollectedError(String),
     #[error("Unexpected Infallible error")]
     Infallible(#[from] Infallible),
     #[error("Dataplane error: {0}")]
@@ -117,57 +119,47 @@ impl CliError {
         }
     }
 
-    /// Looks at the error value and attempts to gracefully handle reporting it
+    /// Looks at the error value and attempts to create a user facing error message
     ///
     /// Sometimes, specific errors require specific user-facing error messages.
     /// Here is where we define those messages, as well as the exit code that the
     /// program should return when exiting after those errors.
-    pub fn print(self) -> Result<()> {
+    pub fn get_user_error(self) -> Result<String> {
         match &self {
             Self::ClientError(FluvioError::AdminApi(api)) => match api {
                 ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
-                    println!("Topic already exists");
-                    Ok(())
+                    Ok("Topic already exists".to_string())
                 }
                 ApiError::Code(ErrorCode::ManagedConnectorAlreadyExists, _) => {
-                    println!("Connector already exists");
-                    Ok(())
+                    Ok("Connector already exists".to_string())
                 }
-                ApiError::Code(ErrorCode::TopicNotFound, _) => {
-                    println!("Topic not found");
-                    Ok(())
-                }
+                ApiError::Code(ErrorCode::TopicNotFound, _) => Ok("Topic not found".to_string()),
+                ApiError::Code(ErrorCode::SmartModuleNotFound{ name: _ }, _) => Ok("Smart Module not found".to_string()),
                 ApiError::Code(ErrorCode::ManagedConnectorNotFound, _) => {
-                    println!("Connector not found");
-                    Ok(())
+                    Ok("Connector not found".to_string())
                 }
                 ApiError::Code(ErrorCode::TopicInvalidName, _) => {
-                    println!("Invalid topic name: topic name may only include lowercase letters (a-z), numbers (0-9), and hyphens (-).");
-                    Ok(())
+                    Ok("Invalid topic name: topic name may only include lowercase letters (a-z), numbers (0-9), and hyphens (-).".to_string())
                 }
                 ApiError::Code(ErrorCode::TableFormatAlreadyExists, _) => {
-                    println!("TableFormat already exists");
-                    Ok(())
+                    Ok("TableFormat already exists".to_string())
                 }
                 ApiError::Code(ErrorCode::TableFormatNotFound, _) => {
-                    println!("TableFormat not found");
-                    Ok(())
+                    Ok("TableFormat not found".to_string())
                 }
                 _ => Err(self),
             },
             Self::ClientError(FluvioError::Socket(SocketError::Io(io)))
                 if io.kind() == ErrorKind::TimedOut =>
             {
-                println!("Network connection timed out while waiting for response");
-                Ok(())
+                Ok("Network connection timed out while waiting for response".to_string())
             }
             #[cfg(feature = "k8s")]
             Self::ClusterCliError(ClusterCliError::TargetError(TargetError::ClientError(
                 FluvioError::Socket(SocketError::Io(io)),
             ))) => match io.kind() {
                 ErrorKind::ConnectionRefused => {
-                    println!("Failed to connect to cluster, make sure you have started or connected to your cluster");
-                    Ok(())
+                    Ok("Failed to connect to cluster, make sure you have started or connected to your cluster".to_string())
                 }
                 _ => Err(self),
             },

--- a/crates/fluvio-cli/src/smartmodule/delete.rs
+++ b/crates/fluvio-cli/src/smartmodule/delete.rs
@@ -2,17 +2,34 @@ use clap::Parser;
 use crate::Result;
 use fluvio::Fluvio;
 use fluvio::metadata::smartmodule::SmartModuleSpec;
+use tracing::debug;
 
 /// Delete an existing SmartModule with the given name
 #[derive(Debug, Parser)]
 pub struct DeleteSmartModuleOpt {
-    name: String,
+    /// Ignore delete errors if any
+    #[clap(short, long, action, required = false)]
+    ignore_error: bool,
+    /// The name(s) of the smart module(s) to be deleted
+    #[clap(value_name = "name", required = true)]
+    names: Vec<String>,
 }
 
 impl DeleteSmartModuleOpt {
     pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
-        admin.delete::<SmartModuleSpec, _>(&self.name).await?;
+        for name in self.names.iter() {
+            debug!("deleting smart module: {}", name);
+            if let Err(error) = admin.delete::<SmartModuleSpec, _>(name).await {
+                if self.ignore_error {
+                    println!("smart module \"{}\" delete failed with: {}", name, error);
+                } else {
+                    return Err(error.into());
+                }
+            } else {
+                println!("smart module \"{}\" deleted", name);
+            }
+        }
         Ok(())
     }
 }

--- a/crates/fluvio-cli/src/smartmodule/delete.rs
+++ b/crates/fluvio-cli/src/smartmodule/delete.rs
@@ -27,7 +27,7 @@ impl DeleteSmartModuleOpt {
                 err_happened = true;
                 if self.continue_on_error {
                     let user_error = match error.get_user_error() {
-                        Ok(usr_err) => usr_err,
+                        Ok(usr_err) => usr_err.to_string(),
                         Err(err) => format!("{}", err),
                     };
                     println!(

--- a/crates/fluvio-cli/src/smartmodule/delete.rs
+++ b/crates/fluvio-cli/src/smartmodule/delete.rs
@@ -26,7 +26,14 @@ impl DeleteSmartModuleOpt {
                 let error = CliError::from(error);
                 err_happened = true;
                 if self.continue_on_error {
-                    println!("smart module \"{}\" delete failed with: {}", name, error);
+                    let user_error = match error.get_user_error() {
+                        Ok(usr_err) => usr_err,
+                        Err(err) => format!("{}", err),
+                    };
+                    println!(
+                        "smart module \"{}\" delete failed with: {}",
+                        name, user_error
+                    );
                 } else {
                     return Err(error);
                 }
@@ -35,7 +42,7 @@ impl DeleteSmartModuleOpt {
             }
         }
         if err_happened {
-            Err(CliError::Other(
+            Err(CliError::CollectedError(
                 "Failed deleting smart module(s). Check previous errors.".to_string(),
             ))
         } else {

--- a/crates/fluvio-cli/src/smartmodule/delete.rs
+++ b/crates/fluvio-cli/src/smartmodule/delete.rs
@@ -21,7 +21,7 @@ impl DeleteSmartModuleOpt {
         let admin = fluvio.admin().await;
         let mut err_happened = false;
         for name in self.names.iter() {
-            debug!("deleting smart module: {}", name);
+            debug!(name, "deleting smart module");
             if let Err(error) = admin.delete::<SmartModuleSpec, _>(name).await {
                 let error = CliError::from(error);
                 err_happened = true;

--- a/crates/fluvio-cli/src/smartmodule/mod.rs
+++ b/crates/fluvio-cli/src/smartmodule/mod.rs
@@ -16,6 +16,7 @@ use self::delete::DeleteSmartModuleOpt;
 pub enum SmartModuleCmd {
     Create(CreateSmartModuleOpt),
     List(ListSmartModuleOpt),
+    /// Delete one or more Smart Modules with the given name(s)
     Delete(DeleteSmartModuleOpt),
 }
 

--- a/crates/fluvio-cli/src/topic/delete.rs
+++ b/crates/fluvio-cli/src/topic/delete.rs
@@ -32,7 +32,7 @@ impl DeleteTopicOpt {
                 err_happened = true;
                 if self.continue_on_error {
                     let user_error = match error.get_user_error() {
-                        Ok(usr_err) => usr_err,
+                        Ok(usr_err) => usr_err.to_string(),
                         Err(err) => format!("{}", err),
                     };
                     println!("topic \"{}\" delete failed with: {}", name, user_error);

--- a/crates/fluvio-cli/src/topic/delete.rs
+++ b/crates/fluvio-cli/src/topic/delete.rs
@@ -26,7 +26,7 @@ impl DeleteTopicOpt {
         let admin = fluvio.admin().await;
         let mut err_happened = false;
         for name in self.names.iter() {
-            debug!("deleting topic: {}", name);
+            debug!(name, "deleting topic");
             if let Err(error) = admin.delete::<TopicSpec, _>(name).await {
                 let error = CliError::from(error);
                 err_happened = true;

--- a/crates/fluvio-cli/src/topic/delete.rs
+++ b/crates/fluvio-cli/src/topic/delete.rs
@@ -31,7 +31,11 @@ impl DeleteTopicOpt {
                 let error = CliError::from(error);
                 err_happened = true;
                 if self.continue_on_error {
-                    println!("topic \"{}\" delete failed with: {}", name, error);
+                    let user_error = match error.get_user_error() {
+                        Ok(usr_err) => usr_err,
+                        Err(err) => format!("{}", err),
+                    };
+                    println!("topic \"{}\" delete failed with: {}", name, user_error);
                 } else {
                     return Err(error);
                 }
@@ -40,7 +44,7 @@ impl DeleteTopicOpt {
             }
         }
         if err_happened {
-            Err(CliError::Other(
+            Err(CliError::CollectedError(
                 "Failed deleting topic(s). Check previous errors.".to_string(),
             ))
         } else {

--- a/crates/fluvio-cli/src/topic/mod.rs
+++ b/crates/fluvio-cli/src/topic/mod.rs
@@ -28,7 +28,7 @@ pub enum TopicCmd {
     )]
     Create(CreateTopicOpt),
 
-    /// Delete a Topic with the given name
+    /// Delete one or more Topics with the given name(s)
     #[clap(
         name = "delete",
         help_template = COMMAND_TEMPLATE,

--- a/tests/cli/smoke_tests/smart-module-basic.bats
+++ b/tests/cli/smoke_tests/smart-module-basic.bats
@@ -64,5 +64,5 @@ setup_file() {
     debug_msg "status: $status"
     debug_msg "output: ${lines[3]}"
     assert_failure
-    assert_output --partial "SmartModuleNotFound"
+    assert_output --partial "Smart Module not found"
 }


### PR DESCRIPTION
Solves #2427

Allows delete of multiple:
- connectors, 
- smart modules 
- topics

Left out the cluster delete. Does not seem suitable to be able to delete multiple clusters at once.

To be fixed:
- [x] continue-on-error instead of ignore-error
- [x] changelog entry
- [x] update on subcommand description
- [x] friendly error message with `CliError::from(error)`
- [x] split `CliError::print`
- [x] separate error type for multi delete fail
