### PR TITLE
[Merged by Bors] - fix: provide keys for yaml example

### DIFF
--- a/k8-util/DEVELOP.md
+++ b/k8-util/DEVELOP.md
@@ -8,9 +8,12 @@ Starting to serve on 127.0.0.1:8001
 ```
 Add proxy cluster configuration to ~/.kube/config
 ```
+clusters:
 - cluster:
     server: http://localhost:8001
   name: proxy
+
+contexts:
 - context:
     cluster: proxy
     user: minikube

--- a/k8-util/DEVELOP.md
+++ b/k8-util/DEVELOP.md
@@ -1,13 +1,8 @@
 ## Trace K8 API 
 
-Set up Local Proxy to minikube.  It's easy to confingure for other K8 cluster as well:
+Add proxy cluster configuration to `~/.kube/config`
 
-```
-kubectl proxy
-Starting to serve on 127.0.0.1:8001
-```
-Add proxy cluster configuration to ~/.kube/config
-```
+```yml
 clusters:
 - cluster:
     server: http://localhost:8001
@@ -21,14 +16,21 @@ contexts:
 ```
 
 Change kubectl to use proxy:
-```
+
+```bash
 kubectl config use-context proxy
 ```
 
-Use tcpdump to inspect:
+Set up Local Proxy to minikube.  It's easy to confingure for other K8 cluster
+as well:
+
+```bash
+kubectl proxy
+Starting to serve on 127.0.0.1:8001
 ```
+
+Use `tcpdump` to inspect:
+
+```bash
  sudo tcpdump -i any  port 8001 -A
 ```
-
-
-

--- a/k8-util/DEVELOP.md
+++ b/k8-util/DEVELOP.md
@@ -32,5 +32,5 @@ Starting to serve on 127.0.0.1:8001
 Use `tcpdump` to inspect:
 
 ```bash
- sudo tcpdump -i any  port 8001 -A
+sudo tcpdump -i any  port 8001 -A
 ```

--- a/k8-util/DEVELOP.md
+++ b/k8-util/DEVELOP.md
@@ -1,5 +1,13 @@
 ## Trace K8 API 
 
+Set up Local Proxy to minikube.  It's easy to confingure for other K8 cluster
+as well:
+
+```bash
+kubectl proxy --context=minikube
+Starting to serve on 127.0.0.1:8001
+```
+
 Add proxy cluster configuration to `~/.kube/config`
 
 ```yml
@@ -13,20 +21,6 @@ contexts:
     cluster: proxy
     user: minikube
   name: proxy
-```
-
-Change kubectl to use proxy:
-
-```bash
-kubectl config use-context proxy
-```
-
-Set up Local Proxy to minikube.  It's easy to confingure for other K8 cluster
-as well:
-
-```bash
-kubectl proxy
-Starting to serve on 127.0.0.1:8001
 ```
 
 Use `tcpdump` to inspect:


### PR DESCRIPTION
Following who Fluvio is run locally, I have found that Kubernetes
config is missing the section keys as shown in [this documentation][1]
section. Other fields like `apiVersion` are omitted to avoid conflicts with
version mismatch. Also resorts the documentation to follow dependency
order (we need the config set in order to run `kubectl proxy`)

[1]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#proxy