### PR TITLE
refactor(SPU) Remove global contexet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,7 +2234,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sysinfo 0.24.7",
+ "sysinfo 0.25.2",
  "thiserror",
  "tokio",
  "toml",

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -38,7 +38,7 @@ async-io = "1.3.1"
 adaptive_backoff = "0.2.1"
 thiserror = "1"
 once_cell = "1.5"
-sysinfo = "0.24.0"
+sysinfo = "0.25.0"
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio" }

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -19,8 +19,11 @@ use fluvio_socket::{FluvioSocket, SocketError, FluvioSink};
 use fluvio_storage::FileReplica;
 
 use crate::InternalServerError;
-use crate::core::{status_update_owned, local_spu_id, config};
-use crate::replication::SharedReplicaContext;
+use crate::core::{
+    status_update_owned, local_spu_id, config, smartmodule_localstore, spu_local_store,
+    derivedstream_store,
+};
+use crate::replication::{SharedReplicaContext, ReplicaChange, sync_follower_update};
 
 use super::message_sink::{SharedStatusUpdate};
 

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -17,7 +17,7 @@ use fluvio_controlplane::UpdateReplicaRequest;
 use dataplane::api::RequestMessage;
 use fluvio_socket::{FluvioSocket, SocketError, FluvioSink};
 use fluvio_storage::FileReplica;
-use crate::core::SharedGlobalContext;
+use crate::core::{SharedGlobalContext, spu_local_store};
 use crate::InternalServerError;
 
 use super::message_sink::{SharedStatusUpdate};
@@ -324,7 +324,7 @@ impl ScDispatcher<FileReplica> {
                 "received spu sync all"
             );
             trace!("received spu all items: {:#?}", request.all);
