### PR TITLE
[Merged by Bors] - ci: Remove makefile env var check in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,8 @@ jobs:
         run: make download-fluvio-release
 
       - name: Publish artifacts
+        env:
+          FLUVIO_BIN: ~/.fluvio/bin/fluvio
         run: make publish-artifacts-dev
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
@@ -103,6 +105,8 @@ jobs:
           make curl-install-fluvio
 
       - name: Bump latest version of Fluvio CLI with fluvio-packages
+        env:
+          FLUVIO_BIN: ~/.fluvio/bin/fluvio
         run: make bump-fluvio-latest
 
       - name: Slack Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,8 @@ jobs:
 
       - name: Publish artifacts
         if: ${{ steps.check_fluvio.outcome == 'failure' }}
+        env:
+          FLUVIO_BIN: ~/.fluvio/bin/fluvio
         run: |
           make publish-artifacts-stable
 

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -40,11 +40,11 @@ GH_TOKEN?=
 GH_RELEASE_TAG?=dev
 
 # Allow using local `gh` auth token for local testing
-ifeq ($(CI), true)
-ifndef GH_TOKEN
-$(error GH_TOKEN required in CI)
-endif
-endif
+#ifeq ($(CI), true)
+#ifndef GH_TOKEN
+#$(error GH_TOKEN required in CI)
+#endif
+#endif
 
 DIRNAME?=
 TARGET?=


### PR DESCRIPTION
Also make sure the correct Fluvio binary is used in CI for packaging