### PR TITLE
[Merged by Bors] - test: add check for pinned versions

### DIFF
--- a/release-scripts/check-publish-crates.sh
+++ b/release-scripts/check-publish-crates.sh
@@ -43,11 +43,13 @@ function cargo_publish_dry_run_all() {
                 # Multi-line/dedicated dep without version in any line
                 echo "❌ $crate has no version pinned for dependency: $bad_dep"
                 exit 1
-            elif [[ $deps_header -eq 2 ]] && [[ $line =~ ^(.*version.*)$ ]]; then
+            elif [[ $deps_header -eq 2 ]] && \
+                 [[ $line =~ ^(.*version.*)$ ]]; then
                 # Multi-line/location dep has a version defined in a later line
                 deps_header=1
                 bad_dep=""
-            elif [[ $deps_header -eq 1 ]] && [[ $line =~ ^(\[.*\])$ || $line == "" ]]; then
+            elif [[ $deps_header -eq 1 ]] && \
+                 [[ $line =~ ^(\[.*\])$ || $line == "" ]]; then
                 # Leaving a dependencies section
                 deps_header=0
             fi

--- a/release-scripts/check-publish-crates.sh
+++ b/release-scripts/check-publish-crates.sh
@@ -13,6 +13,24 @@ function cargo_publish_dry_run_all() {
     for crate in "${PUBLISH_CRATES[@]}" ; do
         echo "$crate";
         pushd crates/"$crate";
+        
+        # Validate that dependencies with multiple locations defined have
+        # a specific version pinned, to avoid failures at publish time (#2550)
+        deps_header=0
+        while read -r line; do
+            if [[ $line =~ ^\[dependencies\]$ ]]; then
+                # In the dependencies section of Cargo.toml
+                deps_header=1
+            elif [[ $deps_header -eq 1 ]] && [[ $line =~ ^\[.*\]$ ]]; then
+                # Done checking the dependencies section of Cargo.toml
+                break
+            elif [[ $deps_header -eq 1 ]] && [[ $line =~ ^.*\{.*\}.*$ ]] && \
+                 [[ ! $line =~ ^.*version.*$ ]]; then
+                # Dependency has multiple locations defined but no version
+                echo "❌ $crate has no version pinned for a dependency: $line"
+                exit 1
+            fi
+        done < Cargo.toml
 
         # Using `cargo check` instead of `cargo publish --dry-run`
         # because dry-run will only utilize published dependencies.

--- a/release-scripts/check-publish-crates.sh
+++ b/release-scripts/check-publish-crates.sh
@@ -38,7 +38,7 @@ function cargo_publish_dry_run_all() {
                 # Multi-line/dedicated dep without version in first line
                 deps_header=2
                 bad_dep=$line
-            elif [[ $deps_header -eq 2 ]] && [[ $line =~ ^((.*\}.*)())$ ]] && \
+            elif [[ $deps_header -eq 2 ]] && [[ $line =~ ^((.*\}.*)|())$ ]] && \
                  [[ ! $line =~ ^(.*version.*)$ ]]; then
                 # Multi-line/dedicated dep without version in any line
                 echo "❌ $crate has no version pinned for dependency: $bad_dep"


### PR DESCRIPTION
Validate that crates with [multiple locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations) defined have a version specified/pinned.

When replicating the problem described in #2550 (removing the pinned version for `fluvio-package-index` in the `Cargo.toml` for `fluvio-extension-common`), the test now fails with a relevant error message:
![image](https://user-images.githubusercontent.com/11216007/186537222-808fde56-8828-4287-a4f2-b8ac207b260c.png)