### PR TITLE
[Merged by Bors] - ci: add labels to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - bot
+      - github_actions
+      - dependencies
+
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
@@ -11,6 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - bot
+      - github_actions
+      - dependencies
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"] # ignore patch updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       interval: "daily"
     labels:
       - bot
-      - github_actions
+      - rust
       - dependencies
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
Add label to dependabot so we ignore the lint check about conventional commit for these PRs

See: 

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels

and

https://github.com/infinyon/fluvio/blob/ba09505ca20de933ec83853a6dc8fbe508d9f802/.github/workflows/lint_pr.yml#L20