### PR TITLE
[Merged by Bors] - perf: short circuit wait for metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "comfy-table",
  "crc",
  "crossbeam-channel",
+ "fastrand",
  "fluvio",
  "fluvio-cli",
  "fluvio-cluster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ name = "fluvio-stream-model"
 version = "0.8.2"
 dependencies = [
  "async-rwlock",
+ "async-std",
  "event-listener",
  "fluvio-future 0.4.2",
  "fluvio-stream-model",

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -151,8 +151,7 @@ For example, to generate optimized binaries, run, `make build-cluster RELEASE=tr
 
 ### Inlining Helm chart
 
-Fluvio uses helm chart to install and manage Kubernetes components.  They are inline into Fluvio CLI binary.  If there is any issue with helm chart, run `make -C k8-util/helm clean` to clean up helm artifacts.
-You will then need to run `make helm_pkg` to rebuild artifacts.
+Fluvio use helm chart to install and manage Kubernetes components.  They are inline into Fluvio CLI binary.  If there is any issue with helm chart, run `make -C k8-util/helm/clean` to clean up helm arifacts.
 
 
 ### Fluvio binaries Alias

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -151,7 +151,8 @@ For example, to generate optimized binaries, run, `make build-cluster RELEASE=tr
 
 ### Inlining Helm chart
 
-Fluvio use helm chart to install and manage Kubernetes components.  They are inline into Fluvio CLI binary.  If there is any issue with helm chart, run `make -C k8-util/helm/clean` to clean up helm arifacts.
+Fluvio uses helm chart to install and manage Kubernetes components.  They are inline into Fluvio CLI binary.  If there is any issue with helm chart, run `make -C k8-util/helm clean` to clean up helm artifacts.
+You will then need to run `make helm_pkg` to rebuild artifacts.
 
 
 ### Fluvio binaries Alias

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -27,9 +27,15 @@ once_cell = "1.5"
 k8-types = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
+
 tokio = { version = "1.3.0", features = ["macros"] }
 fluvio-future = { version = "0.4.0", features = ["fixture"] }
 fluvio-stream-model = { path = ".", features = ["fixture"] }
+async-std = { version = "1.8.0", default-features = false, features = [
+    "attributes",
+] }
 
 [package.metadata.cargo-udeps.ignore]
-development = ["fluvio-stream-model"] # installed with `fixture` feature in tests
+development = [
+    "fluvio-stream-model",
+] # installed with `fixture` feature in tests

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -84,7 +84,7 @@ where
 
     /// write guard, this is private, use sync API to make changes
     #[inline(always)]
-    pub async fn write<'a>(
+    async fn write<'a>(
         &'_ self,
     ) -> RwLockWriteGuard<'_, DualEpochMap<S::IndexKey, MetadataStoreObject<S, C>>> {
         self.store.write().await

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -785,8 +785,8 @@ mod test_notify {
         }
     }
 
