### PR TITLE
feat: `SmartModuleSourceCode` fields public

### DIFF
--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -101,8 +101,8 @@ mod map_init_params {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Encoder, Decoder)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SmartModuleSourceCode {
-    language: SmartModuleSourceCodeLanguage,
-    payload: String,
+    pub language: SmartModuleSourceCodeLanguage,
+    pub payload: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Encoder, Decoder)]


### PR DESCRIPTION
Makes `SmartModuleSourceCode` fields public in order to be visible for API consumers.

---

Currently on [fluvio-client-node/#262][1] an instance of `Metadata<SmartModuleSpec>` must be returned as a JavaScript object for user consumption. The inner `SmartModuleSpec` holds a `SmartModuleSourceCode` instance, which fields are not accesible to external crates.

[1]: https://github.com/infinyon/fluvio-client-node/pull/262
[2]: https://github.com/infinyon/fluvio-client-node/blob/285faa60452d611569e45c9e06a60f5c42f5637a/src/admin.rs#L516-L540