### PR TITLE
[Merged by Bors] - feat(smdk):  Loading SmartModule Package Id resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,11 +2260,12 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-rwlock",
  "event-listener",
  "fluvio-future 0.4.2",
+ "fluvio-stream-model",
  "k8-types",
  "once_cell",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "fluvio-stream-model",
  "fluvio-types",
  "flv-util",
+ "lenient_semver",
  "semver 1.0.14",
  "serde",
  "serde_yaml 0.9.13",
@@ -3452,6 +3453,35 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver 1.0.14",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver 1.0.14",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver 1.0.14",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
 name = "fluvio-sc"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-channel",
  "async-lock",
  "async-trait",
@@ -2067,6 +2068,7 @@ dependencies = [
 name = "fluvio-service"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "fluvio-future 0.4.2",
  "fluvio-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ exclude = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+anyhow = { version = "1.0.38" }
 
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -84,7 +84,7 @@ mod output {
     impl TableOutputHandler for ListSmartModules {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["NAME", "PNAME", "GROUP", "VERSION", "STATUS", "SIZE"])
+            Row::from(["NAME", "GROUP", "VERSION", "STATUS", "SIZE"])
         }
 
         /// return errors in string format
@@ -100,11 +100,10 @@ mod output {
                     let _spec = &r.spec;
 
                     Row::from([
-                        Cell::new(&r.name).set_alignment(CellAlignment::Left),
-                        Cell::new(r.spec.pkg_name()).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Right),
-                        Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Right),
-                        Cell::new(&r.status.to_string()).set_alignment(CellAlignment::Right),
+                        Cell::new(&r.spec.logical_name(&r.name)).set_alignment(CellAlignment::Left),
+                        Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Left),
+                        Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Left),
+                        Cell::new(&r.status.to_string()).set_alignment(CellAlignment::Left),
                         Cell::new(&r.spec.wasm.payload.len().to_string())
                             .set_alignment(CellAlignment::Right),
                     ])

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -17,6 +17,9 @@ use crate::Result;
 pub struct ListSmartModuleOpt {
     #[clap(flatten)]
     output: OutputFormat,
+
+    #[clap(long)]
+    filter: Option<String>,
 }
 
 #[async_trait]
@@ -27,7 +30,12 @@ impl ClientCmd for ListSmartModuleOpt {
         fluvio: &Fluvio,
     ) -> Result<()> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SmartModuleSpec, _>(vec![]).await?;
+        let filters = if let Some(filter) = self.filter {
+            vec![filter]
+        } else {
+            vec![]
+        };
+        let lists = admin.list::<SmartModuleSpec, _>(filters).await?;
         output::smartmodules_response_to_output(out, lists, self.output.format)
     }
 }

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -84,7 +84,7 @@ mod output {
     impl TableOutputHandler for ListSmartModules {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["NAME", "GROUP", "VERSION", "STATUS", "SIZE"])
+            Row::from(["NAME", "PNAME", "GROUP", "VERSION", "STATUS", "SIZE"])
         }
 
         /// return errors in string format
@@ -101,8 +101,9 @@ mod output {
 
                     Row::from([
                         Cell::new(&r.name).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.spec.group_label()).set_alignment(CellAlignment::Right),
-                        Cell::new(&r.spec.version_label()).set_alignment(CellAlignment::Right),
+                        Cell::new(r.spec.pkg_name()).set_alignment(CellAlignment::Left),
+                        Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Right),
+                        Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Right),
                         Cell::new(&r.status.to_string()).set_alignment(CellAlignment::Right),
                         Cell::new(&r.spec.wasm.payload.len().to_string())
                             .set_alignment(CellAlignment::Right),

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -26,7 +26,7 @@ bytes = { version = "1" }
 flate2 = { version = "1.0.22", optional = true }
 semver = "1.0"
 toml = { version = "0.5.9", optional = true }
-
+lenient_semver = "0.4.2"
 
 # External Fluvio dependencies
 fluvio-future = { version = "0.4.0" }

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -35,7 +35,7 @@ impl SmartModuleMetadata {
 
     /// id that can be used to identify this smartmodule
     pub fn id(&self) -> String {
-        self.package.qualified_name()
+        self.package.store_key()
     }
 }
 
