### PR TITLE
[Merged by Bors] - fix: add summary mode to SmartModule list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           profile: minimal
-          override: true
       - name: Install zig
         run: ./actions/zig-install.sh ${{ matrix.os }}
       - uses: Swatinem/rust-cache@v2

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -210,7 +210,7 @@ mod cmd {
         ) -> Result<()> {
             let maybe_tableformat = if let Some(ref tableformat_name) = self.table_format {
                 let admin = fluvio.admin().await;
-                let tableformats = admin.list::<TableFormatSpec, _>(vec![]).await?;
+                let tableformats = admin.all::<TableFormatSpec>().await?;
 
                 let mut found = None;
 

--- a/crates/fluvio-cli/src/client/derivedstream/list.rs
+++ b/crates/fluvio-cli/src/client/derivedstream/list.rs
@@ -19,7 +19,7 @@ pub struct ListDerivedStreamOpt {
 impl ListDerivedStreamOpt {
     pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<DerivedStreamSpec, _>(vec![]).await?;
+        let lists = admin.all::<DerivedStreamSpec>().await?;
         output::smart_stream_response_to_output(out, lists, self.output.format)
     }
 }

--- a/crates/fluvio-cli/src/client/hub/download.rs
+++ b/crates/fluvio-cli/src/client/hub/download.rs
@@ -122,6 +122,7 @@ async fn download_cluster(config: FluvioConfig, pkgfile: &str) -> Result<()> {
     let spec = SmartModuleSpec {
         meta: Some(sm_meta),
         wasm: sm_wasm,
+        ..Default::default()
     };
 
     println!("trying connection to fluvio {}", config.endpoint);

--- a/crates/fluvio-cli/src/client/partition/list.rs
+++ b/crates/fluvio-cli/src/client/partition/list.rs
@@ -29,7 +29,7 @@ impl ListPartitionOpt {
         let output = self.output.format;
         let admin = fluvio.admin().await;
 
-        let partitions = admin.list::<PartitionSpec, _>(vec![]).await?;
+        let partitions = admin.all::<PartitionSpec>().await?;
 
         // format and dump to screen
         display::format_partition_response_output(out, partitions, output)?;

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -114,12 +114,10 @@ mod output {
                         Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Left),
                         Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Left),
                         Cell::new(
-                            r.spec
-                                .summary
-                                .clone()
-                                .unwrap_or_default()
-                                .wasm_length
-                                .to_string(),
+                            bytesize::ByteSize::b(
+                                r.spec.summary.clone().unwrap_or_default().wasm_length as u64,
+                            )
+                            .to_string(),
                         )
                         .set_alignment(CellAlignment::Right),
                     ])

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -35,7 +35,9 @@ impl ClientCmd for ListSmartModuleOpt {
         } else {
             vec![]
         };
-        let lists = admin.list::<SmartModuleSpec, _>(filters).await?;
+        let lists = admin
+            .list_with_params::<SmartModuleSpec, _>(filters, true)
+            .await?;
         output::smartmodules_response_to_output(out, lists, self.output.format)
     }
 }
@@ -92,7 +94,7 @@ mod output {
     impl TableOutputHandler for ListSmartModules {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["NAME", "GROUP", "VERSION", "STATUS", "SIZE"])
+            Row::from(["NAME", "GROUP", "VERSION", "SIZE"])
         }
 
         /// return errors in string format
@@ -111,9 +113,15 @@ mod output {
                         Cell::new(&r.spec.logical_name(&r.name)).set_alignment(CellAlignment::Left),
                         Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Left),
                         Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.status.to_string()).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.spec.wasm.payload.len().to_string())
-                            .set_alignment(CellAlignment::Right),
+                        Cell::new(
+                            r.spec
+                                .summary
+                                .clone()
+                                .unwrap_or_default()
+                                .wasm_length
+                                .to_string(),
+                        )
+                        .set_alignment(CellAlignment::Right),
                     ])
                 })
                 .collect()

