### PR TITLE
[Merged by Bors] - fix: link to running fluvio cluster using native binaries

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -141,7 +141,7 @@ Kubernetes is currently a requirement for running Fluvio because metadata is sto
 
 
 * Default mode: [Kubernetes-based Fluvio cluster](#kubernetes-based-fluvio-cluster)
-* "local" mode: [OS-process based Fluvio cluster](#os-process-based-fluvio-cluster)
+* `local` mode: [Running Fluvio cluster using native binaries](#running-fluvio-cluster-using-native-binaries)
 
 ### Kubernetes-based Fluvio cluster
 


### PR DESCRIPTION
Replaces a broken link to an out of date section with a new link pointing
to the fluvio native libraries cluster option.