### PR TITLE
[Merged by Bors] - fix: Remove dependency on POSIX coreutils #2597 

### DIFF
--- a/crates/fluvio-channel/src/lib.rs
+++ b/crates/fluvio-channel/src/lib.rs
@@ -345,7 +345,8 @@ impl ChannelConfig {
             toml::to_vec(self).map_err(|err| IoError::new(ErrorKind::Other, format!("{}", err)))?;
 
         let mut file = File::create(path_ref)?;
-        file.write_all(&toml)
+        file.write_all(&toml)?;
+        file.sync_all()
     }
 }
 

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -19,7 +19,6 @@ cli = [
     "comfy-table",
     "tar",
     "flate2",
-    "sysinfo",
     "fluvio-extension-common/target",
     "fluvio-sc-schema/use_serde",
 ]
@@ -58,7 +57,7 @@ duct = { version = "0.13", default-features = false, optional = true }
 comfy-table = { version = "6.0.0", default-features = false, optional = true }
 flate2 = { version = "1", default-features = false, optional = true }
 tar = { version = "0.4", default-features = false, optional = true }
-sysinfo = { version = "0.25.0", default-features = false, optional = true }
+sysinfo = { version = "0.25.0", default-features = false}
 portpicker = "0.1.1"
 
 # External Fluvio dependencies

--- a/crates/fluvio-cluster/src/charts/location.rs
+++ b/crates/fluvio-cluster/src/charts/location.rs
@@ -154,6 +154,7 @@ mod inline {
             let contents = inline_file.contents();
             let mut chart_file = File::create(&chart)?;
             chart_file.write_all(contents)?;
+            chart_file.sync_all()?;
 
             // if there is debug env file, output it as well
             if let Ok(debug_dir) = std::env::var("FLV_INLINE_CHART_DIR") {
@@ -166,6 +167,7 @@ mod inline {
                 let mut debug_file = File::create(debug_chart_path.join(inline_file.path()))
                     .expect("chart cant' be created");
                 debug_file.write_all(contents)?;
+                debug_file.sync_all()?;
             }
 
             Ok(chart)

--- a/crates/fluvio-storage/src/checkpoint.rs
+++ b/crates/fluvio-storage/src/checkpoint.rs
@@ -149,7 +149,7 @@ where
         self.offset = pos;
         self.offset.write_to(&mut contents);
         self.file.write_all(&contents).await?;
-        self.file.flush().await?;
+        self.file.sync_all().await?;
         Ok(())
     }
 }

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -237,7 +237,9 @@ impl Config {
             toml::to_vec(self).map_err(|err| IoError::new(ErrorKind::Other, format!("{}", err)))?;
 
         let mut file = File::create(path_ref)?;
-        file.write_all(&toml)
+        file.write_all(&toml)?;
+        // On windows flush() is noop, but sync_all() calls FlushFileBuffers.
+        file.sync_all()
     }
 
     pub fn version(&self) -> &str {


### PR DESCRIPTION
https://github.com/infinyon/fluvio/issues/2597 There are two commits. The first addresses.

> The POSIX `sync` doesn't appear to have an exact equivalent in the Windows API; it appears that Windows only permits syncing [specific filehandles](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers). But it seems preferable to only flush the files pertinent to Fluvio anyway, rather than all system files.

I looked into it and it seems like on Windows `flush()` is noop, but `sync_all()` calls `FlushFileBuffers`.  
I looked around for places where it seems like config files are being written and I added a `sync_all`.  It is expensive though, so you may want to cross-reference and make sure I didn't place it anywhere it doesn't belong.

We can see what is being called on the Windows by tracing back starting with the all-platform `std::fs:sync_all` 
https://github.com/rust-lang/rust/blob/1.63.0/library/std/src/fs.rs#L424

The Windows implementation of `fsync` calls `FlushFileBuffers`  https://github.com/rust-lang/rust/blob/1.63.0/library/std/src/sys/windows/fs.rs#L307

On windows (and unix) `flush()` is a noop. https://github.com/rust-lang/rust/blob/1.63.0/library/std/src/sys/windows/fs.rs#L447

The second commit replaces calls to `pgrep` and `pkill` with the `Sysinfo` library. 
I was able to run the cluster locally using `kind`, start the `--local` deploy, and use `ps` to see the the target procs are both created and killed.
```
$ flvd cluster start --local --develop

# See the local procs
$ ps x |grep fluvio 
1663086 pts/0    Sl     0:00 /home/user/workspace/fluvio/target/debug/fluvio run sc --local
1663100 pts/0    Sl     0:02 /home/user/workspace/fluvio/target/debug/fluvio-run sc --local
1663131 pts/0    Sl     0:00 /home/user/workspace/fluvio/target/debug/fluvio run spu -i 5001 -p 0.0.0.0:9010 -v 0.0.0.0:9011 --log-base-dir /home/user/.fluvio/data
1663145 pts/0    Sl     0:01 /home/user/workspace/fluvio/target/debug/fluvio-run spu -i 5001 -p 0.0.0.0:9010 -v 0.0.0.0:9011 --log-base-dir /home/user/.fluvio/data

# Run cluster delete
$ flvd cluster delete
Uninstalled fluvio kubernetes components
Uninstalled fluvio local components
Objects and secrets have been cleaned up

# See that the procs are killed.
$ ps  |grep -c fluvio
0
```

