### PR TITLE
feat(cli): added support of `transform` section for connector config

### DIFF
--- a/crates/fluvio-cli/src/connector/mod.rs
+++ b/crates/fluvio-cli/src/connector/mod.rs
@@ -341,9 +341,9 @@ where
         {
             let json: serde_json::Value =
                 Deserialize::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-            Ok(serde_json::to_string(&json).map_err(|err| {
+            serde_json::to_string(&json).map_err(|err| {
                 serde::de::Error::custom(format!("unable to serialize to json: {}", err))
-            })?)
+            })
         }
     }
     deserializer.deserialize_any(MapAsJsonString)

--- a/crates/fluvio-cli/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-cli/test-data/connectors/full-config.yaml
@@ -27,3 +27,8 @@ producer:
   compression: gzip
 consumer:
   partition: 10
+transform:
+  - uses: infinyon/json-sql
+    invoke: insert
+    with:
+      table: "topic_message"

--- a/crates/fluvio-cli/test-data/connectors/with_transform.yaml
+++ b/crates/fluvio-cli/test-data/connectors/with_transform.yaml
@@ -1,0 +1,22 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+transform:
+  - uses: infinyon/sql
+    invoke: insert
+    with:
+      table: "topic_message"
+      map-columns:
+        "device_id":
+          json-key: "device.device_id"
+          value:
+            type: "int"
+            default: 0
+            required: true
+        "record":
+          json-key: "$"
+          value:
+            type: "jsonb"
+            required: true

--- a/crates/fluvio-cli/test-data/connectors/with_transform_many.yaml
+++ b/crates/fluvio-cli/test-data/connectors/with_transform_many.yaml
@@ -1,0 +1,14 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+transform:
+  - uses: infinyon/json-sql
+    invoke: insert
+    with:
+      table: "topic_message"
+  - uses: infinyon/avro-sql
+    invoke: insert
+    with:
+      table: "topic_message"

--- a/crates/fluvio-smartmodule/src/error.rs
+++ b/crates/fluvio-smartmodule/src/error.rs
@@ -29,6 +29,8 @@ pub enum SmartModuleInternalError {
     UndefinedRightRecord = -55,
     #[error("Init params are not found")]
     InitParamsNotFound = -60,
+    #[error("encountered unknown error Init params parsing")]
+    InitParamsParse = -61,
 }
 
 impl Default for SmartModuleInternalError {


### PR DESCRIPTION
Added `transform` section to Connector config.
The yaml config example:
```yaml
transform:
  - uses: infinyon/json-sql
    invoke: insert
    with:
      table: "topic_message"
      map-columns:
        "device_id":
          json-key: "device.device_id"
          value:
            type: "int"
            default: 0
            required: true
        "record":
          json-key: "$"
          value:
            type: "jsonb"
            required: true
```
Everything in `with` section has a free format depending on the smartmodule receiver, which defined in `uses` section. 