### PR TITLE
[Merged by Bors] - docs: Add to instructions for building docker image

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -177,9 +177,9 @@ $ ./k8-util/cluster/reset-kind.sh
 
 ```
 # Install the cross-compilation toolchain needed to compile the docker image (only required the first time)
-# Linux and Windows:
+# x86_64 (most computers):
 $ rustup target add x86_64-unknown-linux-musl
-# macOS:
+# M1 Macs:
 $ rustup target add aarch-unknown-linux-musl
 
 # This will build the Fluvio cli and then create a docker image

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -180,7 +180,7 @@ $ ./k8-util/cluster/reset-kind.sh
 # x86_64 (most computers):
 $ rustup target add x86_64-unknown-linux-musl
 # M1 Macs:
-$ rustup target add aarch-unknown-linux-musl
+$ rustup target add aarch64-unknown-linux-musl
 
 # This will build the Fluvio cli and then create a docker image
 $ make build-cli build_k8_image

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -177,7 +177,10 @@ $ ./k8-util/cluster/reset-kind.sh
 
 ```
 # Install the cross-compilation toolchain needed to compile the docker image (only required the first time)
+# Linux and Windows:
 $ rustup target add x86_64-unknown-linux-musl
+# macOS:
+$ rustup target add aarch-unknown-linux-musl
 
 # This will build the Fluvio cli and then create a docker image
 $ make build-cli build_k8_image

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -176,6 +176,9 @@ $ ./k8-util/cluster/reset-kind.sh
 #### Build Fluvio CLI and docker image from source code
 
 ```
+# Install the cross-compilation toolchain needed to compile the docker image (only required the first time)
+$ rustup target add x86_64-unknown-linux-musl
+
 # This will build the Fluvio cli and then create a docker image
 $ make build-cli build_k8_image
 ```


### PR DESCRIPTION
I ran into a compilation error because I was missing the `x86_64-unknown-linux-musl` target. This adds instructions for installing that.