### PR TITLE
fix: #1131 - remove `kubectl` for `check` and `delete` operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
  "humantime-serde",
  "indicatif",
  "k8-client",
- "k8-config 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config 2.0.0",
  "k8-types",
  "pretty_assertions",
  "semver 1.0.13",
@@ -1803,7 +1803,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "k8-client",
- "k8-config 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8-config 2.0.0",
  "k8-metadata-client",
  "k8-types",
  "once_cell",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "k8-client"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3239,7 +3239,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "k8-config 2.0.0",
+ "k8-config 2.0.1",
  "k8-diff",
  "k8-metadata-client",
  "k8-types",
@@ -3255,6 +3255,8 @@ dependencies = [
 [[package]]
 name = "k8-config"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609ad86e094cea1739cd6caf462ee5d55b7d8143afc3a49962e35aaac560e7de"
 dependencies = [
  "dirs",
  "hostfile",
@@ -3267,9 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "k8-config"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609ad86e094cea1739cd6caf462ee5d55b7d8143afc3a49962e35aaac560e7de"
+version = "2.0.1"
 dependencies = [
  "dirs",
  "hostfile",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "k8-metadata-client"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "k8-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
  "humantime-serde",
  "indicatif",
  "k8-client",
- "k8-config",
+ "k8-config 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-types",
  "pretty_assertions",
  "semver 1.0.13",
@@ -1803,7 +1803,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "k8-client",
- "k8-config",
+ "k8-config 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k8-metadata-client",
  "k8-types",
  "once_cell",
@@ -3230,8 +3230,6 @@ dependencies = [
 [[package]]
 name = "k8-client"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3807003ac1d68b31c1cccc9dd0375f2c582ac2f8bb8f35ff581a3b8ed52d9b4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3241,7 +3239,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "k8-config",
+ "k8-config 2.0.0",
  "k8-diff",
  "k8-metadata-client",
  "k8-types",
@@ -3251,6 +3249,19 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "k8-config"
+version = "2.0.0"
+dependencies = [
+ "dirs",
+ "hostfile",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "thiserror",
  "tracing",
 ]
 
@@ -3272,19 +3283,14 @@ dependencies = [
 [[package]]
 name = "k8-diff"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef435d912eeb448129d7ae11d3c497691f1f383d2d2ff1dff4365a81c7bd4f3b"
 dependencies = [
  "serde",
  "serde_json",
- "tracing",
 ]
 
 [[package]]
 name = "k8-metadata-client"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b5e61b295e6ba9428a64a6a8aee6b05626e8cbe6d4dbcd00617603a7fc8dfa"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3299,8 +3305,6 @@ dependencies = [
 [[package]]
 name = "k8-types"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7652c08ed3d6416ff52f6fa3214519d4ec293921b3a51a21cbd003f2e74c771e"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,8 @@ codegen-units = 256
 [profile.release-lto]
 inherits = "release"
 lto = true
+
+[patch.crates-io]
+k8-client = { path = "../k8-api/src/k8-client" }
+k8-metadata-client = { path = "../k8-api/src/k8-metadata-client" }
+k8-types = { path = "../k8-api/src/k8-types" }

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -189,16 +189,18 @@ impl ClusterUninstaller {
         use k8_types::app::stateful::StatefulSetSpec;
 
         // delete objects if not removed already
-        let _ = self.remove_custom_objects::<SpuGroupSpec>(ns, None, false).await;
+        // let _ = self.remove_custom_objects::<SpuGroupSpec>(ns, None, false).await; // XXX wrong spec type?
         let _ = self.remove_custom_objects::<SpuSpec>(ns, None, false).await;
         let _ = self.remove_custom_objects::<TopicSpec>(ns, None, false).await;
         let _ = self.remove_finalizers_for_partitions(ns).await;
         let _ = self.remove_custom_objects::<PartitionSpec>(ns, None, true).await;
         let _ = self.remove_custom_objects::<StatefulSetSpec>(ns, None, false).await;
+        /* XXX not sure why there isn't a persistent-volume-claim spec
         let _ =
-            self.remove_custom_objects::<PersistentVolumeClaim>(ns, Some("app=spu"), false);
+            self.remove_custom_objects::<PersistentVolumeClaimSpec>(ns, Some("app=spu"), false);
+            */
         let _ = self.remove_custom_objects::<TableFormatSpec>(ns, None, false); // XXX object type "tables"...?
-        let _ = self.remove_custom_objects::<ManagedConnectorSpec>(ns, None, false);
+        // let _ = self.remove_custom_objects::<ManagedConnectorSpec>(ns, None, false); // XXX wrong spec type?
         let _ = self.remove_custom_objects::<DerivedStreamSpec>(ns, None, false);
         let _ = self.remove_custom_objects::<SmartModuleSpec>(ns, None, false);
 
@@ -241,7 +243,7 @@ impl ClusterUninstaller {
             None
         };
         // Ignore the 'DeleteStatus', as long as the deletion succeeds.
-        client.delete_collection::<S, _>(NameSpace::Named(namespace.to_owned()), selector, options).await?.map(|_|());
+        client.delete_collection::<S>(NameSpace::Named(namespace.to_owned()), selector, options).await?;
         Ok(())
     }
 

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -229,10 +229,6 @@ impl ClusterUninstaller {
         // pb.set_message(format!("Removing {} objects", object_type)); // XXX remove
         let client = k8_client::load_and_share()?;
 
-        let mut meta = InputObjectMeta {
-            namespace: namespace.to_owned(),
-            ..Default::default()
-        };
         let options = if force {
             Some(DeleteOptions {
                 // It appears this is technically stricter than `--force`.


### PR DESCRIPTION
This is a partial implementation of #1131. It relies on https://github.com/infinyon/k8-api/pull/191. It only addresses two uses of `kubectl`, one for checking the k8s server version and one for deleting collections of objects.

I couldn't find valid `Spec` type definitions corresponding to SPU groups, persistent volume claims, or managed connectors. Each of these object types does have a `...Spec` type defined, but they implement `fluvio_stream_model::core::core_model::Spec` rather than the required `k8_types::spec_def::Spec`. I'm guessing that these _should_ implement both `Spec` traits, but I don't feel like I understand this part of the code well enough to dive in yet. Notably, it looks to me like SPU groups _do_ have a valid `Spec`-implementing type, `spg::k8::spec::K8SpuGroupSpec`, but `spg::k8` is a private module and it doesn't look like `K8SpuGroupSpec` is publicly re-exported anywhere.

I also found `TableFormatSpec` rather than `TableSpec`, so I'm not sure that's the right `Spec` to use, either.