-            self.ctx.spu_localstore().sync_all(request.all)
+            spu_local_store().sync_all(request.all)
         } else {
             debug!(
                 epoch = request.epoch,
@@ -332,7 +332,7 @@ impl ScDispatcher<FileReplica> {
                 "received spu changes"
             );
             trace!("received spu change items: {:#?}", request.changes);
-            self.ctx.spu_localstore().apply_changes(request.changes)
+            spu_local_store().apply_changes(request.changes)
         };
 
         self.ctx.sync_follower_update().await;

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -17,7 +17,7 @@ use fluvio_controlplane::UpdateReplicaRequest;
 use dataplane::api::RequestMessage;
 use fluvio_socket::{FluvioSocket, SocketError, FluvioSink};
 use fluvio_storage::FileReplica;
-use crate::core::{SharedGlobalContext, spu_local_store, smartmodule_localstore};
+use crate::core::{SharedGlobalContext, spu_local_store, smartmodule_localstore, derivedstream_store};
 use crate::InternalServerError;
 
 use super::message_sink::{SharedStatusUpdate};
@@ -396,7 +396,7 @@ impl ScDispatcher<FileReplica> {
                 "received derivedstream all"
             );
             trace!("received derivedstream all items: {:#?}", request.all);
-            self.ctx.derivedstream_store().sync_all(request.all)
+            derivedstream_store().sync_all(request.all)
         } else {
             debug!(
                 epoch = request.epoch,
@@ -407,9 +407,7 @@ impl ScDispatcher<FileReplica> {
                 "received derivedstream change items: {:#?}",
                 request.changes
             );
-            self.ctx
-                .derivedstream_store()
-                .apply_changes(request.changes)
+            derivedstream_store().apply_changes(request.changes)
         };
 
         debug!(actions = actions.count(), "finished DerivedStream update");

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -17,7 +17,7 @@ use fluvio_controlplane::UpdateReplicaRequest;
 use dataplane::api::RequestMessage;
 use fluvio_socket::{FluvioSocket, SocketError, FluvioSink};
 use fluvio_storage::FileReplica;
-use crate::core::{SharedGlobalContext, spu_local_store};
+use crate::core::{SharedGlobalContext, spu_local_store, smartmodule_localstore};
 use crate::InternalServerError;
 
 use super::message_sink::{SharedStatusUpdate};
@@ -361,7 +361,7 @@ impl ScDispatcher<FileReplica> {
                 "received smartmodule sync all"
             );
             trace!("received spu all items: {:#?}", request.all);
-            self.ctx.smartmodule_localstore().sync_all(request.all)
+            smartmodule_localstore().sync_all(request.all)
         } else {
             debug!(
                 epoch = request.epoch,
@@ -369,9 +369,7 @@ impl ScDispatcher<FileReplica> {
                 "received smartmoudle changes"
             );
             trace!("received spu change items: {:#?}", request.changes);
-            self.ctx
-                .smartmodule_localstore()
-                .apply_changes(request.changes)
+            smartmodule_localstore().apply_changes(request.changes)
         };
 
         debug!(actions = actions.count(), "finished SmartModule update");

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -17,7 +17,10 @@ use fluvio_controlplane::UpdateReplicaRequest;
 use dataplane::api::RequestMessage;
 use fluvio_socket::{FluvioSocket, SocketError, FluvioSink};
 use fluvio_storage::FileReplica;
-use crate::core::{SharedGlobalContext, spu_local_store, smartmodule_localstore, derivedstream_store};
+use crate::core::{
+    SharedGlobalContext, spu_local_store, smartmodule_localstore, derivedstream_store,
+    status_update_owned,
+};
 use crate::InternalServerError;
 
 use super::message_sink::{SharedStatusUpdate};
@@ -43,7 +46,7 @@ pub struct ScDispatcher<S> {
 impl ScDispatcher<FileReplica> {
     pub fn new(ctx: SharedGlobalContext<FileReplica>) -> Self {
         Self {
-            status_update: ctx.status_update_owned(),
+            status_update: status_update_owned(),
             ctx,
             counter: DispatcherCounter::default(),
         }

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -107,23 +107,5 @@ pub(crate) fn initialize(spu_config: SpuConfig) {
         .set(LeaderConnections::shared(spus, replicas))
         .unwrap();
 
-    crate::replication::initialize();
-
-    /*
-    let replicas = ReplicaStore::new_shared();
-
-    GlobalContext {
-        spu_localstore: spus.clone(),
-        replica_localstore: replicas.clone(),
-        smartmodule_localstore: SmartModuleLocalStore::new_shared(),
-        derivedstream_localstore: DerivedStreamStore::new_shared(),
-        config: Arc::new(spu_config),
-        leaders_state: ReplicaLeadersState::new_shared(),
-        followers_state: FollowersState::new_shared(),
-        spu_followers: FollowerNotifier::shared(),
-        status_update: StatusMessageSink::shared(),
-        sm_engine: SmartEngine::default(),
-        leaders: LeaderConnections::shared(spus, replicas),
-    }
-    */
+    crate::replication::initialize_replica();
 }

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 use std::fmt::Debug;
 
+use once_cell::sync::OnceCell;
 use tracing::{debug, error, instrument};
 
 use fluvio_controlplane_metadata::partition::Replica;
@@ -33,6 +34,31 @@ use super::replica::ReplicaStore;
 use super::SharedSpuConfig;
 
 pub use file_replica::ReplicaChange;
+
+pub(crate) static SPU_STORE: OnceCell<SharedSpuLocalStore> = OnceCell::new();
+
+
+/// initialize global variables
+pub(crate) fn initialize(spu_config: SpuConfig) {
+    SPU_STORE.set(SpuLocalStore::new_shared()).unwrap();
+    /* 
+    let replicas = ReplicaStore::new_shared();
+
+    GlobalContext {
+        spu_localstore: spus.clone(),
+        replica_localstore: replicas.clone(),
+        smartmodule_localstore: SmartModuleLocalStore::new_shared(),
+        derivedstream_localstore: DerivedStreamStore::new_shared(),
+        config: Arc::new(spu_config),
+        leaders_state: ReplicaLeadersState::new_shared(),
+        followers_state: FollowersState::new_shared(),
+        spu_followers: FollowerNotifier::shared(),
+        status_update: StatusMessageSink::shared(),
+        sm_engine: SmartEngine::default(),
+        leaders: LeaderConnections::shared(spus, replicas),
+    }
+    */
+}
 
 #[derive(Debug)]
 pub struct GlobalContext<S> {

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -36,6 +36,7 @@ use super::SharedSpuConfig;
 pub use file_replica::ReplicaChange;
 
 static SPU_STORE: OnceCell<SharedSpuLocalStore> = OnceCell::new();
+static REPLICA_STORE: OnceCell<SharedReplicaLocalStore> = OnceCell::new();
 
 pub(crate) fn spu_local_store() -> &'static SpuLocalStore {
     SPU_STORE.get().unwrap()
@@ -45,9 +46,14 @@ pub(crate) fn spu_local_store_owned() -> SharedSpuLocalStore {
     SPU_STORE.get().unwrap().clone()
 }
 
+pub(crate) fn replica_localstore() -> &'static ReplicaStore {
+    REPLICA_STORE.get().unwrap()
+}
+
 /// initialize global variables
 pub(crate) fn initialize(_spu_config: SpuConfig) {
     SPU_STORE.set(SpuLocalStore::new_shared()).unwrap();
+    REPLICA_STORE.set(ReplicaStore::new_shared()).unwrap();
     /*
     let replicas = ReplicaStore::new_shared();
 
@@ -70,7 +76,6 @@ pub(crate) fn initialize(_spu_config: SpuConfig) {
 #[derive(Debug)]
 pub struct GlobalContext<S> {
     config: SharedSpuConfig,
-    replica_localstore: SharedReplicaLocalStore,
     smartmodule_localstore: SharedSmartModuleLocalStore,
     derivedstream_localstore: SharedStreamStreamLocalStore,
     leaders_state: SharedReplicaLeadersState<S>,
@@ -98,7 +103,6 @@ where
         let replicas = ReplicaStore::new_shared();
 
         GlobalContext {
-            replica_localstore: replicas.clone(),
             smartmodule_localstore: SmartModuleLocalStore::new_shared(),
             derivedstream_localstore: DerivedStreamStore::new_shared(),
             config: Arc::new(spu_config),
@@ -114,10 +118,6 @@ where
     /// retrieves local spu id
     pub fn local_spu_id(&self) -> SpuId {
         self.config.id
-    }
-
-    pub fn replica_localstore(&self) -> &ReplicaStore {
-        &self.replica_localstore
     }
 
     pub fn smartmodule_localstore(&self) -> &SmartModuleLocalStore {
@@ -237,9 +237,7 @@ mod file_replica {
             &self,
             request: UpdateReplicaRequest,
         ) -> Vec<ReplicaChange> {
-            let changes = self
-                .replica_localstore()
-                .apply(request.all, request.changes);
+            let changes = replica_localstore().apply(request.all, request.changes);
 
             self.apply_replica_actions(changes).await
         }

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -42,6 +42,7 @@ static DERIVEDSTREAM_STORE: OnceCell<SharedStreamStreamLocalStore> = OnceCell::n
 static FOLLOWER_NOTIFIER: OnceCell<SharedSpuUpdates> = OnceCell::new();
 static STATUS_UPDATE: OnceCell<SharedStatusUpdate> = OnceCell::new();
 static CONFIG: OnceCell<SharedSpuConfig> = OnceCell::new();
+static SMART_ENGINE: OnceCell<SmartEngine> = OnceCell::new();
 
 pub(crate) fn spu_local_store() -> &'static SpuLocalStore {
     SPU_STORE.get().unwrap()
@@ -95,6 +96,10 @@ pub(crate) async fn sync_follower_update() {
         .await;
 }
 
+pub(crate) fn smartengine_owned() -> SmartEngine {
+    SMART_ENGINE.get().unwrap().clone()
+}
+
 /// initialize global variables
 pub(crate) fn initialize(spu_config: SpuConfig) {
     SPU_STORE.set(SpuLocalStore::new_shared()).unwrap();
@@ -109,6 +114,7 @@ pub(crate) fn initialize(spu_config: SpuConfig) {
     FOLLOWER_NOTIFIER.set(FollowerNotifier::shared()).unwrap();
     STATUS_UPDATE.set(StatusMessageSink::shared()).unwrap();
     CONFIG.set(Arc::new(spu_config)).unwrap();
+    SMART_ENGINE.set(SmartEngine::default()).unwrap();
 
     /*
     let replicas = ReplicaStore::new_shared();
@@ -133,7 +139,6 @@ pub(crate) fn initialize(spu_config: SpuConfig) {
 pub struct GlobalContext<S> {
     leaders_state: SharedReplicaLeadersState<S>,
     followers_state: SharedFollowersState<S>,
-    sm_engine: SmartEngine,
     leaders: Arc<LeaderConnections>,
 }
 
@@ -156,7 +161,6 @@ where
         GlobalContext {
             leaders_state: ReplicaLeadersState::new_shared(),
             followers_state: FollowersState::new_shared(),
-            sm_engine: SmartEngine::default(),
             leaders: LeaderConnections::shared(spus, replicas),
         }
     }
@@ -181,11 +185,6 @@ where
     */
 
     /// notify all follower handlers with SPU changes
-    #[instrument(skip(self))]
-
-    pub fn smartengine_owned(&self) -> SmartEngine {
-        self.sm_engine.clone()
-    }
 
     #[allow(unused)]
     pub fn leaders(&self) -> Arc<LeaderConnections> {

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -37,6 +37,7 @@ pub use file_replica::ReplicaChange;
 
 static SPU_STORE: OnceCell<SharedSpuLocalStore> = OnceCell::new();
 static REPLICA_STORE: OnceCell<SharedReplicaLocalStore> = OnceCell::new();
+static SMARTMODULE_STORE: OnceCell<SharedSmartModuleLocalStore> = OnceCell::new();
 
 pub(crate) fn spu_local_store() -> &'static SpuLocalStore {
     SPU_STORE.get().unwrap()
@@ -48,6 +49,10 @@ pub(crate) fn spu_local_store_owned() -> SharedSpuLocalStore {
 
 pub(crate) fn replica_localstore() -> &'static ReplicaStore {
     REPLICA_STORE.get().unwrap()
+}
+
+pub(crate) fn smartmodule_localstore() -> &'static SmartModuleLocalStore {
+    SMARTMODULE_STORE.get().unwrap()
 }
 
 /// initialize global variables
@@ -76,7 +81,6 @@ pub(crate) fn initialize(_spu_config: SpuConfig) {
 #[derive(Debug)]
 pub struct GlobalContext<S> {
     config: SharedSpuConfig,
-    smartmodule_localstore: SharedSmartModuleLocalStore,
     derivedstream_localstore: SharedStreamStreamLocalStore,
     leaders_state: SharedReplicaLeadersState<S>,
     followers_state: SharedFollowersState<S>,
@@ -103,7 +107,6 @@ where
         let replicas = ReplicaStore::new_shared();
 
         GlobalContext {
-            smartmodule_localstore: SmartModuleLocalStore::new_shared(),
             derivedstream_localstore: DerivedStreamStore::new_shared(),
             config: Arc::new(spu_config),
             leaders_state: ReplicaLeadersState::new_shared(),
@@ -118,10 +121,6 @@ where
     /// retrieves local spu id
     pub fn local_spu_id(&self) -> SpuId {
         self.config.id
-    }
-
-    pub fn smartmodule_localstore(&self) -> &SmartModuleLocalStore {
-        &self.smartmodule_localstore
     }
 
     pub fn derivedstream_store(&self) -> &DerivedStreamStore {

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -38,6 +38,7 @@ pub use file_replica::ReplicaChange;
 static SPU_STORE: OnceCell<SharedSpuLocalStore> = OnceCell::new();
 static REPLICA_STORE: OnceCell<SharedReplicaLocalStore> = OnceCell::new();
 static SMARTMODULE_STORE: OnceCell<SharedSmartModuleLocalStore> = OnceCell::new();
+static DERIVEDSTREAM_STORE: OnceCell<SharedStreamStreamLocalStore> = OnceCell::new();
 
 pub(crate) fn spu_local_store() -> &'static SpuLocalStore {
     SPU_STORE.get().unwrap()
@@ -55,10 +56,21 @@ pub(crate) fn smartmodule_localstore() -> &'static SmartModuleLocalStore {
     SMARTMODULE_STORE.get().unwrap()
 }
 
+pub fn derivedstream_store() -> &'static DerivedStreamStore {
+    DERIVEDSTREAM_STORE.get().unwrap()
+}
+
 /// initialize global variables
 pub(crate) fn initialize(_spu_config: SpuConfig) {
     SPU_STORE.set(SpuLocalStore::new_shared()).unwrap();
     REPLICA_STORE.set(ReplicaStore::new_shared()).unwrap();
+    SMARTMODULE_STORE
+        .set(SmartModuleLocalStore::new_shared())
+        .unwrap();
+    DERIVEDSTREAM_STORE
+        .set(DerivedStreamStore::new_shared())
+        .unwrap();
+
     /*
     let replicas = ReplicaStore::new_shared();
 
@@ -81,7 +93,6 @@ pub(crate) fn initialize(_spu_config: SpuConfig) {
 #[derive(Debug)]
 pub struct GlobalContext<S> {
     config: SharedSpuConfig,
-    derivedstream_localstore: SharedStreamStreamLocalStore,
     leaders_state: SharedReplicaLeadersState<S>,
     followers_state: SharedFollowersState<S>,
     spu_followers: SharedSpuUpdates,
@@ -107,7 +118,6 @@ where
         let replicas = ReplicaStore::new_shared();
 
         GlobalContext {
-            derivedstream_localstore: DerivedStreamStore::new_shared(),
             config: Arc::new(spu_config),
             leaders_state: ReplicaLeadersState::new_shared(),
             followers_state: FollowersState::new_shared(),
@@ -121,10 +131,6 @@ where
     /// retrieves local spu id
     pub fn local_spu_id(&self) -> SpuId {
         self.config.id
-    }
-
-    pub fn derivedstream_store(&self) -> &DerivedStreamStore {
-        &self.derivedstream_localstore
     }
 
     pub fn leaders_state(&self) -> &ReplicaLeadersState<S> {

--- a/crates/fluvio-spu/src/core/mod.rs
+++ b/crates/fluvio-spu/src/core/mod.rs
@@ -7,7 +7,7 @@ pub mod replica;
 pub mod smartmodule;
 pub mod derivedstream;
 
-pub(crate) use self::global_context::{GlobalContext, ReplicaChange,initialize};
+pub(crate) use self::global_context::*;
 pub(crate) use self::store::Spec;
 pub(crate) use self::store::LocalStore;
 pub(crate) use self::store::SpecChange;

--- a/crates/fluvio-spu/src/core/mod.rs
+++ b/crates/fluvio-spu/src/core/mod.rs
@@ -7,19 +7,19 @@ pub mod replica;
 pub mod smartmodule;
 pub mod derivedstream;
 
-pub use self::global_context::{GlobalContext, ReplicaChange};
-pub use self::store::Spec;
-pub use self::store::LocalStore;
-pub use self::store::SpecChange;
+pub(crate) use self::global_context::{GlobalContext, ReplicaChange,initialize};
+pub(crate) use self::store::Spec;
+pub(crate) use self::store::LocalStore;
+pub(crate) use self::store::SpecChange;
 
-pub use self::spus::SpuLocalStore;
-pub use self::replica::SharedReplicaLocalStore;
+pub(crate) use self::spus::SpuLocalStore;
+pub(crate) use self::replica::SharedReplicaLocalStore;
 
 use std::sync::Arc;
 use ::fluvio_storage::FileReplica;
 use crate::config::SpuConfig;
 
-pub type SharedGlobalContext<S> = Arc<GlobalContext<S>>;
-pub type DefaultSharedGlobalContext = SharedGlobalContext<FileReplica>;
-pub type SharedSpuConfig = Arc<SpuConfig>;
-pub type FileGlobalContext = GlobalContext<FileReplica>;
+pub(crate) type SharedGlobalContext<S> = Arc<GlobalContext<S>>;
+pub(crate) type DefaultSharedGlobalContext = SharedGlobalContext<FileReplica>;
+pub(crate) type SharedSpuConfig = Arc<SpuConfig>;
+pub(crate) type FileGlobalContext = GlobalContext<FileReplica>;

--- a/crates/fluvio-spu/src/core/mod.rs
+++ b/crates/fluvio-spu/src/core/mod.rs
@@ -15,11 +15,6 @@ pub(crate) use self::store::SpecChange;
 pub(crate) use self::spus::SpuLocalStore;
 pub(crate) use self::replica::SharedReplicaLocalStore;
 
-use std::sync::Arc;
-use ::fluvio_storage::FileReplica;
 use crate::config::SpuConfig;
 
-pub(crate) type SharedGlobalContext<S> = Arc<GlobalContext<S>>;
-pub(crate) type DefaultSharedGlobalContext = SharedGlobalContext<FileReplica>;
-pub(crate) type SharedSpuConfig = Arc<SpuConfig>;
-pub(crate) type FileGlobalContext = GlobalContext<FileReplica>;
+pub(crate) type SharedSpuConfig = std::sync::Arc<SpuConfig>;

--- a/crates/fluvio-spu/src/core/spus/metadata.rs
+++ b/crates/fluvio-spu/src/core/spus/metadata.rs
@@ -54,7 +54,7 @@ impl SpuLocalStore {
 pub mod test {
     use std::collections::BTreeMap;
 
-    use crate::core::SpuLocalStore;
+    use crate::core::{SpuLocalStore};
 
     #[test]
     fn test_indexed_by_id() {

--- a/crates/fluvio-spu/src/lib.rs
+++ b/crates/fluvio-spu/src/lib.rs
@@ -1,19 +1,15 @@
 mod error;
 mod config;
 
-cfg_if::cfg_if! {
-    if #[cfg(unix)] {
-        mod core;
-        mod services;
-        mod start;
-        mod replication;
-        mod control_plane;
-        mod storage;
-        mod smartengine;
-        pub use start::main_loop;
-    }
-}
-
+mod core;
+mod services;
+mod start;
+mod replication;
+mod control_plane;
+mod storage;
+mod smartengine;
+        
+pub use start::main_loop;
 use self::error::InternalServerError;
 pub use config::SpuOpt;
 

--- a/crates/fluvio-spu/src/lib.rs
+++ b/crates/fluvio-spu/src/lib.rs
@@ -8,7 +8,7 @@ mod replication;
 mod control_plane;
 mod storage;
 mod smartengine;
-        
+
 pub use start::main_loop;
 use self::error::InternalServerError;
 pub use config::SpuOpt;

--- a/crates/fluvio-spu/src/main.rs
+++ b/crates/fluvio-spu/src/main.rs
@@ -1,9 +1,5 @@
-
-
-
 fn main() {
     use clap::Parser;
-
 
     fluvio_future::subscriber::init_tracer(None);
 

--- a/crates/fluvio-spu/src/main.rs
+++ b/crates/fluvio-spu/src/main.rs
@@ -1,6 +1,10 @@
-use clap::Parser;
+
+
 
 fn main() {
+    use clap::Parser;
+
+
     fluvio_future::subscriber::init_tracer(None);
 
     let opt = fluvio_spu::SpuOpt::parse();

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -6,7 +6,7 @@ use adaptive_backoff::prelude::*;
 
 use fluvio_types::SpuId;
 use fluvio_types::event::offsets::OffsetPublisher;
-use crate::core::{FileGlobalContext};
+use crate::core::{FileGlobalContext, spu_local_store_owned};
 
 use super::{FollowersState};
 use super::state::{SharedFollowersState, FollowerReplicaState};
@@ -41,7 +41,7 @@ impl FollowerGroups {
             } else {
                 FollowGroupController::run(
                     leader,
-                    ctx.spu_localstore_owned(),
+                    spu_local_store_owned(),
                     ctx.followers_state_owned(),
                     notification,
                     ctx.config_owned(),

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -6,7 +6,7 @@ use adaptive_backoff::prelude::*;
 
 use fluvio_types::SpuId;
 use fluvio_types::event::offsets::OffsetPublisher;
-use crate::core::{FileGlobalContext, spu_local_store_owned};
+use crate::core::{FileGlobalContext, spu_local_store_owned, config_owned};
 
 use super::{FollowersState};
 use super::state::{SharedFollowersState, FollowerReplicaState};
@@ -44,7 +44,7 @@ impl FollowerGroups {
                     spu_local_store_owned(),
                     ctx.followers_state_owned(),
                     notification,
-                    ctx.config_owned(),
+                    config_owned(),
                 );
             }
         }

--- a/crates/fluvio-spu/src/replication/follower/controller.rs
+++ b/crates/fluvio-spu/src/replication/follower/controller.rs
@@ -6,7 +6,8 @@ use adaptive_backoff::prelude::*;
 
 use fluvio_types::SpuId;
 use fluvio_types::event::offsets::OffsetPublisher;
-use crate::core::{FileGlobalContext, spu_local_store_owned, config_owned};
+use crate::core::{spu_local_store_owned, config_owned};
+use crate::replication::FileReplicaContext;
 
 use super::{FollowersState};
 use super::state::{SharedFollowersState, FollowerReplicaState};
@@ -27,7 +28,7 @@ impl FollowerGroups {
 
     /// new follower replica has been added in the group
     /// ensure that controller exists if not spawn controller
-    pub async fn check_new(&self, ctx: &FileGlobalContext, leader: SpuId) {
+    pub async fn check_new(&self, ctx: &FileReplicaContext, leader: SpuId) {
         // check if leader controller exist
         let mut leaders = self.0.write().await;
         // check if we have controllers

--- a/crates/fluvio-spu/src/replication/follower/state.rs
+++ b/crates/fluvio-spu/src/replication/follower/state.rs
@@ -14,7 +14,7 @@ use dataplane::Offset;
 use fluvio_storage::{FileReplica, StorageError, ReplicaStorage, ReplicaStorageConfig};
 use fluvio_types::SpuId;
 use crate::replication::leader::ReplicaOffsetRequest;
-use crate::core::{FileGlobalContext};
+use crate::core::{FileGlobalContext, config};
 use crate::storage::SharableReplicaStorage;
 
 use super::controller::FollowerGroups;
@@ -92,7 +92,7 @@ impl FollowersState<FileReplica> {
                     "creating new follower state"
                 );
 
-                let mut replica_config: ReplicaConfig = ctx.config().into();
+                let mut replica_config: ReplicaConfig = config().into();
                 replica_config.update_from_replica(&replica);
 
                 let replica_state =

--- a/crates/fluvio-spu/src/replication/follower/state.rs
+++ b/crates/fluvio-spu/src/replication/follower/state.rs
@@ -13,8 +13,9 @@ use dataplane::record::RecordSet;
 use dataplane::Offset;
 use fluvio_storage::{FileReplica, StorageError, ReplicaStorage, ReplicaStorageConfig};
 use fluvio_types::SpuId;
+use crate::replication::FileReplicaContext;
 use crate::replication::leader::ReplicaOffsetRequest;
-use crate::core::{FileGlobalContext, config};
+use crate::core::{config};
 use crate::storage::SharableReplicaStorage;
 
 use super::controller::FollowerGroups;
@@ -74,7 +75,7 @@ impl FollowersState<FileReplica> {
     /// otherwise check if there is existing state, if exists return none otherwise create new
     pub async fn add_replica(
         self: Arc<Self>,
-        ctx: &FileGlobalContext,
+        ctx: &FileReplicaContext,
         replica: Replica,
     ) -> Result<Option<FollowerReplicaState<FileReplica>>, StorageError> {
         let leader = replica.leader;

--- a/crates/fluvio-spu/src/replication/leader/connection.rs
+++ b/crates/fluvio-spu/src/replication/leader/connection.rs
@@ -176,7 +176,11 @@ impl FollowerHandler {
         for update in request.replicas.into_iter() {
             debug!(?update, "request");
             let replica_key = update.replica;
-            if let Some(leader) = default_replica_ctx().leaders_state().get(&replica_key).await {
+            if let Some(leader) = default_replica_ctx()
+                .leaders_state()
+                .get(&replica_key)
+                .await
+            {
                 let status = leader
                     .update_states_from_followers(
                         self.follower_id,

--- a/crates/fluvio-spu/src/replication/leader/connection.rs
+++ b/crates/fluvio-spu/src/replication/leader/connection.rs
@@ -10,7 +10,7 @@ use dataplane::api::RequestMessage;
 use fluvio_types::SpuId;
 
 use crate::{
-    core::DefaultSharedGlobalContext,
+    core::{DefaultSharedGlobalContext, follower_notifier},
     replication::follower::sync::{FileSyncRequest},
 };
 
@@ -184,7 +184,7 @@ impl FollowerHandler {
                             hw: update.hw,
                             leo: update.leo,
                         },
-                        self.ctx.follower_notifier(),
+                        follower_notifier(),
                     )
                     .await;
                 debug!(status, replica = %leader.id(), "leader updated");

--- a/crates/fluvio-spu/src/replication/leader/leaders_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/leaders_state.rs
@@ -11,7 +11,7 @@ use fluvio_storage::{FileReplica, StorageError};
 
 use crate::{
     control_plane::SharedStatusUpdate,
-    core::{GlobalContext},
+    core::{config},
 };
 use crate::config::ReplicationConfig;
 use crate::replication::follower::FollowerReplicaState;
@@ -69,19 +69,17 @@ impl<S> ReplicaLeadersState<S> {
 
 impl ReplicaLeadersState<FileReplica> {
     #[instrument(
-        skip(self, ctx,replica,status_update),
+        skip(self, replica,status_update),
         fields(replica = %replica.id)
     )]
     pub async fn add_leader_replica(
         &self,
-        ctx: &GlobalContext<FileReplica>,
         replica: Replica,
         status_update: SharedStatusUpdate,
     ) -> Result<LeaderReplicaState<FileReplica>, StorageError> {
         let replica_id = replica.id.clone();
 
-        let leader_replica =
-            LeaderReplicaState::create(replica, ctx.config(), status_update).await?;
+        let leader_replica = LeaderReplicaState::create(replica, config(), status_update).await?;
         self.insert_leader(replica_id, leader_replica.clone()).await;
         Ok(leader_replica)
     }

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -690,6 +690,7 @@ mod test_leader {
     use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
+    use crate::core::spu_local_store;
     use crate::{
         config::{SpuConfig},
     };
@@ -901,7 +902,7 @@ mod test_leader {
         ];
         let gctx: Arc<GlobalContext<MockStorage>> =
             GlobalContext::new_shared_context(leader_config);
-        gctx.spu_localstore().sync_all(specs);
+        spu_local_store().sync_all(specs);
         gctx.sync_follower_update().await;
 
         let notifier = gctx.follower_notifier();

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -690,7 +690,7 @@ mod test_leader {
     use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
-    use crate::core::spu_local_store;
+    use crate::core::{spu_local_store, follower_notifier};
     use crate::{
         config::{SpuConfig},
     };
@@ -905,7 +905,7 @@ mod test_leader {
         spu_local_store().sync_all(specs);
         gctx.sync_follower_update().await;
 
-        let notifier = gctx.follower_notifier();
+        let notifier = follower_notifier();
         assert!(notifier.get(&5001).await.is_some());
         assert!(notifier.get(&5002).await.is_some());
         assert!(notifier.get(&5000).await.is_none());

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -690,8 +690,8 @@ mod test_leader {
     use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
-    use crate::core::{spu_local_store, config};
-    use crate::replication::{ReplicaContext, sync_follower_update, follower_notifier};
+    use crate::core::{spu_local_store, config, initialize};
+    use crate::replication::{sync_follower_update, follower_notifier};
     use crate::{
         config::{SpuConfig},
     };
@@ -895,12 +895,12 @@ mod test_leader {
             id: 5000,
             ..Default::default()
         };
+        initialize(leader_config);
         let specs = vec![
             SpuSpec::new_private_addr(5000, 9000, "localhost".to_owned()),
             SpuSpec::new_private_addr(5001, 9001, "localhost".to_owned()),
             SpuSpec::new_private_addr(5002, 9002, "localhost".to_owned()),
         ];
-        let _gctx: Arc<ReplicaContext<MockStorage>> = ReplicaContext::new_shared_context();
         spu_local_store().sync_all(specs);
         sync_follower_update().await;
 

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -690,7 +690,8 @@ mod test_leader {
     use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
-    use crate::core::{spu_local_store, follower_notifier, sync_follower_update, config};
+    use crate::core::{spu_local_store, config};
+    use crate::replication::{ReplicaContext, sync_follower_update, follower_notifier};
     use crate::{
         config::{SpuConfig},
     };
@@ -888,7 +889,6 @@ mod test_leader {
 
     #[fluvio_future::test]
     async fn test_update_leader_from_followers() {
-        use crate::core::{GlobalContext};
         use fluvio_controlplane_metadata::spu::{SpuSpec};
 
         let leader_config = SpuConfig {
@@ -900,8 +900,7 @@ mod test_leader {
             SpuSpec::new_private_addr(5001, 9001, "localhost".to_owned()),
             SpuSpec::new_private_addr(5002, 9002, "localhost".to_owned()),
         ];
-        let _gctx: Arc<GlobalContext<MockStorage>> =
-            GlobalContext::new_shared_context(leader_config);
+        let _gctx: Arc<ReplicaContext<MockStorage>> = ReplicaContext::new_shared_context();
         spu_local_store().sync_all(specs);
         sync_follower_update().await;
 

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -690,7 +690,7 @@ mod test_leader {
     use dataplane::batch::BatchRecords;
     use dataplane::fixture::{create_recordset};
 
-    use crate::core::{spu_local_store, follower_notifier};
+    use crate::core::{spu_local_store, follower_notifier, sync_follower_update, config};
     use crate::{
         config::{SpuConfig},
     };
@@ -900,10 +900,10 @@ mod test_leader {
             SpuSpec::new_private_addr(5001, 9001, "localhost".to_owned()),
             SpuSpec::new_private_addr(5002, 9002, "localhost".to_owned()),
         ];
-        let gctx: Arc<GlobalContext<MockStorage>> =
+        let _gctx: Arc<GlobalContext<MockStorage>> =
             GlobalContext::new_shared_context(leader_config);
         spu_local_store().sync_all(specs);
-        gctx.sync_follower_update().await;
+        sync_follower_update().await;
 
         let notifier = follower_notifier();
         assert!(notifier.get(&5001).await.is_some());
@@ -914,7 +914,7 @@ mod test_leader {
         // inserting new replica state, this should set follower offset to -1,-1 as initial state
         let leader: LeaderReplicaState<MockStorage> = LeaderReplicaState::create(
             Replica::new(replica.clone(), 5000, vec![5000, 5001, 5002]),
-            gctx.config(),
+            config(),
             StatusMessageSink::shared(),
         )
         .await

--- a/crates/fluvio-spu/src/replication/mod.rs
+++ b/crates/fluvio-spu/src/replication/mod.rs
@@ -3,3 +3,367 @@ pub(crate) mod leader;
 
 #[cfg(test)]
 pub(crate) mod test;
+
+pub(crate) use global::*;
+
+mod global {
+    use once_cell::sync::OnceCell;
+
+    use crate::core::{spu_local_store, local_spu_id};
+
+    use super::{leader::{SharedSpuUpdates, FollowerNotifier}, DefaultSharedReplicaContext, FileReplicaContext};
+
+    static FOLLOWER_NOTIFIER: OnceCell<SharedSpuUpdates> = OnceCell::new();
+    static DEFAULT_REPLICA_CTX: OnceCell<DefaultSharedReplicaContext> = OnceCell::new();
+
+    pub(crate) fn follower_notifier() -> &'static FollowerNotifier {
+        FOLLOWER_NOTIFIER.get().unwrap()
+    }
+
+    pub(crate) async fn sync_follower_update() {
+        follower_notifier()
+            .sync_from_spus(spu_local_store(), local_spu_id())
+            .await;
+    }
+
+    pub(crate) fn default_replica_ctx() -> &'static DefaultSharedReplicaContext {
+        DEFAULT_REPLICA_CTX.get().unwrap()
+    }
+
+    /// initialize global variables
+    pub(crate) fn initialize() {
+        FOLLOWER_NOTIFIER.set(FollowerNotifier::shared()).unwrap();
+        DEFAULT_REPLICA_CTX.set(FileReplicaContext::new_shared_context()).unwrap();
+    }
+}
+
+pub(crate) use context::*;
+mod context {
+
+    use std::sync::Arc;
+    use std::fmt::Debug;
+
+    use fluvio_storage::FileReplica;
+    use tracing::{debug, error, instrument};
+
+    use fluvio_controlplane_metadata::partition::Replica;
+    use fluvio_storage::{ReplicaStorage};
+
+    use crate::replication::follower::FollowersState;
+    use crate::replication::follower::SharedFollowersState;
+    use crate::replication::leader::{SharedReplicaLeadersState, ReplicaLeadersState};
+
+    pub(crate) type SharedReplicaContext<S> = Arc<ReplicaContext<S>>;
+    pub(crate) type DefaultSharedReplicaContext = SharedReplicaContext<FileReplica>;
+    pub(crate) type FileReplicaContext = ReplicaContext<FileReplica>;
+
+    #[derive(Debug)]
+    pub struct ReplicaContext<S> {
+        leaders_state: SharedReplicaLeadersState<S>,
+        followers_state: SharedFollowersState<S>,
+    }
+
+    // -----------------------------------
+    // Replication Context
+    // -----------------------------------
+
+    impl<S> ReplicaContext<S>
+    where
+        S: ReplicaStorage,
+    {
+        pub fn new_shared_context() -> Arc<Self> {
+            Arc::new(Self::new())
+        }
+
+        pub fn new() -> Self {
+            Self {
+                leaders_state: ReplicaLeadersState::new_shared(),
+                followers_state: FollowersState::new_shared(),
+            }
+        }
+
+        pub fn leaders_state(&self) -> &ReplicaLeadersState<S> {
+            &self.leaders_state
+        }
+
+        pub fn followers_state(&self) -> &FollowersState<S> {
+            &self.followers_state
+        }
+
+        pub fn followers_state_owned(&self) -> SharedFollowersState<S> {
+            self.followers_state.clone()
+        }
+    }
+
+    mod file_replica {
+
+        use fluvio_controlplane::{ReplicaRemovedRequest, UpdateReplicaRequest};
+        use fluvio_storage::{FileReplica, StorageError};
+        use flv_util::actions::Actions;
+        use tracing::{trace, warn};
+
+        use crate::core::{SpecChange, config, status_update_owned, replica_localstore, local_spu_id};
+
+        use super::*;
+
+        #[derive(Debug)]
+        pub enum ReplicaChange {
+            Remove(ReplicaRemovedRequest),
+            StorageError(StorageError),
+        }
+
+        impl ReplicaContext<FileReplica> {
+            /// Promote follower replica as leader,
+            /// This is done in 3 steps
+            /// // 1: Remove follower replica from followers state
+            /// // 2: Terminate followers controller if need to be (if there are no more follower replicas for that controller)
+            /// // 3: add to leaders state
+            #[instrument(
+                skip(self,new_replica,old_replica),
+                fields(
+                    replica = %new_replica.id,
+                    old_leader = old_replica.leader
+                )
+            )]
+            pub async fn promote(&self, new_replica: &Replica, old_replica: &Replica) {
+                if let Some(follower_replica) = self
+                    .followers_state()
+                    .remove_replica(old_replica.leader, &old_replica.id)
+                    .await
+                {
+                    debug!(
+                        replica = %old_replica.id,
+                        "old follower replica exists, promoting to leader"
+                    );
+
+                    self.leaders_state()
+                        .promote_follower(
+                            config().into(),
+                            follower_replica,
+                            new_replica.clone(),
+                            status_update_owned(),
+                        )
+                        .await;
+                } else {
+                    error!("follower replica {} didn't exists!", old_replica.id);
+                }
+            }
+
+            pub async fn apply_replica_update(
+                &self,
+                request: UpdateReplicaRequest,
+            ) -> Vec<ReplicaChange> {
+                let changes = replica_localstore().apply(request.all, request.changes);
+
+                self.apply_replica_actions(changes).await
+            }
+
+            /// apply changes to
+            #[instrument(
+                skip(self),
+                fields(actions=actions.count()))]
+            async fn apply_replica_actions(
+                &self,
+                actions: Actions<SpecChange<Replica>>,
+            ) -> Vec<ReplicaChange> {
+                trace!( actions = ?actions,"replica actions");
+
+                if actions.count() == 0 {
+                    debug!("no replica actions to process. ignoring");
+                    return vec![];
+                }
+
+                let local_id = local_spu_id();
+
+                let mut outputs = vec![];
+                for replica_action in actions.into_iter() {
+                    debug!(action = ?replica_action,"applying");
+
+                    match replica_action {
+                        SpecChange::Add(new_replica) => {
+                            if new_replica.is_being_deleted {
+                                outputs.push(ReplicaChange::Remove(
+                                    self.remove_leader_replica(new_replica).await,
+                                ));
+                            } else if new_replica.leader == local_id {
+                                // we are leader
+                                if let Err(err) = self
+                                    .leaders_state()
+                                    .add_leader_replica(new_replica, status_update_owned())
+                                    .await
+                                {
+                                    outputs.push(ReplicaChange::StorageError(err));
+                                }
+                            } else {
+                                // add follower if we are in follower list
+                                if new_replica.replicas.contains(&local_id) {
+                                    if let Err(err) = self
+                                        .followers_state_owned()
+                                        .add_replica(self, new_replica)
+                                        .await
+                                    {
+                                        outputs.push(ReplicaChange::StorageError(err));
+                                    }
+                                } else {
+                                    debug!(replica = %new_replica.id, "not application to this spu, ignoring");
+                                }
+                            }
+                        }
+                        SpecChange::Delete(deleted_replica) => {
+                            if deleted_replica.leader == local_id {
+                                outputs.push(ReplicaChange::Remove(
+                                    self.remove_leader_replica(deleted_replica).await,
+                                ));
+                            } else {
+                                self.remove_follower_replica(deleted_replica).await;
+                            }
+                        }
+                        SpecChange::Mod(new_replica, old_replica) => {
+                            if new_replica.is_being_deleted {
+                                if new_replica.leader == local_id {
+                                    outputs.push(ReplicaChange::Remove(
+                                        self.remove_leader_replica(new_replica).await,
+                                    ));
+                                } else {
+                                    self.remove_follower_replica(new_replica).await
+                                }
+                            } else {
+                                // check for leader change
+                                if new_replica.leader != old_replica.leader {
+                                    if new_replica.leader == local_id {
+                                        self.promote(&new_replica, &old_replica).await
+                                    } else {
+                                        // we are follower
+                                        // if we were leader before, we demote out self
+                                        if old_replica.leader == local_id {
+                                            self.demote_replica(new_replica).await
+                                        } else {
+                                            // we stay as follower but we switch to new leader
+                                            debug!(
+                                                "still follower but switching leader: {}",
+                                                new_replica
+                                            );
+                                            self.switch_leader_for_follower(
+                                                new_replica,
+                                                old_replica,
+                                            )
+                                            .await
+                                        }
+                                    }
+                                } else if new_replica.leader == local_id {
+                                    if self.leaders_state().get(&new_replica.id).await.is_some() {
+                                    } else {
+                                        error!(
+                                            "leader controller was not found: {}",
+                                            new_replica.id
+                                        );
+                                    }
+                                } else {
+                                    self.followers_state().update_replica(new_replica).await;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                outputs
+            }
+
+            /// reemove leader replica
+            #[instrument(
+                skip(self,replica),
+                fields(
+                    replica = %replica.id,
+                )
+            )]
+            async fn remove_leader_replica(&self, replica: Replica) -> ReplicaRemovedRequest {
+                // try to send message to leader controller if still exists
+                if let Some(previous_state) = self.leaders_state().remove(&replica.id).await {
+                    if let Err(err) = previous_state.remove().await {
+                        error!("error: {} removing replica: {}", err, replica);
+                    } else {
+                        debug!(
+                            replica = %replica.id,
+                            "leader remove was removed"
+                        );
+                    }
+                } else {
+                    // if we don't find existing replica, just warning
+                    warn!("no existing replica found {}", replica);
+                }
+
+                ReplicaRemovedRequest::new(replica.id, true)
+            }
+
+            /// reemove leader replica
+            #[instrument(
+                skip(self,replica),
+                fields(
+                    replica = %replica.id,
+                )
+            )]
+            async fn remove_follower_replica(&self, replica: Replica) {
+                debug!("removing follower replica: {}", replica);
+                if let Some(replica_state) = self
+                    .followers_state()
+                    .remove_replica(replica.leader, &replica.id)
+                    .await
+                {
+                    if let Err(err) = replica_state.remove().await {
+                        error!("error {}, removing replica: {}", err, replica);
+                    }
+                } else {
+                    error!("there was no follower replica: {} to remove", replica);
+                }
+            }
+
+            /// Demote leader replica as follower.
+            /// This only happens on manual election
+            #[instrument(
+                skip(self,replica),
+                fields(
+                    replica = %replica.id,
+                )
+            )]
+            pub async fn demote_replica(&self, replica: Replica) {
+                if let Some(leader_replica_state) = self.leaders_state().remove(&replica.id).await {
+                    drop(leader_replica_state);
+                    if let Err(err) = self
+                        .followers_state_owned()
+                        .add_replica(self, replica)
+                        .await
+                    {
+                        error!("demotion failed: {}", err);
+                    }
+                } else {
+                    error!("leader controller was not found: {}", replica.id)
+                }
+            }
+
+            /// Demote leader replica as follower.
+            /// This only happens on manual election
+            #[instrument(
+                skip(self,new,old),
+                fields(
+                    new = %new.id,
+                    old = %old.id,
+                )
+            )]
+            async fn switch_leader_for_follower(&self, new: Replica, old: Replica) {
+                // we stay as follower but we switch to new leader
+                debug!("still follower but switching leader: {}", new);
+                if self
+                    .followers_state()
+                    .remove_replica(old.leader, &old.id)
+                    .await
+                    .is_none()
+                {
+                    error!("there was no follower replica: {} to switch", new);
+                }
+                if let Err(err) = self.followers_state_owned().add_replica(self, new).await {
+                    error!("leader switch failed: {}", err);
+                }
+            }
+        }
+    }
+}

--- a/crates/fluvio-spu/src/replication/mod.rs
+++ b/crates/fluvio-spu/src/replication/mod.rs
@@ -11,7 +11,10 @@ mod global {
 
     use crate::core::{spu_local_store, local_spu_id};
 
-    use super::{leader::{SharedSpuUpdates, FollowerNotifier}, DefaultSharedReplicaContext, FileReplicaContext};
+    use super::{
+        leader::{SharedSpuUpdates, FollowerNotifier},
+        DefaultSharedReplicaContext, FileReplicaContext,
+    };
 
     static FOLLOWER_NOTIFIER: OnceCell<SharedSpuUpdates> = OnceCell::new();
     static DEFAULT_REPLICA_CTX: OnceCell<DefaultSharedReplicaContext> = OnceCell::new();
@@ -31,9 +34,11 @@ mod global {
     }
 
     /// initialize global variables
-    pub(crate) fn initialize() {
+    pub(crate) fn initialize_replica() {
         FOLLOWER_NOTIFIER.set(FollowerNotifier::shared()).unwrap();
-        DEFAULT_REPLICA_CTX.set(FileReplicaContext::new_shared_context()).unwrap();
+        DEFAULT_REPLICA_CTX
+            .set(FileReplicaContext::new_shared_context())
+            .unwrap();
     }
 }
 
@@ -56,6 +61,8 @@ mod context {
     pub(crate) type SharedReplicaContext<S> = Arc<ReplicaContext<S>>;
     pub(crate) type DefaultSharedReplicaContext = SharedReplicaContext<FileReplica>;
     pub(crate) type FileReplicaContext = ReplicaContext<FileReplica>;
+
+    pub(crate) use file_replica::*;
 
     #[derive(Debug)]
     pub struct ReplicaContext<S> {

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -15,7 +15,7 @@ use fluvio_controlplane_metadata::partition::{Replica};
 use fluvio_controlplane_metadata::spu::{IngressAddr, IngressPort, SpuSpec};
 use dataplane::fixture::{create_recordset};
 
-use crate::core::{DefaultSharedGlobalContext, GlobalContext, spu_local_store};
+use crate::core::{DefaultSharedGlobalContext, GlobalContext, spu_local_store, replica_localstore};
 use crate::config::SpuConfig;
 use crate::services::create_internal_server;
 
@@ -151,7 +151,7 @@ impl TestConfig {
         let replica = self.replica();
 
         let gctx = self.leader_ctx().await;
-        gctx.replica_localstore().sync_all(vec![replica.clone()]);
+        replica_localstore().sync_all(vec![replica.clone()]);
 
         let leader_replica = gctx
             .leaders_state()
@@ -179,7 +179,7 @@ impl TestConfig {
     ) {
         let replica = self.replica();
         let gctx = self.follower_ctx(follower_index).await;
-        gctx.replica_localstore().sync_all(vec![replica.clone()]);
+        replica_localstore().sync_all(vec![replica.clone()]);
 
         gctx.followers_state_owned()
             .add_replica(&gctx, replica.clone())

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -15,7 +15,7 @@ use fluvio_controlplane_metadata::partition::{Replica};
 use fluvio_controlplane_metadata::spu::{IngressAddr, IngressPort, SpuSpec};
 use dataplane::fixture::{create_recordset};
 
-use crate::core::{DefaultSharedGlobalContext, GlobalContext};
+use crate::core::{DefaultSharedGlobalContext, GlobalContext, spu_local_store};
 use crate::config::SpuConfig;
 use crate::services::create_internal_server;
 
@@ -138,7 +138,7 @@ impl TestConfig {
         let leader_config = self.leader_config();
 
         let gctx = GlobalContext::new_shared_context(leader_config);
-        gctx.spu_localstore().sync_all(self.spu_specs());
+        spu_local_store().sync_all(self.spu_specs());
         gctx.sync_follower_update().await;
 
         gctx
@@ -166,7 +166,7 @@ impl TestConfig {
     pub async fn follower_ctx(&self, follower_index: u16) -> DefaultSharedGlobalContext {
         let follower_config = self.follower_config(follower_index);
         let gctx = GlobalContext::new_shared_context(follower_config);
-        gctx.spu_localstore().sync_all(self.spu_specs());
+        spu_local_store().sync_all(self.spu_specs());
         gctx
     }
 

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -17,7 +17,7 @@ use dataplane::fixture::{create_recordset};
 
 use crate::core::{
     DefaultSharedGlobalContext, GlobalContext, spu_local_store, replica_localstore,
-    follower_notifier, status_update_owned, status_update,
+    follower_notifier, status_update_owned, status_update, sync_follower_update,
 };
 use crate::config::SpuConfig;
 use crate::services::create_internal_server;
@@ -142,7 +142,7 @@ impl TestConfig {
 
         let gctx = GlobalContext::new_shared_context(leader_config);
         spu_local_store().sync_all(self.spu_specs());
-        gctx.sync_follower_update().await;
+        sync_follower_update().await;
 
         gctx
     }
@@ -158,7 +158,7 @@ impl TestConfig {
 
         let leader_replica = gctx
             .leaders_state()
-            .add_leader_replica(&gctx, replica.clone(), status_update_owned())
+            .add_leader_replica(replica.clone(), status_update_owned())
             .await
             .expect("leader");
 
@@ -218,7 +218,7 @@ async fn test_just_leader() {
         .base_port(13000_u16)
         .generate("just_leader");
 
-    let (leader_gctx, leader_replica) = builder.leader_replica().await;
+    let (_leader_gctx, leader_replica) = builder.leader_replica().await;
 
     assert_eq!(leader_replica.leo(), 0);
     assert_eq!(leader_replica.hw(), 0);

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -17,7 +17,7 @@ use dataplane::fixture::{create_recordset};
 
 use crate::core::{
     DefaultSharedGlobalContext, GlobalContext, spu_local_store, replica_localstore,
-    follower_notifier,
+    follower_notifier, status_update_owned, status_update,
 };
 use crate::config::SpuConfig;
 use crate::services::create_internal_server;
@@ -158,7 +158,7 @@ impl TestConfig {
 
         let leader_replica = gctx
             .leaders_state()
-            .add_leader_replica(&gctx, replica.clone(), gctx.status_update_owned())
+            .add_leader_replica(&gctx, replica.clone(), status_update_owned())
             .await
             .expect("leader");
 
@@ -223,7 +223,7 @@ async fn test_just_leader() {
     assert_eq!(leader_replica.leo(), 0);
     assert_eq!(leader_replica.hw(), 0);
 
-    let status = leader_gctx.status_update().remove_all().await;
+    let status = status_update().remove_all().await;
     assert!(!status.is_empty());
     let lrs = &status[0];
     assert_eq!(lrs.id, (TOPIC, 0).into());
@@ -240,7 +240,7 @@ async fn test_just_leader() {
     assert_eq!(leader_replica.leo(), 2);
     assert_eq!(leader_replica.hw(), 2);
 
-    let status = leader_gctx.status_update().remove_all().await;
+    let status = status_update().remove_all().await;
     assert!(!status.is_empty());
     let lrs = &status[0];
     assert_eq!(lrs.id, (TOPIC, 0).into());
@@ -268,7 +268,7 @@ async fn test_replication2_existing() {
 
     assert_eq!(leader_replica.leo(), 2);
     assert_eq!(leader_replica.hw(), 0);
-    assert!(!leader_gctx.status_update().remove_all().await.is_empty());
+    assert!(!status_update().remove_all().await.is_empty());
 
     let spu_server = create_internal_server(builder.leader_addr(), leader_gctx.clone()).run();
 
@@ -294,7 +294,7 @@ async fn test_replication2_existing() {
     assert_eq!(follower_replica.hw(), 2);
     assert_eq!(leader_replica.hw(), 2);
 
-    let status = leader_gctx.status_update().remove_all().await;
+    let status = status_update().remove_all().await;
     debug!(?status);
     assert!(!status.is_empty());
     let lrs = &status[0];
@@ -366,7 +366,7 @@ async fn test_replication2_new_records() {
     assert_eq!(follower_replica.hw(), 2);
     assert_eq!(leader_replica.hw(), 2);
 
-    let status = leader_gctx.status_update().remove_all().await;
+    let status = status_update().remove_all().await;
     debug!(?status);
     assert!(!status.is_empty());
     let lrs = &status[0];

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -15,7 +15,10 @@ use fluvio_controlplane_metadata::partition::{Replica};
 use fluvio_controlplane_metadata::spu::{IngressAddr, IngressPort, SpuSpec};
 use dataplane::fixture::{create_recordset};
 
-use crate::core::{DefaultSharedGlobalContext, GlobalContext, spu_local_store, replica_localstore};
+use crate::core::{
+    DefaultSharedGlobalContext, GlobalContext, spu_local_store, replica_localstore,
+    follower_notifier,
+};
 use crate::config::SpuConfig;
 use crate::services::create_internal_server;
 
@@ -230,7 +233,7 @@ async fn test_just_leader() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -259,7 +262,7 @@ async fn test_replication2_existing() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -344,7 +347,7 @@ async fn test_replication2_new_records() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -393,7 +396,7 @@ async fn test_replication3_existing() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -482,7 +485,7 @@ async fn test_replication3_new_records() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -606,7 +609,7 @@ async fn test_replication_dispatch_in_sequence() {
     assert_eq!(leader.hw(), 0);
 
     leader
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 
@@ -697,7 +700,7 @@ async fn test_replication_dispatch_out_of_sequence() {
     assert_eq!(leader.hw(), 0);
 
     leader
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(&mut create_recordset(2), follower_notifier())
         .await
         .expect("write");
 

--- a/crates/fluvio-spu/src/services/internal/mod.rs
+++ b/crates/fluvio-spu/src/services/internal/mod.rs
@@ -7,7 +7,6 @@ use tracing::info;
 use fluvio_service::FluvioApiServer;
 use service_impl::InternalService;
 
-
 use crate::core::local_spu_id;
 
 pub use self::fetch_stream_request::FetchStreamRequest;
@@ -15,8 +14,8 @@ pub use self::fetch_stream_request::FetchStreamResponse;
 pub use self::api::SPUPeerApiEnum;
 pub use self::api::SpuPeerRequest;
 
-#[derive(Clone,Debug)]
-pub(crate) struct InternalServiceImpl;
+#[derive(Clone, Debug)]
+pub struct InternalServiceImpl;
 
 pub(crate) type InternalApiServer =
     FluvioApiServer<SpuPeerRequest, SPUPeerApiEnum, InternalServiceImpl, InternalService>;
@@ -29,5 +28,5 @@ pub fn create_internal_server(addr: String) -> InternalApiServer {
         addr
     );
 
-    FluvioApiServer::new(addr, InternalServiceImpl{}, InternalService::new())
+    FluvioApiServer::new(addr, InternalServiceImpl {}, InternalService::new())
 }

--- a/crates/fluvio-spu/src/services/internal/mod.rs
+++ b/crates/fluvio-spu/src/services/internal/mod.rs
@@ -8,6 +8,7 @@ use fluvio_service::FluvioApiServer;
 use service_impl::InternalService;
 
 use crate::core::DefaultSharedGlobalContext;
+use crate::core::local_spu_id;
 
 pub use self::fetch_stream_request::FetchStreamRequest;
 pub use self::fetch_stream_request::FetchStreamResponse;
@@ -21,7 +22,7 @@ pub(crate) type InternalApiServer =
 pub fn create_internal_server(addr: String, ctx: DefaultSharedGlobalContext) -> InternalApiServer {
     info!(
         "starting SPU: {} at internal service at: {}",
-        ctx.local_spu_id(),
+        local_spu_id(),
         addr
     );
 

--- a/crates/fluvio-spu/src/services/internal/mod.rs
+++ b/crates/fluvio-spu/src/services/internal/mod.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use fluvio_service::FluvioApiServer;
 use service_impl::InternalService;
 
-use crate::core::DefaultSharedGlobalContext;
+
 use crate::core::local_spu_id;
 
 pub use self::fetch_stream_request::FetchStreamRequest;
@@ -15,16 +15,19 @@ pub use self::fetch_stream_request::FetchStreamResponse;
 pub use self::api::SPUPeerApiEnum;
 pub use self::api::SpuPeerRequest;
 
+#[derive(Clone,Debug)]
+pub(crate) struct InternalServiceImpl;
+
 pub(crate) type InternalApiServer =
-    FluvioApiServer<SpuPeerRequest, SPUPeerApiEnum, DefaultSharedGlobalContext, InternalService>;
+    FluvioApiServer<SpuPeerRequest, SPUPeerApiEnum, InternalServiceImpl, InternalService>;
 
 // start server
-pub fn create_internal_server(addr: String, ctx: DefaultSharedGlobalContext) -> InternalApiServer {
+pub fn create_internal_server(addr: String) -> InternalApiServer {
     info!(
         "starting SPU: {} at internal service at: {}",
         local_spu_id(),
         addr
     );
 
-    FluvioApiServer::new(addr, ctx, InternalService::new())
+    FluvioApiServer::new(addr, InternalServiceImpl{}, InternalService::new())
 }

--- a/crates/fluvio-spu/src/services/internal/service_impl.rs
+++ b/crates/fluvio-spu/src/services/internal/service_impl.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 use fluvio_service::{wait_for_request, FluvioService};
 use fluvio_socket::{FluvioSocket, SocketError};
 
-use crate::core::DefaultSharedGlobalContext;
+use crate::core::{DefaultSharedGlobalContext, follower_notifier};
 use crate::replication::leader::FollowerHandler;
 use super::SpuPeerRequest;
 use super::SPUPeerApiEnum;
@@ -51,7 +51,7 @@ impl FluvioService for InternalService {
                     "received fetch stream"
                 );
                 // check if follower_id is valid
-                if let Some(spu_update) = ctx.follower_notifier().get(&follower_id).await {
+                if let Some(spu_update) = follower_notifier().get(&follower_id).await {
                     let response = FetchStreamResponse::new(follower_id);
                     let res_msg = req_msg.new_response(response);
                     sink

--- a/crates/fluvio-spu/src/services/internal/service_impl.rs
+++ b/crates/fluvio-spu/src/services/internal/service_impl.rs
@@ -8,7 +8,6 @@ use tracing::{debug, warn};
 use fluvio_service::{wait_for_request, FluvioService};
 use fluvio_socket::{FluvioSocket, SocketError};
 
-
 use crate::replication::follower_notifier;
 use crate::replication::leader::FollowerHandler;
 use super::{SpuPeerRequest, InternalServiceImpl};
@@ -29,10 +28,10 @@ impl FluvioService for InternalService {
     type Context = InternalServiceImpl;
     type Request = SpuPeerRequest;
 
-    #[instrument(skip(self, ctx))]
+    #[instrument(skip(self))]
     async fn respond(
         self: Arc<Self>,
-        ctx: InternalServiceImpl,
+        _ctx: InternalServiceImpl,
         socket: FluvioSocket,
         _connection: ConnectInfo,
     ) -> Result<(), SocketError> {

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -21,6 +21,7 @@ use fluvio_spu_schema::server::SpuServerApiKey;
 use fluvio_types::event::StickyEvent;
 
 use crate::core::DefaultSharedGlobalContext;
+use crate::core::local_spu_id;
 use self::api_versions::handle_api_version_request;
 use self::produce_handler::handle_produce_request;
 use self::fetch_handler::handle_fetch_request;
@@ -34,7 +35,7 @@ pub(crate) type SpuPublicServer =
 
 pub fn create_public_server(addr: String, ctx: DefaultSharedGlobalContext) -> SpuPublicServer {
     info!(
-        spu_id = ctx.local_spu_id(),
+        spu_id = local_spu_id(),
         %addr,
         "Starting SPU public service:",
     );

--- a/crates/fluvio-spu/src/services/public/offset_request.rs
+++ b/crates/fluvio-spu/src/services/public/offset_request.rs
@@ -10,12 +10,12 @@ use fluvio_spu_schema::server::fetch_offset::FetchOffsetPartitionResponse;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 use dataplane::ErrorCode;
 
-use crate::core::DefaultSharedGlobalContext;
+use crate::replication::default_replica_ctx;
 
-#[instrument(skip(req_msg, ctx))]
+
+#[instrument(skip(req_msg))]
 pub async fn handle_offset_request(
     req_msg: RequestMessage<FetchOffsetsRequest>,
-    ctx: DefaultSharedGlobalContext,
 ) -> Result<ResponseMessage<FetchOffsetsResponse>, IoError> {
     let request = req_msg.request();
     trace!("handling flv fetch request: {:#?}", request);
@@ -37,7 +37,7 @@ pub async fn handle_offset_request(
                 ..Default::default()
             };
             let rep_id = ReplicaKey::new(topic.clone(), *partition);
-            if let Some(ref replica) = ctx.leaders_state().get(&rep_id).await {
+            if let Some(ref replica) = default_replica_ctx().leaders_state().get(&rep_id).await {
                 trace!("offset fetch request for replica found: {}", rep_id);
                 let (start_offset, hw) = replica.start_offset_info().await;
                 partition_response.error_code = ErrorCode::None;

--- a/crates/fluvio-spu/src/services/public/offset_request.rs
+++ b/crates/fluvio-spu/src/services/public/offset_request.rs
@@ -12,7 +12,6 @@ use dataplane::ErrorCode;
 
 use crate::replication::default_replica_ctx;
 
-
 #[instrument(skip(req_msg))]
 pub async fn handle_offset_request(
     req_msg: RequestMessage<FetchOffsetsRequest>,

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -20,7 +20,7 @@ use tokio::select;
 use std::time::Duration;
 use fluvio_future::timer::sleep;
 
-use crate::core::{ replica_localstore};
+use crate::core::{replica_localstore};
 use crate::replication::{default_replica_ctx, follower_notifier};
 
 struct TopicWriteResult {
@@ -69,9 +69,7 @@ pub async fn handle_produce_request(
     skip(topic_request),
     fields(topic = %topic_request.name),
 )]
-async fn handle_produce_topic(
-    topic_request: DefaultTopicRequest,
-) -> TopicWriteResult {
+async fn handle_produce_topic(topic_request: DefaultTopicRequest) -> TopicWriteResult {
     trace!("Handling produce request for topic:");
 
     let mut topic_result = TopicWriteResult {
@@ -169,11 +167,7 @@ fn validate_records<R: BatchRecords>(
 /// error code. The timeout is not shared between partitions.
 ///
 /// For isolation = ReadUncommitted - it's no op.
-async fn wait_for_acks(
-    isolation: Isolation,
-    timeout: Duration,
-    results: &mut [TopicWriteResult],
-) {
+async fn wait_for_acks(isolation: Isolation, timeout: Duration, results: &mut [TopicWriteResult]) {
     trace!(?isolation, "waiting for acks");
     match &isolation {
         Isolation::ReadCommitted => {
@@ -182,7 +176,11 @@ async fn wait_for_acks(
                     trace!(?partition.replica_id, %partition.error_code, "partition result with error, skip waiting");
                     continue;
                 }
-                let leader_state = match default_replica_ctx().leaders_state().get(&partition.replica_id).await {
+                let leader_state = match default_replica_ctx()
+                    .leaders_state()
+                    .get(&partition.replica_id)
+                    .await
+                {
                     Some(leader_state) => leader_state,
                     None => {
                         debug!(%partition.replica_id, "Replica not found");

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -20,7 +20,7 @@ use tokio::select;
 use std::time::Duration;
 use fluvio_future::timer::sleep;
 
-use crate::core::DefaultSharedGlobalContext;
+use crate::core::{DefaultSharedGlobalContext, replica_localstore};
 
 struct TopicWriteResult {
     topic: String,
@@ -110,7 +110,7 @@ async fn handle_produce_partition<R: BatchRecords>(
         }
     };
 
-    let replica_metadata = match ctx.replica_localstore().spec(&replica_id) {
+    let replica_metadata = match replica_localstore().spec(&replica_id) {
         Some(replica_metadata) => replica_metadata,
         None => {
             error!(%replica_id, "Replica not found");

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -20,7 +20,7 @@ use tokio::select;
 use std::time::Duration;
 use fluvio_future::timer::sleep;
 
-use crate::core::{DefaultSharedGlobalContext, replica_localstore};
+use crate::core::{DefaultSharedGlobalContext, replica_localstore, follower_notifier};
 
 struct TopicWriteResult {
     topic: String,
@@ -125,7 +125,7 @@ async fn handle_produce_partition<R: BatchRecords>(
     }
 
     let write_result = leader_state
-        .write_record_set(&mut records, ctx.follower_notifier())
+        .write_record_set(&mut records, follower_notifier())
         .await;
 
     match write_result {

--- a/crates/fluvio-spu/src/services/public/tests/produce.rs
+++ b/crates/fluvio-spu/src/services/public/tests/produce.rs
@@ -14,12 +14,11 @@ use fluvio_future::timer::sleep;
 use fluvio_socket::{MultiplexerSocket, FluvioSocket};
 use flv_util::fixture::ensure_clean_dir;
 
-
 use crate::{
     config::SpuConfig,
     core::{replica_localstore, status_update_owned, config, initialize},
     services::public::{create_public_server, tests::create_filter_records},
-    replication::{leader::LeaderReplicaState, ReplicaContext, default_replica_ctx},
+    replication::{leader::LeaderReplicaState, default_replica_ctx},
 };
 
 #[fluvio_future::test(ignore)]
@@ -143,7 +142,7 @@ async fn test_produce_invalid_compression() {
     let mut spu_config = SpuConfig::default();
     spu_config.log.base_dir = test_path;
     initialize(spu_config);
- 
+
     let server_end_event = create_public_server(addr.to_owned()).run();
 
     // wait for stream controller async to start
@@ -213,7 +212,7 @@ async fn test_produce_request_timed_out() {
 
     let public_addr = config.leader_public_addr();
 
-    let (leader_ctx, _) = config.leader_replica().await;
+    let _ = config.leader_replica().await;
 
     let server_end_event = create_public_server(public_addr.clone()).run();
 
@@ -274,7 +273,7 @@ async fn test_produce_not_waiting_replication() {
         .base_port(14020_u16)
         .generate("produce_request_timed_out");
 
-    let (leader_ctx, _) = config.leader_replica().await;
+    let _ = config.leader_replica().await;
     let public_addr = config.leader_public_addr();
 
     let server_end_event = create_public_server(public_addr.clone()).run();
@@ -333,13 +332,11 @@ async fn test_produce_waiting_replication() {
         .base_port(14030_u16)
         .generate("produce_waiting_replication");
 
-    let (leader_ctx, leader_replica) = config.leader_replica().await;
+    let leader_replica = config.leader_replica().await;
     let public_addr = config.leader_public_addr();
 
-    let public_server_end_event =
-        create_public_server(public_addr.clone()).run();
-    let private_server_end_event =
-        create_internal_server(config.leader_addr()).run();
+    let public_server_end_event = create_public_server(public_addr.clone()).run();
+    let private_server_end_event = create_internal_server(config.leader_addr()).run();
 
     // wait for stream controller async to start
     sleep(Duration::from_millis(100)).await;

--- a/crates/fluvio-spu/src/services/public/tests/produce.rs
+++ b/crates/fluvio-spu/src/services/public/tests/produce.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 use crate::{
     config::SpuConfig,
-    core::GlobalContext,
+    core::{GlobalContext, replica_localstore},
     services::public::{create_public_server, tests::create_filter_records},
     replication::leader::LeaderReplicaState,
 };
@@ -41,7 +41,7 @@ async fn test_produce_basic() {
     let topic = "test_produce";
     let test = Replica::new((topic, 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    ctx.replica_localstore().sync_all(vec![test.clone()]);
+    replica_localstore().sync_all(vec![test.clone()]);
 
     let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
         .await
@@ -152,7 +152,7 @@ async fn test_produce_invalid_compression() {
     let mut test = Replica::new((topic, 0), 5001, vec![5001]);
     test.compression_type = CompressionAlgorithm::Gzip;
     let test_id = test.id.clone();
-    ctx.replica_localstore().sync_all(vec![test.clone()]);
+    replica_localstore().sync_all(vec![test.clone()]);
 
     let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
         .await

--- a/crates/fluvio-spu/src/services/public/tests/produce.rs
+++ b/crates/fluvio-spu/src/services/public/tests/produce.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 use crate::{
     config::SpuConfig,
-    core::{GlobalContext, replica_localstore, status_update_owned},
+    core::{GlobalContext, replica_localstore, status_update_owned, config},
     services::public::{create_public_server, tests::create_filter_records},
     replication::leader::LeaderReplicaState,
 };
@@ -43,7 +43,7 @@ async fn test_produce_basic() {
     let test_id = test.id.clone();
     replica_localstore().sync_all(vec![test.clone()]);
 
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -154,7 +154,7 @@ async fn test_produce_invalid_compression() {
     let test_id = test.id.clone();
     replica_localstore().sync_all(vec![test.clone()]);
 
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;

--- a/crates/fluvio-spu/src/services/public/tests/produce.rs
+++ b/crates/fluvio-spu/src/services/public/tests/produce.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 use crate::{
     config::SpuConfig,
-    core::{GlobalContext, replica_localstore},
+    core::{GlobalContext, replica_localstore, status_update_owned},
     services::public::{create_public_server, tests::create_filter_records},
     replication::leader::LeaderReplicaState,
 };
@@ -43,7 +43,7 @@ async fn test_produce_basic() {
     let test_id = test.id.clone();
     replica_localstore().sync_all(vec![test.clone()]);
 
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -154,7 +154,7 @@ async fn test_produce_invalid_compression() {
     let test_id = test.id.clone();
     replica_localstore().sync_all(vec![test.clone()]);
 
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -35,7 +35,7 @@ use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest};
 use crate::{
     core::{
         GlobalContext, spu_local_store, replica_localstore, smartmodule_localstore,
-        follower_notifier, status_update_owned,
+        follower_notifier, status_update_owned, config,
     },
     services::public::tests::create_filter_records,
 };
@@ -118,7 +118,7 @@ async fn test_stream_fetch_basic() {
         let topic = format!("test{}", version);
         let test = Replica::new((topic.clone(), 0), 5001, vec![5001]);
         let test_id = test.id.clone();
-        let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+        let replica = LeaderReplicaState::create(test, config(), status_update_owned())
             .await
             .expect("replica");
         ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -451,7 +451,7 @@ async fn test_stream_fetch_filter(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -650,7 +650,7 @@ async fn test_stream_fetch_filter_individual(
     let topic = "testfilter";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -787,7 +787,7 @@ async fn test_stream_filter_error_fetch(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -933,7 +933,7 @@ async fn test_stream_filter_max(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1080,7 +1080,7 @@ async fn test_stream_fetch_map(
     let topic = "test_map_error";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1251,7 +1251,7 @@ async fn test_stream_fetch_map_error(
     let topic = "test_map_error";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1400,7 +1400,7 @@ async fn test_stream_aggregate_fetch_single_batch(
     let topic = "testaggregate";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1558,7 +1558,7 @@ async fn test_stream_aggregate_fetch_multiple_batch(
     let topic = "testaggregatebatch";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1694,7 +1694,7 @@ async fn test_stream_fetch_and_new_request(
     let topic = "test_stream_fetch_and_new_request";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1813,7 +1813,7 @@ async fn test_stream_fetch_invalid_wasm_module(
     let topic = "test_invalid_wasm";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1922,7 +1922,7 @@ async fn test_stream_fetch_array_map(
     let topic = "test_array_map";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2055,7 +2055,7 @@ async fn test_stream_fetch_filter_map(
     let topic = "test_filter_map";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2192,7 +2192,7 @@ async fn test_stream_fetch_filter_with_params(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2406,7 +2406,7 @@ async fn test_stream_fetch_invalid_smartmodule(
     let topic = "test_invalid_smartmodule";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
+    let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2478,7 +2478,7 @@ async fn test_stream_fetch_join(
     let test_left = Replica::new((topic_left.to_owned(), 0), 5001, vec![5001]);
     let test_id_left = test_left.id.clone();
     let replica_left =
-        LeaderReplicaState::create(test_left.clone(), ctx.config(), status_update_owned())
+        LeaderReplicaState::create(test_left.clone(), config(), status_update_owned())
             .await
             .expect("replica");
     ctx.leaders_state()
@@ -2490,7 +2490,7 @@ async fn test_stream_fetch_join(
     let test_right = Replica::new((topic_right.to_owned(), 0), 5001, vec![5001]);
     let test_id_right = test_right.id.clone();
     let replica_right =
-        LeaderReplicaState::create(test_right.clone(), ctx.config(), status_update_owned())
+        LeaderReplicaState::create(test_right.clone(), config(), status_update_owned())
             .await
             .expect("replica");
     replica_localstore().insert(test_right);

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -32,7 +32,10 @@ use fluvio_spu_schema::server::{
 use fluvio_spu_schema::server::stream_fetch::SmartModuleWasmCompressed;
 use fluvio_spu_schema::server::stream_fetch::LegacySmartModulePayload;
 use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest};
-use crate::{core::GlobalContext, services::public::tests::create_filter_records};
+use crate::{
+    core::{GlobalContext, spu_local_store},
+    services::public::tests::create_filter_records,
+};
 use crate::config::SpuConfig;
 use crate::replication::leader::LeaderReplicaState;
 use crate::services::public::create_public_server;
@@ -2461,7 +2464,7 @@ async fn test_stream_fetch_join(
     // wait for stream controller async to start
     sleep(Duration::from_millis(100)).await;
 
-    let spu_localstore = ctx.spu_localstore();
+    let spu_localstore = spu_local_store();
     let spu_spec = SpuSpec::new_public_addr(5001, port, "127.0.0.1".into());
     spu_localstore.insert(spu_spec);
 

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -10,7 +10,6 @@ use fluvio_controlplane_metadata::{
     partition::Replica,
     smartmodule::{SmartModule, SmartModuleWasm, SmartModuleWasmFormat, SmartModuleSpec},
 };
-use fluvio_storage::{FileReplica};
 use flv_util::fixture::ensure_clean_dir;
 use futures_util::{Future, StreamExt};
 
@@ -38,7 +37,7 @@ use crate::{
         initialize,
     },
     services::public::tests::create_filter_records,
-    replication::{ReplicaContext, default_replica_ctx, follower_notifier},
+    replication::{default_replica_ctx, follower_notifier},
 };
 use crate::config::SpuConfig;
 use crate::replication::leader::LeaderReplicaState;
@@ -2425,7 +2424,10 @@ async fn test_stream_fetch_invalid_smartmodule(
     let replica = LeaderReplicaState::create(test, config(), status_update_owned())
         .await
         .expect("replica");
-    default_replica_ctx().leaders_state().insert(test_id, replica.clone()).await;
+    default_replica_ctx()
+        .leaders_state()
+        .insert(test_id, replica.clone())
+        .await;
 
     let stream_request = DefaultStreamFetchRequest {
         topic: topic.to_owned(),
@@ -2496,7 +2498,8 @@ async fn test_stream_fetch_join(
         LeaderReplicaState::create(test_left.clone(), config(), status_update_owned())
             .await
             .expect("replica");
-    default_replica_ctx().leaders_state()
+    default_replica_ctx()
+        .leaders_state()
         .insert(test_id_left, replica_left.clone())
         .await;
 
@@ -2509,7 +2512,8 @@ async fn test_stream_fetch_join(
             .await
             .expect("replica");
     replica_localstore().insert(test_right);
-    default_replica_ctx().leaders_state()
+    default_replica_ctx()
+        .leaders_state()
         .insert(test_id_right, replica_right.clone())
         .await;
 

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -33,7 +33,7 @@ use fluvio_spu_schema::server::stream_fetch::SmartModuleWasmCompressed;
 use fluvio_spu_schema::server::stream_fetch::LegacySmartModulePayload;
 use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest};
 use crate::{
-    core::{GlobalContext, spu_local_store},
+    core::{GlobalContext, spu_local_store, replica_localstore},
     services::public::tests::create_filter_records,
 };
 use crate::config::SpuConfig;
@@ -2482,7 +2482,7 @@ async fn test_stream_fetch_join(
         .insert(test_id_left, replica_left.clone())
         .await;
 
-    ctx.replica_localstore().insert(test_left.clone());
+    replica_localstore().insert(test_left.clone());
     let topic_right = JOIN_RIGHT_TOPIC;
     let test_right = Replica::new((topic_right.to_owned(), 0), 5001, vec![5001]);
     let test_id_right = test_right.id.clone();
@@ -2490,7 +2490,7 @@ async fn test_stream_fetch_join(
         LeaderReplicaState::create(test_right.clone(), ctx.config(), ctx.status_update_owned())
             .await
             .expect("replica");
-    ctx.replica_localstore().insert(test_right);
+    replica_localstore().insert(test_right);
     ctx.leaders_state()
         .insert(test_id_right, replica_right.clone())
         .await;

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -35,7 +35,7 @@ use fluvio_spu_schema::server::stream_fetch::{DefaultStreamFetchRequest};
 use crate::{
     core::{
         GlobalContext, spu_local_store, replica_localstore, smartmodule_localstore,
-        follower_notifier,
+        follower_notifier, status_update_owned,
     },
     services::public::tests::create_filter_records,
 };
@@ -118,7 +118,7 @@ async fn test_stream_fetch_basic() {
         let topic = format!("test{}", version);
         let test = Replica::new((topic.clone(), 0), 5001, vec![5001]);
         let test_id = test.id.clone();
-        let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+        let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
             .await
             .expect("replica");
         ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -451,7 +451,7 @@ async fn test_stream_fetch_filter(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -650,7 +650,7 @@ async fn test_stream_fetch_filter_individual(
     let topic = "testfilter";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -787,7 +787,7 @@ async fn test_stream_filter_error_fetch(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -933,7 +933,7 @@ async fn test_stream_filter_max(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1080,7 +1080,7 @@ async fn test_stream_fetch_map(
     let topic = "test_map_error";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1251,7 +1251,7 @@ async fn test_stream_fetch_map_error(
     let topic = "test_map_error";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1400,7 +1400,7 @@ async fn test_stream_aggregate_fetch_single_batch(
     let topic = "testaggregate";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1558,7 +1558,7 @@ async fn test_stream_aggregate_fetch_multiple_batch(
     let topic = "testaggregatebatch";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1694,7 +1694,7 @@ async fn test_stream_fetch_and_new_request(
     let topic = "test_stream_fetch_and_new_request";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1813,7 +1813,7 @@ async fn test_stream_fetch_invalid_wasm_module(
     let topic = "test_invalid_wasm";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -1922,7 +1922,7 @@ async fn test_stream_fetch_array_map(
     let topic = "test_array_map";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2055,7 +2055,7 @@ async fn test_stream_fetch_filter_map(
     let topic = "test_filter_map";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2192,7 +2192,7 @@ async fn test_stream_fetch_filter_with_params(
 
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2406,7 +2406,7 @@ async fn test_stream_fetch_invalid_smartmodule(
     let topic = "test_invalid_smartmodule";
     let test = Replica::new((topic.to_owned(), 0), 5001, vec![5001]);
     let test_id = test.id.clone();
-    let replica = LeaderReplicaState::create(test, ctx.config(), ctx.status_update_owned())
+    let replica = LeaderReplicaState::create(test, ctx.config(), status_update_owned())
         .await
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
@@ -2478,7 +2478,7 @@ async fn test_stream_fetch_join(
     let test_left = Replica::new((topic_left.to_owned(), 0), 5001, vec![5001]);
     let test_id_left = test_left.id.clone();
     let replica_left =
-        LeaderReplicaState::create(test_left.clone(), ctx.config(), ctx.status_update_owned())
+        LeaderReplicaState::create(test_left.clone(), ctx.config(), status_update_owned())
             .await
             .expect("replica");
     ctx.leaders_state()
@@ -2490,7 +2490,7 @@ async fn test_stream_fetch_join(
     let test_right = Replica::new((topic_right.to_owned(), 0), 5001, vec![5001]);
     let test_id_right = test_right.id.clone();
     let replica_right =
-        LeaderReplicaState::create(test_right.clone(), ctx.config(), ctx.status_update_owned())
+        LeaderReplicaState::create(test_right.clone(), ctx.config(), status_update_owned())
             .await
             .expect("replica");
     replica_localstore().insert(test_right);

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -13,7 +13,7 @@ use fluvio_spu_schema::server::stream_fetch::{
 };
 use futures_util::{StreamExt, stream::BoxStream};
 
-use crate::core::DefaultSharedGlobalContext;
+use crate::core::{DefaultSharedGlobalContext, smartmodule_localstore};
 
 pub struct SmartModuleContext {
     pub smartmodule_instance: Box<dyn SmartModuleInstance>,
@@ -144,7 +144,7 @@ impl SmartModuleContext {
         // then get smartmodule context
         let payload = match invocation.wasm {
             SmartModuleInvocationWasm::Predefined(name) => {
-                if let Some(smartmodule) = ctx.smartmodule_localstore().spec(&name) {
+                if let Some(smartmodule) = smartmodule_localstore().spec(&name) {
                     let wasm = SmartModuleWasmCompressed::Gzip(smartmodule.spec.wasm.payload);
                     LegacySmartModulePayload {
                         wasm,

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -67,7 +67,6 @@ pub fn create_services(
     Option<InternalApiServer>,
     Option<SpuPublicServer>,
 ) {
-
     crate::core::initialize(local_spu.clone());
     let ctx = FileReplicaContext::new_shared_context(local_spu);
 

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -67,6 +67,8 @@ pub fn create_services(
     Option<InternalApiServer>,
     Option<SpuPublicServer>,
 ) {
+
+    crate::core::initialize(local_spu.clone());
     let ctx = FileReplicaContext::new_shared_context(local_spu);
 
     let public_ep_addr = ctx.config().public_socket_addr().to_owned();

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -6,7 +6,6 @@ use crate::services::public::{SpuPublicServer, create_public_server};
 use crate::core::{config};
 use crate::control_plane::ScDispatcher;
 
-
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main_loop(opt: SpuOpt) {
@@ -35,8 +34,7 @@ pub fn main_loop(opt: SpuOpt) {
     info!(uptime = sys.uptime(), "Uptime in secs");
 
     run_block_on(async move {
-        let (internal_server, public_server) =
-            create_services(spu_config.clone(), true, true);
+        let (internal_server, public_server) = create_services(spu_config.clone(), true, true);
 
         let _public_shutdown = internal_server.unwrap().run();
         let _private_shutdown = public_server.unwrap().run();
@@ -59,12 +57,9 @@ pub fn create_services(
     local_spu: SpuConfig,
     internal: bool,
     public: bool,
-) -> (
-    Option<InternalApiServer>,
-    Option<SpuPublicServer>,
-) {
-    crate::core::initialize(local_spu.clone());
-   
+) -> (Option<InternalApiServer>, Option<SpuPublicServer>) {
+    crate::core::initialize(local_spu);
+
     let public_ep_addr = config().public_socket_addr().to_owned();
     let private_ep_addr = config().private_socket_addr().to_owned();
 

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -4,7 +4,7 @@ use crate::config::{SpuConfig, SpuOpt};
 use crate::services::create_internal_server;
 use crate::services::internal::InternalApiServer;
 use crate::services::public::{SpuPublicServer, create_public_server};
-use crate::core::DefaultSharedGlobalContext;
+use crate::core::{DefaultSharedGlobalContext, config};
 use crate::core::GlobalContext;
 use crate::control_plane::ScDispatcher;
 
@@ -70,8 +70,8 @@ pub fn create_services(
     crate::core::initialize(local_spu.clone());
     let ctx = FileReplicaContext::new_shared_context(local_spu);
 
-    let public_ep_addr = ctx.config().public_socket_addr().to_owned();
-    let private_ep_addr = ctx.config().private_socket_addr().to_owned();
+    let public_ep_addr = config().public_socket_addr().to_owned();
+    let private_ep_addr = config().private_socket_addr().to_owned();
 
     let public_server = if public {
         Some(create_public_server(public_ep_addr, ctx.clone()))


### PR DESCRIPTION
`Global Context` in the SPU is carry over from very earlier day of fluvio.  
`Once_cell` is better way to define global variables.