-    #[fluvio_future::test]
-    async fn test_wait_for_first_change_assumptions() {
+    #[test]
+    fn test_wait_for_first_change_assumptions() {
         let topic_store = Arc::new(DefaultTestStore::default());
 
         // wait_for_first_change() requires that ChangeListener is initialized with current_change = 0

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -795,11 +795,8 @@ mod test_notify {
         let topic_store = Arc::new(DefaultTestStore::default());
         let last_change = Arc::new(AtomicI64::new(0));
         let shutdown = SimpleEvent::shared();
-        // ctx is used to provide an ordering on updates. See MetadataItem for u32
-        let initial_context = 2u32;
         let topic_name = "topic";
-        let initial_topic =
-            DefaultTest::with_spec(topic_name, TestSpec::default()).with_context(initial_context);
+        let initial_topic = DefaultTest::with_spec(topic_name, TestSpec::default());
         let has_been_updated = Arc::new(AtomicBool::default());
 
         // Start a batch of listeners before changes have been.
@@ -823,8 +820,8 @@ mod test_notify {
         }
 
         // update with apply_changes
-        let topic = DefaultTest::with_spec(topic_name, TestSpec::default())
-            .with_context(initial_context + 1);
+        let topic = DefaultTest::with_spec(topic_name, TestSpec::default());
+
         let _ = topic_store.apply_changes(vec![LSUpdate::Mod(topic)]).await;
 
         // Test batch again to make sure returns correctly after an apply_changes

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -402,44 +402,6 @@ mod listener {
 
     use super::{LocalStore, Spec, MetadataItem, MetadataChanges};
 
-    // /// thin wrapper for an event publisher. blocks until the current change in the event publisher is > 0
-    // /// useful for making sure metadata has been delivered before querying store
-    // pub struct AtLeastOneChangeListener<'a> {
-    //     event_publisher: &'a EventPublisher,
-    // }
-
-    // impl<'a> AtLeastOneChangeListener<'a> {
-    //     /// only constructed by the associated LocalStore that owns the EventPublisher
-    //     pub(crate) fn new(event_publisher: &'a EventPublisher) -> Self {
-    //         Self { event_publisher }
-    //     }
-
-    //     /// check if there should be any changes
-    //     /// this should be done before event listener
-    //     /// to ensure no events are missed
-    //     #[inline]
-    //     pub fn has_change(&'a self) -> bool {
-    //         self.event_publisher.current_change() > 0
-    //     }
-
-    //     /// returns when the event_publisher has a current_change greater than 0
-    //     pub async fn listen(&'a self) {
-    //         if self.has_change() {
-    //             return;
-    //         }
-
-    //         let listener = self.event_publisher.listen();
-
-    //         if self.has_change() {
-    //             return;
-    //         }
-
-    //         trace!("waiting for publisher");
-
-    //         listener.await;
-    //     }
-    // }
-
     /// listen for changes local store
     pub struct ChangeListener<S, C>
     where

--- a/crates/fluvio-stream-model/src/store/event.rs
+++ b/crates/fluvio-stream-model/src/store/event.rs
@@ -34,11 +34,7 @@ impl EventPublisher {
         self.change.load(DEFAULT_EVENT_ORDERING)
     }
 
-    pub fn increment(&self) -> i64 {
-        self.change.fetch_add(1, DEFAULT_EVENT_ORDERING)
-    }
-
-    /// store new value
+    /// stores new value and notifies any listeners
     pub fn store_change(&self, value: i64) {
         self.change.store(value, DEFAULT_EVENT_ORDERING);
         self.notify()

--- a/crates/fluvio-stream-model/src/store/event.rs
+++ b/crates/fluvio-stream-model/src/store/event.rs
@@ -25,7 +25,7 @@ impl EventPublisher {
         Arc::new(Self::new())
     }
 
-    pub fn notify(&self) {
+    fn notify(&self) {
         self.event.notify(usize::MAX);
     }
 
@@ -41,6 +41,7 @@ impl EventPublisher {
     /// store new value
     pub fn store_change(&self, value: i64) {
         self.change.store(value, DEFAULT_EVENT_ORDERING);
+        self.notify()
     }
 
     pub fn listen(&self) -> EventListener {

--- a/crates/fluvio-stream-model/src/store/metadata.rs
+++ b/crates/fluvio-stream-model/src/store/metadata.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use tracing::trace;
 
 use crate::core::{Spec, MetadataContext, MetadataItem, MetadataRevExtension};
-use crate::store::{LocalStore};
+use crate::store::LocalStore;
 
 pub type DefaultMetadataObject<S> = MetadataStoreObject<S, u32>;
 

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -20,6 +20,8 @@ clap = { version = "3.1.8", features = [
 ], default-features = false }
 async-trait = "0.1.21"
 rand = "0.8"
+# Cryptographically secure rand is unnecessary and slow enough to affect for benchmark testing
+fastrand = "1.8.0"
 md-5 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -61,9 +63,7 @@ fluvio-controlplane-metadata = { features = [
 # Fluvio test framework Attribute macro
 fluvio-test-derive = { path = "../fluvio-test-derive" }
 fluvio-test-util = { path = "../fluvio-test-util" }
-fluvio-protocol = { path = "../fluvio-protocol", features = [
-    "api",
-] }
+fluvio-protocol = { path = "../fluvio-protocol", features = ["api"] }
 
 # Fluvio test framework Options derive
 fluvio-test-case-derive = { path = "../fluvio-test-case-derive" }

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -14,9 +14,9 @@ use fluvio_test_util::test_meta::{BaseCli, TestCase, TestCli, TestOption};
 use fluvio_test_util::test_meta::test_result::TestResult;
 use fluvio_test_util::test_meta::environment::{EnvDetail, EnvironmentSetup};
 use fluvio_test_util::setup::TestCluster;
-use fluvio_test_util::test_runner::test_driver::{TestDriver};
+use fluvio_test_util::test_runner::test_driver::TestDriver;
 use fluvio_test_util::test_runner::test_meta::FluvioTestMeta;
-use fluvio_test_util::{async_process};
+use fluvio_test_util::async_process;
 
 // This is important for `inventory` crate
 #[allow(unused_imports)]

--- a/crates/fluvio-test/src/tests/consumer.rs
+++ b/crates/fluvio-test/src/tests/consumer.rs
@@ -9,7 +9,7 @@ use hdrhistogram::Histogram;
 
 use fluvio_protocol::link::ErrorCode;
 use fluvio::consumer::Record;
-use fluvio::{ConsumerConfig, MultiplePartitionConsumer, PartitionConsumer};
+use fluvio::{ConsumerConfig, MultiplePartitionConsumer, PartitionConsumer, RecordKey};
 use fluvio::Offset;
 
 use fluvio_test_derive::fluvio_test;
@@ -18,7 +18,7 @@ use fluvio_test_util::test_meta::{TestOption, TestCase};
 use fluvio_test_util::async_process;
 use fluvio_future::io::Stream;
 
-use crate::tests::TestRecord;
+use crate::tests::{TestRecord, TestRecordBuilder};
 
 #[derive(Debug, Clone)]
 pub struct ConsumerTestCase {
@@ -28,7 +28,7 @@ pub struct ConsumerTestCase {
 
 impl From<TestCase> for ConsumerTestCase {
     fn from(test_case: TestCase) -> Self {
-        let producer_stress_option = test_case
+        let consumer_stress_option = test_case
             .option
             .as_any()
             .downcast_ref::<ConsumerTestOption>()
@@ -36,7 +36,7 @@ impl From<TestCase> for ConsumerTestCase {
             .to_owned();
         ConsumerTestCase {
             environment: test_case.environment,
-            option: producer_stress_option,
+            option: consumer_stress_option,
         }
     }
 }
@@ -47,6 +47,14 @@ pub struct ConsumerTestOption {
     /// Num of consumers to create
     #[clap(long, default_value = "1")]
     pub consumers: u16,
+
+    /// Number of records to send to the topic before running the test
+    #[clap(long, default_value = "100")]
+    pub num_setup_records: u32,
+
+    /// Size of payload portion of records to send to the topic before running the test
+    #[clap(long, default_value = "1000")]
+    pub setup_record_size: usize,
 
     /// Max records to consume before stopping
     /// Default, stop when end of topic reached
@@ -87,6 +95,10 @@ pub struct ConsumerTestOption {
     /// Opt-in to detailed output printed to stdout
     #[clap(long, short)]
     verbose: bool,
+
+    /// Allow the test to pass if no records are received
+    #[clap(long)]
+    allow_empty_topic: bool,
 }
 
 //fn parse_seconds(s: &str) -> Result<Duration, ParseIntError> {
@@ -176,13 +188,23 @@ async fn consume_work<S: ?Sized>(
         }
     }
 
+    println!(
+        "{} && {} = {}",
+        records_recvd,
+        !test_case.option.allow_empty_topic,
+        records_recvd == 0 && !test_case.option.allow_empty_topic
+    );
+    if records_recvd == 0 && !test_case.option.allow_empty_topic {
+        panic!("Consumer test failed, received no records. If this is intentional, run with --allow-empty-topic");
+    }
+
     let consume_p99 = Duration::from_nanos(latency_histogram.value_at_percentile(0.99));
 
     // Stored as bytes per second. Convert to kilobytes per second
     let throughput_p99 = throughput_histogram.max() / 1_000;
 
     println!(
-        "[consumer-{}] Consume P99: {:?} Peak Throughput: {:?} kB/s",
+        "[consumer-{}] Consume P99: {:?} Peak Throughput: {:?} kB/s. # Records: {records_recvd}",
         consumer_id, consume_p99, throughput_p99
     );
 }
@@ -250,6 +272,52 @@ pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         Offset::absolute(raw_offset.into()).expect("Couldn't create absolute offset")
     };
 
+    if test_case.option.num_setup_records != 0 {
+        println!(
+            "producing {} records for topic {}",
+            test_case.option.num_setup_records,
+            test_case.environment.base_topic_name()
+        );
+        // Default producer behaviour round robins between partitions so we don't need to handle the multi-partition case differently
+        async_process!(
+            async {
+                test_driver
+                    .connect()
+                    .await
+                    .expect("Connecting to cluster failed");
+
+                let producer = test_driver
+                    .create_producer(&test_case.environment.base_topic_name())
+                    .await;
+
+                let records: Vec<(RecordKey, Vec<u8>)> = (0..test_case.option.num_setup_records)
+                    .map(|_| {
+                        // Generate test data
+                        let record = TestRecordBuilder::new()
+                            .with_random_data(test_case.option.setup_record_size)
+                            .build();
+                        (
+                            RecordKey::NULL,
+                            serde_json::to_string(&record)
+                                .expect("Convert record to json string failed")
+                                .as_bytes()
+                                .to_vec(),
+                        )
+                    })
+                    .collect();
+
+                producer
+                    .send_all(records)
+                    .await
+                    .expect("failed to send all");
+                producer.flush().await.expect("failed to flush");
+            },
+            format!("consumer-prepopulate-topic")
+        )
+        .join()
+        .expect("Populate records for consumer test failed");
+    }
+
     println!("\nStarting Consumer test");
 
     println!("Consumers: {}", consumers);
@@ -302,8 +370,7 @@ pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         consumer_wait.push(consumer);
     }
 
-    let _: Vec<_> = consumer_wait
-        .into_iter()
-        .map(|p| p.join().expect("Consumer thread fail"))
-        .collect();
+    for p in consumer_wait {
+        p.join().expect("Consumer thread fail")
+    }
 }

--- a/crates/fluvio-test/src/tests/consumer.rs
+++ b/crates/fluvio-test/src/tests/consumer.rs
@@ -233,8 +233,7 @@ async fn get_multi_stream(
     )
 }
 
-// Default to using the producer test's topic
-#[fluvio_test(name = "consumer", topic = "producer-test")]
+#[fluvio_test(name = "consumer", topic = "consumer-test")]
 pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
     let test_case: ConsumerTestCase = test_case.into();
     let consumers = test_case.option.consumers;

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -72,11 +72,6 @@ impl TestRecordBuilder {
         self
     }
 
-    pub fn with_empty_data(mut self, data_size: usize) -> Self {
-        self.data = (0..data_size).map(|_| 'A').collect();
-        self
-    }
-
     pub fn with_random_data(mut self, data_size: usize) -> Self {
         self.data = Self::random_data(data_size);
         self

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -72,6 +72,11 @@ impl TestRecordBuilder {
         self
     }
 
+    pub fn with_empty_data(mut self, data_size: usize) -> Self {
+        self.data = (0..data_size).map(|_| 'A').collect();
+        self
+    }
+
     pub fn with_random_data(mut self, data_size: usize) -> Self {
         self.data = Self::random_data(data_size);
         self
@@ -87,17 +92,13 @@ impl TestRecordBuilder {
     }
 
     fn random_data(data_size: usize) -> String {
-        use rand::Rng;
-
         const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                                 abcdefghijklmnopqrstuvwxyz\
                                 0123456789)(*&^%$#@!~";
 
-        let mut rng = rand::thread_rng();
-
         let data: String = (0..data_size)
             .map(|_| {
-                let idx = rng.gen_range(0..CHARSET.len());
+                let idx = fastrand::usize(0..CHARSET.len());
                 CHARSET[idx] as char
             })
             .collect();

--- a/crates/fluvio-test/src/tests/producer.rs
+++ b/crates/fluvio-test/src/tests/producer.rs
@@ -111,15 +111,6 @@ async fn producer_work(
         //  calculate actual latency, throughput
         // }
 
-        // This bottlenecks the system, not good for throughput test
-        // let record = TestRecordBuilder::new()
-        //     .with_tag(format!("{}:{}", producer_id, record_n))
-        //     .with_empty_data(test_case.option.record_size)
-        //     .build();
-        // let record = serde_json::to_string(&record)
-        //     .expect("Convert record to json string failed")
-        //     .as_bytes()
-        //     .to_vec();
         let record_size = record.len() as u64;
 
         //debug!("{:?}", &record);

--- a/crates/fluvio-test/src/tests/producer.rs
+++ b/crates/fluvio-test/src/tests/producer.rs
@@ -5,7 +5,6 @@ use fluvio::{RecordKey, TopicProducer};
 use fluvio_test_derive::fluvio_test;
 use fluvio_test_util::test_meta::environment::EnvironmentSetup;
 use fluvio_test_util::test_meta::{TestOption, TestCase};
-use crate::tests::TestRecordBuilder;
 use fluvio_test_util::async_process;
 //use tracing::debug;
 use hdrhistogram::Histogram;

--- a/crates/fluvio-test/src/tests/producer.rs
+++ b/crates/fluvio-test/src/tests/producer.rs
@@ -49,7 +49,7 @@ pub struct ProducerTestOption {
     #[clap(long, default_value = "100")]
     pub num_records: u32,
 
-    /// Size of dynamic payload portion of test record
+    /// Size of test record. This test doesn't use the TestRecord struct so this is the total size, not just the dynamic payload size
     #[clap(long, default_value = "1000")]
     pub record_size: usize,
 
@@ -233,8 +233,7 @@ pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
         producer_wait.push(producer);
     }
 
-    let _: Vec<_> = producer_wait
-        .into_iter()
-        .map(|p| p.join().expect("Producer thread fail"))
-        .collect();
+    for p in producer_wait {
+        p.join().expect("Producer thread fail")
+    }
 }

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -180,6 +180,7 @@ impl InnerTopicProducer {
 
     async fn push_record(self: Arc<Self>, record: Record) -> Result<PushRecord> {
         let topics = self.spu_pool.metadata.topics();
+
         let topic_spec = topics
             .lookup_by_key(&self.topic)
             .await?

--- a/crates/fluvio/src/sync/controller.rs
+++ b/crates/fluvio/src/sync/controller.rs
@@ -14,7 +14,7 @@ use fluvio_socket::AsyncResponse;
 use fluvio_sc_schema::objects::{
     Metadata, MetadataUpdate, ObjectApiWatchRequest, ObjectApiWatchResponse, WatchResponse,
 };
-use fluvio_sc_schema::{AdminSpec};
+use fluvio_sc_schema::AdminSpec;
 
 use crate::metadata::core::Spec;
 

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -108,6 +108,12 @@ mod context {
             use tokio::select;
             use fluvio_future::timer::sleep;
 
+            // We can short circuit here if already present
+            let found = search(self.store().read().await);
+            if found.is_some() {
+                return Ok(found);
+            }
+
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));
             let mut listener = self.store.change_listener();
 

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -121,13 +121,7 @@ mod context {
             select! {
 
                 _ = listener.listen() => {
-                    // since the listeners change count is always 0 and listener.listen() only returns when change count > 0,
-                    // calling for sync_changes() will always trigger an allocation.
-                    // Since we don't do anything with the changes and sync_changes() doesn't add new changes to the cache, it's wasteful to call
-
-                    // this should be full sync
-                    // let changes = listener.sync_changes().await;
-                    // trace!("{} received changes: {:#?}",S::LABEL,changes);
+                    // We don't need to call sync_changes() because listener is dropped immediately
 
                     Ok(search(self.store().read().await))
                 },

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -116,10 +116,10 @@ mod context {
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));
             let listener = self.store().at_least_one_change_listener();
 
-            // wait for either changes from store or timeout
+            // No changes recieved yet, wait for first changes from store or timeout
             select! {
 
-                _ = listener.listen_for_at_least_one_change() => {
+                _ = listener.listen() => {
                     Ok(search(self.store().read().await))
                 },
                 _ = &mut timer => {

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -114,12 +114,11 @@ mod context {
             }
 
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));
-            let listener = self.store().change_listener();
 
             // No changes recieved yet, wait for first changes from store or timeout
             select! {
 
-                _ = listener.listen_for_at_least_one_change() => {
+                _ = self.store.wait_for_first_change() => {
                     Ok(search(self.store().read().await))
                 },
                 _ = &mut timer => {

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -115,9 +115,14 @@ mod context {
             select! {
 
                 _ = listener.listen() => {
+                    // since the listeners change count is always 0 and listener.listen() only returns when change count > 0,
+                    // calling for sync_changes() will always trigger an allocation.
+                    // Since we don't do anything with the changes and sync_changes() doesn't add new changes to the cache, it's wasteful to call
+
                     // this should be full sync
-                    let changes = listener.sync_changes().await;
-                    trace!("{} received changes: {:#?}",S::LABEL,changes);
+                    // let changes = listener.sync_changes().await;
+                    // trace!("{} received changes: {:#?}",S::LABEL,changes);
+                    // println!("{} received changes: {:#?}",S::LABEL,changes);
 
                     Ok(search(self.store().read().await))
                 },

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -122,7 +122,6 @@ mod context {
                     // this should be full sync
                     // let changes = listener.sync_changes().await;
                     // trace!("{} received changes: {:#?}",S::LABEL,changes);
-                    // println!("{} received changes: {:#?}",S::LABEL,changes);
 
                     Ok(search(self.store().read().await))
                 },

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -10,7 +10,7 @@ mod context {
     use std::fmt::Display;
     use std::io::Error as IoError;
 
-    use tracing::{debug, trace, instrument};
+    use tracing::{debug, instrument};
     use async_rwlock::RwLockReadGuard;
     use once_cell::sync::Lazy;
 

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -109,9 +109,8 @@ mod context {
             use fluvio_future::timer::sleep;
 
             // We can short circuit here if already present
-            let found = search(self.store().read().await);
-            if found.is_some() {
-                return Ok(found);
+            if let Some(found) = search(self.store().read().await) {
+                return Ok(Some(found));
             }
 
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -114,12 +114,12 @@ mod context {
             }
 
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));
-            let listener = self.store().at_least_one_change_listener();
+            let listener = self.store().change_listener();
 
             // No changes recieved yet, wait for first changes from store or timeout
             select! {
 
-                _ = listener.listen() => {
+                _ = listener.listen_for_at_least_one_change() => {
                     Ok(search(self.store().read().await))
                 },
                 _ = &mut timer => {

--- a/crates/fluvio/src/sync/mod.rs
+++ b/crates/fluvio/src/sync/mod.rs
@@ -115,14 +115,12 @@ mod context {
             }
 
             let mut timer = sleep(Duration::from_millis(*MAX_WAIT_TIME));
-            let mut listener = self.store.change_listener();
+            let listener = self.store().at_least_one_change_listener();
 
             // wait for either changes from store or timeout
             select! {
 
-                _ = listener.listen() => {
-                    // We don't need to call sync_changes() because listener is dropped immediately
-
+                _ = listener.listen_for_at_least_one_change() => {
                     Ok(search(self.store().read().await))
                 },
                 _ = &mut timer => {


### PR DESCRIPTION
1. Added some performance fixes to producer test framework itself.
2. Performance improvements to `sync::lookup_and_wait`
3. Benchmarked results for producer 1 X 100,000 and 3 X 150,000.

Example bench output
```
Start running fluvio test runner
Testing connection to Fluvio cluster in profile
starting test in child process
Creating the topic: producer-test
topic "producer-test" already exists

Starting Producer test
Producers: 3
# Records: 150000
Starting Producer #0
Starting Producer #1
Starting Producer #2
[producer-2] Produce P99: 6.783µs Peak Throughput: 155189 kB/s
[producer-1] Produce P99: 6.751µs Peak Throughput: 157286 kB/s
[producer-0] Produce P99: 6.783µs Peak Throughput: 157286 kB/s
test passed, signalling success to parent
Test passed
+----------+---------------+
| Pass?    | true          |
|----------+---------------|
| Duration | 23.135994663s |
+----------+---------------+
```


### profiling results
No change

```
# 1 X 100K
[producer-0] Produce P99: 18.175µs Peak Throughput: 65011 kB/s

#3 X 150
[producer-0] Produce P99: 19.199µs Peak Throughput: 62128 kB/s
[producer-1] Produce P99: 19.327µs Peak Throughput: 61341 kB/s
[producer-2] Produce P99: 19.199µs Peak Throughput: 61865 kB/s
```

Test harness improvements only
```
# 1 X 100K
[producer-0] Produce P99: 13.759µs Peak Throughput: 78118 kB/s

#3 X 150
[producer-2] Produce P99: 13.951µs Peak Throughput: 74973 kB/s
[producer-1] Produce P99: 14.015µs Peak Throughput: 76021 kB/s
[producer-0] Produce P99: 14.079µs Peak Throughput: 74448 kB/s
```

Short circuiting
```
# 1 X 100K
[producer-0] Produce P99: 7.103µs Peak Throughput: 147849 kB/s

#3 X 150
[producer-2] Produce P99: 6.783µs Peak Throughput: 155189 kB/s
[producer-1] Produce P99: 6.751µs Peak Throughput: 157286 kB/s
[producer-0] Produce P99: 6.783µs Peak Throughput: 157286 kB/s
```