--- a/crates/fluvio-cli/src/client/tableformat/list.rs
+++ b/crates/fluvio-cli/src/client/tableformat/list.rs
@@ -23,7 +23,7 @@ impl ListTableFormatsOpt {
     /// Process list connectors cli request
     pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<(), CliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<TableFormatSpec, _>(vec![]).await?;
+        let lists = admin.all::<TableFormatSpec>().await?;
 
         output::tableformats_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cli/src/client/topic/list.rs
+++ b/crates/fluvio-cli/src/client/topic/list.rs
@@ -33,7 +33,7 @@ impl ListTopicsOpt {
         debug!("list topics {:#?} ", output_type);
         let admin = fluvio.admin().await;
 
-        let topics = admin.list::<TopicSpec, _>(vec![]).await?;
+        let topics = admin.all::<TopicSpec>().await?;
         display::format_response_output(out, topics, output_type)?;
         Ok(())
     }

--- a/crates/fluvio-cli/src/connector/list.rs
+++ b/crates/fluvio-cli/src/connector/list.rs
@@ -23,7 +23,7 @@ impl ListManagedConnectorsOpt {
     /// Process list connectors cli request
     pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<(), CliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<ManagedConnectorSpec, _>(vec![]).await?;
+        let lists = admin.list::<ManagedConnectorSpec, String>(vec![]).await?;
 
         output::managed_connectors_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cli/src/connector/list.rs
+++ b/crates/fluvio-cli/src/connector/list.rs
@@ -23,7 +23,7 @@ impl ListManagedConnectorsOpt {
     /// Process list connectors cli request
     pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<(), CliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<ManagedConnectorSpec, String>(vec![]).await?;
+        let lists = admin.all::<ManagedConnectorSpec>().await?;
 
         output::managed_connectors_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cli/src/connector/update.rs
+++ b/crates/fluvio-cli/src/connector/update.rs
@@ -42,7 +42,7 @@ impl UpdateManagedConnectorOpt {
         let admin = fluvio.admin().await;
 
         // admin.find ?
-        let lists = admin.list::<ManagedConnectorSpec, String>(vec![]).await?;
+        let lists = admin.all::<ManagedConnectorSpec>().await?;
         let existing_config = match lists.into_iter().find(|c| c.name == config.name) {
             None => {
                 return Err(CliError::InvalidConnector(format!(

--- a/crates/fluvio-cli/src/connector/update.rs
+++ b/crates/fluvio-cli/src/connector/update.rs
@@ -42,7 +42,7 @@ impl UpdateManagedConnectorOpt {
         let admin = fluvio.admin().await;
 
         // admin.find ?
-        let lists = admin.list::<ManagedConnectorSpec, _>(vec![]).await?;
+        let lists = admin.list::<ManagedConnectorSpec, String>(vec![]).await?;
         let existing_config = match lists.into_iter().find(|c| c.name == config.name) {
             None => {
                 return Err(CliError::InvalidConnector(format!(

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -240,22 +240,22 @@ impl DiagnosticsOpt {
         };
 
         println!("getting topic spec");
-        let topics = admin.list::<TopicSpec, String>(vec![]).await?;
+        let topics = admin.all::<TopicSpec>().await?;
         let topics = serde_yaml::to_string(&topics).unwrap();
         write_spec(topics, "topics")?;
 
         println!("getting partition spec");
-        let partitions = admin.list::<PartitionSpec, String>(vec![]).await?;
+        let partitions = admin.all::<PartitionSpec>().await?;
         let partitions = serde_yaml::to_string(&partitions).unwrap();
         write_spec(partitions, "partitions")?;
 
         println!("getting spu spec");
-        let spus = admin.list::<SpuSpec, String>(vec![]).await?;
+        let spus = admin.all::<SpuSpec>().await?;
         let spu_description = serde_yaml::to_string(&spus).unwrap();
         write_spec(spu_description, "spus")?;
 
         println!("getting spg spec");
-        let spgs = admin.list::<SpuGroupSpec, String>(vec![]).await?;
+        let spgs = admin.all::<SpuGroupSpec>().await?;
         let spgs = serde_yaml::to_string(&spgs).unwrap();
         write_spec(spgs, "spgs")?;
 

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -240,22 +240,22 @@ impl DiagnosticsOpt {
         };
 
         println!("getting topic spec");
-        let topics = admin.list::<TopicSpec, _>([]).await?;
+        let topics = admin.list::<TopicSpec,String>(vec![]).await?;
         let topics = serde_yaml::to_string(&topics).unwrap();
         write_spec(topics, "topics")?;
 
         println!("getting partition spec");
-        let partitions = admin.list::<PartitionSpec, _>([]).await?;
+        let partitions = admin.list::<PartitionSpec, String>(vec![]).await?;
         let partitions = serde_yaml::to_string(&partitions).unwrap();
         write_spec(partitions, "partitions")?;
 
         println!("getting spu spec");
-        let spus = admin.list::<SpuSpec, _>([]).await?;
+        let spus = admin.list::<SpuSpec, String>(vec![]).await?;
         let spu_description = serde_yaml::to_string(&spus).unwrap();
         write_spec(spu_description, "spus")?;
 
         println!("getting spg spec");
-        let spgs = admin.list::<SpuGroupSpec, _>([]).await?;
+        let spgs = admin.list::<SpuGroupSpec, String>(vec![]).await?;
         let spgs = serde_yaml::to_string(&spgs).unwrap();
         write_spec(spgs, "spgs")?;
 

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -240,7 +240,7 @@ impl DiagnosticsOpt {
         };
 
         println!("getting topic spec");
-        let topics = admin.list::<TopicSpec,String>(vec![]).await?;
+        let topics = admin.list::<TopicSpec, String>(vec![]).await?;
         let topics = serde_yaml::to_string(&topics).unwrap();
         write_spec(topics, "topics")?;
 

--- a/crates/fluvio-cluster/src/cli/group/list.rs
+++ b/crates/fluvio-cluster/src/cli/group/list.rs
@@ -27,7 +27,7 @@ impl ListManagedSpuGroupsOpt {
         fluvio: &Fluvio,
     ) -> Result<(), ClusterCliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec, String>(vec![]).await?;
+        let lists = admin.all::<SpuGroupSpec>().await?;
 
         output::spu_group_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cluster/src/cli/group/list.rs
+++ b/crates/fluvio-cluster/src/cli/group/list.rs
@@ -27,7 +27,7 @@ impl ListManagedSpuGroupsOpt {
         fluvio: &Fluvio,
     ) -> Result<(), ClusterCliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec,String>(vec![]).await?;
+        let lists = admin.list::<SpuGroupSpec, String>(vec![]).await?;
 
         output::spu_group_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cluster/src/cli/group/list.rs
+++ b/crates/fluvio-cluster/src/cli/group/list.rs
@@ -27,7 +27,7 @@ impl ListManagedSpuGroupsOpt {
         fluvio: &Fluvio,
     ) -> Result<(), ClusterCliError> {
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec, _>(vec![]).await?;
+        let lists = admin.list::<SpuGroupSpec,String>(vec![]).await?;
 
         output::spu_group_response_to_output(out, lists, self.output.format)
     }

--- a/crates/fluvio-cluster/src/cli/spu/list.rs
+++ b/crates/fluvio-cluster/src/cli/spu/list.rs
@@ -39,7 +39,7 @@ impl ListSpusOpt {
         let spus = if self.custom {
             // List custom SPUs only
             admin
-                .list::<CustomSpuSpec, _>(vec![])
+                .all::<CustomSpuSpec>()
                 .await?
                 .into_iter()
                 .map(|custom_spu| Metadata {
@@ -50,7 +50,7 @@ impl ListSpusOpt {
                 .collect()
         } else {
             // List all SPUs
-            admin.list::<SpuSpec, _>(vec![]).await?
+            admin.all::<SpuSpec>().await?
         };
 
         // format and dump to screen

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -1160,7 +1160,7 @@ impl ClusterInstaller {
         while time.elapsed().unwrap() < timeout_duration {
             debug!("retrieving spu specs");
 
-            let spu = admin.list::<SpuSpec,String>(vec![]).await?;
+            let spu = admin.list::<SpuSpec, String>(vec![]).await?;
 
             debug!(?spu);
 
@@ -1316,7 +1316,7 @@ impl ClusterInstaller {
         let spg_name = self.config.group_name.clone();
         pb.set_message(format!("📝 Checking for existing SPU Group: {}", spg_name));
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec,String>(vec![]).await?;
+        let lists = admin.list::<SpuGroupSpec, String>(vec![]).await?;
         if lists.is_empty() {
             pb.set_message(format!(
                 "🤖 Creating SPU Group: {} with replicas: {}",

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -1160,7 +1160,7 @@ impl ClusterInstaller {
         while time.elapsed().unwrap() < timeout_duration {
             debug!("retrieving spu specs");
 
-            let spu = admin.list::<SpuSpec, _>([]).await?;
+            let spu = admin.list::<SpuSpec,String>(vec![]).await?;
 
             debug!(?spu);
 
@@ -1316,7 +1316,7 @@ impl ClusterInstaller {
         let spg_name = self.config.group_name.clone();
         pb.set_message(format!("📝 Checking for existing SPU Group: {}", spg_name));
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec, _>([]).await?;
+        let lists = admin.list::<SpuGroupSpec,String>(vec![]).await?;
         if lists.is_empty() {
             pb.set_message(format!(
                 "🤖 Creating SPU Group: {} with replicas: {}",

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -1316,7 +1316,7 @@ impl ClusterInstaller {
         let spg_name = self.config.group_name.clone();
         pb.set_message(format!("📝 Checking for existing SPU Group: {}", spg_name));
         let admin = fluvio.admin().await;
-        let lists = admin.list::<SpuGroupSpec, String>(vec![]).await?;
+        let lists = admin.all::<SpuGroupSpec>().await?;
         if lists.is_empty() {
             pb.set_message(format!(
                 "🤖 Creating SPU Group: {} with replicas: {}",

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -568,7 +568,7 @@ impl LocalInstaller {
         ));
         // wait for list of spu
         while time.elapsed().unwrap() < timeout_duration {
-            let spus = admin.list::<SpuSpec, _>(vec![]).await?;
+            let spus = admin.all::<SpuSpec>().await?;
             let ready_spu = spus.iter().filter(|spu| spu.status.is_online()).count();
             let elapsed = time.elapsed().unwrap();
             pb.set_message(format!(

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/k8.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/k8.rs
@@ -5,7 +5,7 @@ use crate::k8_types::{Crd, GROUP, V1, CrdNames, Spec, Status, DefaultHeader};
 
 use super::SmartModuleStatus;
 use super::SmartModuleSpec;
-use super::SmartModuleWasm;
+use super::spec_v1::SmartModuleSpecV1;
 
 const V2: &str = "v2";
 
@@ -29,51 +29,6 @@ impl Spec for SmartModuleSpec {
 }
 
 impl Status for SmartModuleStatus {}
-
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SmartModuleSpecV1 {
-    pub input_kind: SmartModuleInputKind,
-    pub output_kind: SmartModuleOutputKind,
-    pub wasm: SmartModuleWasm,
-    pub parameters: Option<Vec<SmartModuleParameter>>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum SmartModuleInputKind {
-    Stream,
-    External,
-}
-
-impl Default for SmartModuleInputKind {
-    fn default() -> SmartModuleInputKind {
-        SmartModuleInputKind::Stream
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum SmartModuleOutputKind {
-    Stream,
-    External,
-    Table,
-}
-
-impl Default for SmartModuleOutputKind {
-    fn default() -> SmartModuleOutputKind {
-        SmartModuleOutputKind::Stream
-    }
-}
-
-impl std::fmt::Display for SmartModuleSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "SmartModuleSpec")
-    }
-}
-
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
-
-pub struct SmartModuleParameter {
-    name: String,
-}
 
 const SMART_MODULE_V1_API: Crd = Crd {
     group: GROUP,
@@ -112,8 +67,7 @@ impl From<SmartModuleSpecV1> for SmartModuleSpec {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::smartmodule::SmartModuleInputKind;
+    use crate::smartmodule::spec_v1::SmartModuleInputKind;
 
     #[test]
     fn test_sm_spec_v1_simple() {

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/mod.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/mod.rs
@@ -2,6 +2,7 @@ mod spec;
 mod status;
 mod package;
 mod params;
+mod spec_v1;
 
 pub use self::spec::*;
 pub use self::status::*;

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -10,6 +10,8 @@ use super::SmartModuleMetadata;
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SmartModuleSpec {
     pub meta: Option<SmartModuleMetadata>,
+    #[cfg_attr(feature = "use_serde", serde(skip))]
+    pub summary: Option<SmartModuleWasmSummary>, // only passed from SC to CLI
     pub wasm: SmartModuleWasm,
 }
 
@@ -41,6 +43,22 @@ impl SmartModuleSpec {
             .map(|meta| meta.package.version.to_string())
             .unwrap_or_else(|| "".to_owned())
     }
+
+    /// get summary version
+    pub fn summary(&self) -> Self {
+        Self {
+            meta: self.meta.clone(),
+            summary: Some(SmartModuleWasmSummary {
+                wasm_length: self.wasm.payload.len() as u32,
+            }),
+            wasm: SmartModuleWasm::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Encoder, Decoder)]
+pub struct SmartModuleWasmSummary {
+    pub wasm_length: u32,
 }
 
 #[derive(Clone, Default, Eq, PartialEq, Encoder, Decoder)]

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -13,9 +13,9 @@ use super::{
     spec_v1::{SmartModuleSpecV1},
 };
 
-const V2_FORMAT: Version = 9;
+const V2_FORMAT: Version = 10;
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Decoder)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SmartModuleSpec {
     pub meta: Option<SmartModuleMetadata>,
@@ -24,16 +24,20 @@ pub struct SmartModuleSpec {
     pub wasm: SmartModuleWasm,
 }
 
+// custom encoding to handle prev version
 impl Encoder for SmartModuleSpec {
     fn write_size(&self, version: Version) -> usize {
-        debug!("write size: version: {}", version);
-        if version <= V2_FORMAT {
-            debug!("computing size for smart module spec v1");
-            let spec_v1 = SmartModuleSpecV1 {
-                wasm: self.wasm.clone(),
-                ..Default::default()
-            };
-            spec_v1.write_size(version)
+        if version < V2_FORMAT {
+            //trace!("computing size for smart module spec v1");
+            // just used for computing size
+            let spec_v1 = SmartModuleSpecV1::default();
+            let mut size = 0;
+            size += spec_v1.input_kind.write_size(version);
+            size += spec_v1.output_kind.write_size(version);
+            size += spec_v1.source_code.write_size(version);
+            size += self.wasm.write_size(version);
+            size += spec_v1.parameters.write_size(version);
+            size
         } else {
             let mut size = 0;
             size += self.meta.write_size(version);
@@ -47,18 +51,39 @@ impl Encoder for SmartModuleSpec {
     where
         T: BufMut,
     {
-        if version <= V2_FORMAT {
+        if version < V2_FORMAT {
             debug!("encoding for smart module spec v1");
-            let spec_v1 = SmartModuleSpecV1 {
-                wasm: self.wasm.clone(),
-                ..Default::default()
-            };
-            spec_v1.encode(dest, version)?;
+            let spec_v1 = SmartModuleSpecV1::default();
+            spec_v1.input_kind.encode(dest, version)?;
+            spec_v1.output_kind.encode(dest, version)?;
+            spec_v1.source_code.encode(dest, version)?;
+            self.wasm.encode(dest, version)?;
+            spec_v1.parameters.encode(dest, version)?;
         } else {
             self.meta.encode(dest, version)?;
             self.summary.encode(dest, version)?;
             self.wasm.encode(dest, version)?;
         }
+        Ok(())
+    }
+}
+
+impl Decoder for SmartModuleSpec {
+    fn decode<T>(&mut self, src: &mut T, version: Version) -> Result<(), IoError>
+    where
+        T: bytes::Buf,
+    {
+        if version < V2_FORMAT {
+            debug!("decoding for smart module spec v1");
+            let mut spec_v1 = SmartModuleSpecV1::default();
+            spec_v1.decode(src, version)?;
+            self.wasm = spec_v1.wasm;
+        } else {
+            self.meta.decode(src, version)?;
+            self.summary.decode(src, version)?;
+            self.wasm.decode(src, version)?;
+        }
+
         Ok(())
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec_v1.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec_v1.rs
@@ -1,0 +1,41 @@
+use fluvio_protocol::{Encoder, Decoder};
+
+use super::spec::SmartModuleWasm;
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Encoder, Decoder)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SmartModuleSpecV1 {
+    pub input_kind: SmartModuleInputKind,
+    pub output_kind: SmartModuleOutputKind,
+    pub wasm: SmartModuleWasm,
+    pub parameters: Option<Vec<SmartModuleParameter>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Encoder, Decoder, Default)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SmartModuleInputKind {
+    #[default]
+    Stream,
+    External,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Encoder, Decoder, Default)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SmartModuleOutputKind {
+    #[default]
+    Stream,
+    External,
+    Table,
+}
+
+impl std::fmt::Display for SmartModuleSpecV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "SmartModuleSpec")
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Encoder, Decoder)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SmartModuleParameter {
+    name: String,
+}

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec_v1.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec_v1.rs
@@ -7,8 +7,23 @@ use super::spec::SmartModuleWasm;
 pub struct SmartModuleSpecV1 {
     pub input_kind: SmartModuleInputKind,
     pub output_kind: SmartModuleOutputKind,
+    pub source_code: Option<SmartModuleSourceCode>,
     pub wasm: SmartModuleWasm,
     pub parameters: Option<Vec<SmartModuleParameter>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Encoder, Decoder)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SmartModuleSourceCode {
+    language: SmartModuleSourceCodeLanguage,
+    payload: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encoder, Decoder, Default)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SmartModuleSourceCodeLanguage {
+    #[default]
+    Rust,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Encoder, Decoder, Default)]

--- a/crates/fluvio-controlplane/src/requests/update_smartmodule.rs
+++ b/crates/fluvio-controlplane/src/requests/update_smartmodule.rs
@@ -14,6 +14,7 @@ pub type UpdateSmartModuleRequest = ControlPlaneRequest<SmartModule>;
 impl Request for UpdateSmartModuleRequest {
     const API_KEY: u16 = InternalSpuApi::UpdateSmartModule as u16;
     type Response = UpdateSmartModuleResponse;
+    const DEFAULT_API_VERSION: i16 = 10; // align with pubic api to get version encoding
 }
 
 #[derive(Decoder, Encoder, Default, Debug)]

--- a/crates/fluvio-protocol/src/api/mod.rs
+++ b/crates/fluvio-protocol/src/api/mod.rs
@@ -31,12 +31,20 @@ mod common {
 
     use crate::{Encoder, Decoder};
 
+    const fn max(a: i16, b: i16) -> i16 {
+        if a > b {
+            a
+        } else {
+            b
+        }
+    }
+
     pub trait Request: Encoder + Decoder + Debug {
         const API_KEY: u16;
 
         const DEFAULT_API_VERSION: i16 = 0;
-        const MIN_API_VERSION: i16 = 0;
-        const MAX_API_VERSION: i16 = -1;
+        const MIN_API_VERSION: i16 = max(Self::DEFAULT_API_VERSION - 1, 0); // by default, only suport last version
+        const MAX_API_VERSION: i16 = Self::DEFAULT_API_VERSION;
 
         type Response: Encoder + Decoder + Debug;
     }

--- a/crates/fluvio-protocol/src/link/versions.rs
+++ b/crates/fluvio-protocol/src/link/versions.rs
@@ -7,6 +7,7 @@ use crate::api::Request;
 use super::ErrorCode;
 
 pub const VERSIONS_API_KEY: u16 = 18;
+pub const V10_PLATFORM: i16 = 2;
 
 // -----------------------------------
 // ApiVersionsRequest
@@ -24,7 +25,7 @@ pub struct ApiVersionsRequest {
 
 impl Request for ApiVersionsRequest {
     const API_KEY: u16 = VERSIONS_API_KEY;
-    const DEFAULT_API_VERSION: i16 = 1;
+    const DEFAULT_API_VERSION: i16 = V10_PLATFORM;
     type Response = ApiVersionsResponse;
 }
 
@@ -52,6 +53,10 @@ pub struct ApiVersionKey {
 pub struct PlatformVersion(String);
 
 impl PlatformVersion {
+    pub fn new(version: &semver::Version) -> Self {
+        Self(version.to_string())
+    }
+
     /// Creates a `semver::Version` object of the inner version
     pub fn to_semver(&self) -> semver::Version {
         // This is safe because of this type's invariant:

--- a/crates/fluvio-sc-schema/src/objects/create.rs
+++ b/crates/fluvio-sc-schema/src/objects/create.rs
@@ -33,7 +33,8 @@ pub struct CommonCreateRequest {
 
 impl Request for ObjectApiCreateRequest {
     const API_KEY: u16 = AdminPublicApiKey::Create as u16;
-    const DEFAULT_API_VERSION: i16 = 9;
+    const MIN_API_VERSION: i16 = 9;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = Status;
 }
 
@@ -214,3 +215,5 @@ macro_rules! CreateFrom {
 }
 
 pub(crate) use CreateFrom;
+
+use super::COMMON_VERSION;

--- a/crates/fluvio-sc-schema/src/objects/delete.rs
+++ b/crates/fluvio-sc-schema/src/objects/delete.rs
@@ -11,7 +11,7 @@ use fluvio_protocol::api::Request;
 use crate::{DeletableAdminSpec};
 use crate::Status;
 use crate::AdminPublicApiKey;
-use super::{DeleteApiEnum};
+use super::{DeleteApiEnum, COMMON_VERSION};
 
 DeleteApiEnum!(DeleteRequest);
 
@@ -36,6 +36,7 @@ where
 
 impl Request for ObjectApiDeleteRequest {
     const API_KEY: u16 = AdminPublicApiKey::Delete as u16;
-    const DEFAULT_API_VERSION: i16 = 1;
+    const MIN_API_VERSION: i16 = 1; // previous version
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = Status;
 }

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -6,12 +6,10 @@ use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::api::Request;
 
 use crate::{AdminPublicApiKey, AdminSpec};
-use super::{ObjectApiEnum};
+use super::{ObjectApiEnum, COMMON_VERSION};
 
 ObjectApiEnum!(ListRequest);
 ObjectApiEnum!(ListResponse);
-
-pub const MIN_API_WITH_FILTER: u16 = 10;
 
 #[derive(Debug, Default, Encoder, Decoder)]
 pub struct ListRequest<S: AdminSpec> {
@@ -34,7 +32,7 @@ where
 
 impl Request for ObjectApiListRequest {
     const API_KEY: u16 = AdminPublicApiKey::List as u16;
-    const DEFAULT_API_VERSION: i16 = 10;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = ObjectApiListResponse;
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -11,6 +11,8 @@ use super::{ObjectApiEnum};
 ObjectApiEnum!(ListRequest);
 ObjectApiEnum!(ListResponse);
 
+pub const MIN_API_WITH_FILTER: u16 = 10;
+
 #[derive(Debug, Default, Encoder, Decoder)]
 pub struct ListRequest<S: AdminSpec> {
     pub name_filters: Vec<S::ListFilter>,
@@ -27,7 +29,7 @@ where
 
 impl Request for ObjectApiListRequest {
     const API_KEY: u16 = AdminPublicApiKey::List as u16;
-    const DEFAULT_API_VERSION: i16 = 9;
+    const DEFAULT_API_VERSION: i16 = 10;
     type Response = ObjectApiListResponse;
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -16,14 +16,19 @@ pub const MIN_API_WITH_FILTER: u16 = 10;
 #[derive(Debug, Default, Encoder, Decoder)]
 pub struct ListRequest<S: AdminSpec> {
     pub name_filters: Vec<S::ListFilter>,
+    #[fluvio(min_version = 10)]
+    pub summary: bool, // if true, only return summary
 }
 
 impl<S> ListRequest<S>
 where
     S: AdminSpec,
 {
-    pub fn new(name_filters: Vec<S::ListFilter>) -> Self {
-        Self { name_filters }
+    pub fn new(name_filters: Vec<S::ListFilter>, summary: bool) -> Self {
+        Self {
+            name_filters,
+            summary,
+        }
     }
 }
 

--- a/crates/fluvio-sc-schema/src/objects/mod.rs
+++ b/crates/fluvio-sc-schema/src/objects/mod.rs
@@ -13,6 +13,8 @@ pub use crate::NameFilter;
 pub(crate) use object_macro::*;
 pub(crate) use delete_macro::*;
 
+pub(crate) const COMMON_VERSION: i16 = 10; // from now, we use a single version for all objects
+
 mod metadata {
 
     use std::convert::{TryFrom, TryInto};

--- a/crates/fluvio-sc-schema/src/objects/mod.rs
+++ b/crates/fluvio-sc-schema/src/objects/mod.rs
@@ -519,7 +519,7 @@ mod test {
     use crate::customspu::CustomSpuSpec;
 
     fn create_req() -> ObjectApiListRequest {
-        let list_request: ListRequest<TopicSpec> = ListRequest::new(vec![]);
+        let list_request: ListRequest<TopicSpec> = ListRequest::new(vec![], false);
         list_request.into()
     }
 

--- a/crates/fluvio-sc-schema/src/request.rs
+++ b/crates/fluvio-sc-schema/src/request.rs
@@ -99,7 +99,7 @@ mod test {
     use crate::topic::TopicSpec;
 
     fn create_req() -> ObjectApiListRequest {
-        let list_request: ListRequest<TopicSpec> = ListRequest::new(vec![]);
+        let list_request: ListRequest<TopicSpec> = ListRequest::new(vec![], false);
         list_request.into()
     }
 

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -30,16 +30,11 @@ mod convert {
     #[derive(Debug, Encoder, Decoder, Default)]
     pub struct SmartModuleFilter {
         pub name: String,
-        #[fluvio(min_version = crate::objects::MIN_API_WITH_FILTER)]
-        pub summary: bool, // if true, only return summary
     }
 
     impl From<String> for SmartModuleFilter {
         fn from(name: String) -> Self {
-            Self {
-                name,
-                summary: false,
-            }
+            Self { name }
         }
     }
 

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -1,9 +1,11 @@
 pub use fluvio_controlplane_metadata::smartmodule::*;
+pub use convert::SmartModuleFilter;
 
 mod convert {
 
+    use fluvio_protocol::{Encoder, Decoder};
     use crate::{
-        AdminSpec, CreatableAdminSpec, DeletableAdminSpec, NameFilter,
+        AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{
             CreateFrom, DeleteRequest, ListRequest, ListResponse, Metadata, ObjectFrom,
             ObjectTryFrom, WatchRequest, WatchResponse,
@@ -12,7 +14,7 @@ mod convert {
     use super::SmartModuleSpec;
 
     impl AdminSpec for SmartModuleSpec {
-        type ListFilter = NameFilter;
+        type ListFilter = SmartModuleFilter;
         type WatchResponseType = Self;
         type ListType = Metadata<Self>;
     }
@@ -23,6 +25,22 @@ mod convert {
 
     impl DeletableAdminSpec for SmartModuleSpec {
         type DeleteKey = String;
+    }
+
+    #[derive(Debug, Encoder, Decoder, Default)]
+    pub struct SmartModuleFilter {
+        pub name: String,
+        #[fluvio(min_version = crate::objects::MIN_API_WITH_FILTER)]
+        pub summary: bool       // if true, only return summary
+    }
+
+    impl From<String> for SmartModuleFilter {
+        fn from(name: String) -> Self {
+            Self {
+                name,
+                summary: false
+            }
+        }
     }
 
     CreateFrom!(SmartModuleSpec, SmartModule);

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -31,14 +31,14 @@ mod convert {
     pub struct SmartModuleFilter {
         pub name: String,
         #[fluvio(min_version = crate::objects::MIN_API_WITH_FILTER)]
-        pub summary: bool       // if true, only return summary
+        pub summary: bool, // if true, only return summary
     }
 
     impl From<String> for SmartModuleFilter {
         fn from(name: String) -> Self {
             Self {
                 name,
-                summary: false
+                summary: false,
             }
         }
     }

--- a/crates/fluvio-sc/src/services/public_api/api_version.rs
+++ b/crates/fluvio-sc/src/services/public_api/api_version.rs
@@ -13,12 +13,8 @@ use fluvio_sc_schema::objects::{
 use fluvio_sc_schema::AdminPublicApiKey;
 
 // Fluvi Client version 0.14.0 corresponds to Platform version 10.0.0
-static FLUVIO_V10: Lazy<Version> = Lazy::new(|| Version::parse("0.14.0").unwrap());
-static PLATFORM_VER: Lazy<Version> = Lazy::new(|| Version::parse(crate::VERSION).unwrap());
 
-pub(crate) fn is_v10(client_version: &Version) -> bool {
-    client_version >= &FLUVIO_V10
-}
+static PLATFORM_VER: Lazy<Version> = Lazy::new(|| Version::parse(crate::VERSION).unwrap());
 
 #[instrument(skip(request))]
 pub async fn handle_api_versions_request(
@@ -76,17 +72,5 @@ fn make_version_key(key: AdminPublicApiKey, min_version: i16, max_version: i16) 
         api_key,
         min_version,
         max_version,
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use super::*;
-
-    #[test]
-    fn test_v10() {
-        assert!(is_v10(&Version::parse("0.14.1").unwrap()));
-        assert!(!is_v10(&Version::parse("0.13.3").unwrap()));
     }
 }

--- a/crates/fluvio-sc/src/services/public_api/api_version.rs
+++ b/crates/fluvio-sc/src/services/public_api/api_version.rs
@@ -20,9 +20,10 @@ static PLATFORM_VER: Lazy<Version> = Lazy::new(|| Version::parse(crate::VERSION)
 pub async fn handle_api_versions_request(
     request: RequestMessage<ApiVersionsRequest>,
 ) -> Result<ResponseMessage<ApiVersionsResponse>> {
-    let mut response = ApiVersionsResponse::default();
-
-    response.platform_version = PlatformVersion::new(&PLATFORM_VER);
+    let mut response = ApiVersionsResponse {
+        platform_version: PlatformVersion::new(&PLATFORM_VER),
+        ..Default::default()
+    };
 
     let client_version = Version::parse(&request.request().client_version)?;
     debug!(client_version = %client_version, "client version");
@@ -44,15 +45,6 @@ pub async fn handle_api_versions_request(
         ObjectApiListRequest::MIN_API_VERSION,
         ObjectApiListRequest::MAX_API_VERSION,
     ));
-
-    /*
-    response.api_keys.push(make_version_key(
-        AdminPublicApiKey::List,
-        ObjectApiListRequest::MIN_API_VERSION,
-       // if is_v10(&client_version) { ObjectApiListRequest::MAX_API_VERSION } else { ObjectApiListRequest::MIN_API_VERSION },
-        ObjectApiListRequest::MIN_API_VERSION,
-    ));
-    */
 
     response.api_keys.push(make_version_key(
         AdminPublicApiKey::Watch,

--- a/crates/fluvio-sc/src/services/public_api/api_version.rs
+++ b/crates/fluvio-sc/src/services/public_api/api_version.rs
@@ -1,5 +1,7 @@
-use std::io::Error;
-use tracing::{trace, instrument};
+use tracing::{trace, instrument, debug};
+use semver::Version;
+use once_cell::sync::Lazy;
+use anyhow::Result;
 
 use fluvio_protocol::api::{RequestMessage, ResponseMessage, Request};
 use fluvio_protocol::link::versions::{
@@ -10,36 +12,56 @@ use fluvio_sc_schema::objects::{
 };
 use fluvio_sc_schema::AdminPublicApiKey;
 
+// Fluvi Client version 0.14.0 corresponds to Platform version 10.0.0
+static FLUVIO_V10: Lazy<Version> = Lazy::new(|| Version::parse("0.14.0").unwrap());
+static PLATFORM_VER: Lazy<Version> = Lazy::new(|| Version::parse(crate::VERSION).unwrap());
+
+pub(crate) fn is_v10(client_version: &Version) -> bool {
+    client_version >= &FLUVIO_V10
+}
+
 #[instrument(skip(request))]
 pub async fn handle_api_versions_request(
     request: RequestMessage<ApiVersionsRequest>,
-) -> Result<ResponseMessage<ApiVersionsResponse>, Error> {
+) -> Result<ResponseMessage<ApiVersionsResponse>> {
     let mut response = ApiVersionsResponse::default();
 
-    let platform_version = semver::Version::parse(crate::VERSION)
-        .expect("Platform Version (from VERSION file) must be semver");
-    response.platform_version = PlatformVersion::from(platform_version);
+    response.platform_version = PlatformVersion::new(&PLATFORM_VER);
+
+    let client_version = Version::parse(&request.request().client_version)?;
+    debug!(client_version = %client_version, "client version");
 
     // topic versions
     response.api_keys.push(make_version_key(
         AdminPublicApiKey::Create,
-        ObjectApiCreateRequest::DEFAULT_API_VERSION,
-        ObjectApiCreateRequest::DEFAULT_API_VERSION,
+        ObjectApiCreateRequest::MIN_API_VERSION,
+        ObjectApiCreateRequest::MAX_API_VERSION,
     ));
     response.api_keys.push(make_version_key(
         AdminPublicApiKey::Delete,
-        ObjectApiDeleteRequest::DEFAULT_API_VERSION,
-        ObjectApiDeleteRequest::DEFAULT_API_VERSION,
+        ObjectApiDeleteRequest::MIN_API_VERSION,
+        ObjectApiDeleteRequest::MAX_API_VERSION,
     ));
+
     response.api_keys.push(make_version_key(
         AdminPublicApiKey::List,
-        ObjectApiListRequest::DEFAULT_API_VERSION,
-        ObjectApiListRequest::DEFAULT_API_VERSION,
+        ObjectApiListRequest::MIN_API_VERSION,
+        ObjectApiListRequest::MAX_API_VERSION,
     ));
+
+    /*
+    response.api_keys.push(make_version_key(
+        AdminPublicApiKey::List,
+        ObjectApiListRequest::MIN_API_VERSION,
+       // if is_v10(&client_version) { ObjectApiListRequest::MAX_API_VERSION } else { ObjectApiListRequest::MIN_API_VERSION },
+        ObjectApiListRequest::MIN_API_VERSION,
+    ));
+    */
+
     response.api_keys.push(make_version_key(
         AdminPublicApiKey::Watch,
-        ObjectApiWatchRequest::DEFAULT_API_VERSION,
-        ObjectApiWatchRequest::DEFAULT_API_VERSION,
+        ObjectApiWatchRequest::MIN_API_VERSION,
+        ObjectApiWatchRequest::MAX_API_VERSION,
     ));
 
     trace!("flv api versions response: {:#?}", response);
@@ -54,5 +76,17 @@ fn make_version_key(key: AdminPublicApiKey, min_version: i16, max_version: i16) 
         api_key,
         min_version,
         max_version,
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_v10() {
+        assert!(is_v10(&Version::parse("0.14.1").unwrap()));
+        assert!(!is_v10(&Version::parse("0.13.3").unwrap()));
     }
 }

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -16,9 +16,7 @@ pub async fn handle_list_request<AC: AuthContext>(
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ResponseMessage<ObjectApiListResponse>> {
     let (header, req) = request.get_header_request();
-    debug!("list request: {:#?}", req);
-
-    println!("List Request {:#?}", req);
+    debug!("list header: {:#?}, request: {:#?}", header, req);
 
     let response = match req {
         ObjectApiListRequest::Topic(req) => ObjectApiListResponse::Topic(

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -45,6 +45,7 @@ pub async fn handle_list_request<AC: AuthContext>(
         ObjectApiListRequest::SmartModule(req) => ObjectApiListResponse::SmartModule(
             fetch_smart_modules(
                 req.name_filters,
+                req.summary,
                 &auth_ctx.auth,
                 auth_ctx.global_ctx.smartmodules(),
             )

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -14,7 +14,7 @@ use fluvio_sc_schema::smartmodule::SmartModuleFilter;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;
 
-#[instrument(skip(filters, auth))]
+#[instrument(skip(filters, auth, object_ctx))]
 pub(crate) async fn fetch_smart_modules<AC: AuthContext, M>(
     filters: Vec<SmartModuleFilter>,
     summary: bool,
@@ -63,6 +63,7 @@ where
                     .count()
                     > 0
             {
+                debug!("found matching smart module: {:#?}", value.spec);
                 if summary {
                     Some(Metadata {
                         name: value.key().clone(),
@@ -78,7 +79,7 @@ where
         })
         .collect();
 
-    debug!(fetch_items = objects.len(),);
+    debug!(fetched_items = objects.len(),);
     trace!("fetch {:#?}", objects);
 
     Ok(ListResponse::new(objects))

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -63,7 +63,15 @@ where
                     .count()
                     > 0
             {
-                Some(AdminSpec::convert_from(value))
+                if summary {
+                    Some(Metadata {
+                        name: value.key().clone(),
+                        spec: value.spec().summary(),
+                        status: value.status().clone(),
+                    })
+                } else {
+                    Some(AdminSpec::convert_from(value))
+                }
             } else {
                 None
             }

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -17,6 +17,7 @@ use fluvio_controlplane_metadata::extended::SpecExt;
 #[instrument(skip(filters, auth))]
 pub(crate) async fn fetch_smart_modules<AC: AuthContext, M>(
     filters: Vec<SmartModuleFilter>,
+    summary: bool,
     auth: &AC,
     object_ctx: &StoreContext<SmartModuleSpec, M>,
 ) -> Result<ListResponse<SmartModuleSpec>>
@@ -129,7 +130,7 @@ mod test {
         let sm_ctx = StoreContext::new_with_store(Arc::new(local_sm_store));
         assert_eq!(sm_ctx.store().read().await.len(), 2);
         assert_eq!(
-            fetch_smart_modules(vec![], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec![], false, &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()
@@ -137,7 +138,7 @@ mod test {
             2
         );
         assert_eq!(
-            fetch_smart_modules(vec!["test".to_owned().into()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["test".to_owned().into()], false, &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()
@@ -146,7 +147,7 @@ mod test {
         );
 
         assert_eq!(
-            fetch_smart_modules(vec!["sm1".to_owned().into()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["sm1".to_owned().into()], false, &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()
@@ -156,7 +157,7 @@ mod test {
 
         // no matching
         assert_eq!(
-            fetch_smart_modules(vec!["sm2".to_owned().into()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["sm2".to_owned().into()], false, &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -9,13 +9,14 @@ use fluvio_controlplane_metadata::smartmodule::{SmartModuleSpec, SmartModulePack
 use fluvio_sc_schema::AdminSpec;
 use fluvio_stream_dispatcher::store::StoreContext;
 
-use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata};
+use fluvio_sc_schema::objects::{ListResponse, Metadata};
+use fluvio_sc_schema::smartmodule::SmartModuleFilter;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;
 
 #[instrument(skip(filters, auth))]
 pub(crate) async fn fetch_smart_modules<AC: AuthContext, M>(
-    filters: Vec<NameFilter>,
+    filters: Vec<SmartModuleFilter>,
     auth: &AC,
     object_ctx: &StoreContext<SmartModuleSpec, M>,
 ) -> Result<ListResponse<SmartModuleSpec>>
@@ -41,7 +42,7 @@ where
     // convert filter into key filter
     let mut sm_keys = vec![];
     for filter in filters.into_iter() {
-        sm_keys.push(SmartModulePackageKey::from_qualified_name(&filter)?);
+        sm_keys.push(SmartModulePackageKey::from_qualified_name(&filter.name)?);
     }
 
     let reader = object_ctx.store().read().await;
@@ -136,7 +137,7 @@ mod test {
             2
         );
         assert_eq!(
-            fetch_smart_modules(vec!["test".to_owned()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["test".to_owned().into()], &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()
@@ -145,7 +146,7 @@ mod test {
         );
 
         assert_eq!(
-            fetch_smart_modules(vec!["sm1".to_owned()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["sm1".to_owned().into()], &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()
@@ -155,7 +156,7 @@ mod test {
 
         // no matching
         assert_eq!(
-            fetch_smart_modules(vec!["sm2".to_owned()], &root_auth, &sm_ctx)
+            fetch_smart_modules(vec!["sm2".to_owned().into()], &root_auth, &sm_ctx)
                 .await
                 .expect("search")
                 .inner()

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -49,7 +49,7 @@ where
     let objects: Vec<Metadata<SmartModuleSpec>> = reader
         .values()
         .filter_map(|value| {
-            println!("value: {:#?}", value);
+            //println!("value: {:#?}", value);
             if sm_keys.is_empty()
                 || sm_keys
                     .iter()

--- a/crates/fluvio-sc/src/services/public_api/watch.rs
+++ b/crates/fluvio-sc/src/services/public_api/watch.rs
@@ -33,8 +33,8 @@ pub fn handle_watch_request<AC>(
     sink: ExclusiveFlvSink,
     end_event: Arc<StickyEvent>,
 ) -> Result<(), IoError> {
-    debug!("handling watch request");
     let (header, req) = request.get_header_request();
+    debug!("handling watch header: {:#?}, request: {:#?}", header, req);
 
     match req {
         ObjectApiWatchRequest::Topic(_) => WatchController::<TopicSpec>::update(

--- a/crates/fluvio-test/src/tests/batching/mod.rs
+++ b/crates/fluvio-test/src/tests/batching/mod.rs
@@ -27,10 +27,7 @@ pub async fn batching(
 
     let leader = {
         let admin: FluvioAdmin = test_driver.client().admin().await;
-        let partitions = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+        let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
         let test_topic = &partitions[0];
         test_topic.spec.leader
     };

--- a/crates/fluvio-test/src/tests/election/mod.rs
+++ b/crates/fluvio-test/src/tests/election/mod.rs
@@ -36,10 +36,7 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
 
     let admin = test_driver.client().admin().await;
 
-    let partitions = admin
-        .list::<PartitionSpec, _>(vec![])
-        .await
-        .expect("partitions");
+    let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
 
     assert_eq!(partitions.len(), 1);
     let test_topic = &partitions[0];
@@ -70,10 +67,7 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
 
     println!("checking for new leader");
 
-    let partition_status2 = admin
-        .list::<PartitionSpec, _>(vec![])
-        .await
-        .expect("partitions");
+    let partition_status2 = admin.all::<PartitionSpec>().await.expect("partitions");
 
     let status2 = &partition_status2[0];
     assert_eq!(status2.spec.leader, follower_id); // switch leader to follower
@@ -91,10 +85,7 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
     sleep(Duration::from_secs(ACK_WAIT)).await;
 
     {
-        let partition_status = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+        let partition_status = admin.all::<PartitionSpec>().await.expect("partitions");
         let leader_status = &partition_status[0].status.leader;
         assert_eq!(leader_status.leo, 2);
         assert_eq!(leader_status.hw, 1);
@@ -110,10 +101,7 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
 
     println!("checking that prev leader has fully caught up");
     {
-        let partition_status = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+        let partition_status = admin.all::<PartitionSpec>().await.expect("partitions");
         let leader_status = &partition_status[0].status.leader;
         assert_eq!(leader_status.leo, 2);
         assert_eq!(leader_status.hw, 2);
@@ -129,10 +117,7 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
     println!("checking leader again");
 
     {
-        let partition_status = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+        let partition_status = admin.all::<PartitionSpec>().await.expect("partitions");
         let leader_status = &partition_status[0];
         assert_eq!(leader_status.spec.leader, leader);
     }

--- a/crates/fluvio-test/src/tests/producer_fail/mod.rs
+++ b/crates/fluvio-test/src/tests/producer_fail/mod.rs
@@ -30,10 +30,7 @@ pub async fn produce_batch(
 
     let leader = {
         let admin: FluvioAdmin = test_driver.client().admin().await;
-        let partitions = admin
-            .list::<PartitionSpec, _>(vec![])
-            .await
-            .expect("partitions");
+        let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
         let test_topic = &partitions[0];
         test_topic.spec.leader
     };

--- a/crates/fluvio-test/src/tests/reconnection/mod.rs
+++ b/crates/fluvio-test/src/tests/reconnection/mod.rs
@@ -35,10 +35,7 @@ pub async fn reconnection(mut test_driver: TestDriver, mut test_case: TestCase) 
 
     let admin = test_driver.client().admin().await;
 
-    let partitions = admin
-        .list::<PartitionSpec, _>(vec![])
-        .await
-        .expect("partitions");
+    let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
 
     let test_topic = &partitions[0];
     let leader = test_topic.spec.leader;

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -178,10 +178,7 @@ pub async fn validate_consume_message_api(
             sleep(Duration::from_secs(wait_delay_sec)).await;
 
             let admin = test_driver.client().admin().await;
-            let partitions = admin
-                .list::<PartitionSpec, _>(vec![])
-                .await
-                .expect("partitions");
+            let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
 
             println!("partitions: {:#?}", partitions);
 

--- a/crates/fluvio-test/src/tests/smoke/offsets.rs
+++ b/crates/fluvio-test/src/tests/smoke/offsets.rs
@@ -33,7 +33,7 @@ pub async fn find_offsets(test_driver: &TestDriver, test_case: &SmokeTestCase) -
 
 async fn last_leo(admin: &mut FluvioAdmin, topic: &str) -> i64 {
     let partitions = admin
-        .list::<PartitionSpec, _>(vec![])
+        .all::<PartitionSpec>()
         .await
         .expect("get partitions status");
 

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -197,11 +197,25 @@ impl FluvioAdmin {
         Ok(())
     }
 
+    /// return all instance of this spec
+    #[instrument(skip(self))]
+    pub async fn all<S>(&self) -> Result<Vec<S::ListType>, FluvioError>
+    where
+        S: AdminSpec,
+        <S as AdminSpec>::ListFilter: From<std::string::String>,
+        ObjectApiListRequest: From<ListRequest<S>>,
+        ListResponse<S>: TryFrom<ObjectApiListResponse>,
+        <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,
+    {
+        self.list::<S, String>(vec![]).await
+    }
+
+    /// return all instance of this spec by filter
     #[instrument(skip(self, filters))]
     pub async fn list<S, F>(&self, filters: Vec<F>) -> Result<Vec<S::ListType>, FluvioError>
     where
         S: AdminSpec,
-        F: Into<S::ListFilter>,
+        S::ListFilter: From<F>,
         ObjectApiListRequest: From<ListRequest<S>>,
         ListResponse<S>: TryFrom<ObjectApiListResponse>,
         <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -198,10 +198,10 @@ impl FluvioAdmin {
     }
 
     #[instrument(skip(self, filters))]
-    pub async fn list<S, F>(&self, filters: F) -> Result<Vec<S::ListType>, FluvioError>
+    pub async fn list<S, F>(&self, filters: Vec<F>) -> Result<Vec<S::ListType>, FluvioError>
     where
         S: AdminSpec,
-        F: Into<Vec<S::ListFilter>>,
+        F: Into<S::ListFilter>,
         ObjectApiListRequest: From<ListRequest<S>>,
         ListResponse<S>: TryFrom<ObjectApiListResponse>,
         <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,
@@ -209,7 +209,7 @@ impl FluvioAdmin {
         use std::io::Error as IoError;
         use std::io::ErrorKind;
 
-        let list_request = ListRequest::new(filters.into());
+        let list_request = ListRequest::new(filters.into_iter().map(Into::into).collect());
 
         let list_request: ObjectApiListRequest = list_request.into();
         let response = self.send_receive(list_request).await?;

--- a/crates/smartmodule-development-kit/src/load.rs
+++ b/crates/smartmodule-development-kit/src/load.rs
@@ -31,6 +31,7 @@ impl LoadOpt {
         let spec = SmartModuleSpec {
             meta: Some(pkg_metadata),
             wasm: SmartModuleWasm::from_raw_wasm_bytes(&raw_bytes)?,
+            ..Default::default()
         };
 
         let fluvio_config = self.target.clone().load()?;


### PR DESCRIPTION
resolves #2667.

* Add summary mode to filter such that SmartModule list won't fetch WASM 
* Fixed backward compatibility with previous release by bump up Object Api version and provide backward encoding/decoding.
* Update Fluvio object API list to have customizable filter with variations.
* Use Bytesize to display SmartModule size