### PR TITLE
[Merged by Bors] - fix:  upgrade bug 

### DIFF
--- a/makefiles/check.mk
+++ b/makefiles/check.mk
@@ -65,4 +65,4 @@ run-client-doc-test: install_rustup_target
 
 
 fluvio_run_bin: install_rustup_target
-	cargo build --bin fluvio-run $(RELEASE_FLAG) --target $(TARGET) $(DEBUG_SMARTMODULE_FLAG)
+	cargo build --bin fluvio-run -p fluvio-run $(RELEASE_FLAG) --target $(TARGET) $(DEBUG_SMARTMODULE_FLAG)


### PR DESCRIPTION
With feature related changes, SC is picking up other features result in hyper using Tokio rater than `async-std`.
Fix is to build `fluvio-run` with package specification.

Without this, upgrade may result in hyper panicking due to Tokio not available. 

This could be reason why some of the CI job could be failing.
