### PR TITLE
[Merged by Bors] - `CONTRIBUTING` link to architecture overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Please open an Issue on GitHub with the label `question`.
 
 Follow our [Download Fluvio](https://www.fluvio.io/download/) and the corresponding "Get Started" page to get fluvio up and running.
 
-To learn about the Fluvio Architecture and contribute to Fluvio project, please visit the [Architecture](https://www.fluvio.io/docs/architecture/) section.
+To learn about the Fluvio Architecture and contribute to Fluvio project, please visit the [Architecture](https://www.fluvio.io/docs/architecture/overview/) section.
 
 ## Contributing
 


### PR DESCRIPTION
The [Architecture index page](https://github.com/infinyon/fluvio-website/blob/master/content/docs/architecture/_index.md) is currently blank except for the "Architecture" title. Filling it out probably isn't useful or necessary since the documentation is already indexed in the sidebar, and an overview page exists. So I suggest that the `CONTRIBUTING` page, which currently links to the blank index page, should link instead to the "Overview" page.

The simplest way to do this is as I've proposed here, modifying the link in `CONTRIBUTING.md`. But it might be preferable to set up a redirect from https://www.fluvio.io/docs/architecture/ to https://www.fluvio.io/docs/architecture/overview/.