### PR TITLE
[Merged by Bors] - feat: general admin watch API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
  "sysinfo",
  "tempdir",
  "thiserror",
+ "tokio",
  "tracing",
  "tui",
  "url",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -72,6 +72,7 @@ humantime-serde = "1.1.1"
 bytesize = { version = "1.1.0", features = ['serde'] }
 indicatif = "0.17.0"
 async-trait = "0.1.21"
+tokio = { version = "1.3.0", features = ["macros"] }
 
 # Fluvio dependencies
 k8-config = { version = "2.0.0", optional = true }

--- a/crates/fluvio-cli/src/client/smartmodule/mod.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/mod.rs
@@ -1,6 +1,7 @@
 mod create;
 mod list;
 mod delete;
+mod watch;
 
 pub use cmd::SmartModuleCmd;
 
@@ -22,11 +23,13 @@ mod cmd {
     use super::create::CreateSmartModuleOpt;
     use super::list::ListSmartModuleOpt;
     use super::delete::DeleteSmartModuleOpt;
+    use super::watch::WatchSmartModuleOpt;
 
     #[derive(Debug, Parser)]
     pub enum SmartModuleCmd {
         Create(CreateSmartModuleOpt),
         List(ListSmartModuleOpt),
+        Watch(WatchSmartModuleOpt),
         /// Delete one or more SmartModules with the given name(s)
         Delete(DeleteSmartModuleOpt),
     }
@@ -46,6 +49,9 @@ mod cmd {
                     opt.process(out, target).await?;
                 }
                 Self::Delete(opt) => {
+                    opt.process(out, target).await?;
+                }
+                Self::Watch(opt) => {
                     opt.process(out, target).await?;
                 }
             }

