### PR TITLE
fix: remove prompt to `fluvio-smartmodule` version

### DIFF
--- a/smartmodule/cargo_template/Cargo.toml
+++ b/smartmodule/cargo_template/Cargo.toml
@@ -8,14 +8,10 @@ edition = "2021"
 crate-type = ['cdylib']
 
 [dependencies]
-fluvio-smartmodule = { {{smartmodule-version}} }
+fluvio-smartmodule = { git = "https://github.com/infinyon/fluvio.git" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-{% if smartmodule-init %}
-{% if smartmodule-type == "filter" %}
-once_cell = "1.13.0"
-{% endif %}
-{% endif %}
+{% if smartmodule-init %}{% if smartmodule-type == "filter" %}once_cell = "1.13.0"{% endif %}{% endif %}
 
 [profile.release-lto]
 inherits = "release"

--- a/smartmodule/cargo_template/cargo-generate.toml
+++ b/smartmodule/cargo_template/cargo-generate.toml
@@ -1,8 +1,3 @@
-[placeholders.smartmodule-version]
-type = "string"
-default = "git = \"https://github.com/infinyon/fluvio.git\""
-prompt = "SmartModule Version"
-
 [placeholders.smartmodule-type]
 type = "string"
 prompt = "Which type of SmartModule would you like?"


### PR DESCRIPTION
Uses the `git` repository from fluvio to gather the latest version always
for the `fluvio-smartmodule` crate.

---

## Example

Execute `smdk generate <SM NAME>` to create a new project.
Note that the SmartModule version prompt is no more. 

```bash
smdk generate cool-smart-module
Generating new SmartModule project: cool-smart-module
🔧   Destination: /Users/esteban/Desktop/cool-smart-module ...
🔧   Generating template ...
✔ 🤷   Which type of SmartModule would you like? · filter
✔ 🤷   Want to use SmartModule init? · true
Ignoring: /var/folders/vx/lkxmsbr95dd4r0j1pwkg0skm0000gn/T/.tmpIzCcps/cargo-generate.toml
[1/5]   Done: Cargo.toml
[2/5]   Done: README.md
[3/5]   Done: Smart.toml
[4/5]   Done: src/lib.rs
[5/5]   Done: src
🔧   Moving generated files into: `/Users/esteban/Desktop/cool-smart-module`...
💡   Initializing a fresh Git repository
✨   Done! New project created /Users/esteban/Desktop/cool-smart-module
```

Then check on the `Cargo.toml` file to verify the `fluvio-smartmodule` is included
with the git repo as the source of the crate.

```bash
[package]
name = "cool-smart-module"
version = "0.1.0"
authors = ["Esteban Borai"]
edition = "2021"

[lib]
crate-type = ['cdylib']

[dependencies]
fluvio-smartmodule = { git = "https://github.com/infinyon/fluvio.git" }
serde = { version = "1", features = ["derive"] }
serde_json = "1"
once_cell = "1.13.0"

[profile.release-lto]
inherits = "release"
lto = true
```

Build your fresh SmartModule using `smdk build`!

```bash
smdk build
# Output from cargo build
```
