### PR TITLE
[Merged by Bors] - chore: exclude md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on:
       - trying
   pull_request:
     branches: [master]
+    paths:
+    - '**'
+    - '!/*.md'
+    - '!/**.md'
   workflow_dispatch:
     inputs:
       verbose:


### PR DESCRIPTION
Similar to connector CI: https://github.com/infinyon/fluvio-connectors/blob/main/.github/workflows/ci.yml.  Excluding MD from triggering CI