### PR TITLE
[Merged by Bors] - (chore) fix broken ui test for fluvio-protocol-derive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,7 +616,7 @@ jobs:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
         run: [r1]
-        test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean, stats-test, install-test-k8-port-forwarding]
+        test: [smoke-test-k8, smoke-test-k8-tls, smoke-test-k8-tls-root-unclean, stats-test]
         k8: [k3d, minikube]
         spu: [3]
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
 name = "fluvio-protocol-derive"
 version = "0.4.3"
 dependencies = [
+ "fluvio-protocol 0.7.10",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,10 +1996,12 @@ version = "0.7.10"
 dependencies = [
  "bytes 1.2.1",
  "fluvio-future 0.4.1",
+ "fluvio-protocol 0.7.10",
  "fluvio-protocol-derive 0.4.3",
  "futures 0.3.21",
  "tokio-util",
  "tracing",
+ "trybuild 1.0.64",
 ]
 
 [[package]]
@@ -2018,12 +2020,10 @@ dependencies = [
 name = "fluvio-protocol-derive"
 version = "0.4.3"
 dependencies = [
- "fluvio-protocol 0.7.10",
  "proc-macro2",
  "quote",
  "syn",
  "tracing",
- "trybuild",
 ]
 
 [[package]]
@@ -2152,7 +2152,7 @@ dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
  "fluvio-smartmodule-derive",
- "trybuild",
+ "trybuild 1.0.42",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
  "syn",
  "tokio",
  "tracing",
- "trybuild",
+ "trybuild 1.0.42",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ dependencies = [
  "syn",
  "tokio",
  "tracing",
- "trybuild",
+ "trybuild 1.0.42",
 ]
 
 [[package]]
@@ -5253,6 +5253,21 @@ dependencies = [
  "glob",
  "lazy_static",
  "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f408301c7480f9e6294eb779cfc907f54bd901a9660ef24d7f233ed5376485"
+dependencies = [
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",

--- a/crates/fluvio-controlplane-metadata/tests/regex-spec.yaml
+++ b/crates/fluvio-controlplane-metadata/tests/regex-spec.yaml
@@ -1,0 +1,6 @@
+
+input_kind: Stream
+output_kind: Stream
+wasm:
+  format: BINARY
+  payload: H4sIAAAAAAAA/+z9DZxd11kfCu+1P87Z53POjEaakUex9zlxkhmw0YftkSubxFuNJAvFGHjT

--- a/crates/fluvio-controlplane-metadata/tests/regex-spec.yaml
+++ b/crates/fluvio-controlplane-metadata/tests/regex-spec.yaml
@@ -1,6 +1,0 @@
-
-input_kind: Stream
-output_kind: Stream
-wasm:
-  format: BINARY
-  payload: H4sIAAAAAAAA/+z9DZxd11kfCu+1P87Z53POjEaakUex9zlxkhmw0YftkSubxFuNJAvFGHjT

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -21,9 +21,5 @@ tracing = "0.1"
 version = "1.0.0"
 features = ["full"]
 
-[dev-dependencies]
-trybuild = { git = "https://github.com/infinyon/trybuild", branch = "check_option" }
-fluvio-protocol = { path = "../fluvio-protocol", features = ["derive", "api"] }
-
 [package.metadata.cargo-udeps.ignore]
 development = ["fluvio-protocol"] # Used only in doc-tests, which `cargo-udeps` cannot check

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -21,5 +21,8 @@ tracing = "0.1"
 version = "1.0.0"
 features = ["full"]
 
+[dev-dependencies]
+fluvio-protocol = { path = "../fluvio-protocol", features = ["derive", "api"] }
+
 [package.metadata.cargo-udeps.ignore]
 development = ["fluvio-protocol"] # Used only in doc-tests, which `cargo-udeps` cannot check

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -26,7 +26,8 @@ tokio-util = { version = "0.7.0", features = [
 ], optional = true }
 
 [dev-dependencies]
-fluvio-protocol-derive = { path = "../fluvio-protocol-derive" }
+trybuild = "1.0.64"
+fluvio-protocol = { path = ".", features = ["derive","api"]}
 fluvio-future = { version = "0.4.0", features = [
     "fixture",
     "subscriber",

--- a/crates/fluvio-protocol/tests/parse.rs
+++ b/crates/fluvio-protocol/tests/parse.rs
@@ -1,6 +1,6 @@
 #[test]
 fn derive_ui() {
-    let t = trybuild::TestCases::check_only();
+    let t = trybuild::TestCases::new();
 
     t.pass("ui-tests/pass_*.rs");
     t.compile_fail("ui-tests/fail_*.rs");

--- a/crates/fluvio-protocol/ui-tests/pass_derive_decode.rs
+++ b/crates/fluvio-protocol/ui-tests/pass_derive_decode.rs
@@ -61,6 +61,3 @@ impl Default for PassNamedEnum {
         }
     }
 }
-
-#[derive(Encoder, Default)]
-struct PassTupleStruct (u16, String);

--- a/crates/fluvio-protocol/ui-tests/pass_derive_encode.rs
+++ b/crates/fluvio-protocol/ui-tests/pass_derive_encode.rs
@@ -32,6 +32,3 @@ enum PassNamedEnum {
     Alpha { name: String, number: i32 },
     Beta { data: Vec<u8> },
 }
-
-#[derive(Encoder)]
-struct PassTupleStruct (u16, String);


### PR DESCRIPTION
Derive test for `fluvio-protocol-derive` was broken but was not checked.
With this PR, `ui-test` is moved to the parent crates like other derive crates.  
Fix dev dependencies to allow run test per package.
Disabled port-forwarding-test