### PR TITLE
[Merged by Bors] - Fix build failure for SmartModule examples

### DIFF
--- a/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/aggregate.rs
@@ -31,8 +31,11 @@ pub fn generate_aggregate_smartmodule(func: &SmartModuleFn, has_params: bool) ->
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]

--- a/crates/fluvio-smartmodule-derive/src/generator/array_map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/array_map.rs
@@ -31,8 +31,11 @@ pub fn generate_array_map_smartmodule(func: &SmartModuleFn, has_params: bool) ->
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]

--- a/crates/fluvio-smartmodule-derive/src/generator/filter.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/filter.rs
@@ -30,9 +30,13 @@ pub fn generate_filter_smartmodule(func: &SmartModuleFn, has_params: bool) -> To
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
+
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]
             pub unsafe fn filter(ptr: *mut u8, len: usize, version: i16) -> i32 {

--- a/crates/fluvio-smartmodule-derive/src/generator/filter_map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/filter_map.rs
@@ -31,8 +31,11 @@ pub fn generate_filter_map_smartmodule(func: &SmartModuleFn, has_params: bool) -
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]

--- a/crates/fluvio-smartmodule-derive/src/generator/init.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/init.rs
@@ -7,8 +7,11 @@ pub fn generate_init_smartmodule(func: &SmartModuleFn) -> TokenStream {
     let user_code = func.func;
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod _system {
 
             #[no_mangle]

--- a/crates/fluvio-smartmodule-derive/src/generator/join.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/join.rs
@@ -31,8 +31,11 @@ pub fn generate_join_smartmodule(func: &SmartModuleFn, has_params: bool) -> Toke
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]

--- a/crates/fluvio-smartmodule-derive/src/generator/map.rs
+++ b/crates/fluvio-smartmodule-derive/src/generator/map.rs
@@ -31,8 +31,11 @@ pub fn generate_map_smartmodule(func: &SmartModuleFn, has_params: bool) -> Token
     };
 
     quote! {
+
+        #[allow(dead_code)]
         #user_code
 
+        #[cfg(target_arch = "wasm32")]
         mod __system {
             #[no_mangle]
             #[allow(clippy::missing_safety_doc)]


### PR DESCRIPTION
Make `cargo build` work.   This is caused by the `wasm32` specific code in the SmartModule compiled under all targets.  Fix is to put `wasm32` related codes under `#[cfg(target_arch = "wasm32")]`.   