### PR TITLE
[Merged by Bors] - fix: use `wait_time` by default in `StoreContext`

### DIFF
--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2021"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-stream-dispatcher/src/store/mod.rs
+++ b/crates/fluvio-stream-dispatcher/src/store/mod.rs
@@ -223,7 +223,7 @@ mod context {
         where
             S::IndexKey: Display,
         {
-            self.wait_action_with_timeout(key, action, Duration::from_secs(*MAX_WAIT_TIME))
+            self.wait_action_with_timeout(key, action, Duration::from_secs(self.wait_time))
                 .await
         }
 


### PR DESCRIPTION
`fn wait_action` should use `self.wait_time by default instead of `MAX_WAIT_TIME` const.


That way we can use `set_wait_time` and the `StoreContext` will use that as it would be expected. Note that default value of `wait_time` is `MAX_WAIT_TIME`.