### PR TITLE
[Merged by Bors] - feat(metrics): added metrics to smartengine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,6 +2536,7 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-smartmodule",
  "fluvio-types",
+ "opentelemetry",
  "thiserror",
  "tracing",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -13,6 +13,7 @@ description = "The official Fluvio SmartEngine"
 
 [features]
 wasi = ["wasmtime-wasi"]
+otel-metrics = ["opentelemetry/metrics"]
 
 
 [dependencies]
@@ -30,6 +31,7 @@ fluvio-protocol = { path = "../fluvio-protocol", version = "0.8.0", features = [
     "record",
 ] }
 fluvio-smartmodule = { path = "../fluvio-smartmodule", version = "0.3.0", default-features = false }
+opentelemetry = { version = "0.18.0", optional = true }
 
 [dev-dependencies]
 fluvio-types = { path = "../fluvio-types" }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.4.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -14,6 +14,7 @@ description = "The official Fluvio SmartEngine"
 [features]
 wasi = ["wasmtime-wasi"]
 otel-metrics = ["opentelemetry/metrics"]
+default = ["otel-metrics"]
 
 
 [dependencies]

--- a/crates/fluvio-smartengine/src/instance.rs
+++ b/crates/fluvio-smartengine/src/instance.rs
@@ -15,11 +15,13 @@ use fluvio_smartmodule::dataplane::smartmodule::{
 use crate::error::EngineError;
 use crate::init::SmartModuleInit;
 use crate::{WasmSlice, memory, SmartModuleChainBuilder, State, WasmState};
+use crate::metrics::SmartModuleMetrics;
 
 pub(crate) struct SmartModuleInstance {
     ctx: SmartModuleInstanceContext,
     init: Option<SmartModuleInit>,
     transform: Box<dyn DowncastableTransform>,
+    metrics: SmartModuleMetrics,
 }
 
 impl SmartModuleInstance {
@@ -43,6 +45,7 @@ impl SmartModuleInstance {
             ctx,
             init,
             transform,
+            metrics: SmartModuleMetrics::new(),
         }
     }
 
@@ -51,7 +54,13 @@ impl SmartModuleInstance {
         input: SmartModuleInput,
         store: &mut WasmState,
     ) -> Result<SmartModuleOutput> {
-        self.transform.process(input, &mut self.ctx, store)
+        self.metrics.inc_invocations();
+        self.metrics.add_bytes_in(input.raw_bytes().len() as u64);
+        let result = self.transform.process(input, &mut self.ctx, store);
+        if let Ok(ref output) = result {
+            self.metrics.add_records_out(output.successes.len() as u64);
+        }
+        result
     }
 
     // TODO: Move this to SPU

--- a/crates/fluvio-smartengine/src/lib.rs
+++ b/crates/fluvio-smartengine/src/lib.rs
@@ -12,3 +12,5 @@ pub type Version = i16;
 
 #[cfg(test)]
 mod fixture;
+
+mod metrics;

--- a/crates/fluvio-smartengine/src/metrics.rs
+++ b/crates/fluvio-smartengine/src/metrics.rs
@@ -1,0 +1,131 @@
+#[cfg(feature = "otel-metrics")]
+pub(crate) struct ChainMetrics {
+    context: opentelemetry::Context,
+    invocations: opentelemetry::metrics::Counter<u64>,
+    records: opentelemetry::metrics::Counter<u64>,
+    bytes: opentelemetry::metrics::Counter<u64>,
+}
+
+#[cfg(feature = "otel-metrics")]
+impl ChainMetrics {
+    pub(crate) fn new() -> Self {
+        let meter = opentelemetry::global::meter("smartengine");
+        let context = opentelemetry::Context::new();
+        let invocations = meter
+            .u64_counter("fluvio.smartengine.chain.invocations")
+            .init();
+        let records = meter.u64_counter("fluvio.smartengine.chain.records").init();
+        let bytes = meter.u64_counter("fluvio.smartengine.chain.bytes").init();
+
+        Self {
+            context,
+            invocations,
+            records,
+            bytes,
+        }
+    }
+
+    pub(crate) fn inc_invocations(&self) {
+        self.invocations.add(&self.context, 1u64, &[]);
+    }
+
+    pub(crate) fn add_records_out(&self, value: u64) {
+        self.records.add(
+            &self.context,
+            value,
+            &[opentelemetry::KeyValue::new("direction", "transmit")],
+        );
+    }
+
+    pub(crate) fn add_bytes_in(&self, value: u64) {
+        self.bytes.add(
+            &self.context,
+            value,
+            &[opentelemetry::KeyValue::new("direction", "receive")],
+        );
+    }
+}
+
+#[cfg(not(feature = "otel-metrics"))]
+pub(crate) struct ChainMetrics;
+
+#[cfg(not(feature = "otel-metrics"))]
+impl ChainMetrics {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    pub(crate) fn inc_invocations(&self) {}
+
+    pub(crate) fn add_records_out(&self, _value: u64) {}
+
+    pub(crate) fn add_bytes_in(&self, _value: u64) {}
+}
+
+#[cfg(feature = "otel-metrics")]
+pub(crate) struct SmartModuleMetrics {
+    context: opentelemetry::Context,
+    invocations: opentelemetry::metrics::Counter<u64>,
+    records: opentelemetry::metrics::Counter<u64>,
+    bytes: opentelemetry::metrics::Counter<u64>,
+}
+
+#[cfg(feature = "otel-metrics")]
+impl SmartModuleMetrics {
+    pub(crate) fn new() -> Self {
+        let meter = opentelemetry::global::meter("smartengine");
+        let context = opentelemetry::Context::new();
+        let invocations = meter
+            .u64_counter("fluvio.smartengine.smartmodule.invocations")
+            .init();
+        let records = meter
+            .u64_counter("fluvio.smartengine.smartmodule.records")
+            .init();
+        let bytes = meter
+            .u64_counter("fluvio.smartengine.smartmodule.bytes")
+            .init();
+
+        Self {
+            context,
+            invocations,
+            records,
+            bytes,
+        }
+    }
+
+    pub(crate) fn inc_invocations(&self) {
+        self.invocations.add(&self.context, 1u64, &[]);
+    }
+
+    pub(crate) fn add_records_out(&self, value: u64) {
+        self.records.add(
+            &self.context,
+            value,
+            &[opentelemetry::KeyValue::new("direction", "transmit")],
+        );
+    }
+
+    pub(crate) fn add_bytes_in(&self, value: u64) {
+        self.bytes.add(
+            &self.context,
+            value,
+            &[opentelemetry::KeyValue::new("direction", "receive")],
+        );
+    }
+}
+
+#[cfg(not(feature = "otel-metrics"))]
+pub(crate) struct SmartModuleMetrics;
+
+#[cfg(not(feature = "otel-metrics"))]
+impl SmartModuleMetrics {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    pub(crate) fn inc_invocations(&self) {}
+
+    pub(crate) fn add_records_out(&self, _value: u64) {}
+
+    pub(crate) fn add_bytes_in(&self, _value: u64) {}
+}


### PR DESCRIPTION
So far, due to current implementation details, we can't send the following metrics:
1. Input records count for chain and smartmodules.
2. Output bytes count for chain and smartmodules.
3. Smartmodule name for all metrics.

We will be able to add these metrics later, but it will require changes in the current implementation.