@@ -58,8 +58,14 @@ pub struct SmartModulePackage {
 }
 
 impl SmartModulePackage {
-    /// return qualified name that can be fit into k8s resource name
-    pub fn qualified_name(&self) -> String {
+    /// convert from qualified name into package info
+    /// qualified name is in format of "group/name@version"
+    pub fn from_qualified_name(fqdn: &str) -> Self {
+        Self::default()
+    }
+
+    /// return key for storing SmartModule in the store
+    pub fn store_key(&self) -> String {
         format!(
             "{}-{}-{}",
             self.name,
@@ -138,7 +144,7 @@ mod package_test {
             repository: None,
         };
 
-        assert_eq!(pkg.qualified_name(), "test-fluvio-0-1-0");
+        assert_eq!(pkg.store_key(), "test-fluvio-0-1-0");
     }
 }
 

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -64,7 +64,7 @@ impl SmartModulePackage {
             "{}-{}-{}",
             self.name,
             self.group,
-            self.version.to_string().replace(".", "-")
+            self.version.to_string().replace('.', "-")
         )
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -83,18 +83,21 @@ pub struct SmartModulePackageKey {
     pub version: Option<FluvioSemVersion>,
 }
 
+const GROUP_SEPARATOR: char = '/';
+const VERSION_SEPARATOR: char = '@';
+
 impl SmartModulePackageKey {
     /// convert from qualified name into package info
     /// qualified name is in format of "group/name@version"
     pub fn from_qualified_name(fqdn: &str) -> Result<Self, SmartModuleKeyError> {
         let mut pkg = Self::default();
-        let mut split = fqdn.split("/");
+        let mut split = fqdn.split(GROUP_SEPARATOR);
         let first_token = split.next().unwrap().to_owned();
         if let Some(name_part) = split.next() {
             // group name is found
             pkg.group = Some(first_token);
             // let split name part
-            let mut version_split = name_part.split("@");
+            let mut version_split = name_part.split(VERSION_SEPARATOR);
             let second_token = version_split.next().unwrap().to_owned();
             if let Some(version_part) = version_split.next() {
                 // version is found

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -33,8 +33,9 @@ impl SmartModuleMetadata {
         Ok(metadata)
     }
 
-    pub fn id(&self) -> &str {
-        &self.package.name
+    /// id that can be used to identify this smartmodule
+    pub fn id(&self) -> String {
+        self.package.qualified_name()
     }
 }
 
@@ -54,6 +55,18 @@ pub struct SmartModulePackage {
     pub description: Option<String>,
     pub license: Option<String>,
     pub repository: Option<String>,
+}
+
+impl SmartModulePackage {
+    /// return qualified name that can be fit into k8s resource name
+    pub fn qualified_name(&self) -> String {
+        format!(
+            "{}-{}-{}",
+            self.name,
+            self.group,
+            self.version.to_string().replace(".", "-")
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,6 +119,26 @@ impl Decoder for FluvioSemVersion {
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
         self.0 = version;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod package_test {
+    use super::{SmartModulePackage, FluvioSemVersion};
+
+    #[test]
+    fn test_pkg_name() {
+        let pkg = SmartModulePackage {
+            name: "test".to_owned(),
+            group: "fluvio".to_owned(),
+            version: FluvioSemVersion::parse("0.1.0").unwrap(),
+            api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
+            description: None,
+            license: None,
+            repository: None,
+        };
+
+        assert_eq!(pkg.qualified_name(), "test-fluvio-0-1-0");
     }
 }
 

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -14,6 +14,13 @@ pub struct SmartModuleSpec {
 }
 
 impl SmartModuleSpec {
+    /// return logical name.  if there is package then use it otherwise return it
+    pub fn logical_name(&self, object_name: &str) -> String {
+        self.meta
+            .as_ref()
+            .map(|meta| meta.package.name.to_string())
+            .unwrap_or_else(|| object_name.to_string())
+    }
     pub fn pkg_name(&self) -> &str {
         self.meta
             .as_ref()

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -14,14 +14,21 @@ pub struct SmartModuleSpec {
 }
 
 impl SmartModuleSpec {
-    pub fn group_label(&self) -> String {
+    pub fn pkg_name(&self) -> &str {
         self.meta
             .as_ref()
-            .map(|meta| meta.package.group.clone())
-            .unwrap_or_else(|| "".to_owned())
+            .map(|meta| &meta.package.name as &str)
+            .unwrap_or_else(|| "")
     }
 
-    pub fn version_label(&self) -> String {
+    pub fn pkg_group(&self) -> &str {
+        self.meta
+            .as_ref()
+            .map(|meta| &meta.package.group as &str)
+            .unwrap_or_else(|| "")
+    }
+
+    pub fn pkg_version(&self) -> String {
         self.meta
             .as_ref()
             .map(|meta| meta.package.version.to_string())

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -40,6 +40,7 @@ semver = "1.0.0"
 once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
 sysinfo = "0.26.0"
+anyhow = { version = "1.0.38" }
 
 # Fluvio dependencies
 fluvio-auth = { path = "../fluvio-auth" }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -40,7 +40,7 @@ semver = "1.0.0"
 once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
 sysinfo = "0.26.0"
-anyhow = { workspace = true }
+anyhow = { version = "1.0.38" }
 
 # Fluvio dependencies
 fluvio-auth = { path = "../fluvio-auth" }
@@ -72,3 +72,4 @@ flv-tls-proxy = { version = "0.6.0" }
 rand = "0.8.4"
 fluvio-future = { version = "0.4.0", features = ["fixture"] }
 flv-util = { version = "0.5.0", features = ["fixture"] }
+fluvio-stream-model = { path = "../fluvio-stream-model", features = ["fixture"] }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -40,7 +40,7 @@ semver = "1.0.0"
 once_cell = "1.5"
 cfg-if = { version = "1.0.0" }
 sysinfo = "0.26.0"
-anyhow = { version = "1.0.38" }
+anyhow = { workspace = true }
 
 # Fluvio dependencies
 fluvio-auth = { path = "../fluvio-auth" }

--- a/crates/fluvio-sc/src/services/private_api/private_server.rs
+++ b/crates/fluvio-sc/src/services/private_api/private_server.rs
@@ -10,10 +10,10 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::time::Duration;
 
-use tracing::error;
-use tracing::{debug, info, trace, instrument};
+use tracing::{debug, info, trace, instrument, error};
 use async_trait::async_trait;
 use futures_util::stream::Stream;
+use anyhow::Result;
 
 use fluvio_types::SpuId;
 use fluvio_protocol::api::RequestMessage;
@@ -54,7 +54,7 @@ impl FluvioService for ScInternalService {
         context: SharedContext,
         socket: FluvioSocket,
         _connection: ConnectInfo,
-    ) -> Result<(), SocketError> {
+    ) -> Result<()> {
         let (mut sink, mut stream) = socket.split();
         let mut api_stream = stream.api_stream::<InternalScRequest, InternalScKey>();
 

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -1,6 +1,5 @@
-use std::io::Error as IoError;
-
 use tracing::{debug, instrument};
+use anyhow::Result;
 
 use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_sc_schema::{
@@ -9,12 +8,13 @@ use fluvio_sc_schema::{
 use fluvio_auth::{AuthContext};
 
 use crate::services::auth::AuthServiceContext;
+use super::smartmodule::fetch_smart_modules;
 
 #[instrument(skip(request, auth_ctx))]
 pub async fn handle_list_request<AC: AuthContext>(
     request: RequestMessage<ObjectApiListRequest>,
     auth_ctx: &AuthServiceContext<AC>,
-) -> Result<ResponseMessage<ObjectApiListResponse>, IoError> {
+) -> Result<ResponseMessage<ObjectApiListResponse>> {
     let (header, req) = request.get_header_request();
     debug!("list request: {:#?}", req);
 
@@ -43,7 +43,7 @@ pub async fn handle_list_request<AC: AuthContext>(
             .await?,
         ),
         ObjectApiListRequest::SmartModule(req) => ObjectApiListResponse::SmartModule(
-            fetch::handle_fetch_request(
+            fetch_smart_modules(
                 req.name_filters,
                 auth_ctx,
                 auth_ctx.global_ctx.smartmodules(),

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -18,6 +18,8 @@ pub async fn handle_list_request<AC: AuthContext>(
     let (header, req) = request.get_header_request();
     debug!("list request: {:#?}", req);
 
+    println!("List Request {:#?}", req);
+
     let response = match req {
         ObjectApiListRequest::Topic(req) => ObjectApiListResponse::Topic(
             super::topic::handle_fetch_topics_request(req.name_filters, auth_ctx).await?,

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -45,7 +45,7 @@ pub async fn handle_list_request<AC: AuthContext>(
         ObjectApiListRequest::SmartModule(req) => ObjectApiListResponse::SmartModule(
             fetch_smart_modules(
                 req.name_filters,
-                auth_ctx,
+                &auth_ctx.auth,
                 auth_ctx.global_ctx.smartmodules(),
             )
             .await?,

--- a/crates/fluvio-sc/src/services/public_api/public_server.rs
+++ b/crates/fluvio-sc/src/services/public_api/public_server.rs
@@ -11,18 +11,18 @@ use std::marker::PhantomData;
 use std::fmt::Debug;
 use std::io::Error as IoError;
 
-use fluvio_service::ConnectInfo;
 use tracing::debug;
 use tracing::instrument;
 use async_trait::async_trait;
+use anyhow::Result;
 
+use fluvio_service::ConnectInfo;
 use fluvio_types::event::StickyEvent;
 use fluvio_auth::Authorization;
 //use fluvio_service::aAuthorization;
 use fluvio_service::api_loop;
 use fluvio_service::call_service;
 use fluvio_socket::FluvioSocket;
-use fluvio_socket::SocketError;
 use fluvio_service::FluvioService;
 use fluvio_sc_schema::AdminPublicApiKey;
 use fluvio_sc_schema::AdminPublicDecodedRequest;
@@ -55,7 +55,7 @@ where
         ctx: Self::Context,
         mut socket: FluvioSocket,
         _connection: ConnectInfo,
-    ) -> Result<(), SocketError> {
+    ) -> Result<()> {
         let auth_context = ctx
             .auth
             .create_auth_context(&mut socket)

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -48,6 +48,7 @@ where
     let objects: Vec<Metadata<SmartModuleSpec>> = reader
         .values()
         .filter_map(|value| {
+            println!("value: {:#?}", value);
             if sm_keys.is_empty()
                 || sm_keys
                     .iter()
@@ -60,8 +61,7 @@ where
                     .count()
                     > 0
             {
-                let list_obj = AdminSpec::convert_from(value);
-                Some(list_obj)
+                Some(AdminSpec::convert_from(value))
             } else {
                 None
             }
@@ -106,6 +106,9 @@ mod test {
             api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
             ..Default::default()
         };
+
+        assert_ne!(pkg.store_key(),"sm2");
+
         let test_data = vec![
             SmartModuleTest::with_spec("sm1", SmartModuleSpec::default()),
             SmartModuleTest::with_spec(
@@ -139,6 +142,25 @@ mod test {
                 .inner()
                 .len(),
             0
+        );
+
+        assert_eq!(
+            fetch_smart_modules(vec!["sm1".to_owned()], &root_auth, &sm_ctx)
+                .await
+                .expect("search")
+                .inner()
+                .len(),
+            1
+        );
+
+        // no matching
+        assert_eq!(
+            fetch_smart_modules(vec!["sm2".to_owned()], &root_auth, &sm_ctx)
+                .await
+                .expect("search")
+                .inner()
+                .len(),
+            1
         );
     }
 }

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -107,7 +107,7 @@ mod test {
             ..Default::default()
         };
 
-        assert_ne!(pkg.store_key(),"sm2");
+        assert_ne!(pkg.store_key(), "sm2");
 
         let test_data = vec![
             SmartModuleTest::with_spec("sm1", SmartModuleSpec::default()),

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -1,0 +1,66 @@
+use std::io::{Error, ErrorKind};
+
+use fluvio_controlplane_metadata::core::Spec;
+use fluvio_controlplane_metadata::smartmodule::SmartModuleSpec;
+use fluvio_sc_schema::AdminSpec;
+use fluvio_stream_dispatcher::store::StoreContext;
+use tracing::{debug, trace, instrument};
+
+use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata};
+use fluvio_auth::{AuthContext, TypeAction};
+use fluvio_controlplane_metadata::store::{KeyFilter};
+use fluvio_controlplane_metadata::extended::SpecExt;
+
+use crate::services::auth::AuthServiceContext;
+
+#[instrument(skip(filters, auth_ctx))]
+pub async fn handle_fetch_request<AC: AuthContext>(
+    filters: Vec<NameFilter>,
+    auth_ctx: &AuthServiceContext<AC>,
+    object_ctx: &StoreContext<SmartModuleSpec>,
+) -> Result<ListResponse<SmartModuleSpec>, Error>
+where
+    AC: AuthContext,
+{
+    debug!("fetching list of smart modules");
+
+    if let Ok(authorized) = auth_ctx
+        .auth
+        .allow_type_action(SmartModuleSpec::OBJECT_TYPE, TypeAction::Read)
+        .await
+    {
+        if !authorized {
+            debug!(ty = %SmartModuleSpec::LABEL, "authorization failed");
+            // If permission denied, return empty list;
+            return Ok(ListResponse::new(vec![]));
+        }
+    } else {
+        return Err(Error::new(ErrorKind::Interrupted, "authorization io error"));
+    }
+
+    // convert filter into key filter
+    //let sm_key_filter = filters.into_iter().map(|filter| filter.into()).collect::<Vec<KeyFilter>>();
+
+    let reader = object_ctx.store().read().await;
+    let objects: Vec<Metadata<SmartModuleSpec>> = reader
+        .values()
+        .filter_map(|value| {
+            if filters
+                .iter()
+                .filter(|filter_value| filter_value.filter(value.key().as_ref()))
+                .count()
+                > 0
+            {
+                let list_obj = AdminSpec::convert_from(value);
+                Some(list_obj)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    debug!(fetch_items = objects.len(),);
+    trace!("fetch {:#?}", objects);
+
+    Ok(ListResponse::new(objects))
+}

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/mod.rs
@@ -1,5 +1,7 @@
 mod create;
 mod delete;
+mod list;
 
 pub use create::*;
 pub use delete::*;
+pub use list::*;

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/mod.rs
@@ -2,6 +2,6 @@ mod create;
 mod delete;
 mod list;
 
-pub use create::*;
-pub use delete::*;
-pub use list::*;
+pub(crate) use create::*;
+pub(crate) use delete::*;
+pub(crate) use list::*;

--- a/crates/fluvio-service/Cargo.toml
+++ b/crates/fluvio-service/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.18"
 async-trait = "0.1.21"
 pin-utils = "0.1.0-alpha.4"
 tokio = { version = "1.3.0", features = ["macros"] }
+anyhow = { workspace = true }
 
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }

--- a/crates/fluvio-service/src/server.rs
+++ b/crates/fluvio-service/src/server.rs
@@ -8,12 +8,13 @@ use std::os::unix::io::AsRawFd;
 use futures_util::StreamExt;
 use async_trait::async_trait;
 use tracing::{instrument, debug, error, info};
+use anyhow::Result;
 
 use fluvio_future::net::{TcpListener, TcpStream};
 use fluvio_future::task::spawn;
 use fluvio_protocol::api::ApiMessage;
 use fluvio_protocol::Decoder as FluvioDecoder;
-use fluvio_socket::{FluvioSocket, SocketError};
+use fluvio_socket::{FluvioSocket};
 use fluvio_types::event::StickyEvent;
 
 pub struct ConnectInfo {
@@ -40,7 +41,7 @@ pub trait FluvioService {
         context: Self::Context,
         socket: FluvioSocket,
         connection: ConnectInfo,
-    ) -> Result<(), SocketError>;
+    ) -> Result<()>;
 }
 
 /// Transform Service into Futures 01

--- a/crates/fluvio-service/src/test_request.rs
+++ b/crates/fluvio-service/src/test_request.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
+use anyhow::Result;
 
 use fluvio_protocol::api::{
     api_decode, ApiMessage, Request, RequestHeader, RequestMessage, ResponseMessage,
@@ -14,7 +15,6 @@ use fluvio_protocol::bytes::Buf;
 use fluvio_protocol::derive::Decoder;
 use fluvio_protocol::derive::Encoder;
 
-use fluvio_socket::SocketError;
 use fluvio_socket::FluvioSocket;
 
 use crate::api_loop;
@@ -138,7 +138,7 @@ impl FluvioService for TestService {
         _context: Self::Context,
         socket: FluvioSocket,
         _connection: ConnectInfo,
-    ) -> Result<(), SocketError> {
+    ) -> Result<()> {
         let (mut sink, mut stream) = socket.split();
         let mut api_stream = stream.api_stream::<TestApiRequest, TestKafkaApiEnum>();
 

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 cfg-if = "1.0.0"
-anyhow = "1.0.38"
+anyhow = { workspace = true }
 tracing = "0.1.27"
 bytes = "1.0.0"
 clap = { version = "3.1.8", features = ["std", "derive", "env"], default-features = false }
@@ -40,6 +40,7 @@ thiserror = "1"
 once_cell = "1.5"
 sysinfo = "0.26.0"
 nix = { version = "0.25"}
+
 
 # Fluvio dependencies
 fluvio = { path = "../fluvio" }

--- a/crates/fluvio-spu/src/core/store.rs
+++ b/crates/fluvio-spu/src/core/store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 //
 //  Peer Spus (all spus in the system, received from Sc)
 //      >>> define what each element of SPU is used for
@@ -5,6 +6,7 @@
 use std::sync::Arc;
 use std::fmt::Display;
 use std::fmt::Debug;
+use std::sync::RwLockReadGuard;
 
 use tracing::trace;
 use tracing::debug;
@@ -100,6 +102,10 @@ where
 
     pub fn delete(&self, id: &S::Key) -> Option<S> {
         self.0.write().remove(id)
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<BTreeMap<S::Key, S>> {
+        self.0.read()
     }
 
     #[allow(dead_code)]
@@ -238,7 +244,6 @@ where
         actions
     }
 
-    #[allow(unused)]
     pub fn spec(&self, key: &S::Key) -> Option<S> {
         self.0.read().get(key).cloned()
     }

--- a/crates/fluvio-spu/src/services/internal/service_impl.rs
+++ b/crates/fluvio-spu/src/services/internal/service_impl.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fluvio_service::ConnectInfo;
-use tracing::instrument;
-use tracing::{debug, warn};
+use tracing::{debug, warn, instrument};
+use anyhow::Result;
 
-use fluvio_service::{wait_for_request, FluvioService};
-use fluvio_socket::{FluvioSocket, SocketError};
+use fluvio_service::{wait_for_request, FluvioService, ConnectInfo};
+use fluvio_socket::FluvioSocket;
 
 use crate::core::DefaultSharedGlobalContext;
 use crate::replication::leader::FollowerHandler;
@@ -34,7 +33,7 @@ impl FluvioService for InternalService {
         ctx: DefaultSharedGlobalContext,
         socket: FluvioSocket,
         _connection: ConnectInfo,
-    ) -> Result<(), SocketError> {
+    ) -> Result<()> {
         let (mut sink, mut stream) = socket.split();
         let mut api_stream = stream.api_stream::<SpuPeerRequest, SPUPeerApiEnum>();
 

--- a/crates/fluvio-spu/src/services/public/mod.rs
+++ b/crates/fluvio-spu/src/services/public/mod.rs
@@ -13,8 +13,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{info, debug, trace, instrument};
 use futures_util::StreamExt;
+use anyhow::Result;
 
-use fluvio_socket::{FluvioSocket, SocketError};
+use fluvio_socket::FluvioSocket;
 use fluvio_service::{FluvioApiServer, FluvioService, ConnectInfo, call_service};
 use fluvio_spu_schema::server::SpuServerRequest;
 use fluvio_spu_schema::server::SpuServerApiKey;
@@ -64,7 +65,7 @@ impl FluvioService for PublicService {
         context: DefaultSharedGlobalContext,
         socket: FluvioSocket,
         _connection: ConnectInfo,
-    ) -> Result<(), SocketError> {
+    ) -> Result<()> {
         let (sink, mut stream) = socket.split();
 
         let mut shared_sink = sink.as_shared();

--- a/crates/fluvio-spu/src/smartengine/context.rs
+++ b/crates/fluvio-spu/src/smartengine/context.rs
@@ -144,7 +144,13 @@ impl SmartModuleContext {
         // then get smartmodule context
         let payload = match invocation.wasm {
             SmartModuleInvocationWasm::Predefined(name) => {
-                if let Some(smartmodule) = ctx.smartmodule_localstore().spec(&name) {
+                if let Some(smartmodule) = ctx
+                    .smartmodule_localstore()
+                    .find_by_pk_key(&name)
+                    .map_err(|_err| ErrorCode::SmartModuleNotFound {
+                        name: name.to_owned(),
+                    })?
+                {
                     let wasm = SmartModuleWasmCompressed::Gzip(smartmodule.spec.wasm.payload);
                     LegacySmartModulePayload {
                         wasm,

--- a/crates/fluvio-spu/src/smartengine/context.rs
+++ b/crates/fluvio-spu/src/smartengine/context.rs
@@ -147,8 +147,8 @@ impl SmartModuleContext {
                 if let Some(smartmodule) = ctx
                     .smartmodule_localstore()
                     .find_by_pk_key(&name)
-                    .map_err(|_err| ErrorCode::SmartModuleNotFound {
-                        name: name.to_owned(),
+                    .map_err(|err| {
+                        ErrorCode::Other(format!("error parsing SmartModule name: {}", err))
                     })?
                 {
                     let wasm = SmartModuleWasmCompressed::Gzip(smartmodule.spec.wasm.payload);

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2021"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 [features]
 use_serde = ["serde"]
 k8 = ["use_serde", "k8-types"]
+fixture = []
 
 [dependencies]
 tracing = "0.1.19"
@@ -28,3 +29,4 @@ k8-types = { version = "0.6.0", optional = true }
 [dev-dependencies]
 tokio = { version = "1.3.0", features = ["macros"] }
 fluvio-future = { version = "0.4.0", features = ["fixture"] }
+fluvio-stream-model = { path = ".", features = ["fixture"] }

--- a/crates/fluvio-stream-model/src/epoch/dual_epoch_map.rs
+++ b/crates/fluvio-stream-model/src/epoch/dual_epoch_map.rs
@@ -400,7 +400,7 @@ where
 #[cfg(test)]
 mod test {
 
-    use crate::test_fixture::{DefaultTest, TestEpochMap};
+    use crate::fixture::{DefaultTest, TestEpochMap};
 
     use super::ChangeFlag;
 

--- a/crates/fluvio-stream-model/src/lib.rs
+++ b/crates/fluvio-stream-model/src/lib.rs
@@ -6,8 +6,8 @@ pub mod store;
 #[cfg(feature = "k8")]
 pub use k8_types;
 
-#[cfg(test)]
-pub(crate) mod test_fixture {
+#[cfg(feature = "fixture")]
+pub mod fixture {
 
     use crate::core::{Spec, Status, MetadataItem, MetadataContext, MetadataRevExtension};
     use crate::store::MetadataStoreObject;

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -559,7 +559,7 @@ mod listener {
 mod test {
 
     use crate::store::actions::LSUpdate;
-    use crate::test_fixture::{TestSpec, TestStatus, DefaultTest, TestMeta};
+    use crate::fixture::{TestSpec, TestStatus, DefaultTest, TestMeta};
 
     use super::LocalStore;
 
@@ -672,7 +672,7 @@ mod test_notify {
 
     use crate::store::actions::LSUpdate;
     use crate::store::event::SimpleEvent;
-    use crate::test_fixture::{TestSpec, DefaultTest, TestMeta};
+    use crate::fixture::{TestSpec, DefaultTest, TestMeta};
 
     use super::LocalStore;
 

--- a/crates/smdk/src/load.rs
+++ b/crates/smdk/src/load.rs
@@ -43,7 +43,7 @@ impl LoadOpt {
     }
 
     async fn create(&self, config: FluvioConfig, spec: SmartModuleSpec, id: String) -> Result<()> {
-        println!("trying connectiong to fluvio...");
+        println!("trying connectiong to fluvio {}", config.endpoint);
         let fluvio = Fluvio::connect_with_config(&config).await?;
 
         let admin = fluvio.admin().await;

--- a/crates/smdk/src/load.rs
+++ b/crates/smdk/src/load.rs
@@ -26,7 +26,7 @@ impl LoadOpt {
         let pkg_metadata = SmartModuleMetadata::from_toml("./SmartModule.toml")?;
         println!("Using SmartModule package: {}", pkg_metadata.package.name);
 
-        let sm_id = pkg_metadata.id().to_string();
+        let sm_id = pkg_metadata.id();
         let raw_bytes = self.wasm.load_raw_wasm_file()?;
         let spec = SmartModuleSpec {
             meta: Some(pkg_metadata),


### PR DESCRIPTION
Wrapping up SmartModule load: #2631.

* Implemented search of SmartModule by partial matching against the name, group, and version.
* Add `--filter` option for SmartModule List
* Look up SmartModule by key in the SPU

```
$ fluvio  consume test -B  --smartmodule infinyon/regex@0.2 -e regex="A"
```