### PR TITLE
[Merged by Bors] - feat: generate SmartModules using SMDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,12 @@ name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arrayvec"
@@ -456,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c0869a9faa81f8bbf8102371105d6d0a7b79167a04c340b04ab16892246a11"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "built"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +606,42 @@ dependencies = [
  "once_cell",
  "rustix",
  "winx",
+]
+
+[[package]]
+name = "cargo-generate"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93123a31e37accdbf3872120a09f11be29b3fa1f148bc552269123d2a2ebb04e"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console",
+ "dialoguer",
+ "dirs",
+ "git-config",
+ "git2",
+ "heck",
+ "home",
+ "ignore",
+ "indicatif 0.16.2",
+ "liquid",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "names",
+ "paste",
+ "path-absolutize",
+ "regex",
+ "remove_dir_all 0.7.0",
+ "rhai",
+ "sanitize-filename",
+ "semver 1.0.14",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -1155,6 +1218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1279,17 @@ checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
+dependencies = [
+ "console",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -1626,7 +1713,7 @@ dependencies = [
  "home",
  "humantime",
  "humantime-serde",
- "indicatif",
+ "indicatif 0.17.1",
  "k8-client",
  "k8-config",
  "k8-types",
@@ -1694,7 +1781,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "include_dir",
- "indicatif",
+ "indicatif 0.17.1",
  "k8-client",
  "k8-config",
  "k8-metadata-client",
@@ -2216,7 +2303,7 @@ dependencies = [
  "futures 0.3.24",
  "futures-lite",
  "hdrhistogram",
- "indicatif",
+ "indicatif 0.17.1",
  "inventory",
  "md-5",
  "nix 0.25.0",
@@ -2598,10 +2685,211 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-actor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8c968681797b2ea4a0ac5fc2c76736b4b614ce41343aaf8bcd1a24900caf7e"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-date",
+ "itoa",
+ "nom",
+ "quick-error",
+]
+
+[[package]]
+name = "git-config"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceaa6a05c22909ab2d35a78028ad0aa2e2e8770823a17e5886b0e14f8a5dbb91"
+dependencies = [
+ "bstr",
+ "dirs",
+ "git-features",
+ "git-glob",
+ "git-path",
+ "git-ref",
+ "git-sec",
+ "libc",
+ "memchr",
+ "nom",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "git-date"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc4a4f5b00b095d9a28f160a1fc4a1ea4aff46c72543e58504e5021a744c859e"
+dependencies = [
+ "bstr",
+ "itoa",
+]
+
+[[package]]
+name = "git-features"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc60803d9fa0a09798c678736158d6c5a2b922e84b0e38d305a73f83955aaa5"
+dependencies = [
+ "git-hash",
+ "libc",
+ "sha1_smol",
+ "walkdir",
+]
+
+[[package]]
+name = "git-glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1879e27b5cb57bee828ea57a1ce9a004e9ae51fa71a2d4fb031175386df246"
+dependencies = [
+ "bitflags",
+ "bstr",
+]
+
+[[package]]
+name = "git-hash"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54f21dd924b7b34e90967091890139afd743a271ed1ebf60bfbe3b65030c4a3"
+dependencies = [
+ "hex",
+ "thiserror",
+]
+
+[[package]]
+name = "git-lock"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff6ad736a93573e219cb9b81c2edb6df0ced812f886e8003df375d96e650e73"
+dependencies = [
+ "fastrand",
+ "git-tempfile",
+ "quick-error",
+]
+
+[[package]]
+name = "git-object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83648a7a66f17b9622c41bb91017bd1355dc9f89dd3b9ae40fe9479bbc4ec63b"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-actor",
+ "git-features",
+ "git-hash",
+ "git-validate",
+ "hex",
+ "itoa",
+ "nom",
+ "quick-error",
+ "smallvec",
+]
+
+[[package]]
+name = "git-path"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ae8522ceaabaeb1c0ac66737cf6805fbf50e6c83b2e8f5fa93dbfe257b6487"
+dependencies = [
+ "bstr",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "git-ref"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fbaa807f037407a66205c3cbdd580853c694ffd1c04ac26d790f1fee28a24f"
+dependencies = [
+ "git-actor",
+ "git-features",
+ "git-hash",
+ "git-lock",
+ "git-object",
+ "git-path",
+ "git-tempfile",
+ "git-validate",
+ "memmap2",
+ "nom",
+ "quick-error",
+]
+
+[[package]]
+name = "git-sec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ab3ba4de24a5cf22d0a2389a537f1a70bb68f13f0394817748f142ebf8e7ff"
+dependencies = [
+ "bitflags",
+ "dirs",
+ "git-path",
+ "libc",
+ "windows",
+]
+
+[[package]]
+name = "git-tempfile"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a7fbcd706c6811bb1206d760b592142eb0a054133bfaf4c1f480017347a067"
+dependencies = [
+ "dashmap",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "git-validate"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af1453adfe6011f0ef71824591b7cdd85850c27bbf3dc8fa855574bed2fe107"
+dependencies = [
+ "bstr",
+ "quick-error",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -2654,7 +2942,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2833,6 +3121,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3172,18 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -3112,6 +3430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3467,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,6 +3517,63 @@ name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "liquid"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f55b9db2305857de3b3ceaa0e75cb51a76aaec793875fe152e139cb8fed05c"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93764837aeac37f14b74708cd88a44d82edfa9ad2b1bcd9a3b4d8802fdd9f98"
+dependencies = [
+ "anymap2",
+ "itertools",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time 0.3.14",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926454345f103e8433833077acdbfaa7c3e4b90788d585a8358f02f0b8f5a469"
+dependencies = [
+ "proc-macro2",
+ "proc-quote",
+ "syn",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd06ca30ae026d26ee7fa8596f9590959e2d3726bc5a0f16a21ac4f050ec83c0"
+dependencies = [
+ "itertools",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time 0.3.14",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "lock_api"
@@ -3250,6 +3663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3711,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "names"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3595,6 +4026,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
+name = "path-absolutize"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3de4b40bd9736640f14c438304c09538159802388febb02c8abaae0846c1f13"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,12 +4237,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-quote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e84ab161de78c915302ca325a19bee6df272800e2ae1a43fe3ef430bab2a100"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "proc-quote-impl",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-quote-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3851,6 +4330,12 @@ checksum = "da9d016ac1e3cfe2ba7fe96c1c27ecb539e05dc4941d6572aedf44d95bbb4782"
 dependencies = [
  "qty-macros",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -4020,6 +4505,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+dependencies = [
+ "libc",
+ "log",
+ "num_cpus",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,6 +4552,32 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rhai"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eec3a3db30f591ece18c66b3db4c9fa26f3bce20bc821c50550968361f84333"
+dependencies = [
+ "ahash 0.8.0",
+ "bitflags",
+ "instant",
+ "num-traits",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36791b0b801159db25130fd46ac726d2751c070260bba3a4a0a3eeb6231bb82a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4116,6 +4640,25 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c502bdb638f1396509467cb0580ef3b29aa2a45c5d43e5d84928241280296c"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "schannel"
@@ -4286,6 +4829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4406,10 +4955,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "smdk"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "cargo-generate",
  "cargo_metadata",
  "clap",
  "convert_case 0.6.0",
@@ -4560,7 +5121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
- "remove_dir_all",
+ "remove_dir_all 0.5.3",
 ]
 
 [[package]]
@@ -4573,7 +5134,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all",
+ "remove_dir_all 0.5.3",
  "winapi",
 ]
 
@@ -4919,6 +5480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-bom"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ec69f541d875b783ca40184d655f2927c95f0bffd486faa83cd3ac3529ec32"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,6 +5588,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -5529,16 +6107,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -5548,10 +6139,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5560,16 +6163,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "winreg"
@@ -5662,6 +6283,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,6 +4983,8 @@ dependencies = [
  "fluvio-smartengine",
  "fluvio-smartmodule",
  "fluvio-smartmodule-package",
+ "include_dir",
+ "tempdir",
  "thiserror",
  "tracing",
 ]

--- a/crates/smdk/Cargo.toml
+++ b/crates/smdk/Cargo.toml
@@ -26,6 +26,7 @@ cargo_metadata = "0.15.0"
 cargo-generate = "0.16.0"
 convert_case = "0.6.0"
 include_dir = "0.7.2"
+tempdir = "0.3.7"
 
 fluvio = { path = "../fluvio", default-features = false }
 fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }

--- a/crates/smdk/Cargo.toml
+++ b/crates/smdk/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { version = "1.0.38" }
 cargo_metadata = "0.15.0"
 cargo-generate = "0.16.0"
 convert_case = "0.6.0"
+include_dir = "0.7.2"
 
 fluvio = { path = "../fluvio", default-features = false }
 fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }

--- a/crates/smdk/Cargo.toml
+++ b/crates/smdk/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "4.0.0"
 thiserror = "1.0.20"
 anyhow = { version = "1.0.38" }
 cargo_metadata = "0.15.0"
+cargo-generate = "0.16.0"
 convert_case = "0.6.0"
 
 fluvio = { path = "../fluvio", default-features = false }

--- a/crates/smdk/src/cmd.rs
+++ b/crates/smdk/src/cmd.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use anyhow::Result;
 
 use crate::build::BuildOpt;
+use crate::generate::GenerateOpt;
 use crate::test::TestOpt;
 use crate::load::LoadOpt;
 
@@ -10,6 +11,8 @@ use crate::load::LoadOpt;
 pub enum SmdkCommand {
     /// Builds SmartModule into WASM
     Build(BuildOpt),
+    /// Generates a new SmartModule Project
+    Generate(GenerateOpt),
     Test(TestOpt),
     Load(LoadOpt),
 }
@@ -17,7 +20,8 @@ pub enum SmdkCommand {
 impl SmdkCommand {
     pub(crate) fn process(self) -> Result<()> {
         match self {
-            Self::Build(opt) => opt.process(),
+            SmdkCommand::Build(opt) => opt.process(),
+            SmdkCommand::Generate(opt) => opt.process(),
             SmdkCommand::Test(opt) => opt.process(),
             SmdkCommand::Load(opt) => opt.process(),
         }

--- a/crates/smdk/src/generate.rs
+++ b/crates/smdk/src/generate.rs
@@ -19,12 +19,24 @@ pub struct GenerateOpt {
     template: Option<String>,
 }
 
+/// Abstraction on different of template options available for generating a
+/// new SmartModule project.
+///
+/// May hold a reference to a `TempDir` which should not be dropped before
+/// accomplishing the project generation procedure.
 struct Template {
     template_path: TemplatePath,
     _temp_dir: Option<TempDir>,
 }
 
 impl Template {
+    /// Extracts inlined directory contents into a temporary directory and
+    /// builds a `TemplatePath` instance with the `path` pointing to the temp
+    /// directory created.
+    ///
+    /// Is important to hold the reference to the `_temp_dir` until generation
+    /// process is completed, otherwise the temp directory will be deleted
+    /// before reaching the generation process.
     fn inline() -> Result<Self> {
         let temp_dir = TempDir::new("smartmodule_template")?;
         let path = temp_dir.path().to_str().unwrap().to_string();

--- a/crates/smdk/src/generate.rs
+++ b/crates/smdk/src/generate.rs
@@ -1,0 +1,52 @@
+use anyhow::{Error, Result};
+use clap::Parser;
+use cargo_generate::{GenerateArgs, TemplatePath, generate};
+
+const GIT_TEMPLATE: &str =
+    "https://github.com/infinyon/fluvio/tree/master/smartmodule/cargo_template";
+
+/// Generate new SmartModule project
+#[derive(Debug, Parser)]
+pub struct GenerateOpt {
+    name: String,
+}
+
+impl GenerateOpt {
+    pub(crate) fn process(&self) -> Result<()> {
+        println!("Generating new SmartModule project: {}", self.name);
+        let template_path = TemplatePath {
+            git: Some(String::from(GIT_TEMPLATE)),
+            auto_path: None,
+            subfolder: None,
+            test: false,
+            branch: None,
+            tag: None,
+            path: None,
+            favorite: None,
+        };
+        let args = GenerateArgs {
+            template_path,
+            name: Some(self.name.clone()),
+            list_favorites: false,
+            force: false,
+            verbose: true,
+            template_values_file: None,
+            silent: false,
+            config: None,
+            vcs: None,
+            lib: false,
+            bin: false,
+            ssh_identity: None,
+            define: Vec::default(),
+            init: false,
+            destination: None,
+            force_git_init: false,
+            allow_commands: false,
+            overwrite: false,
+            other_args: None,
+        };
+
+        generate(args).map_err(Error::from)?;
+        Ok(())
+    }
+}

--- a/crates/smdk/src/generate.rs
+++ b/crates/smdk/src/generate.rs
@@ -112,10 +112,7 @@ impl GenerateOpt {
             other_args: None,
         };
 
-        generate(args).map_err(|err| {
-            println!("An error ocurred generating repo: {:?}", err);
-            Error::from(err)
-        })?;
+        generate(args).map_err(Error::from)?;
 
         Ok(())
     }

--- a/crates/smdk/src/generate.rs
+++ b/crates/smdk/src/generate.rs
@@ -117,3 +117,34 @@ impl GenerateOpt {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::fs::read_dir;
+
+    use super::Template;
+
+    #[test]
+    fn test_inline_template() {
+        let template = Template::inline().unwrap();
+
+        assert!(
+            template._temp_dir.is_some(),
+            "The temporary directory reference is not provided"
+        );
+
+        let temp_dir = template._temp_dir.unwrap();
+        let temp_dir = read_dir(temp_dir.path());
+        assert!(temp_dir.is_ok(), "The temporary directory doesn't exists");
+
+        let mut temp_dir = temp_dir.unwrap();
+        let smart_toml =
+            temp_dir.find(|entry| entry.as_ref().unwrap().file_name().eq("Smart.toml"));
+
+        assert!(
+            smart_toml.is_some(),
+            "Smart.toml from template is not included in temporary dir"
+        );
+        assert!(smart_toml.unwrap().is_ok());
+    }
+}

--- a/crates/smdk/src/generate.rs
+++ b/crates/smdk/src/generate.rs
@@ -2,20 +2,25 @@ use anyhow::{Error, Result};
 use clap::Parser;
 use cargo_generate::{GenerateArgs, TemplatePath, generate};
 
-const GIT_TEMPLATE: &str =
+const DEFAULT_TEMPLATE: &str =
     "https://github.com/infinyon/fluvio/tree/master/smartmodule/cargo_template";
 
 /// Generate new SmartModule project
 #[derive(Debug, Parser)]
 pub struct GenerateOpt {
     name: String,
+    /// Template to generate project from.
+    ///
+    /// Must be a GIT repository
+    #[clap(long, default_value = DEFAULT_TEMPLATE)]
+    temaplate: String,
 }
 
 impl GenerateOpt {
     pub(crate) fn process(&self) -> Result<()> {
         println!("Generating new SmartModule project: {}", self.name);
         let template_path = TemplatePath {
-            git: Some(String::from(GIT_TEMPLATE)),
+            git: Some(String::from(self.temaplate.as_str())),
             auto_path: None,
             subfolder: None,
             test: false,

--- a/crates/smdk/src/main.rs
+++ b/crates/smdk/src/main.rs
@@ -1,5 +1,6 @@
 mod build;
 mod cmd;
+mod generate;
 mod test;
 mod load;
 mod wasm;

--- a/smartmodule/cargo_template/Cargo.toml
+++ b/smartmodule/cargo_template/Cargo.toml
@@ -11,6 +11,11 @@ crate-type = ['cdylib']
 fluvio-smartmodule = { {{smartmodule-version}} }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+{% if smartmodule-init %}
+{% if smartmodule-type == "filter" %}
+once_cell = "1.13.0"
+{% endif %}
+{% endif %}
 
 [profile.release-lto]
 inherits = "release"

--- a/smartmodule/cargo_template/Cargo.toml
+++ b/smartmodule/cargo_template/Cargo.toml
@@ -12,6 +12,6 @@ fluvio-smartmodule = { {{smartmodule-version}} }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-
-[profile.release]
+[profile.release-lto]
+inherits = "release"
 lto = true

--- a/smartmodule/cargo_template/Smart.toml
+++ b/smartmodule/cargo_template/Smart.toml
@@ -6,7 +6,5 @@ package_version = "0.1"
 description = "{{project-description}}"
 license = "Apache-2.0"
 
-
-
 [cargo]
 profile = "release"

--- a/smartmodule/cargo_template/cargo-generate.toml
+++ b/smartmodule/cargo_template/cargo-generate.toml
@@ -13,8 +13,3 @@ default = "filter"
 type = "bool"
 prompt = "Want to use SmartModule init?"
 default = false
-
-[placeholders.smartmodule-params]
-type = "bool"
-prompt = "Want to use SmartModule parameters?"
-default = false

--- a/smartmodule/cargo_template/cargo-generate.toml
+++ b/smartmodule/cargo_template/cargo-generate.toml
@@ -8,7 +8,13 @@ type = "string"
 prompt = "Which type of SmartModule would you like?"
 choices = ["filter", "map", "filter-map", "array-map", "aggregate"]
 default = "filter"
+
 [placeholders.smartmodule-init]
 type = "bool"
 prompt = "Want to use SmartModule init?"
+default = false
+
+[placeholders.smartmodule-params]
+type = "bool"
+prompt = "Want to use SmartModule parameters?"
 default = false

--- a/smartmodule/cargo_template/src/lib.rs
+++ b/smartmodule/cargo_template/src/lib.rs
@@ -82,13 +82,14 @@ pub fn aggregate(accumulator: RecordData, current: &Record{% if smartmodule-para
 #[derive(fluvio_smartmodule::SmartOpt, Default)]
 pub struct SmartModuleOpt;
 {% endif %}
-
 {% if smartmodule-init %}
-
 {% if smartmodule-type == "filter" %}
 static CRITERIA: OnceCell<String> = OnceCell::new();
 
+#[smartmodule(init)]
 fn init(params: SmartModuleExtraParams) -> Result<()> {
+    // You can refer to the example SmartModules in Fluvio's GitHub Repository
+    // https://github.com/infinyon/fluvio/tree/master/smartmodule
     if let Some(key) = params.get("key") {
         CRITERIA.set(key.clone()).map_err(|err| eyre!("failed setting key: {:#?}", err))
     } else {
@@ -102,4 +103,5 @@ fn init(params: SmartModuleExtraParams) -> Result<()> {
     // https://github.com/infinyon/fluvio/tree/master/smartmodule
     todo!("Provide initialization logic for your SmartModule")
 }
+{% endif %}
 {% endif %}

--- a/smartmodule/cargo_template/src/lib.rs
+++ b/smartmodule/cargo_template/src/lib.rs
@@ -1,3 +1,6 @@
+{% if smartmodule-init %}
+use fluvio_smartmodule::dataplane::smartmodule::{SmartModuleExtraParams, SmartModuleInitError};
+{% endif %}
 {% if smartmodule-type == "filter" %}
 use fluvio_smartmodule::{smartmodule, Result, Record};
 
@@ -78,4 +81,25 @@ pub fn aggregate(accumulator: RecordData, current: &Record{% if smartmodule-para
 {% if smartmodule-params  %}
 #[derive(fluvio_smartmodule::SmartOpt, Default)]
 pub struct SmartModuleOpt;
+{% endif %}
+
+{% if smartmodule-init %}
+
+{% if smartmodule-type == "filter" %}
+static CRITERIA: OnceCell<String> = OnceCell::new();
+
+fn init(params: SmartModuleExtraParams) -> Result<()> {
+    if let Some(key) = params.get("key") {
+        CRITERIA.set(key.clone()).map_err(|err| eyre!("failed setting key: {:#?}", err))
+    } else {
+        Err(SmartModuleInitError::MissingParam("key".to_string()).into())
+    }
+}
+{% else %}
+#[smartmodule(init)]
+fn init(params: SmartModuleExtraParams) -> Result<()> {
+    // You can refer to the example SmartModules in Fluvio's GitHub Repository
+    // https://github.com/infinyon/fluvio/tree/master/smartmodule
+    todo!("Provide initialization logic for your SmartModule")
+}
 {% endif %}

--- a/smartmodule/cargo_template/src/lib.rs
+++ b/smartmodule/cargo_template/src/lib.rs
@@ -1,5 +1,9 @@
 {% if smartmodule-init %}
 use fluvio_smartmodule::dataplane::smartmodule::{SmartModuleExtraParams, SmartModuleInitError};
+{% if smartmodule-type == "filter" %}
+use once_cell::sync::OnceCell;
+use fluvio_smartmodule::eyre;
+{% endif %}
 {% endif %}
 {% if smartmodule-type == "filter" %}
 use fluvio_smartmodule::{smartmodule, Result, Record};


### PR DESCRIPTION
Provides support to generate new SmartModules using `cargo-generate` as a libary.

Resolve: https://github.com/infinyon/fluvio/issues/2621

---

## Examples

### Generates SmartModule Projects using `smdk generate`

```bash
➜  Desktop smdk generate log-filter
Generating new SmartModule project: log-filter
🔧   Destination: /Users/esteban/Desktop/log-filter ...
🔧   Generating template ...
✔ 🤷   Which type of SmartModule would you like? · filter
✔ 🤷   Want to use SmartModule parameters? · false
🤷   SmartModule Version [default: git = "https://github.com/infinyon/fluvio.git"]: git = "https://github.com/infinyon/fluvio.git"
✔ 🤷   Want to use SmartModule init? · true
Ignoring: /var/folders/0g/l702s31x2mj4zdlw2_43rpyr0000gn/T/.tmpwQ4Yql/cargo-generate.toml
[1/5]   Done: Cargo.toml
[2/5]   Done: README.md
[3/5]   Done: Smart.toml
[4/5]   Done: src/lib.rs
[5/5]   Done: src
🔧   Moving generated files into: `/Users/esteban/Desktop/log-filter`...
💡   Initializing a fresh Git repository
✨   Done! New project created /Users/esteban/Desktop/log-filter
```

### Generated Project

```bash
total 24
drwxr-xr-x  7 esteban  staff   224B Oct  2 13:54 .
drwx------+ 6 esteban  staff   192B Oct  2 13:54 ..
drwxr-xr-x  9 esteban  staff   288B Oct  2 13:54 .git
-rw-r--r--  1 esteban  staff   358B Oct  2 13:54 Cargo.toml
-rw-r--r--  1 esteban  staff   1.8K Oct  2 13:54 README.md
-rw-r--r--  1 esteban  staff   152B Oct  2 13:54 Smart.toml
drwxr-xr-x  3 esteban  staff    96B Oct  2 13:54 src
```

### Generated `src/lib.rs` with the provided options

```rust
use fluvio_smartmodule::dataplane::smartmodule::{SmartModuleExtraParams, SmartModuleInitError};

use once_cell::sync::OnceCell;
use fluvio_smartmodule::eyre;



use fluvio_smartmodule::{smartmodule, Result, Record};

#[smartmodule(filter)]
pub fn filter(record: &Record) -> Result<bool> {
    let string = std::str::from_utf8(record.value.as_ref())?;
    Ok(string.contains('a'))
}




static CRITERIA: OnceCell<String> = OnceCell::new();

#[smartmodule(init)]
fn init(params: SmartModuleExtraParams) -> Result<()> {
    // You can refer to the example SmartModules in Fluvio's GitHub Repository
    // https://github.com/infinyon/fluvio/tree/master/smartmodule
    if let Some(key) = params.get("key") {
        CRITERIA.set(key.clone()).map_err(|err| eyre!("failed setting key: {:#?}", err))
    } else {
        Err(SmartModuleInitError::MissingParam("key".to_string()).into())
    }
}
```

### Building SMDK Project

```bash
➜  Desktop cd ./log-filter
➜  log-filter git:(main) ✗ smdk build
    Updating git repository `https://github.com/infinyon/fluvio.git`
    Updating crates.io index
   Compiling proc-macro2 v1.0.46
```

### Testing SM Project using `smdk test`

```
➜  log-filter git:(main) ✗ smdk test --params "key=a" --text "testing"
project name: "log-filter"
loading module at: target/wasm32-unknown-unknown/release-lto/log_filter.wasm
0 records outputed
➜  log-filter git:(main) ✗ smdk test --params "key=a" --text "tasty"
project name: "log-filter"
loading module at: target/wasm32-unknown-unknown/release-lto/log_filter.wasm
1 records outputed
tasty
```