### PR TITLE
[Merged by Bors] - add support for unstable feature in SmartEngine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "cargo",

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -14,6 +14,7 @@ description = "The official Fluvio SmartEngine"
 [features]
 smartmodule = ["fluvio-controlplane-metadata", "flate2"]
 wasi = ["wasmtime-wasi"]
+unstable = []
 
 [dependencies]
 wasmtime = "0.39.0"

--- a/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/aggregate.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
 
 use tracing::{debug, instrument};
 use anyhow::Result;
@@ -18,6 +19,7 @@ const AGGREGATE_FN_NAME: &str = "aggregate";
 type OldAggregateFn = TypedFunc<(i32, i32), i32>;
 type AggregateFn = TypedFunc<(i32, i32, u32), i32>;
 
+#[derive(Debug)]
 pub struct SmartModuleAggregate {
     base: SmartModuleContext,
     aggregate_fn: AggregateFnKind,
@@ -26,6 +28,15 @@ pub struct SmartModuleAggregate {
 pub enum AggregateFnKind {
     Old(OldAggregateFn),
     New(AggregateFn),
+}
+
+impl Debug for AggregateFnKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Old(_aggregate_fn) => write!(f, "OldAggregateFn"),
+            Self::New(_aggregate_fn) => write!(f, "AggregateFn"),
+        }
+    }
 }
 
 impl AggregateFnKind {
@@ -89,6 +100,10 @@ impl SmartModuleInstance for SmartModuleAggregate {
         Ok(output.base)
     }
     fn params(&self) -> SmartModuleExtraParams {
-        self.base.params.clone()
+        self.base.get_params().clone()
+    }
+
+    fn mut_ctx(&mut self) -> &mut SmartModuleContext {
+        &mut self.base
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/filter.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter.rs
@@ -1,4 +1,6 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
+
 use anyhow::Result;
 use wasmtime::{AsContextMut, Trap, TypedFunc};
 
@@ -14,6 +16,7 @@ const FILTER_FN_NAME: &str = "filter";
 type OldFilterFn = TypedFunc<(i32, i32), i32>;
 type FilterFn = TypedFunc<(i32, i32, u32), i32>;
 
+#[derive(Debug)]
 pub struct SmartModuleFilter {
     base: SmartModuleContext,
     filter_fn: FilterFnKind,
@@ -22,6 +25,15 @@ pub struct SmartModuleFilter {
 enum FilterFnKind {
     Old(OldFilterFn),
     New(FilterFn),
+}
+
+impl Debug for FilterFnKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Old(_) => write!(f, "OldFilterFn"),
+            Self::New(_) => write!(f, "FilterFn"),
+        }
+    }
 }
 
 impl FilterFnKind {
@@ -73,6 +85,10 @@ impl SmartModuleInstance for SmartModuleFilter {
     }
 
     fn params(&self) -> SmartModuleExtraParams {
-        self.base.params.clone()
+        self.base.get_params().clone()
+    }
+
+    fn mut_ctx(&mut self) -> &mut SmartModuleContext {
+        &mut self.base
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/filter_map.rs
@@ -1,13 +1,16 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
+
 use anyhow::Result;
 use wasmtime::{AsContextMut, Trap, TypedFunc};
 
-use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
+use dataplane::smartmodule::{
+    SmartModuleInput, SmartModuleOutput, SmartModuleExtraParams, SmartModuleInternalError,
+};
+
 use crate::{
     WasmSlice,
-    smartmodule::{
-        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
-    },
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
     error::Error,
 };
 
@@ -15,6 +18,7 @@ const FILTER_MAP_FN_NAME: &str = "filter_map";
 type OldFilterMapFn = TypedFunc<(i32, i32), i32>;
 type FilterMapFn = TypedFunc<(i32, i32, u32), i32>;
 
+#[derive(Debug)]
 pub struct SmartModuleFilterMap {
     base: SmartModuleContext,
     filter_map_fn: FilterMapFnKind,
@@ -23,6 +27,15 @@ pub struct SmartModuleFilterMap {
 enum FilterMapFnKind {
     Old(OldFilterMapFn),
     New(FilterMapFn),
+}
+
+impl Debug for FilterMapFnKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Old(_) => write!(f, "OldFilterMapFn"),
+            Self::New(_) => write!(f, "FilterMapFn"),
+        }
+    }
 }
 
 impl FilterMapFnKind {
@@ -77,6 +90,10 @@ impl SmartModuleInstance for SmartModuleFilterMap {
     }
 
     fn params(&self) -> SmartModuleExtraParams {
-        self.base.params.clone()
+        self.base.get_params().clone()
+    }
+
+    fn mut_ctx(&mut self) -> &mut SmartModuleContext {
+        &mut self.base
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/join.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/join.rs
@@ -1,22 +1,23 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
 
 use anyhow::Result;
 use tracing::{debug, instrument};
 use wasmtime::{AsContextMut, Trap, TypedFunc};
 
-use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
+use dataplane::smartmodule::{
+    SmartModuleInput, SmartModuleOutput, SmartModuleExtraParams, SmartModuleInternalError,
+};
 use crate::{
     WasmSlice,
-    smartmodule::{
-        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
-        error::Error,
-    },
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, error::Error},
 };
 
 const JOIN_FN_NAME: &str = "join";
 type OldJoinFn = TypedFunc<(i32, i32), i32>;
 type JoinFn = TypedFunc<(i32, i32, u32), i32>;
 
+#[derive(Debug)]
 pub struct SmartModuleJoin {
     base: SmartModuleContext,
     join_fn: JoinFnKind,
@@ -25,6 +26,15 @@ pub struct SmartModuleJoin {
 pub enum JoinFnKind {
     Old(OldJoinFn),
     New(JoinFn),
+}
+
+impl Debug for JoinFnKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Old(_join_fn) => write!(f, "OldJoinFn"),
+            Self::New(_join_fn) => write!(f, "JoinFn"),
+        }
+    }
 }
 
 impl JoinFnKind {
@@ -75,6 +85,10 @@ impl SmartModuleInstance for SmartModuleJoin {
     }
 
     fn params(&self) -> SmartModuleExtraParams {
-        self.base.params.clone()
+        self.base.get_params().clone()
+    }
+
+    fn mut_ctx(&mut self) -> &mut SmartModuleContext {
+        &mut self.base
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/map.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/map.rs
@@ -1,13 +1,16 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
+
 use anyhow::Result;
 use wasmtime::{AsContextMut, Trap, TypedFunc};
 
-use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleInternalError};
+use dataplane::smartmodule::{
+    SmartModuleInput, SmartModuleOutput, SmartModuleExtraParams, SmartModuleInternalError,
+};
+
 use crate::{
     WasmSlice,
-    smartmodule::{
-        SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance, SmartModuleExtraParams,
-    },
+    smartmodule::{SmartModuleWithEngine, SmartModuleContext, SmartModuleInstance},
     error::Error,
 };
 
@@ -15,6 +18,7 @@ const MAP_FN_NAME: &str = "map";
 type OldMapFn = TypedFunc<(i32, i32), i32>;
 type MapFn = TypedFunc<(i32, i32, u32), i32>;
 
+#[derive(Debug)]
 pub struct SmartModuleMap {
     base: SmartModuleContext,
     map_fn: MapFnKind,
@@ -22,6 +26,15 @@ pub struct SmartModuleMap {
 enum MapFnKind {
     Old(OldMapFn),
     New(MapFn),
+}
+
+impl Debug for MapFnKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Old(..) => write!(f, "OldMapFn"),
+            Self::New(..) => write!(f, "MapFn"),
+        }
+    }
 }
 
 impl MapFnKind {
@@ -70,6 +83,10 @@ impl SmartModuleInstance for SmartModuleMap {
     }
 
     fn params(&self) -> SmartModuleExtraParams {
-        self.base.params.clone()
+        self.base.get_params().clone()
+    }
+
+    fn mut_ctx(&mut self) -> &mut SmartModuleContext {
+        &mut self.base
     }
 }

--- a/crates/fluvio-smartengine/src/smartmodule/mod.rs
+++ b/crates/fluvio-smartengine/src/smartmodule/mod.rs
@@ -1,28 +1,3 @@
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
-use std::fmt::{self, Debug};
-
-use dataplane::record::Record;
-use dataplane::smartmodule::SmartModuleExtraParams;
-use tracing::{debug, instrument, trace};
-use anyhow::{Error, Result};
-use wasmtime::{Memory, Engine, Module, Caller, Extern, Trap, Instance, IntoFunc, Store};
-
-use crate::smartmodule::filter::SmartModuleFilter;
-use crate::smartmodule::map::SmartModuleMap;
-use crate::filter_map::SmartModuleFilterMap;
-use crate::smartmodule::array_map::SmartModuleArrayMap;
-use crate::smartmodule::aggregate::SmartModuleAggregate;
-use crate::smartmodule::join::SmartModuleJoin;
-
-use dataplane::core::{Encoder, Decoder};
-use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleRuntimeError};
-use crate::smartmodule::file_batch::FileBatchIterator;
-use dataplane::batch::{Batch, MemoryRecords};
-use fluvio_spu_schema::server::stream_fetch::{
-    SmartModuleKind, LegacySmartModulePayload, SmartModuleContextData,
-};
-
 mod memory;
 pub mod filter;
 pub mod map;
@@ -36,683 +11,761 @@ pub(crate) mod error;
 
 pub type WasmSlice = (i32, i32, u32);
 
-#[cfg(feature = "smartmodule")]
-use fluvio_controlplane_metadata::smartmodule::{SmartModuleSpec};
+pub use engine::*;
 
-#[cfg(feature = "wasi")]
-type State = wasmtime_wasi::WasiCtx;
+mod engine {
 
-#[cfg(not(feature = "wasi"))]
-type State = ();
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+    use std::fmt::{self, Debug};
 
-use self::join_stream::SmartModuleJoinStream;
+    use tracing::{debug, instrument, trace};
+    use anyhow::{Error, Result};
+    use wasmtime::{Memory, Engine, Module, Caller, Extern, Trap, Instance, IntoFunc, Store};
 
-const DEFAULT_SMARTENGINE_VERSION: i16 = 17;
-
-#[derive(Default, Clone)]
-pub struct SmartEngine(pub(crate) Engine);
-
-impl SmartEngine {
+    use dataplane::record::Record;
+    use dataplane::smartmodule::{SmartModuleExtraParams};
+    use dataplane::batch::{Batch, MemoryRecords};
+    use dataplane::core::{Encoder, Decoder};
+    use dataplane::smartmodule::{SmartModuleInput, SmartModuleOutput, SmartModuleRuntimeError};
+    use fluvio_spu_schema::server::stream_fetch::{
+        SmartModuleKind, LegacySmartModulePayload, SmartModuleContextData,
+    };
     #[cfg(feature = "smartmodule")]
-    pub fn create_module_from_smartmodule_spec(
-        self,
-        spec: &SmartModuleSpec,
-    ) -> Result<SmartModuleWithEngine> {
-        use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasmFormat};
-        use flate2::bufread::GzDecoder;
-        use std::io::Read;
+    use fluvio_controlplane_metadata::smartmodule::{SmartModuleSpec};
 
-        let wasm_module = &spec.wasm;
-        let mut decoder = GzDecoder::new(&*wasm_module.payload);
-        let mut buffer = Vec::with_capacity(wasm_module.payload.len());
-        decoder.read_to_end(&mut buffer)?;
+    use crate::smartmodule::filter::SmartModuleFilter;
+    use crate::smartmodule::map::SmartModuleMap;
+    use crate::filter_map::SmartModuleFilterMap;
+    use crate::smartmodule::array_map::SmartModuleArrayMap;
+    use crate::smartmodule::aggregate::SmartModuleAggregate;
+    use crate::smartmodule::join::SmartModuleJoin;
+    use crate::smartmodule::file_batch::FileBatchIterator;
 
-        let module = match wasm_module.format {
-            SmartModuleWasmFormat::Binary => Module::from_binary(&self.0, &buffer)?,
-            SmartModuleWasmFormat::Text => return Err(Error::msg("Format not supported")),
-        };
-        Ok(SmartModuleWithEngine {
-            module,
-            engine: self,
-        })
+    use super::join_stream::SmartModuleJoinStream;
+    use super::error;
+    use super::WasmSlice;
+    use super::memory;
+
+    const DEFAULT_SMARTENGINE_VERSION: i16 = 17;
+
+    #[cfg(feature = "wasi")]
+    type State = wasmtime_wasi::WasiCtx;
+
+    #[cfg(not(feature = "wasi"))]
+    type State = ();
+
+    #[derive(Default, Clone)]
+    pub struct SmartEngine(pub(crate) Engine);
+
+    impl SmartEngine {
+        #[cfg(feature = "smartmodule")]
+        pub fn create_module_from_smartmodule_spec(
+            self,
+            spec: &SmartModuleSpec,
+        ) -> Result<SmartModuleWithEngine> {
+            use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasmFormat};
+            use flate2::bufread::GzDecoder;
+            use std::io::Read;
+
+            let wasm_module = &spec.wasm;
+            let mut decoder = GzDecoder::new(&*wasm_module.payload);
+            let mut buffer = Vec::with_capacity(wasm_module.payload.len());
+            decoder.read_to_end(&mut buffer)?;
+
+            let module = match wasm_module.format {
+                SmartModuleWasmFormat::Binary => Module::from_binary(&self.0, &buffer)?,
+                SmartModuleWasmFormat::Text => return Err(Error::msg("Format not supported")),
+            };
+            Ok(SmartModuleWithEngine {
+                module,
+                engine: self,
+            })
+        }
+
+        pub fn create_module_from_binary(self, bytes: &[u8]) -> Result<SmartModuleWithEngine> {
+            let module = Module::from_binary(&self.0, bytes)?;
+            Ok(SmartModuleWithEngine {
+                module,
+                engine: self,
+            })
+        }
+
+        #[tracing::instrument(skip(self))]
+        pub fn create_module_from_payload(
+            self,
+            smart_payload: LegacySmartModulePayload,
+            maybe_version: Option<i16>,
+        ) -> Result<Box<dyn SmartModuleInstance>> {
+            debug!("Creating module from payload");
+            let version = maybe_version.unwrap_or(DEFAULT_SMARTENGINE_VERSION);
+            let smartmodule = self.create_module_from_binary(&smart_payload.wasm.get_raw()?)?;
+            let smartmodule_instance: Box<dyn SmartModuleInstance> = match &smart_payload.kind {
+                SmartModuleKind::Filter => {
+                    Box::new(smartmodule.create_filter(smart_payload.params, version)?)
+                }
+                SmartModuleKind::FilterMap => {
+                    Box::new(smartmodule.create_filter_map(smart_payload.params, version)?)
+                }
+                SmartModuleKind::Map => {
+                    Box::new(smartmodule.create_map(smart_payload.params, version)?)
+                }
+                SmartModuleKind::ArrayMap => {
+                    Box::new(smartmodule.create_array_map(smart_payload.params, version)?)
+                }
+                SmartModuleKind::Join(_) => {
+                    Box::new(smartmodule.create_join(smart_payload.params, version)?)
+                }
+                SmartModuleKind::JoinStream {
+                    topic: _,
+                    derivedstream: _,
+                } => Box::new(smartmodule.create_join_stream(smart_payload.params, version)?),
+                SmartModuleKind::Aggregate { accumulator } => {
+                    Box::new(smartmodule.create_aggregate(
+                        smart_payload.params,
+                        accumulator.clone(),
+                        version,
+                    )?)
+                }
+                SmartModuleKind::Generic(context) => smartmodule.create_generic_smartmodule(
+                    smart_payload.params,
+                    context,
+                    version,
+                )?,
+            };
+            Ok(smartmodule_instance)
+        }
     }
 
-    pub fn create_module_from_binary(self, bytes: &[u8]) -> Result<SmartModuleWithEngine> {
-        let module = Module::from_binary(&self.0, bytes)?;
-        Ok(SmartModuleWithEngine {
-            module,
-            engine: self,
-        })
+    #[cfg(not(feature = "wasi"))]
+    impl SmartEngine {
+        fn new_store(&self) -> Store<State> {
+            Store::new(&self.0, ())
+        }
+
+        fn instantiate<Params, Args>(
+            &self,
+            store: &mut wasmtime::Store<State>,
+            module: &Module,
+            host_fn: impl IntoFunc<State, Params, Args>,
+        ) -> Result<Instance, Error> {
+            let func = wasmtime::Func::wrap(&mut *store, host_fn);
+            Instance::new(store, module, &[func.into()])
+        }
     }
-    pub fn create_module_from_payload(
-        self,
-        smart_payload: LegacySmartModulePayload,
-        maybe_version: Option<i16>,
-    ) -> Result<Box<dyn SmartModuleInstance>> {
-        let version = maybe_version.unwrap_or(DEFAULT_SMARTENGINE_VERSION);
-        let smartmodule = self.create_module_from_binary(&smart_payload.wasm.get_raw()?)?;
-        let smartmodule_instance: Box<dyn SmartModuleInstance> = match &smart_payload.kind {
-            SmartModuleKind::Filter => {
-                Box::new(smartmodule.create_filter(smart_payload.params, version)?)
+
+    #[cfg(feature = "wasi")]
+    impl SmartEngine {
+        fn new_store(&self) -> Store<State> {
+            let wasi = wasmtime_wasi::WasiCtxBuilder::new()
+                .inherit_stderr()
+                .inherit_stdout()
+                .build();
+            Store::new(&self.0, wasi)
+        }
+
+        fn instantiate<Params, Args>(
+            &self,
+            store: &mut Store<State>,
+            module: &Module,
+            host_fn: impl IntoFunc<State, Params, Args>,
+        ) -> Result<Instance, Error> {
+            let mut linker = wasmtime::Linker::new(&self.0);
+            wasmtime_wasi::add_to_linker(&mut linker, |c| c)?;
+            let copy_records_fn_import = module
+                .imports()
+                .find(|import| import.name().eq("copy_records"))
+                .ok_or_else(|| Error::msg("At least one import is required"))?;
+            linker.func_wrap(
+                copy_records_fn_import.module(),
+                copy_records_fn_import.name(),
+                host_fn,
+            )?;
+            linker.instantiate(store, module)
+        }
+    }
+
+    impl Debug for SmartEngine {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "SmartModuleEngine")
+        }
+    }
+
+    pub struct SmartModuleWithEngine {
+        pub(crate) module: Module,
+        pub(crate) engine: SmartEngine,
+    }
+
+    impl SmartModuleWithEngine {
+        fn create_filter(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleFilter, error::Error> {
+            let filter = SmartModuleFilter::new(self, params, version)?;
+            Ok(filter)
+        }
+
+        fn create_map(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleMap, error::Error> {
+            let map = SmartModuleMap::new(self, params, version)?;
+            Ok(map)
+        }
+
+        fn create_filter_map(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleFilterMap, error::Error> {
+            let filter_map = SmartModuleFilterMap::new(self, params, version)?;
+            Ok(filter_map)
+        }
+
+        fn create_array_map(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleArrayMap, error::Error> {
+            let map = SmartModuleArrayMap::new(self, params, version)?;
+            Ok(map)
+        }
+
+        fn create_join(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleJoin, error::Error> {
+            let join = SmartModuleJoin::new(self, params, version)?;
+            Ok(join)
+        }
+
+        fn create_join_stream(
+            &self,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<SmartModuleJoinStream, error::Error> {
+            let join = SmartModuleJoinStream::new(self, params, version)?;
+            Ok(join)
+        }
+
+        fn create_aggregate(
+            &self,
+            params: SmartModuleExtraParams,
+            accumulator: Vec<u8>,
+            version: i16,
+        ) -> Result<SmartModuleAggregate, error::Error> {
+            let aggregate = SmartModuleAggregate::new(self, params, accumulator, version)?;
+            Ok(aggregate)
+        }
+
+        /// Create smartmodule without knowing its type. This function will try to initialize the smartmodule as each one of
+        /// the available smartmodules until there is success or all the kinds of smartmodules is tried.  
+        fn create_generic_smartmodule(
+            &self,
+            params: SmartModuleExtraParams,
+            context: &SmartModuleContextData,
+            version: i16,
+        ) -> Result<Box<dyn SmartModuleInstance>, error::Error> {
+            match self.create_filter(params.clone(), version) {
+                Ok(filter) => return Ok(Box::new(filter)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
             }
-            SmartModuleKind::FilterMap => {
-                Box::new(smartmodule.create_filter_map(smart_payload.params, version)?)
+
+            match self.create_map(params.clone(), version) {
+                Ok(map) => return Ok(Box::new(map)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
             }
-            SmartModuleKind::Map => {
-                Box::new(smartmodule.create_map(smart_payload.params, version)?)
+
+            match self.create_filter_map(params.clone(), version) {
+                Ok(filter_map) => return Ok(Box::new(filter_map)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
             }
-            SmartModuleKind::ArrayMap => {
-                Box::new(smartmodule.create_array_map(smart_payload.params, version)?)
+
+            match self.create_array_map(params.clone(), version) {
+                Ok(array_map) => return Ok(Box::new(array_map)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
             }
-            SmartModuleKind::Join(_) => {
-                Box::new(smartmodule.create_join(smart_payload.params, version)?)
+
+            let accumulator = match context {
+                SmartModuleContextData::Aggregate { accumulator } => accumulator.clone(),
+                _ => vec![],
+            };
+            match self.create_aggregate(params.clone(), accumulator, version) {
+                Ok(aggregate) => return Ok(Box::new(aggregate)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
             }
-            SmartModuleKind::JoinStream {
-                topic: _,
-                derivedstream: _,
-            } => Box::new(smartmodule.create_join_stream(smart_payload.params, version)?),
-            SmartModuleKind::Aggregate { accumulator } => Box::new(smartmodule.create_aggregate(
-                smart_payload.params,
-                accumulator.clone(),
+
+            match self.create_join(params.clone(), version) {
+                Ok(join) => return Ok(Box::new(join)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
+            }
+
+            match self.create_join_stream(params, version) {
+                Ok(join_stream) => return Ok(Box::new(join_stream)),
+                Err(error::Error::NotNamedExport(_, _)) => {}
+                Err(any_other_error) => return Err(any_other_error),
+            }
+
+            Err(error::Error::NotValidExports)
+        }
+    }
+
+    pub struct SmartModuleContext {
+        pub(crate) store: Store<State>,
+        pub(crate) instance: Instance,
+        records_cb: Arc<RecordsCallBack>,
+        params: SmartModuleExtraParams,
+        version: i16,
+    }
+
+    impl Debug for SmartModuleContext {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "SmartModuleContext")
+        }
+    }
+
+    impl SmartModuleContext {
+        pub fn new(
+            module: &SmartModuleWithEngine,
+            params: SmartModuleExtraParams,
+            version: i16,
+        ) -> Result<Self, error::Error> {
+            let mut store = module.engine.new_store();
+            let cb = Arc::new(RecordsCallBack::new());
+            let records_cb = cb.clone();
+            let copy_records_fn = move |mut caller: Caller<'_, State>, ptr: i32, len: i32| {
+                debug!(len, "callback from wasm filter");
+                let memory = match caller.get_export("memory") {
+                    Some(Extern::Memory(mem)) => mem,
+                    _ => return Err(Trap::new("failed to find host memory")),
+                };
+
+                let records = RecordsMemory { ptr, len, memory };
+                cb.set(records);
+                Ok(())
+            };
+
+            let instance = module
+                .engine
+                .instantiate(&mut store, &module.module, copy_records_fn)
+                .map_err(error::Error::Instantiate)?;
+            Ok(Self {
+                store,
+                instance,
+                records_cb,
+                params,
                 version,
-            )?),
-            SmartModuleKind::Generic(context) => {
-                smartmodule.create_generic_smartmodule(smart_payload.params, context, version)?
-            }
-        };
-        Ok(smartmodule_instance)
-    }
-}
-
-#[cfg(not(feature = "wasi"))]
-impl SmartEngine {
-    fn new_store(&self) -> Store<State> {
-        Store::new(&self.0, ())
-    }
-
-    fn instantiate<Params, Args>(
-        &self,
-        store: &mut wasmtime::Store<State>,
-        module: &Module,
-        host_fn: impl IntoFunc<State, Params, Args>,
-    ) -> Result<Instance, Error> {
-        let func = wasmtime::Func::wrap(&mut *store, host_fn);
-        Instance::new(store, module, &[func.into()])
-    }
-}
-
-#[cfg(feature = "wasi")]
-impl SmartEngine {
-    fn new_store(&self) -> Store<State> {
-        let wasi = wasmtime_wasi::WasiCtxBuilder::new()
-            .inherit_stderr()
-            .inherit_stdout()
-            .build();
-        Store::new(&self.0, wasi)
-    }
-
-    fn instantiate<Params, Args>(
-        &self,
-        store: &mut Store<State>,
-        module: &Module,
-        host_fn: impl IntoFunc<State, Params, Args>,
-    ) -> Result<Instance, Error> {
-        let mut linker = wasmtime::Linker::new(&self.0);
-        wasmtime_wasi::add_to_linker(&mut linker, |c| c)?;
-        let copy_records_fn_import = module
-            .imports()
-            .find(|import| import.name().eq("copy_records"))
-            .ok_or_else(|| Error::msg("At least one import is required"))?;
-        linker.func_wrap(
-            copy_records_fn_import.module(),
-            copy_records_fn_import.name(),
-            host_fn,
-        )?;
-        linker.instantiate(store, module)
-    }
-}
-
-impl Debug for SmartEngine {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SmartModuleEngine")
-    }
-}
-
-pub struct SmartModuleWithEngine {
-    pub(crate) module: Module,
-    pub(crate) engine: SmartEngine,
-}
-
-impl SmartModuleWithEngine {
-    fn create_filter(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleFilter, error::Error> {
-        let filter = SmartModuleFilter::new(self, params, version)?;
-        Ok(filter)
-    }
-
-    fn create_map(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleMap, error::Error> {
-        let map = SmartModuleMap::new(self, params, version)?;
-        Ok(map)
-    }
-
-    fn create_filter_map(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleFilterMap, error::Error> {
-        let filter_map = SmartModuleFilterMap::new(self, params, version)?;
-        Ok(filter_map)
-    }
-
-    fn create_array_map(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleArrayMap, error::Error> {
-        let map = SmartModuleArrayMap::new(self, params, version)?;
-        Ok(map)
-    }
-
-    fn create_join(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleJoin, error::Error> {
-        let join = SmartModuleJoin::new(self, params, version)?;
-        Ok(join)
-    }
-
-    fn create_join_stream(
-        &self,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<SmartModuleJoinStream, error::Error> {
-        let join = SmartModuleJoinStream::new(self, params, version)?;
-        Ok(join)
-    }
-
-    fn create_aggregate(
-        &self,
-        params: SmartModuleExtraParams,
-        accumulator: Vec<u8>,
-        version: i16,
-    ) -> Result<SmartModuleAggregate, error::Error> {
-        let aggregate = SmartModuleAggregate::new(self, params, accumulator, version)?;
-        Ok(aggregate)
-    }
-
-    /// Create smartmodule without knowing its type. This function will try to initialize the smartmodule as each one of
-    /// the available smartmodules until there is success or all the kinds of smartmodules is tried.  
-    fn create_generic_smartmodule(
-        &self,
-        params: SmartModuleExtraParams,
-        context: &SmartModuleContextData,
-        version: i16,
-    ) -> Result<Box<dyn SmartModuleInstance>, error::Error> {
-        match self.create_filter(params.clone(), version) {
-            Ok(filter) => return Ok(Box::new(filter)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
+            })
         }
 
-        match self.create_map(params.clone(), version) {
-            Ok(map) => return Ok(Box::new(map)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
+        pub fn get_params(&self) -> &SmartModuleExtraParams {
+            &self.params
         }
 
-        match self.create_filter_map(params.clone(), version) {
-            Ok(filter_map) => return Ok(Box::new(filter_map)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
+        pub fn write_input<E: Encoder>(&mut self, input: &E) -> Result<WasmSlice> {
+            self.records_cb.clear();
+            let mut input_data = Vec::new();
+            input.encode(&mut input_data, self.version)?;
+            debug!(len = input_data.len(), "input data");
+            let array_ptr =
+                memory::copy_memory_to_instance(&mut self.store, &self.instance, &input_data)?;
+            let length = input_data.len();
+            Ok((array_ptr as i32, length as i32, self.version as u32))
         }
 
-        match self.create_array_map(params.clone(), version) {
-            Ok(array_map) => return Ok(Box::new(array_map)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
+        pub fn read_output<D: Decoder + Default>(&mut self) -> Result<D> {
+            let bytes = self
+                .records_cb
+                .get()
+                .and_then(|m| m.copy_memory_from(&mut self.store).ok())
+                .unwrap_or_default();
+            let mut output = D::default();
+            output.decode(&mut std::io::Cursor::new(bytes), self.version)?;
+            Ok(output)
         }
-
-        let accumulator = match context {
-            SmartModuleContextData::Aggregate { accumulator } => accumulator.clone(),
-            _ => vec![],
-        };
-        match self.create_aggregate(params.clone(), accumulator, version) {
-            Ok(aggregate) => return Ok(Box::new(aggregate)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
-        }
-
-        match self.create_join(params.clone(), version) {
-            Ok(join) => return Ok(Box::new(join)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
-        }
-
-        match self.create_join_stream(params, version) {
-            Ok(join_stream) => return Ok(Box::new(join_stream)),
-            Err(error::Error::NotNamedExport(_, _)) => {}
-            Err(any_other_error) => return Err(any_other_error),
-        }
-
-        Err(error::Error::NotValidExports)
-    }
-}
-
-pub struct SmartModuleContext {
-    store: Store<State>,
-    instance: Instance,
-    records_cb: Arc<RecordsCallBack>,
-    params: SmartModuleExtraParams,
-    version: i16,
-}
-
-impl SmartModuleContext {
-    pub fn new(
-        module: &SmartModuleWithEngine,
-        params: SmartModuleExtraParams,
-        version: i16,
-    ) -> Result<Self, error::Error> {
-        let mut store = module.engine.new_store();
-        let cb = Arc::new(RecordsCallBack::new());
-        let records_cb = cb.clone();
-        let copy_records_fn = move |mut caller: Caller<'_, State>, ptr: i32, len: i32| {
-            debug!(len, "callback from wasm filter");
-            let memory = match caller.get_export("memory") {
-                Some(Extern::Memory(mem)) => mem,
-                _ => return Err(Trap::new("failed to find host memory")),
-            };
-
-            let records = RecordsMemory { ptr, len, memory };
-            cb.set(records);
-            Ok(())
-        };
-
-        let instance = module
-            .engine
-            .instantiate(&mut store, &module.module, copy_records_fn)
-            .map_err(error::Error::Instantiate)?;
-        Ok(Self {
-            store,
-            instance,
-            records_cb,
-            params,
-            version,
-        })
     }
 
-    pub fn write_input<E: Encoder>(&mut self, input: &E) -> Result<WasmSlice> {
-        self.records_cb.clear();
-        let mut input_data = Vec::new();
-        input.encode(&mut input_data, self.version)?;
-        debug!(len = input_data.len(), "input data");
-        let array_ptr =
-            self::memory::copy_memory_to_instance(&mut self.store, &self.instance, &input_data)?;
-        let length = input_data.len();
-        Ok((array_ptr as i32, length as i32, self.version as u32))
+    pub trait SmartModuleInstance: Send + Sync + Debug {
+        fn process(&mut self, input: SmartModuleInput) -> Result<SmartModuleOutput>;
+        fn params(&self) -> SmartModuleExtraParams;
+        fn mut_ctx(&mut self) -> &mut SmartModuleContext;
     }
 
-    pub fn read_output<D: Decoder + Default>(&mut self) -> Result<D> {
-        let bytes = self
-            .records_cb
-            .get()
-            .and_then(|m| m.copy_memory_from(&mut self.store).ok())
-            .unwrap_or_default();
-        let mut output = D::default();
-        output.decode(&mut std::io::Cursor::new(bytes), self.version)?;
-        Ok(output)
-    }
-}
+    impl dyn SmartModuleInstance + '_ {
+        #[instrument(skip(self, iter, max_bytes, join_last_record))]
+        pub fn process_batch(
+            &mut self,
+            iter: &mut FileBatchIterator,
+            max_bytes: usize,
+            join_last_record: Option<&Record>,
+        ) -> Result<(Batch, Option<SmartModuleRuntimeError>), Error> {
+            let mut smartmodule_batch = Batch::<MemoryRecords>::default();
+            smartmodule_batch.base_offset = -1; // indicate this is uninitialized
+            smartmodule_batch.set_offset_delta(-1); // make add_to_offset_delta correctly
 
-pub trait SmartModuleInstance: Send + Sync {
-    fn process(&mut self, input: SmartModuleInput) -> Result<SmartModuleOutput>;
-    fn params(&self) -> SmartModuleExtraParams;
-}
+            let mut total_bytes = 0;
 
-impl dyn SmartModuleInstance + '_ {
-    #[instrument(skip(self, iter, max_bytes, join_last_record))]
-    pub fn process_batch(
-        &mut self,
-        iter: &mut FileBatchIterator,
-        max_bytes: usize,
-        join_last_record: Option<&Record>,
-    ) -> Result<(Batch, Option<SmartModuleRuntimeError>), Error> {
-        let mut smartmodule_batch = Batch::<MemoryRecords>::default();
-        smartmodule_batch.base_offset = -1; // indicate this is uninitialized
-        smartmodule_batch.set_offset_delta(-1); // make add_to_offset_delta correctly
+            loop {
+                let file_batch = match iter.next() {
+                    // we process entire batches.  entire batches are process as group
+                    // if we can't fit current batch into max bytes then it is discarded
+                    Some(batch_result) => batch_result?,
+                    None => {
+                        debug!(
+                            total_records = smartmodule_batch.records().len(),
+                            "No more batches, SmartModuleInstance end"
+                        );
+                        return Ok((smartmodule_batch, None));
+                    }
+                };
 
-        let mut total_bytes = 0;
+                debug!(
+                    current_batch_offset = file_batch.batch.base_offset,
+                    current_batch_offset_delta = file_batch.offset_delta(),
+                    smartmodule_offset_delta = smartmodule_batch.get_header().last_offset_delta,
+                    smartmodule_base_offset = smartmodule_batch.base_offset,
+                    smartmodule_records = smartmodule_batch.records().len(),
+                    "Starting SmartModuleInstance processing"
+                );
 
-        loop {
-            let file_batch = match iter.next() {
-                // we process entire batches.  entire batches are process as group
-                // if we can't fit current batch into max bytes then it is discarded
-                Some(batch_result) => batch_result?,
-                None => {
+                let now = Instant::now();
+
+                let mut join_record = vec![];
+                join_last_record.encode(&mut join_record, 0)?;
+
+                let input = SmartModuleInput {
+                    base_offset: file_batch.batch.base_offset,
+                    record_data: file_batch.records.clone(),
+                    join_record,
+                    params: self.params().clone(),
+                };
+                let output = self.process(input)?;
+                debug!(smartmodule_execution_time = %now.elapsed().as_millis());
+
+                let maybe_error = output.error;
+                let mut records = output.successes;
+
+                trace!("smartmodule processed records: {:#?}", records);
+
+                // there are smartmoduleed records!!
+                if records.is_empty() {
+                    debug!("smartmodules records empty");
+                } else {
+                    // set base offset if this is first time
+                    if smartmodule_batch.base_offset == -1 {
+                        smartmodule_batch.base_offset = file_batch.base_offset();
+                    }
+
+                    // difference between smartmodule batch and and current batch
+                    // since base are different we need update delta offset for each records
+                    let relative_base_offset =
+                        smartmodule_batch.base_offset - file_batch.base_offset();
+
+                    for record in &mut records {
+                        record.add_base_offset(relative_base_offset);
+                    }
+
+                    let record_bytes = records.write_size(0);
+
+                    // if smartmodule bytes exceed max bytes then we skip this batch
+                    if total_bytes + record_bytes > max_bytes {
+                        debug!(
+                            total_bytes = total_bytes + record_bytes,
+                            max_bytes, "Total SmartModuleInstance bytes reached"
+                        );
+                        return Ok((smartmodule_batch, maybe_error));
+                    }
+
+                    total_bytes += record_bytes;
+
                     debug!(
-                        total_records = smartmodule_batch.records().len(),
-                        "No more batches, SmartModuleInstance end"
+                        smartmodule_records = records.len(),
+                        total_bytes, "finished smartmoduleing"
                     );
-                    return Ok((smartmodule_batch, None));
-                }
-            };
-
-            debug!(
-                current_batch_offset = file_batch.batch.base_offset,
-                current_batch_offset_delta = file_batch.offset_delta(),
-                smartmodule_offset_delta = smartmodule_batch.get_header().last_offset_delta,
-                smartmodule_base_offset = smartmodule_batch.base_offset,
-                smartmodule_records = smartmodule_batch.records().len(),
-                "Starting SmartModuleInstance processing"
-            );
-
-            let now = Instant::now();
-
-            let mut join_record = vec![];
-            join_last_record.encode(&mut join_record, 0)?;
-
-            let input = SmartModuleInput {
-                base_offset: file_batch.batch.base_offset,
-                record_data: file_batch.records.clone(),
-                join_record,
-                params: self.params().clone(),
-            };
-            let output = self.process(input)?;
-            debug!(smartmodule_execution_time = %now.elapsed().as_millis());
-
-            let maybe_error = output.error;
-            let mut records = output.successes;
-
-            trace!("smartmodule processed records: {:#?}", records);
-
-            // there are smartmoduleed records!!
-            if records.is_empty() {
-                debug!("smartmodules records empty");
-            } else {
-                // set base offset if this is first time
-                if smartmodule_batch.base_offset == -1 {
-                    smartmodule_batch.base_offset = file_batch.base_offset();
+                    smartmodule_batch.mut_records().append(&mut records);
                 }
 
-                // difference between smartmodule batch and and current batch
-                // since base are different we need update delta offset for each records
-                let relative_base_offset = smartmodule_batch.base_offset - file_batch.base_offset();
-
-                for record in &mut records {
-                    record.add_base_offset(relative_base_offset);
-                }
-
-                let record_bytes = records.write_size(0);
-
-                // if smartmodule bytes exceed max bytes then we skip this batch
-                if total_bytes + record_bytes > max_bytes {
+                // only increment smartmodule offset delta if smartmodule_batch has been initialized
+                if smartmodule_batch.base_offset != -1 {
                     debug!(
-                        total_bytes = total_bytes + record_bytes,
-                        max_bytes, "Total SmartModuleInstance bytes reached"
+                        offset_delta = file_batch.offset_delta(),
+                        "adding to offset delta"
                     );
+                    smartmodule_batch.add_to_offset_delta(file_batch.offset_delta() + 1);
+                }
+
+                // If we had a processing error, return current batch and error
+                if maybe_error.is_some() {
                     return Ok((smartmodule_batch, maybe_error));
                 }
-
-                total_bytes += record_bytes;
-
-                debug!(
-                    smartmodule_records = records.len(),
-                    total_bytes, "finished smartmoduleing"
-                );
-                smartmodule_batch.mut_records().append(&mut records);
-            }
-
-            // only increment smartmodule offset delta if smartmodule_batch has been initialized
-            if smartmodule_batch.base_offset != -1 {
-                debug!(
-                    offset_delta = file_batch.offset_delta(),
-                    "adding to offset delta"
-                );
-                smartmodule_batch.add_to_offset_delta(file_batch.offset_delta() + 1);
-            }
-
-            // If we had a processing error, return current batch and error
-            if maybe_error.is_some() {
-                return Ok((smartmodule_batch, maybe_error));
             }
         }
-    }
-}
 
-#[derive(Clone)]
-pub struct RecordsMemory {
-    ptr: i32,
-    len: i32,
-    memory: Memory,
-}
+        /// initialize smartmodule instance using parameters
+        /// it must be have fn called init with parameters
+        /// this is experimental feature and may be removed in future
+        #[cfg(feature = "unstable")]
+        #[instrument]
+        pub fn invoke_constructor(&mut self) -> Result<(), Error> {
+            use wasmtime::TypedFunc;
+            use dataplane::smartmodule::SmartModuleInternalError;
 
-impl RecordsMemory {
-    fn copy_memory_from(&self, store: &mut Store<State>) -> Result<Vec<u8>> {
-        let mut bytes = vec![0u8; self.len as u32 as usize];
-        self.memory.read(store, self.ptr as usize, &mut bytes)?;
-        Ok(bytes)
-    }
-}
+            const INIT_FN_NAME: &str = "init";
 
-pub struct RecordsCallBack(Mutex<Option<RecordsMemory>>);
+            let params = self.params();
+            let ctx = self.mut_ctx();
+            let slice = ctx.write_input(&params)?;
+            let init_fn: TypedFunc<(i32, i32, u32), i32> =
+                ctx.instance.get_typed_func(&mut ctx.store, INIT_FN_NAME)?;
+            let filter_output = init_fn.call(&mut ctx.store, slice)?;
 
-impl RecordsCallBack {
-    fn new() -> Self {
-        Self(Mutex::new(None))
-    }
+            if filter_output < 0 {
+                let internal_error = SmartModuleInternalError::try_from(filter_output)
+                    .unwrap_or(SmartModuleInternalError::UnknownError);
+                return Err(internal_error.into());
+            }
 
-    fn set(&self, records: RecordsMemory) {
-        let mut write_inner = self.0.lock().unwrap();
-        write_inner.replace(records);
-    }
-
-    fn clear(&self) {
-        let mut write_inner = self.0.lock().unwrap();
-        write_inner.take();
+            Ok(())
+        }
     }
 
-    fn get(&self) -> Option<RecordsMemory> {
-        let reader = self.0.lock().unwrap();
-        reader.clone()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::path::{PathBuf, Path};
-
-    use crate::SmartEngine;
-
-    use super::DEFAULT_SMARTENGINE_VERSION;
-    const FLUVIO_WASM_FILTER: &str = "fluvio_wasm_filter";
-    const FLUVIO_WASM_MAP: &str = "fluvio_wasm_map_double";
-    const FLUVIO_WASM_ARRAY_MAP: &str = "fluvio_wasm_array_map_array";
-    const FLUVIO_WASM_FILTER_MAP: &str = "fluvio_wasm_filter_map";
-    const FLUVIO_WASM_AGGREGATE: &str = "fluvio_wasm_aggregate";
-    const FLUVIO_WASM_JOIN: &str = "fluvio_wasm_join";
-
-    fn read_wasm_module(module_name: &str) -> Vec<u8> {
-        let spu_dir = std::env::var("CARGO_MANIFEST_DIR").expect("target");
-        let wasm_path = PathBuf::from(spu_dir)
-            .parent()
-            .expect("parent")
-            .join(format!(
-                "fluvio-smartmodule/examples/target/wasm32-unknown-unknown/release/{}.wasm",
-                module_name
-            ));
-        read_module_from_path(wasm_path)
+    #[derive(Clone)]
+    pub struct RecordsMemory {
+        ptr: i32,
+        len: i32,
+        memory: Memory,
     }
 
-    fn read_module_from_path(filter_path: impl AsRef<Path>) -> Vec<u8> {
-        let path = filter_path.as_ref();
-        std::fs::read(path).unwrap_or_else(|_| panic!("Unable to read file {}", path.display()))
+    impl RecordsMemory {
+        fn copy_memory_from(&self, store: &mut Store<State>) -> Result<Vec<u8>> {
+            let mut bytes = vec![0u8; self.len as u32 as usize];
+            self.memory.read(store, self.ptr as usize, &mut bytes)?;
+            Ok(bytes)
+        }
     }
 
-    #[ignore]
-    #[test]
-    fn create_filter() {
-        let filter = read_wasm_module(FLUVIO_WASM_FILTER);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&filter)
-            .expect("Failed to create filter");
+    pub struct RecordsCallBack(Mutex<Option<RecordsMemory>>);
 
-        engine
-            .create_filter(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .expect("failed to create filter");
+    impl RecordsCallBack {
+        fn new() -> Self {
+            Self(Mutex::new(None))
+        }
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
+        fn set(&self, records: RecordsMemory) {
+            let mut write_inner = self.0.lock().unwrap();
+            write_inner.replace(records);
+        }
+
+        fn clear(&self) {
+            let mut write_inner = self.0.lock().unwrap();
+            write_inner.take();
+        }
+
+        fn get(&self) -> Option<RecordsMemory> {
+            let reader = self.0.lock().unwrap();
+            reader.clone()
+        }
     }
 
-    #[ignore]
-    #[test]
-    fn create_map() {
-        let filter = read_wasm_module(FLUVIO_WASM_MAP);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&filter)
-            .expect("Failed to create map");
+    #[cfg(test)]
+    mod test {
+        use std::path::{PathBuf, Path};
 
-        engine
-            .create_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .expect("failed to create map");
+        use crate::SmartEngine;
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
-    }
+        use super::DEFAULT_SMARTENGINE_VERSION;
+        const FLUVIO_WASM_FILTER: &str = "fluvio_wasm_filter";
+        const FLUVIO_WASM_MAP: &str = "fluvio_wasm_map_double";
+        const FLUVIO_WASM_ARRAY_MAP: &str = "fluvio_wasm_array_map_array";
+        const FLUVIO_WASM_FILTER_MAP: &str = "fluvio_wasm_filter_map";
+        const FLUVIO_WASM_AGGREGATE: &str = "fluvio_wasm_aggregate";
+        const FLUVIO_WASM_JOIN: &str = "fluvio_wasm_join";
 
-    #[ignore]
-    #[test]
-    fn create_filter_map() {
-        let filter = read_wasm_module(FLUVIO_WASM_FILTER_MAP);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&filter)
-            .expect("Failed to create filter map");
+        fn read_wasm_module(module_name: &str) -> Vec<u8> {
+            let spu_dir = std::env::var("CARGO_MANIFEST_DIR").expect("target");
+            let wasm_path = PathBuf::from(spu_dir)
+                .parent()
+                .expect("parent")
+                .join(format!(
+                    "fluvio-smartmodule/examples/target/wasm32-unknown-unknown/release/{}.wasm",
+                    module_name
+                ));
+            read_module_from_path(wasm_path)
+        }
 
-        engine
-            .create_filter_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .expect("failed to create filter map");
+        fn read_module_from_path(filter_path: impl AsRef<Path>) -> Vec<u8> {
+            let path = filter_path.as_ref();
+            std::fs::read(path).unwrap_or_else(|_| panic!("Unable to read file {}", path.display()))
+        }
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
-    }
+        #[ignore]
+        #[test]
+        fn create_filter() {
+            let filter = read_wasm_module(FLUVIO_WASM_FILTER);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&filter)
+                .expect("Failed to create filter");
 
-    #[ignore]
-    #[test]
-    fn create_array_map() {
-        let arraymap = read_wasm_module(FLUVIO_WASM_ARRAY_MAP);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&arraymap)
-            .expect("Failed to create arraymap");
+            engine
+                .create_filter(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .expect("failed to create filter");
 
-        engine
-            .create_array_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .expect("failed to create arraymap");
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
-    }
+        #[ignore]
+        #[test]
+        fn create_map() {
+            let filter = read_wasm_module(FLUVIO_WASM_MAP);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&filter)
+                .expect("Failed to create map");
 
-    #[ignore]
-    #[test]
-    fn create_aggregate() {
-        let agg = read_wasm_module(FLUVIO_WASM_AGGREGATE);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&agg)
-            .expect("Failed to create aggregate");
+            engine
+                .create_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .expect("failed to create map");
 
-        engine
-            .create_aggregate(
-                Default::default(),
-                Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create aggregate");
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
-    }
+        #[ignore]
+        #[test]
+        fn create_filter_map() {
+            let filter = read_wasm_module(FLUVIO_WASM_FILTER_MAP);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&filter)
+                .expect("Failed to create filter map");
 
-    #[ignore]
-    #[test]
-    fn create_join() {
-        let join = read_wasm_module(FLUVIO_WASM_JOIN);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&join)
-            .expect("Failed to create join");
+            engine
+                .create_filter_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .expect("failed to create filter map");
 
-        engine
-            .create_join(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .expect("failed to create join");
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
 
-        // generic
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
-    }
+        #[ignore]
+        #[test]
+        fn create_array_map() {
+            let arraymap = read_wasm_module(FLUVIO_WASM_ARRAY_MAP);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&arraymap)
+                .expect("Failed to create arraymap");
 
-    #[ignore]
-    #[test]
-    fn invalid_wasm_data() {
-        //we try to create a map smartmodule with a filter smartmodule
+            engine
+                .create_array_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .expect("failed to create arraymap");
 
-        let filter = read_wasm_module(FLUVIO_WASM_FILTER);
-        let engine = SmartEngine::default()
-            .create_module_from_binary(&filter)
-            .expect("Failed to create join");
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
 
-        engine
-            .create_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
-            .map(|_| "SmartModuleMap")
-            .expect_err("SmartModule Map was created with a filter module");
+        #[ignore]
+        #[test]
+        fn create_aggregate() {
+            let agg = read_wasm_module(FLUVIO_WASM_AGGREGATE);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&agg)
+                .expect("Failed to create aggregate");
 
-        // generic creation should work!
-        engine
-            .create_generic_smartmodule(
-                Default::default(),
-                &Default::default(),
-                DEFAULT_SMARTENGINE_VERSION,
-            )
-            .expect("failed to create generic smartmodule");
+            engine
+                .create_aggregate(
+                    Default::default(),
+                    Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create aggregate");
+
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
+
+        #[ignore]
+        #[test]
+        fn create_join() {
+            let join = read_wasm_module(FLUVIO_WASM_JOIN);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&join)
+                .expect("Failed to create join");
+
+            engine
+                .create_join(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .expect("failed to create join");
+
+            // generic
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
+
+        #[ignore]
+        #[test]
+        fn invalid_wasm_data() {
+            //we try to create a map smartmodule with a filter smartmodule
+
+            let filter = read_wasm_module(FLUVIO_WASM_FILTER);
+            let engine = SmartEngine::default()
+                .create_module_from_binary(&filter)
+                .expect("Failed to create join");
+
+            engine
+                .create_map(Default::default(), DEFAULT_SMARTENGINE_VERSION)
+                .map(|_| "SmartModuleMap")
+                .expect_err("SmartModule Map was created with a filter module");
+
+            // generic creation should work!
+            engine
+                .create_generic_smartmodule(
+                    Default::default(),
+                    &Default::default(),
+                    DEFAULT_SMARTENGINE_VERSION,
+                )
+                .expect("failed to create generic smartmodule");
+        }
     }
 }


### PR DESCRIPTION
Clean up the SmartEngine crate's top-level module to use proper module structure to enforce modularity.
Add Debug trait to a various structs to make it easier to add logging trace.
Added unstable feature flag with the following new experimental API:
* invoke_constructor to initialize SmartModule with `init` signature.  