### PR TITLE
fix: use semver for smartmodule version in template

### DIFF
--- a/smartmodule/cargo_template/cargo-generate.toml
+++ b/smartmodule/cargo_template/cargo-generate.toml
@@ -1,6 +1,6 @@
 [placeholders.smartmodule-version]
 type = "string"
-default = "git = \"https://github.com/infinyon/fluvio.git\""
+default = "0.1.0"
 prompt = "SmartModule Version"
 
 [placeholders.smartmodule-type]


### PR DESCRIPTION
Replaces default version with `0.1.0` in the SmartModule Template.

---

```bash
➜  Desktop smdk generate mysmartmodule
Generating new SmartModule project: mysmartmodule
🔧   Destination: /Users/esteban/Desktop/mysmartmodule ...
🔧   Generating template ...
✔ 🤷   Which type of SmartModule would you like? · filter
🤷   SmartModule Version [default: 0.1.0]: 0.1.0
✔ 🤷   Want to use SmartModule init? · true
Ignoring: /var/folders/vx/lkxmsbr95dd4r0j1pwkg0skm0000gn/T/.tmpTduylq/cargo-generate.toml
[1/5]   Done: Cargo.toml
[2/5]   Done: README.md
[3/5]   Done: Smart.toml
[4/5]   Done: src/lib.rs
[5/5]   Done: src
🔧   Moving generated files into: `/Users/esteban/Desktop/mysmartmodule`...
💡   Initializing a fresh Git repository
✨   Done! New project created /Users/esteban/Desktop/mysmartmodule
➜  Desktop
```