### PR TITLE
[Merged by Bors] - fix(smart module): Fix deleting SmartModule with package

### DIFF
--- a/crates/fluvio-cli/src/client/smartmodule/download.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/download.rs
@@ -108,7 +108,7 @@ async fn download_cluster(config: FluvioConfig, pkgfile: &str) -> Result<()> {
         .map_err(|_| CliError::PackageError("package missing {sm_wasm_file}".into()))?;
     let sm_wasm = SmartModuleWasm::from_raw_wasm_bytes(&sm_wasm_bytes)?;
 
-    let sm_id = sm_meta.id();
+    let sm_id = sm_meta.store_id();
     let spec = SmartModuleSpec {
         meta: Some(sm_meta),
         wasm: sm_wasm,

--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -7,7 +7,7 @@ use crate::Result;
 use fluvio_cli_common::error::CliError as CommonCliError;
 use fluvio_cli_common::install::{
     fetch_latest_version, fetch_package_file, fluvio_extensions_dir, install_bin, install_println,
-    fluvio_bin_dir,
+    fluvio_base_dir,
 };
 use crate::install::update::{
     check_update_required, prompt_required_update, check_update_available, prompt_available_update,

--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -7,7 +7,7 @@ use crate::Result;
 use fluvio_cli_common::error::CliError as CommonCliError;
 use fluvio_cli_common::install::{
     fetch_latest_version, fetch_package_file, fluvio_extensions_dir, install_bin, install_println,
-    fluvio_base_dir,
+    fluvio_bin_dir,
 };
 use crate::install::update::{
     check_update_required, prompt_required_update, check_update_available, prompt_available_update,

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -165,7 +165,7 @@ impl SmartModulePackageKey {
         };
 
         let version_id = if let Some(version) = &self.version {
-            format!("-{}", version.to_string())
+            format!("-{}", version)
         } else {
             "".to_owned()
         };

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -45,8 +45,8 @@ impl SmartModuleMetadata {
     }
 
     /// id that can be used to identify this smartmodule
-    pub fn id(&self) -> String {
-        self.package.store_key()
+    pub fn store_id(&self) -> String {
+        self.package.store_id()
     }
 }
 
@@ -69,14 +69,14 @@ pub struct SmartModulePackage {
 }
 
 impl SmartModulePackage {
-    /// return key for storing SmartModule in the store
-    pub fn store_key(&self) -> String {
-        format!(
-            "{}-{}-{}",
-            self.name,
-            self.group,
-            self.version.to_string().replace('.', "-")
-        )
+    /// id that can be used to identify this smartmodule
+    pub fn store_id(&self) -> String {
+        (SmartModulePackageKey {
+            name: self.name.clone(),
+            group: Some(self.group.clone()),
+            version: Some(self.version.clone()),
+        })
+        .store_id()
     }
 }
 
@@ -155,6 +155,23 @@ impl SmartModulePackageKey {
             self.name == name
         }
     }
+
+    /// return key for storing SmartModule in the store
+    pub fn store_id(&self) -> String {
+        let group_id = if let Some(package) = &self.group {
+            format!("-{}", package)
+        } else {
+            "".to_owned()
+        };
+
+        let version_id = if let Some(version) = &self.version {
+            format!("-{}", version.to_string())
+        } else {
+            "".to_owned()
+        };
+
+        format!("{}{}{}", self.name, group_id, version_id)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -214,6 +231,9 @@ impl Decoder for FluvioSemVersion {
     }
 }
 
+/// Convert from name into something that can be used as key in the store
+/// For now, we respect
+
 #[cfg(test)]
 mod package_test {
     use crate::smartmodule::SmartModulePackageKey;
@@ -232,7 +252,7 @@ mod package_test {
             repository: None,
         };
 
-        assert_eq!(pkg.store_key(), "test-fluvio-0-1-0");
+        assert_eq!(pkg.store_id(), "test-fluvio-0.1.0");
     }
 
     #[test]
@@ -282,18 +302,18 @@ mod package_test {
             api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
             ..Default::default()
         };
-        assert!(key.is_match(&valid_pkg.store_key(), Some(&valid_pkg)));
+        assert!(key.is_match(&valid_pkg.store_id(), Some(&valid_pkg)));
         assert!(
             SmartModulePackageKey::from_qualified_name("mygroup/module1")
                 .expect("parse")
-                .is_match(&valid_pkg.store_key(), Some(&valid_pkg))
+                .is_match(&valid_pkg.store_id(), Some(&valid_pkg))
         );
         assert!(SmartModulePackageKey::from_qualified_name("module1")
             .expect("parse")
-            .is_match(&valid_pkg.store_key(), Some(&valid_pkg)));
+            .is_match(&valid_pkg.store_id(), Some(&valid_pkg)));
         assert!(!SmartModulePackageKey::from_qualified_name("module2")
             .expect("parse")
-            .is_match(&valid_pkg.store_key(), Some(&valid_pkg)));
+            .is_match(&valid_pkg.store_id(), Some(&valid_pkg)));
 
         let in_valid_pkg = SmartModulePackage {
             name: "module2".to_owned(),
@@ -302,11 +322,27 @@ mod package_test {
             api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
             ..Default::default()
         };
-        assert!(!key.is_match(&in_valid_pkg.store_key(), Some(&in_valid_pkg)));
+        assert!(!key.is_match(&in_valid_pkg.store_id(), Some(&in_valid_pkg)));
 
         assert!(SmartModulePackageKey::from_qualified_name("module1")
             .expect("parse")
             .is_match("module1", None));
+    }
+
+    #[test]
+    fn test_pk_key_store_id() {
+        assert_eq!(
+            SmartModulePackageKey::from_qualified_name("module1")
+                .expect("parse")
+                .store_id(),
+            "module1"
+        );
+        assert_eq!(
+            SmartModulePackageKey::from_qualified_name("mygroup/module1@0.1")
+                .expect("parse")
+                .store_id(),
+            "module1-mygroup-0.1.0"
+        );
     }
 }
 

--- a/crates/fluvio-sc/src/services/public_api/delete.rs
+++ b/crates/fluvio-sc/src/services/public_api/delete.rs
@@ -4,9 +4,8 @@
 //! Delete topic request handler. Lookup topic in local metadata, grab its K8 context
 //! and send K8 a delete message.
 //!
-use std::io::Error;
-
 use tracing::{instrument, trace, debug};
+use anyhow::Result;
 
 use fluvio_protocol::link::ErrorCode;
 use fluvio_protocol::api::{RequestMessage, ResponseMessage};
@@ -21,7 +20,7 @@ use crate::services::auth::AuthServiceContext;
 pub async fn handle_delete_request<AC: AuthContext>(
     request: RequestMessage<ObjectApiDeleteRequest>,
     auth_ctx: &AuthServiceContext<AC>,
-) -> Result<ResponseMessage<Status>, Error> {
+) -> Result<ResponseMessage<Status>> {
     let (header, del_req) = request.get_header_request();
 
     debug!(?del_req, "del request");

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/delete.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/delete.rs
@@ -37,22 +37,19 @@ pub async fn handle_delete_smartmodule<AC: AuthContext>(
         return Err(Error::new(ErrorKind::Interrupted, "authorization io error").into());
     }
 
-    let sm_fqdn = SmartModulePackageKey::from_qualified_name(&name)?;
+    let sm_fqdn = SmartModulePackageKey::from_qualified_name(&name)?.store_id();
+
+    debug!(%sm_fqdn,"delete smart modules with");
 
     let status = if auth_ctx
         .global_ctx
         .smartmodules()
         .store()
-        .value(&name)
+        .value(&sm_fqdn)
         .await
         .is_some()
     {
-        if let Err(err) = auth_ctx
-            .global_ctx
-            .smartmodules()
-            .delete(sm_fqdn.store_id())
-            .await
-        {
+        if let Err(err) = auth_ctx.global_ctx.smartmodules().delete(sm_fqdn).await {
             Status::new(
                 name.clone(),
                 ErrorCode::SmartModuleError,

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -107,12 +107,12 @@ mod test {
             ..Default::default()
         };
 
-        assert_ne!(pkg.store_key(), "sm2");
+        assert_ne!(pkg.store_id(), "sm2");
 
         let test_data = vec![
             SmartModuleTest::with_spec("sm1", SmartModuleSpec::default()),
             SmartModuleTest::with_spec(
-                pkg.store_key(),
+                pkg.store_id(),
                 SmartModuleSpec {
                     meta: Some(SmartModuleMetadata {
                         package: pkg,

--- a/crates/smartmodule-development-kit/src/load.rs
+++ b/crates/smartmodule-development-kit/src/load.rs
@@ -26,7 +26,7 @@ impl LoadOpt {
         let pkg_metadata = SmartModuleMetadata::from_toml("./SmartModule.toml")?;
         println!("Using SmartModule package: {}", pkg_metadata.package.name);
 
-        let sm_id = pkg_metadata.id();
+        let sm_id = pkg_metadata.package.name.clone(); // pass anything, this should be overriden by SC
         let raw_bytes = self.wasm.load_raw_wasm_file()?;
         let spec = SmartModuleSpec {
             meta: Some(pkg_metadata),

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -2,7 +2,7 @@
 PUBLISH_BINARIES=fluvio fluvio-run fluvio-channel fluvio-test smdk
 
 # CI has to set RELEASE=true to run commands that update public
-RELEASE?=false
+#RELEASE?=false
 ifneq ($(RELEASE),true)
 DRY_RUN_ECHO=echo
 #$(info Dry run mode - No public changes)


### PR DESCRIPTION
use store id instead of raw name to account for the package name.
update the SmartModule id mapping to use `.` for version