### PR TITLE
[Merged by Bors] - feat(smartmodule): added error for init params failure

### DIFF
--- a/crates/fluvio-smartmodule/src/error.rs
+++ b/crates/fluvio-smartmodule/src/error.rs
@@ -29,6 +29,8 @@ pub enum SmartModuleInternalError {
     UndefinedRightRecord = -55,
     #[error("Init params are not found")]
     InitParamsNotFound = -60,
+    #[error("encountered unknown error in Init params parsing")]
+    InitParamsParse = -61,
 }
 
 impl Default for SmartModuleInternalError {


### PR DESCRIPTION
Added an error for indicating a parsing failure in SmartModule Init method.