### PR TITLE
[Merged by Bors] - ci: enable fast fail for smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -864,7 +864,7 @@ jobs:
     #if: ${{ false }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
Hopefully this will fix CI step `done` not checking