--- a/crates/fluvio-cli/src/client/smartmodule/watch.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/watch.rs
@@ -35,6 +35,7 @@ impl ClientCmd for WatchSmartModuleOpt {
             select! {
                 next = watch_stream.next() => {
                     if let Some(Ok(event)) = next {
+                        // low level printing, should be replaced
                         println!("SmartModule event: {:?}", event);
                     } else {
                         println!("SmartModule event stream ended");

--- a/crates/fluvio-cli/src/client/smartmodule/watch.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/watch.rs
@@ -35,9 +35,9 @@ impl ClientCmd for WatchSmartModuleOpt {
             select! {
                 next = watch_stream.next() => {
                     if let Some(Ok(event)) = next {
-                        println!("Watch event: {:?}", event);
+                        println!("SmartModule event: {:?}", event);
                     } else {
-                        println!("watch stream ended");
+                        println!("SmartModule event stream ended");
                         break;
                     }
                 }

--- a/crates/fluvio-cli/src/client/smartmodule/watch.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/watch.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use clap::Parser;
+use tokio::select;
+
+use fluvio::metadata::smartmodule::SmartModuleSpec;
+use fluvio::Fluvio;
+use fluvio_future::io::StreamExt;
+
+use crate::client::cmd::ClientCmd;
+use crate::common::output::Terminal;
+use crate::common::OutputFormat;
+use crate::Result;
+
+/// List all existing SmartModules
+#[derive(Debug, Parser)]
+pub struct WatchSmartModuleOpt {
+    #[clap(flatten)]
+    output: OutputFormat,
+}
+
+#[async_trait]
+impl ClientCmd for WatchSmartModuleOpt {
+    async fn process_client<O: Terminal + Debug + Send + Sync>(
+        self,
+        _out: Arc<O>,
+        fluvio: &Fluvio,
+    ) -> Result<()> {
+        let admin = fluvio.admin().await;
+
+        let mut watch_stream = admin.watch::<SmartModuleSpec>().await?;
+        loop {
+            select! {
+                next = watch_stream.next() => {
+                    if let Some(Ok(event)) = next {
+                        println!("Watch event: {:?}", event);
+                    } else {
+                        println!("watch stream ended");
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -116,17 +116,6 @@ impl SmartModuleSpec {
             .map(|meta| meta.package.version.to_string())
             .unwrap_or_else(|| "".to_owned())
     }
-
-    /// get summary version
-    pub fn summary(&self) -> Self {
-        Self {
-            meta: self.meta.clone(),
-            summary: Some(SmartModuleWasmSummary {
-                wasm_length: self.wasm.payload.len() as u32,
-            }),
-            wasm: SmartModuleWasm::default(),
-        }
-    }
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Encoder, Decoder)]

--- a/crates/fluvio-sc-schema/src/connector/mod.rs
+++ b/crates/fluvio-sc-schema/src/connector/mod.rs
@@ -5,16 +5,14 @@ mod convert {
     use crate::{
         AdminSpec, CreatableAdminSpec, DeletableAdminSpec, NameFilter,
         objects::{
-            CreateFrom, DeleteRequest, ListRequest, ListResponse, Metadata, ObjectFrom,
-            ObjectTryFrom, WatchRequest, WatchResponse,
+            CreateFrom, DeleteRequest, ListRequest, ListResponse, ObjectFrom, ObjectTryFrom,
+            WatchRequest, WatchResponse,
         },
     };
     use super::ManagedConnectorSpec;
 
     impl AdminSpec for ManagedConnectorSpec {
         type ListFilter = NameFilter;
-        type ListType = Metadata<Self>;
-        type WatchResponseType = Self;
     }
 
     impl CreatableAdminSpec for ManagedConnectorSpec {

--- a/crates/fluvio-sc-schema/src/connector/mod.rs
+++ b/crates/fluvio-sc-schema/src/connector/mod.rs
@@ -3,7 +3,7 @@ pub use fluvio_controlplane_metadata::connector::*;
 mod convert {
 
     use crate::{
-        AdminSpec, CreatableAdminSpec, DeletableAdminSpec, NameFilter,
+        AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{
             CreateFrom, DeleteRequest, ListRequest, ListResponse, ObjectFrom, ObjectTryFrom,
             WatchRequest, WatchResponse,
@@ -11,9 +11,7 @@ mod convert {
     };
     use super::ManagedConnectorSpec;
 
-    impl AdminSpec for ManagedConnectorSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for ManagedConnectorSpec {}
 
     impl CreatableAdminSpec for ManagedConnectorSpec {
         const CREATE_TYPE: u8 = 3;

--- a/crates/fluvio-sc-schema/src/customspu/mod.rs
+++ b/crates/fluvio-sc-schema/src/customspu/mod.rs
@@ -8,13 +8,11 @@ use crate::objects::ListRequest;
 use crate::objects::ListResponse;
 use crate::{
     AdminSpec, NameFilter,
-    objects::{ObjectFrom, ObjectTryFrom, Metadata, WatchResponse, WatchRequest},
+    objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest},
 };
 
 impl AdminSpec for CustomSpuSpec {
     type ListFilter = NameFilter;
-    type ListType = Metadata<Self>;
-    type WatchResponseType = Self;
 }
 
 impl CreatableAdminSpec for CustomSpuSpec {

--- a/crates/fluvio-sc-schema/src/customspu/mod.rs
+++ b/crates/fluvio-sc-schema/src/customspu/mod.rs
@@ -7,13 +7,11 @@ use crate::objects::DeleteRequest;
 use crate::objects::ListRequest;
 use crate::objects::ListResponse;
 use crate::{
-    AdminSpec, NameFilter,
+    AdminSpec,
     objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest},
 };
 
-impl AdminSpec for CustomSpuSpec {
-    type ListFilter = NameFilter;
-}
+impl AdminSpec for CustomSpuSpec {}
 
 impl CreatableAdminSpec for CustomSpuSpec {
     const CREATE_TYPE: u8 = 1;

--- a/crates/fluvio-sc-schema/src/derivedstream/mod.rs
+++ b/crates/fluvio-sc-schema/src/derivedstream/mod.rs
@@ -5,7 +5,6 @@ mod convert {
     use crate::AdminSpec;
     use crate::CreatableAdminSpec;
     use crate::DeletableAdminSpec;
-    use crate::NameFilter;
     use crate::objects::CreateFrom;
     use crate::objects::DeleteRequest;
     use crate::objects::ListRequest;
@@ -17,9 +16,7 @@ mod convert {
 
     use super::DerivedStreamSpec;
 
-    impl AdminSpec for DerivedStreamSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for DerivedStreamSpec {}
 
     impl CreatableAdminSpec for DerivedStreamSpec {
         const CREATE_TYPE: u8 = 10;

--- a/crates/fluvio-sc-schema/src/derivedstream/mod.rs
+++ b/crates/fluvio-sc-schema/src/derivedstream/mod.rs
@@ -10,7 +10,6 @@ mod convert {
     use crate::objects::DeleteRequest;
     use crate::objects::ListRequest;
     use crate::objects::ListResponse;
-    use crate::objects::Metadata;
     use crate::objects::ObjectFrom;
     use crate::objects::ObjectTryFrom;
     use crate::objects::WatchRequest;
@@ -20,8 +19,6 @@ mod convert {
 
     impl AdminSpec for DerivedStreamSpec {
         type ListFilter = NameFilter;
-        type WatchResponseType = Self;
-        type ListType = Metadata<Self>;
     }
 
     impl CreatableAdminSpec for DerivedStreamSpec {

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -61,8 +61,8 @@ mod admin {
         }
 
         /// return summary version of myself
-        fn summary(&self) -> Self {
-            self.clone()
+        fn summary(self) -> Self {
+            self
         }
     }
 

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -59,6 +59,11 @@ mod admin {
         {
             obj.clone().into()
         }
+
+        /// return summary version of myself
+        fn summary(&self) -> Self {
+            self.clone()
+        }
     }
 
     /// Not every Admin Object can be created directly

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -47,13 +47,8 @@ mod admin {
 
     use super::core::{Spec};
 
-    /// filter by name
-    pub type NameFilter = String;
-
     /// AdminSpec can perform list and watch
     pub trait AdminSpec: Spec + Encoder + Decoder {
-        type ListFilter: Encoder + Decoder + Sized + Debug;
-
         /// convert metadata object to list type object
         fn convert_from<C: fluvio_controlplane_metadata::core::MetadataItem>(
             obj: &fluvio_controlplane_metadata::store::MetadataStoreObject<Self, C>,

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -43,6 +43,8 @@ mod admin {
     use fluvio_protocol::{Encoder, Decoder};
     use fluvio_controlplane_metadata::{store::MetadataStoreObject};
 
+    use crate::objects::Metadata;
+
     use super::core::{Spec};
 
     /// filter by name
@@ -51,15 +53,14 @@ mod admin {
     /// AdminSpec can perform list and watch
     pub trait AdminSpec: Spec + Encoder + Decoder {
         type ListFilter: Encoder + Decoder + Sized + Debug;
-        type ListType: Encoder + Decoder + Debug;
-        type WatchResponseType: Spec + Encoder + Decoder;
 
         /// convert metadata object to list type object
         fn convert_from<C: fluvio_controlplane_metadata::core::MetadataItem>(
             obj: &fluvio_controlplane_metadata::store::MetadataStoreObject<Self, C>,
-        ) -> Self::ListType
+        ) -> Metadata<Self>
         where
-            <Self as AdminSpec>::ListType: From<MetadataStoreObject<Self, C>>,
+            Metadata<Self>: From<MetadataStoreObject<Self, C>>,
+            Self::Status: Encoder + Decoder + Debug,
         {
             obj.clone().into()
         }

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -3,6 +3,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
+use fluvio_controlplane_metadata::store::KeyFilter;
 use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::api::Request;
 
@@ -32,6 +33,25 @@ pub struct ListFilters {
 impl From<Vec<ListFilter>> for ListFilters {
     fn from(filters: Vec<ListFilter>) -> Self {
         Self { filters }
+    }
+}
+
+impl Into<Vec<ListFilter>> for ListFilters {
+    fn into(self) -> Vec<ListFilter> {
+        self.filters
+    }
+}
+
+impl KeyFilter<str> for ListFilters {
+    fn filter(&self, value: &str) -> bool {
+        if self.filters.is_empty() {
+            return true;
+        }
+        self.filters
+            .iter()
+            .filter(|key| key.name.filter(value))
+            .count()
+            > 0
     }
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -36,9 +36,9 @@ impl From<Vec<ListFilter>> for ListFilters {
     }
 }
 
-impl Into<Vec<ListFilter>> for ListFilters {
-    fn into(self) -> Vec<ListFilter> {
-        self.filters
+impl From<ListFilters> for Vec<ListFilter> {
+    fn from(filter: ListFilters) -> Self {
+        filter.filters
     }
 }
 

--- a/crates/fluvio-sc-schema/src/objects/list.rs
+++ b/crates/fluvio-sc-schema/src/objects/list.rs
@@ -6,7 +6,7 @@ use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::api::Request;
 
 use crate::{AdminPublicApiKey, AdminSpec};
-use super::{ObjectApiEnum, COMMON_VERSION};
+use super::{ObjectApiEnum, COMMON_VERSION, Metadata};
 
 ObjectApiEnum!(ListRequest);
 ObjectApiEnum!(ListResponse);
@@ -37,19 +37,23 @@ impl Request for ObjectApiListRequest {
 }
 
 #[derive(Debug, Default, Encoder, Decoder)]
-pub struct ListResponse<S: AdminSpec> {
-    inner: Vec<S::ListType>,
+pub struct ListResponse<S: AdminSpec>
+where
+    S::Status: Encoder + Decoder + Debug,
+{
+    inner: Vec<Metadata<S>>,
 }
 
 impl<S> ListResponse<S>
 where
     S: AdminSpec,
+    S::Status: Encoder + Decoder + Debug,
 {
-    pub fn new(inner: Vec<S::ListType>) -> Self {
+    pub fn new(inner: Vec<Metadata<S>>) -> Self {
         Self { inner }
     }
 
-    pub fn inner(self) -> Vec<S::ListType> {
+    pub fn inner(self) -> Vec<Metadata<S>> {
         self.inner
     }
 }

--- a/crates/fluvio-sc-schema/src/objects/mod.rs
+++ b/crates/fluvio-sc-schema/src/objects/mod.rs
@@ -26,6 +26,7 @@ mod metadata {
     use fluvio_controlplane_metadata::store::MetadataStoreObject;
     use fluvio_controlplane_metadata::core::{MetadataContext, MetadataItem};
 
+    use crate::AdminSpec;
     use crate::core::Spec;
 
     #[derive(Encoder, Decoder, Default, Clone, Debug)]
@@ -56,6 +57,20 @@ mod metadata {
                 name: meta.key.to_string(),
                 spec: meta.spec,
                 status: meta.status,
+            }
+        }
+    }
+
+    impl<S> Metadata<S>
+    where
+        S: AdminSpec + Encoder + Decoder,
+        S::Status: Encoder + Decoder,
+    {
+        pub fn summary(self) -> Self {
+            Self {
+                name: self.name,
+                spec: self.spec.summary(),
+                status: self.status,
             }
         }
     }

--- a/crates/fluvio-sc-schema/src/objects/mod.rs
+++ b/crates/fluvio-sc-schema/src/objects/mod.rs
@@ -9,7 +9,6 @@ pub use list::*;
 pub use watch::*;
 pub use metadata::*;
 
-pub use crate::NameFilter;
 pub(crate) use object_macro::*;
 pub(crate) use delete_macro::*;
 

--- a/crates/fluvio-sc-schema/src/objects/watch.rs
+++ b/crates/fluvio-sc-schema/src/objects/watch.rs
@@ -26,6 +26,18 @@ pub struct WatchRequest<S: AdminSpec> {
     data: PhantomData<S>,
 }
 
+impl<S> WatchRequest<S>
+where
+    S: AdminSpec,
+{
+    pub fn summary() -> Self {
+        Self {
+            summary: true,
+            ..Default::default()
+        }
+    }
+}
+
 impl Request for ObjectApiWatchRequest {
     const API_KEY: u16 = AdminPublicApiKey::Watch as u16;
     const DEFAULT_API_VERSION: i16 = COMMON_VERSION;

--- a/crates/fluvio-sc-schema/src/objects/watch.rs
+++ b/crates/fluvio-sc-schema/src/objects/watch.rs
@@ -11,7 +11,7 @@ use fluvio_controlplane_metadata::message::Message;
 use crate::{AdminPublicApiKey, AdminSpec};
 use crate::core::Spec;
 
-use super::{Metadata, ObjectApiEnum};
+use super::{Metadata, ObjectApiEnum, COMMON_VERSION};
 
 ObjectApiEnum!(WatchRequest);
 ObjectApiEnum!(WatchResponse);
@@ -21,12 +21,14 @@ ObjectApiEnum!(WatchResponse);
 #[derive(Debug, Encoder, Default, Decoder)]
 pub struct WatchRequest<S: AdminSpec> {
     epoch: Epoch,
+    #[fluvio(min_version = 10)]
+    pub summary: bool, // if true, only return summary
     data: PhantomData<S>,
 }
 
 impl Request for ObjectApiWatchRequest {
     const API_KEY: u16 = AdminPublicApiKey::Watch as u16;
-    const DEFAULT_API_VERSION: i16 = 9;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = ObjectApiWatchResponse;
 }
 

--- a/crates/fluvio-sc-schema/src/objects/watch.rs
+++ b/crates/fluvio-sc-schema/src/objects/watch.rs
@@ -35,21 +35,21 @@ impl Request for ObjectApiWatchRequest {
 #[derive(Debug, Default, Encoder, Decoder)]
 pub struct WatchResponse<S: AdminSpec>
 where
-    <S::WatchResponseType as Spec>::Status: Encoder + Decoder,
+    S::Status: Encoder + Decoder,
 {
-    inner: MetadataUpdate<S::WatchResponseType>,
+    inner: MetadataUpdate<S>,
 }
 
 impl<S> WatchResponse<S>
 where
     S: AdminSpec,
-    <S::WatchResponseType as Spec>::Status: Encoder + Decoder,
+    S::Status: Encoder + Decoder,
 {
-    pub fn new(inner: MetadataUpdate<S::WatchResponseType>) -> Self {
+    pub fn new(inner: MetadataUpdate<S>) -> Self {
         Self { inner }
     }
 
-    pub fn inner(self) -> MetadataUpdate<S::WatchResponseType> {
+    pub fn inner(self) -> MetadataUpdate<S> {
         self.inner
     }
 }

--- a/crates/fluvio-sc-schema/src/partition/mod.rs
+++ b/crates/fluvio-sc-schema/src/partition/mod.rs
@@ -8,14 +8,12 @@ mod convert {
     use crate::objects::ObjectTryFrom;
     use crate::{
         AdminSpec, NameFilter,
-        objects::{Metadata, WatchRequest, WatchResponse},
+        objects::{WatchRequest, WatchResponse},
     };
     use super::*;
 
     impl AdminSpec for PartitionSpec {
         type ListFilter = NameFilter;
-        type WatchResponseType = Self;
-        type ListType = Metadata<Self>;
     }
 
     ObjectFrom!(WatchRequest, Partition);

--- a/crates/fluvio-sc-schema/src/partition/mod.rs
+++ b/crates/fluvio-sc-schema/src/partition/mod.rs
@@ -7,14 +7,12 @@ mod convert {
     use crate::objects::ObjectFrom;
     use crate::objects::ObjectTryFrom;
     use crate::{
-        AdminSpec, NameFilter,
+        AdminSpec,
         objects::{WatchRequest, WatchResponse},
     };
     use super::*;
 
-    impl AdminSpec for PartitionSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for PartitionSpec {}
 
     ObjectFrom!(WatchRequest, Partition);
     ObjectFrom!(WatchResponse, Partition);

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -14,9 +14,9 @@ mod convert {
     use super::SmartModuleSpec;
 
     impl AdminSpec for SmartModuleSpec {
-        fn summary(&self) -> Self {
+        fn summary(self) -> Self {
             Self {
-                meta: self.meta.clone(),
+                meta: self.meta,
                 summary: Some(SmartModuleWasmSummary {
                     wasm_length: self.wasm.payload.len() as u32,
                 }),

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -1,5 +1,4 @@
 pub use fluvio_controlplane_metadata::smartmodule::*;
-pub use convert::SmartModuleFilter;
 
 mod convert {
 
@@ -13,9 +12,7 @@ mod convert {
     };
     use super::SmartModuleSpec;
 
-    impl AdminSpec for SmartModuleSpec {
-        type ListFilter = SmartModuleFilter;
-    }
+    impl AdminSpec for SmartModuleSpec {}
 
     impl CreatableAdminSpec for SmartModuleSpec {
         const CREATE_TYPE: u8 = 4;
@@ -23,17 +20,6 @@ mod convert {
 
     impl DeletableAdminSpec for SmartModuleSpec {
         type DeleteKey = String;
-    }
-
-    #[derive(Debug, Encoder, Decoder, Default)]
-    pub struct SmartModuleFilter {
-        pub name: String,
-    }
-
-    impl From<String> for SmartModuleFilter {
-        fn from(name: String) -> Self {
-            Self { name }
-        }
     }
 
     CreateFrom!(SmartModuleSpec, SmartModule);

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -2,7 +2,6 @@ pub use fluvio_controlplane_metadata::smartmodule::*;
 
 mod convert {
 
-    use fluvio_protocol::{Encoder, Decoder};
     use crate::{
         AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -2,6 +2,8 @@ pub use fluvio_controlplane_metadata::smartmodule::*;
 
 mod convert {
 
+    use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasmSummary, SmartModuleWasm};
+
     use crate::{
         AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{
@@ -11,7 +13,17 @@ mod convert {
     };
     use super::SmartModuleSpec;
 
-    impl AdminSpec for SmartModuleSpec {}
+    impl AdminSpec for SmartModuleSpec {
+        fn summary(&self) -> Self {
+            Self {
+                meta: self.meta.clone(),
+                summary: Some(SmartModuleWasmSummary {
+                    wasm_length: self.wasm.payload.len() as u32,
+                }),
+                wasm: SmartModuleWasm::default(),
+            }
+        }
+    }
 
     impl CreatableAdminSpec for SmartModuleSpec {
         const CREATE_TYPE: u8 = 4;

--- a/crates/fluvio-sc-schema/src/smartmodule/mod.rs
+++ b/crates/fluvio-sc-schema/src/smartmodule/mod.rs
@@ -7,16 +7,14 @@ mod convert {
     use crate::{
         AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{
-            CreateFrom, DeleteRequest, ListRequest, ListResponse, Metadata, ObjectFrom,
-            ObjectTryFrom, WatchRequest, WatchResponse,
+            CreateFrom, DeleteRequest, ListRequest, ListResponse, ObjectFrom, ObjectTryFrom,
+            WatchRequest, WatchResponse,
         },
     };
     use super::SmartModuleSpec;
 
     impl AdminSpec for SmartModuleSpec {
         type ListFilter = SmartModuleFilter;
-        type WatchResponseType = Self;
-        type ListType = Metadata<Self>;
     }
 
     impl CreatableAdminSpec for SmartModuleSpec {

--- a/crates/fluvio-sc-schema/src/spg/mod.rs
+++ b/crates/fluvio-sc-schema/src/spg/mod.rs
@@ -5,16 +5,14 @@ mod convert {
     use crate::{
         AdminSpec, CreatableAdminSpec, DeletableAdminSpec, NameFilter,
         objects::{
-            CreateFrom, DeleteRequest, ListRequest, ListResponse, Metadata, ObjectFrom,
-            ObjectTryFrom, WatchRequest, WatchResponse,
+            CreateFrom, DeleteRequest, ListRequest, ListResponse, ObjectFrom, ObjectTryFrom,
+            WatchRequest, WatchResponse,
         },
     };
     use super::SpuGroupSpec;
 
     impl AdminSpec for SpuGroupSpec {
         type ListFilter = NameFilter;
-        type ListType = Metadata<Self>;
-        type WatchResponseType = Self;
     }
 
     impl CreatableAdminSpec for SpuGroupSpec {

--- a/crates/fluvio-sc-schema/src/spg/mod.rs
+++ b/crates/fluvio-sc-schema/src/spg/mod.rs
@@ -3,7 +3,7 @@ pub use fluvio_controlplane_metadata::spg::*;
 mod convert {
 
     use crate::{
-        AdminSpec, CreatableAdminSpec, DeletableAdminSpec, NameFilter,
+        AdminSpec, CreatableAdminSpec, DeletableAdminSpec,
         objects::{
             CreateFrom, DeleteRequest, ListRequest, ListResponse, ObjectFrom, ObjectTryFrom,
             WatchRequest, WatchResponse,
@@ -11,9 +11,7 @@ mod convert {
     };
     use super::SpuGroupSpec;
 
-    impl AdminSpec for SpuGroupSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for SpuGroupSpec {}
 
     impl CreatableAdminSpec for SpuGroupSpec {
         const CREATE_TYPE: u8 = 2;

--- a/crates/fluvio-sc-schema/src/spu/mod.rs
+++ b/crates/fluvio-sc-schema/src/spu/mod.rs
@@ -3,13 +3,11 @@ pub use fluvio_controlplane_metadata::spu::{SpuSpec};
 use crate::objects::ListRequest;
 use crate::objects::ListResponse;
 use crate::{
-    AdminSpec, NameFilter,
+    AdminSpec,
     objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest},
 };
 
-impl AdminSpec for SpuSpec {
-    type ListFilter = NameFilter;
-}
+impl AdminSpec for SpuSpec {}
 
 ObjectFrom!(WatchRequest, Spu);
 ObjectFrom!(WatchResponse, Spu);

--- a/crates/fluvio-sc-schema/src/spu/mod.rs
+++ b/crates/fluvio-sc-schema/src/spu/mod.rs
@@ -2,7 +2,6 @@ pub use fluvio_controlplane_metadata::spu::{SpuSpec};
 
 use crate::objects::ListRequest;
 use crate::objects::ListResponse;
-use crate::objects::Metadata;
 use crate::{
     AdminSpec, NameFilter,
     objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest},
@@ -10,8 +9,6 @@ use crate::{
 
 impl AdminSpec for SpuSpec {
     type ListFilter = NameFilter;
-    type ListType = Metadata<Self>;
-    type WatchResponseType = Self;
 }
 
 ObjectFrom!(WatchRequest, Spu);

--- a/crates/fluvio-sc-schema/src/tableformat/mod.rs
+++ b/crates/fluvio-sc-schema/src/tableformat/mod.rs
@@ -8,14 +8,12 @@ mod convert {
     };
     use crate::{
         AdminSpec, NameFilter,
-        objects::{ListRequest, Metadata, WatchResponse},
+        objects::{ListRequest, WatchResponse},
     };
     use super::TableFormatSpec;
 
     impl AdminSpec for TableFormatSpec {
         type ListFilter = NameFilter;
-        type ListType = Metadata<Self>;
-        type WatchResponseType = Self;
     }
 
     impl CreatableAdminSpec for TableFormatSpec {

--- a/crates/fluvio-sc-schema/src/tableformat/mod.rs
+++ b/crates/fluvio-sc-schema/src/tableformat/mod.rs
@@ -7,14 +7,12 @@ mod convert {
         CreateFrom, DeleteRequest, ListResponse, ObjectFrom, ObjectTryFrom, WatchRequest,
     };
     use crate::{
-        AdminSpec, NameFilter,
+        AdminSpec,
         objects::{ListRequest, WatchResponse},
     };
     use super::TableFormatSpec;
 
-    impl AdminSpec for TableFormatSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for TableFormatSpec {}
 
     impl CreatableAdminSpec for TableFormatSpec {
         const CREATE_TYPE: u8 = 5;

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -47,14 +47,12 @@ mod convert {
     use crate::objects::DeleteRequest;
     use crate::objects::ListRequest;
     use crate::objects::ListResponse;
-    use crate::{AdminSpec, NameFilter};
+    use crate::{AdminSpec};
     use crate::objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest};
 
     use super::TopicSpec;
 
-    impl AdminSpec for TopicSpec {
-        type ListFilter = NameFilter;
-    }
+    impl AdminSpec for TopicSpec {}
 
     impl CreatableAdminSpec for TopicSpec {
         const CREATE_TYPE: u8 = 0;

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -48,14 +48,12 @@ mod convert {
     use crate::objects::ListRequest;
     use crate::objects::ListResponse;
     use crate::{AdminSpec, NameFilter};
-    use crate::objects::{ObjectFrom, ObjectTryFrom, Metadata, WatchResponse, WatchRequest};
+    use crate::objects::{ObjectFrom, ObjectTryFrom, WatchResponse, WatchRequest};
 
     use super::TopicSpec;
 
     impl AdminSpec for TopicSpec {
         type ListFilter = NameFilter;
-        type ListType = Metadata<Self>;
-        type WatchResponseType = Self;
     }
 
     impl CreatableAdminSpec for TopicSpec {

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -44,7 +44,7 @@ pub async fn handle_list_request<AC: AuthContext>(
         ),
         ObjectApiListRequest::SmartModule(req) => ObjectApiListResponse::SmartModule(
             fetch_smart_modules(
-                req.name_filters,
+                req.name_filters.into(),
                 req.summary,
                 &auth_ctx.auth,
                 auth_ctx.global_ctx.smartmodules(),
@@ -85,16 +85,17 @@ mod fetch {
     use fluvio_stream_dispatcher::store::StoreContext;
     use tracing::{debug, trace, instrument};
 
-    use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata};
+    use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilters};
     use fluvio_auth::{AuthContext, TypeAction};
-    use fluvio_controlplane_metadata::store::{KeyFilter, MetadataStoreObject};
+    use fluvio_controlplane_metadata::store::{MetadataStoreObject};
     use fluvio_controlplane_metadata::extended::SpecExt;
+    use fluvio_controlplane_metadata::store::KeyFilter;
 
     use crate::services::auth::AuthServiceContext;
 
     #[instrument(skip(filters, auth_ctx))]
     pub async fn handle_fetch_request<AC: AuthContext, S>(
-        filters: Vec<NameFilter>,
+        filters: ListFilters,
         auth_ctx: &AuthServiceContext<AC>,
         object_ctx: &StoreContext<S>,
     ) -> Result<ListResponse<S>, Error>

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -85,7 +85,7 @@ mod fetch {
     use fluvio_stream_dispatcher::store::StoreContext;
     use tracing::{debug, trace, instrument};
 
-    use fluvio_sc_schema::objects::{ListResponse, NameFilter};
+    use fluvio_sc_schema::objects::{ListResponse, NameFilter, Metadata};
     use fluvio_auth::{AuthContext, TypeAction};
     use fluvio_controlplane_metadata::store::{KeyFilter, MetadataStoreObject};
     use fluvio_controlplane_metadata::extended::SpecExt;
@@ -103,7 +103,7 @@ mod fetch {
         S: AdminSpec + SpecExt,
         <S as Spec>::Status: Encoder + Decoder,
         <S as Spec>::IndexKey: AsRef<str>,
-        <S as AdminSpec>::ListType: From<MetadataStoreObject<S, K8MetaItem>>,
+        Metadata<S>: From<MetadataStoreObject<S, K8MetaItem>>,
     {
         debug!(ty = %S::LABEL,"fetching");
 
@@ -122,11 +122,11 @@ mod fetch {
         }
 
         let reader = object_ctx.store().read().await;
-        let objects: Vec<<S as AdminSpec>::ListType> = reader
+        let objects: Vec<Metadata<S>> = reader
             .values()
             .filter_map(|value| {
                 if filters.filter(value.key().as_ref()) {
-                    let list_obj: <S as AdminSpec>::ListType = AdminSpec::convert_from(value);
+                    let list_obj: Metadata<S> = AdminSpec::convert_from(value);
                     Some(list_obj)
                 } else {
                     None

--- a/crates/fluvio-sc/src/services/public_api/partition/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/partition/mod.rs
@@ -2,7 +2,7 @@ use std::io::{Error, ErrorKind};
 
 use tracing::{trace, debug, instrument};
 
-use fluvio_sc_schema::objects::{ListResponse, Metadata};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilters};
 use fluvio_sc_schema::partition::{PartitionSpec};
 use fluvio_controlplane_metadata::extended::SpecExt;
 use fluvio_auth::{AuthContext, TypeAction};
@@ -11,7 +11,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(_filters, auth_ctx))]
 pub async fn handle_fetch_request<AC: AuthContext>(
-    _filters: Vec<String>,
+    _filters: ListFilters,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<PartitionSpec>, Error> {
     debug!("fetching custom spu list");

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -67,7 +67,7 @@ where
                 if summary {
                     Some(Metadata {
                         name: value.key().clone(),
-                        spec: value.spec().summary(),
+                        spec: value.spec().clone().summary(),
                         status: value.status().clone(),
                     })
                 } else {

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -10,13 +10,13 @@ use fluvio_sc_schema::AdminSpec;
 use fluvio_stream_dispatcher::store::StoreContext;
 
 use fluvio_sc_schema::objects::{ListResponse, Metadata};
-use fluvio_sc_schema::smartmodule::SmartModuleFilter;
+use fluvio_sc_schema::objects::ListFilter;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;
 
 #[instrument(skip(filters, auth, object_ctx))]
 pub(crate) async fn fetch_smart_modules<AC: AuthContext, M>(
-    filters: Vec<SmartModuleFilter>,
+    filters: Vec<ListFilter>,
     summary: bool,
     auth: &AC,
     object_ctx: &StoreContext<SmartModuleSpec, M>,

--- a/crates/fluvio-sc/src/services/public_api/spg/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/spg/fetch.rs
@@ -2,9 +2,8 @@ use std::io::{Error, ErrorKind};
 
 use tracing::{debug, trace, instrument};
 
-use fluvio_sc_schema::objects::{ListResponse, Metadata};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilters};
 use fluvio_sc_schema::spg::SpuGroupSpec;
-use fluvio_sc_schema::{NameFilter};
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::store::KeyFilter;
 use fluvio_controlplane_metadata::extended::SpecExt;
@@ -13,7 +12,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_spu_groups_request<AC: AuthContext>(
-    filters: Vec<NameFilter>,
+    filters: ListFilters,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<SpuGroupSpec>, Error> {
     debug!("fetching spu groups");

--- a/crates/fluvio-sc/src/services/public_api/spu/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/spu/fetch.rs
@@ -2,7 +2,7 @@ use std::io::{Error, ErrorKind};
 
 use tracing::{trace, debug, instrument};
 
-use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilter};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilters};
 use fluvio_sc_schema::spu::SpuSpec;
 use fluvio_sc_schema::customspu::CustomSpuSpec;
 use fluvio_auth::{AuthContext, TypeAction};
@@ -13,7 +13,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_custom_spu_request<AC: AuthContext>(
-    filters: Vec<ListFilter>,
+    filters: ListFilters,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<CustomSpuSpec>, Error> {
     debug!("fetching custom spu list");
@@ -61,7 +61,7 @@ pub async fn handle_fetch_custom_spu_request<AC: AuthContext>(
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_spus_request<AC: AuthContext>(
-    filters: Vec<ListFilter>,
+    filters: ListFilters,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<SpuSpec>, Error> {
     debug!("fetching spu list");

--- a/crates/fluvio-sc/src/services/public_api/spu/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/spu/fetch.rs
@@ -2,7 +2,7 @@ use std::io::{Error, ErrorKind};
 
 use tracing::{trace, debug, instrument};
 
-use fluvio_sc_schema::objects::{ListResponse, Metadata};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilter};
 use fluvio_sc_schema::spu::SpuSpec;
 use fluvio_sc_schema::customspu::CustomSpuSpec;
 use fluvio_auth::{AuthContext, TypeAction};
@@ -13,7 +13,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_custom_spu_request<AC: AuthContext>(
-    filters: Vec<String>,
+    filters: Vec<ListFilter>,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<CustomSpuSpec>, Error> {
     debug!("fetching custom spu list");
@@ -61,7 +61,7 @@ pub async fn handle_fetch_custom_spu_request<AC: AuthContext>(
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_spus_request<AC: AuthContext>(
-    filters: Vec<String>,
+    filters: Vec<ListFilter>,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<SpuSpec>, Error> {
     debug!("fetching spu list");

--- a/crates/fluvio-sc/src/services/public_api/topic/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/fetch.rs
@@ -2,7 +2,7 @@ use tracing::{trace, debug, instrument};
 use std::io::{Error, ErrorKind};
 
 use fluvio_controlplane_metadata::store::KeyFilter;
-use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilter, ListFilters};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilters};
 use fluvio_sc_schema::topic::TopicSpec;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;

--- a/crates/fluvio-sc/src/services/public_api/topic/fetch.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/fetch.rs
@@ -2,7 +2,7 @@ use tracing::{trace, debug, instrument};
 use std::io::{Error, ErrorKind};
 
 use fluvio_controlplane_metadata::store::KeyFilter;
-use fluvio_sc_schema::objects::{ListResponse, Metadata};
+use fluvio_sc_schema::objects::{ListResponse, Metadata, ListFilter, ListFilters};
 use fluvio_sc_schema::topic::TopicSpec;
 use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;
@@ -11,7 +11,7 @@ use crate::services::auth::AuthServiceContext;
 
 #[instrument(skip(filters, auth_ctx))]
 pub async fn handle_fetch_topics_request<AC: AuthContext>(
-    filters: Vec<String>,
+    filters: ListFilters,
     auth_ctx: &AuthServiceContext<AC>,
 ) -> Result<ListResponse<TopicSpec>, Error> {
     debug!("retrieving topic list: {:#?}", filters);

--- a/crates/fluvio-sc/src/services/public_api/watch.rs
+++ b/crates/fluvio-sc/src/services/public_api/watch.rs
@@ -208,7 +208,7 @@ where
                 .into_iter()
                 .map(|u| u.into())
                 .map(|d: Metadata<S>| if self.summary { d.summary() } else { d })
-                .map(|v| Message::update(v))
+                .map(Message::update)
                 .collect();
             let mut deletes = deletes
                 .into_iter()

--- a/crates/fluvio-sc/src/services/public_api/watch.rs
+++ b/crates/fluvio-sc/src/services/public_api/watch.rs
@@ -194,12 +194,21 @@ where
 
         let updates = if changes.is_sync_all() {
             let (updates, _) = changes.parts();
-            MetadataUpdate::with_all(epoch, updates.into_iter().map(|u| u.into()).collect())
+            MetadataUpdate::with_all(
+                epoch,
+                updates
+                    .into_iter()
+                    .map(|u| u.into())
+                    .map(|d: Metadata<S>| if self.summary { d.summary() } else { d })
+                    .collect(),
+            )
         } else {
             let (updates, deletes) = changes.parts();
             let mut changes: Vec<Message<Metadata<S>>> = updates
                 .into_iter()
-                .map(|v| Message::update(v.into()))
+                .map(|u| u.into())
+                .map(|d: Metadata<S>| if self.summary { d.summary() } else { d })
+                .map(|v| Message::update(v))
                 .collect();
             let mut deletes = deletes
                 .into_iter()

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -116,18 +116,13 @@ impl FluvioAdmin {
     /// ```
     #[instrument(skip(config))]
     pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
-        use fluvio_protocol::api::Request;
-
         let connector = DomainConnector::try_from(config.tls.clone())?;
         let config = ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);
         let inner_client = config.connect().await?;
         debug!(addr = %inner_client.config().addr(), "connected to cluster");
 
         let (socket, config, versions) = inner_client.split();
-        if let Some(watch_version) = versions.lookup_version(
-            ObjectApiWatchRequest::API_KEY,
-            ObjectApiWatchRequest::DEFAULT_API_VERSION,
-        ) {
+        if let Some(watch_version) = versions.lookup_version::<ObjectApiWatchRequest>() {
             let socket = MultiplexerSocket::shared(socket);
             let metadata = MetadataStores::start(socket.clone(), watch_version).await?;
             let versioned_socket = VersionedSerialSocket::new(socket, config, versions);

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -242,7 +242,8 @@ impl FluvioAdmin {
         use std::io::Error as IoError;
         use std::io::ErrorKind;
 
-        let list_request = ListRequest::new(filters.into_iter().map(Into::into).collect(), summary);
+        let filter_list: Vec<ListFilter> = filters.into_iter().map(Into::into).collect();
+        let list_request = ListRequest::new(filter_list, summary);
 
         let list_request: ObjectApiListRequest = list_request.into();
         let response = self.send_receive(list_request).await?;

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -258,7 +258,8 @@ impl FluvioAdmin {
             .map(|out: ListResponse<S>| out.inner())
     }
 
-    /// primitive watch stream
+    /// Watch stream of changes for metadata
+    /// There is caching, this is just pass through
     #[instrument(skip(self))]
     pub async fn watch<S>(
         &self,
@@ -270,6 +271,7 @@ impl FluvioAdmin {
         WatchResponse<S>: TryFrom<ObjectApiWatchResponse>,
         <WatchResponse<S> as TryFrom<ObjectApiWatchResponse>>::Error: Display + Send,
     {
+        // only summary for watch
         let watch_request: WatchRequest<S> = WatchRequest::summary();
 
         let watch_req: ObjectApiWatchRequest = watch_request.into();
@@ -293,6 +295,7 @@ impl FluvioAdmin {
     }
 }
 
+/// API for streaming cached metadata
 #[cfg(feature = "unstable")]
 mod unstable {
     use super::*;

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -8,7 +8,7 @@ use tracing::{debug, trace, instrument};
 
 use fluvio_sc_schema::objects::{
     CommonCreateRequest, DeleteRequest, ObjectApiCreateRequest, ObjectApiDeleteRequest,
-    ObjectApiListRequest, ObjectApiListResponse, ObjectApiWatchRequest, Metadata,
+    ObjectApiListRequest, ObjectApiListResponse, ObjectApiWatchRequest, Metadata, ListFilter,
 };
 use fluvio_sc_schema::{AdminSpec, DeletableAdminSpec, CreatableAdminSpec};
 use fluvio_socket::SocketError;
@@ -203,7 +203,6 @@ impl FluvioAdmin {
     pub async fn all<S>(&self) -> Result<Vec<Metadata<S>>, FluvioError>
     where
         S: AdminSpec,
-        <S as AdminSpec>::ListFilter: From<std::string::String>,
         ObjectApiListRequest: From<ListRequest<S>>,
         ListResponse<S>: TryFrom<ObjectApiListResponse>,
         <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,
@@ -217,7 +216,7 @@ impl FluvioAdmin {
     pub async fn list<S, F>(&self, filters: Vec<F>) -> Result<Vec<Metadata<S>>, FluvioError>
     where
         S: AdminSpec,
-        S::ListFilter: From<F>,
+        ListFilter: From<F>,
         ObjectApiListRequest: From<ListRequest<S>>,
         ListResponse<S>: TryFrom<ObjectApiListResponse>,
         <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,
@@ -234,7 +233,7 @@ impl FluvioAdmin {
     ) -> Result<Vec<Metadata<S>>, FluvioError>
     where
         S: AdminSpec,
-        S::ListFilter: From<F>,
+        ListFilter: From<F>,
         ObjectApiListRequest: From<ListRequest<S>>,
         ListResponse<S>: TryFrom<ObjectApiListResponse>,
         <ListResponse<S> as TryFrom<ObjectApiListResponse>>::Error: Display,

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -284,7 +284,6 @@ where
     > {
         use fluvio_future::task::spawn;
         use futures_util::stream::empty;
-        use fluvio_protocol::api::Request;
 
         let replica = ReplicaKey::new(&self.topic, self.partition);
         let mut serial_socket = self.pool.create_serial_socket(&replica).await?;
@@ -308,10 +307,7 @@ where
         // add wasm module if SPU supports it
         let stream_fetch_version = serial_socket
             .versions()
-            .lookup_version(
-                DefaultStreamFetchRequest::API_KEY,
-                DefaultStreamFetchRequest::DEFAULT_API_VERSION,
-            )
+            .lookup_version::<DefaultStreamFetchRequest>()
             .unwrap_or((WASM_MODULE_API - 1) as i16);
         debug!(%stream_fetch_version, "stream_fetch_version");
 

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -83,8 +83,6 @@ impl Fluvio {
         connector: DomainConnector,
         config: &FluvioConfig,
     ) -> Result<Self, FluvioError> {
-        use fluvio_protocol::api::Request;
-
         let config = ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);
         let inner_client = config.connect().await?;
         debug!("connected to cluster");
@@ -92,10 +90,7 @@ impl Fluvio {
         let (socket, config, versions) = inner_client.split();
 
         // get version for watch
-        if let Some(watch_version) = versions.lookup_version(
-            ObjectApiWatchRequest::API_KEY,
-            ObjectApiWatchRequest::DEFAULT_API_VERSION,
-        ) {
+        if let Some(watch_version) = versions.lookup_version::<ObjectApiWatchRequest>() {
             debug!(platform = %versions.platform_version(),"checking platform version");
             check_platform_compatible(versions.platform_version())?;
 

--- a/crates/fluvio/src/sockets.rs
+++ b/crates/fluvio/src/sockets.rs
@@ -193,15 +193,20 @@ impl Versions {
     }
 
     /// Given an API key, it returns maximum compatible version. None if not found
-    pub fn lookup_version(&self, api_key: u16, client_version: i16) -> Option<i16> {
+    pub fn lookup_version<R: Request>(&self) -> Option<i16> {
         for version in &self.api_versions {
-            if version.api_key == api_key as i16
-                && version.min_version <= client_version
-                && version.max_version >= client_version
-            {
-                return Some(std::cmp::min(version.max_version, client_version));
+            if version.api_key == R::API_KEY as i16 {
+                // try to find most latest maximum version
+                for client_version in (R::MIN_API_VERSION..=R::MAX_API_VERSION).rev() {
+                    if version.min_version <= client_version
+                        && version.max_version >= client_version
+                    {
+                        return Some(client_version);
+                    }
+                }
             }
         }
+
         None
     }
 }
@@ -248,11 +253,7 @@ impl VersionedSerialSocket {
     where
         R: Request + Send + Sync,
     {
-        let req_msg = self.new_request(
-            request,
-            self.versions
-                .lookup_version(R::API_KEY, R::DEFAULT_API_VERSION),
-        );
+        let req_msg = self.new_request(request, self.versions.lookup_version::<R>());
 
         // send request & save response
         self.socket.send_and_receive(req_msg).await
@@ -264,11 +265,7 @@ impl VersionedSerialSocket {
     where
         R: Request + Send + Sync,
     {
-        let req_msg = self.new_request(
-            request,
-            self.versions
-                .lookup_version(R::API_KEY, R::DEFAULT_API_VERSION),
-        );
+        let req_msg = self.new_request(request, self.versions.lookup_version::<R>());
 
         // send request & get a Future that resolves to response
         self.socket.send_async(req_msg).await
@@ -285,11 +282,7 @@ impl VersionedSerialSocket {
         R: Request + Send + Sync + Clone,
         I: IntoIterator<Item = Duration> + Debug + Send,
     {
-        let req_msg = self.new_request(
-            request,
-            self.versions
-                .lookup_version(R::API_KEY, R::DEFAULT_API_VERSION),
-        );
+        let req_msg = self.new_request(request, self.versions.lookup_version::<R>());
 
         // send request & retry it if result is Err
         retry(retries, || self.socket.send_and_receive(req_msg.clone())).await
@@ -321,10 +314,35 @@ impl SerialFrame for VersionedSerialSocket {
 
 #[cfg(test)]
 mod test {
+    use fluvio_protocol::Decoder;
+    use fluvio_protocol::Encoder;
+    use fluvio_protocol::api::Request;
     use fluvio_protocol::link::versions::ApiVersionKey;
 
     use super::ApiVersionsResponse;
     use super::Versions;
+
+    #[derive(Encoder, Decoder, Default, Debug)]
+    struct T1;
+
+    impl Request for T1 {
+        const API_KEY: u16 = 1000;
+        const MIN_API_VERSION: i16 = 6;
+        const MAX_API_VERSION: i16 = 9;
+
+        type Response = u8;
+    }
+
+    #[derive(Encoder, Decoder, Default, Debug)]
+    struct T2;
+
+    impl Request for T2 {
+        const API_KEY: u16 = 1000;
+        const MIN_API_VERSION: i16 = 2;
+        const MAX_API_VERSION: i16 = 3;
+
+        type Response = u8;
+    }
 
     #[test]
     fn test_version_lookup() {
@@ -339,10 +357,7 @@ mod test {
         let versions = Versions::new(response);
 
         // None if api_key not found
-        assert_eq!(versions.lookup_version(0, 10), None);
-        assert_eq!(versions.lookup_version(1000, 4), None); // same api key but version is too low
-        assert_eq!(versions.lookup_version(1000, 5), Some(5));
-        assert_eq!(versions.lookup_version(1000, 7), Some(7));
-        assert_eq!(versions.lookup_version(1000, 11), None);
+        assert_eq!(versions.lookup_version::<T1>(), Some(9));
+        assert_eq!(versions.lookup_version::<T2>(), None);
     }
 }

--- a/crates/fluvio/src/sockets.rs
+++ b/crates/fluvio/src/sockets.rs
@@ -237,6 +237,11 @@ impl VersionedSerialSocket {
         &self.versions
     }
 
+    /// get new socket
+    pub fn new_socket(&self) -> SharedMultiplexerSocket {
+        self.socket.clone()
+    }
+
     /// send and wait for reply serially
     #[instrument(level = "trace", skip(self, request))]
     pub async fn send_receive<R>(&self, request: R) -> Result<R::Response, SocketError>

--- a/crates/fluvio/src/sync/controller.rs
+++ b/crates/fluvio/src/sync/controller.rs
@@ -16,8 +16,6 @@ use fluvio_sc_schema::objects::{
 };
 use fluvio_sc_schema::AdminSpec;
 
-use crate::metadata::core::Spec;
-
 use super::StoreContext;
 use super::CacheMetadataStoreObject;
 use crate::metadata::store::actions::LSUpdate;
@@ -51,7 +49,7 @@ impl SimpleEvent {
 
 /// Synchronize metadata from SC
 pub struct MetadataSyncController<S: AdminSpec> {
-    store: StoreContext<S::WatchResponseType>,
+    store: StoreContext<S>,
     shutdown: Arc<SimpleEvent>,
 }
 
@@ -59,25 +57,22 @@ impl<S> MetadataSyncController<S>
 where
     S: AdminSpec + 'static + Sync + Send,
     AsyncResponse<ObjectApiWatchRequest>: Send,
-    S::WatchResponseType: Encoder + Decoder + Send + Sync,
-    <S::WatchResponseType as Spec>::Status: Sync + Send + Encoder + Decoder,
-    <S::WatchResponseType as Spec>::IndexKey: Display + Sync + Send,
+    S: Encoder + Decoder + Send + Sync,
+    S::Status: Sync + Send + Encoder + Decoder,
+    S::IndexKey: Display + Sync + Send,
     <WatchResponse<S> as TryFrom<ObjectApiWatchResponse>>::Error: Display + Send,
-    CacheMetadataStoreObject<S::WatchResponseType>: TryFrom<Metadata<S::WatchResponseType>>,
+    CacheMetadataStoreObject<S>: TryFrom<Metadata<S>>,
     WatchResponse<S>: TryFrom<ObjectApiWatchResponse>,
-    <Metadata<S::WatchResponseType> as TryInto<CacheMetadataStoreObject<S::WatchResponseType>>>::Error: Display,
+    <Metadata<S> as TryInto<CacheMetadataStoreObject<S>>>::Error: Display,
 {
     pub fn start(
-        store: StoreContext<S::WatchResponseType>,
+        store: StoreContext<S>,
         watch_response: AsyncResponse<ObjectApiWatchRequest>,
         shutdown: Arc<SimpleEvent>,
     ) {
         use fluvio_future::task::spawn;
 
-        let controller = Self {
-            store,
-            shutdown,
-        };
+        let controller = Self { store, shutdown };
 
         debug!(spec = %S::LABEL, "spawning sync controller");
         spawn(controller.dispatch_loop(watch_response));
@@ -89,10 +84,7 @@ where
             spec = S::LABEL,
         )
     )]
-    async fn dispatch_loop(
-        mut self,
-        mut response: AsyncResponse<ObjectApiWatchRequest>,
-    ) {
+    async fn dispatch_loop(mut self, mut response: AsyncResponse<ObjectApiWatchRequest>) {
         use tokio::select;
 
         debug!("{} starting dispatch loop", S::LABEL);
@@ -151,19 +143,16 @@ where
             spec = %S::LABEL,
         ),
     )]
-    async fn sync_metadata(
-        &mut self,
-        updates: MetadataUpdate<S::WatchResponseType>,
-    ) -> Result<(), IoError> {
+    async fn sync_metadata(&mut self, updates: MetadataUpdate<S>) -> Result<(), IoError> {
         // Full sync
         if !updates.all.is_empty() {
             debug!(
                 count = updates.all.len(),
                 "Received full sync, setting store objects:"
             );
-            let mut objects: Vec<CacheMetadataStoreObject<S::WatchResponseType>> = vec![];
+            let mut objects: Vec<CacheMetadataStoreObject<S>> = vec![];
             for meta in updates.all.into_iter() {
-                let store_obj: Result<CacheMetadataStoreObject<S::WatchResponseType>, _> = meta.try_into();
+                let store_obj: Result<CacheMetadataStoreObject<S>, _> = meta.try_into();
                 match store_obj {
                     Ok(obj) => {
                         objects.push(obj);
@@ -191,7 +180,7 @@ where
                 .into_iter()
                 .map(|msg| {
                     let (meta, typ) = (msg.content, msg.header);
-                    let obj: Result<CacheMetadataStoreObject<S::WatchResponseType>, _> = meta.try_into();
+                    let obj: Result<CacheMetadataStoreObject<S>, _> = meta.try_into();
                     obj.map(|it| (typ, it))
                 })
                 .collect::<Result<Vec<_>, _>>()


### PR DESCRIPTION
Add Watch API to client.  This is different from store watch API for watching client metadata.  
Watch API streams metadata from SC only on summary mode.  Summary mode is where we omit certain data like WASM bytes to reduce bandwidth.

Rest of changes is removing associated types for AdminSpec.  This allows AdminSpec to be object safe and eventually move to more simpler API instead of current workaround uses enum to encode object types.   It should be possible to migrate Admin object API to use dynamic trait.  

Also, `lookup_version` algorithm in the client is fixed take advantage of the min and max range.