### PR TITLE
[Merged by Bors] - fix: display fqdn to CLI

### DIFF
--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -94,7 +94,7 @@ mod output {
     impl TableOutputHandler for ListSmartModules {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["NAME", "GROUP", "VERSION", "SIZE"])
+            Row::from(["SMARTMODULE", "SIZE"])
         }
 
         /// return errors in string format
@@ -110,9 +110,7 @@ mod output {
                     let _spec = &r.spec;
 
                     Row::from([
-                        Cell::new(&r.spec.logical_name(&r.name)).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.spec.pkg_group()).set_alignment(CellAlignment::Left),
-                        Cell::new(&r.spec.pkg_version()).set_alignment(CellAlignment::Left),
+                        Cell::new(&r.spec.fqdn(&r.name)).set_alignment(CellAlignment::Left),
                         Cell::new(
                             bytesize::ByteSize::b(
                                 r.spec.summary.clone().unwrap_or_default().wasm_length as u64,

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/package.rs
@@ -82,6 +82,13 @@ impl SmartModulePackage {
     pub fn is_valid(&self) -> bool {
         !self.name.is_empty() && !self.group.is_empty()
     }
+
+    pub fn fqdn(&self) -> String {
+        format!(
+            "{}{}{}{}{}",
+            self.group, GROUP_SEPARATOR, self.name, VERSION_SEPARATOR, self.version
+        )
+    }
 }
 
 #[derive(Debug, Error)]
@@ -281,6 +288,19 @@ mod package_test {
             ..Default::default()
         }
         .is_valid());
+    }
+
+    #[test]
+    fn test_pkg_fqdn() {
+        let pkg = SmartModulePackage {
+            name: "test".to_owned(),
+            group: "fluvio".to_owned(),
+            version: FluvioSemVersion::parse("0.1.0").unwrap(),
+            api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
+            ..Default::default()
+        };
+
+        assert_eq!(pkg.fqdn(), "fluvio/test@0.1.0");
     }
 
     #[test]

--- a/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/spec.rs
@@ -1,7 +1,7 @@
 //!
 //! # SmartModule Spec
 //!
-use std::io::Error as IoError;
+use std::{io::Error as IoError, borrow::Cow};
 
 use bytes::BufMut;
 
@@ -89,32 +89,13 @@ impl Decoder for SmartModuleSpec {
 }
 
 impl SmartModuleSpec {
-    /// return logical name.  if there is package then use it otherwise return it
-    pub fn logical_name(&self, object_name: &str) -> String {
-        self.meta
-            .as_ref()
-            .map(|meta| meta.package.name.to_string())
-            .unwrap_or_else(|| object_name.to_string())
-    }
-    pub fn pkg_name(&self) -> &str {
-        self.meta
-            .as_ref()
-            .map(|meta| &meta.package.name as &str)
-            .unwrap_or_else(|| "")
-    }
-
-    pub fn pkg_group(&self) -> &str {
-        self.meta
-            .as_ref()
-            .map(|meta| &meta.package.group as &str)
-            .unwrap_or_else(|| "")
-    }
-
-    pub fn pkg_version(&self) -> String {
-        self.meta
-            .as_ref()
-            .map(|meta| meta.package.version.to_string())
-            .unwrap_or_else(|| "".to_owned())
+    /// return fully qualified name given store key
+    pub fn fqdn<'a>(&self, store_id: &'a str) -> Cow<'a, str> {
+        if let Some(meta) = &self.meta {
+            meta.package.fqdn().into()
+        } else {
+            Cow::from(store_id)
+        }
     }
 }
 


### PR DESCRIPTION
fix part of the #2702.  Use FQDN instead of separating out group and version:

```
$ fluvio smartmodule list 
SMARTMODULE                  SIZE     
  infinyon/regex-filter@0.1.2  315.9 KB 
  infinyon/jolt@0.1.0          563.6 KB 
```