### PR TITLE
[Merged by Bors] - refactor: smdk hub cli updates

### DIFF
--- a/crates/fluvio-hub-util/src/utils.rs
+++ b/crates/fluvio-hub-util/src/utils.rs
@@ -144,7 +144,7 @@ pub async fn push_package(pkgpath: &str, access: &HubAccess) -> Result<()> {
         .content_type(mime::BYTE_STREAM)
         .body_bytes(pkg_bytes)
         .header("Authorization", &actiontoken);
-    let res = req
+    let mut res = req
         .await
         .map_err(|e| HubUtilError::HubAccess(format!("Failed to connect {e}")))?;
 
@@ -158,7 +158,9 @@ pub async fn push_package(pkgpath: &str, access: &HubAccess) -> Result<()> {
         )),
         _ => {
             debug!("push result: {} \n{res:?}", res.status());
-            let msg = format!("Unknown error: {}", res.status());
+            let bodymsg = res.body_string().await
+                .map_err(|_e| HubUtilError::HubAccess("Failed to download err body".into()))?;
+            let msg = format!("error status code({}) {}", res.status(), bodymsg);
             Err(HubUtilError::HubAccess(msg))
         }
     }

--- a/crates/fluvio-hub-util/src/utils.rs
+++ b/crates/fluvio-hub-util/src/utils.rs
@@ -158,7 +158,9 @@ pub async fn push_package(pkgpath: &str, access: &HubAccess) -> Result<()> {
         )),
         _ => {
             debug!("push result: {} \n{res:?}", res.status());
-            let bodymsg = res.body_string().await
+            let bodymsg = res
+                .body_string()
+                .await
                 .map_err(|_e| HubUtilError::HubAccess("Failed to download err body".into()))?;
             let msg = format!("error status code({}) {}", res.status(), bodymsg);
             Err(HubUtilError::HubAccess(msg))

--- a/crates/smartmodule-development-kit/src/cmd.rs
+++ b/crates/smartmodule-development-kit/src/cmd.rs
@@ -8,7 +8,7 @@ use crate::load::LoadOpt;
 use crate::publish::PublishOpt;
 use crate::hub::HubCmd;
 
-/// Manage and view Fluvio clusters
+/// SmartModule Development Kit utility
 #[derive(Debug, Parser)]
 pub enum SmdkCommand {
     /// Builds SmartModule into WASM

--- a/crates/smartmodule-development-kit/src/cmd.rs
+++ b/crates/smartmodule-development-kit/src/cmd.rs
@@ -20,7 +20,7 @@ pub enum SmdkCommand {
     /// Publish SmartModule to Hub
     Publish(PublishOpt),
     /// Hub options
-    #[clap(subcommand)]
+    #[clap(subcommand, hide = true)]
     Hub(HubCmd),
 }
 

--- a/crates/smartmodule-development-kit/src/hub.rs
+++ b/crates/smartmodule-development-kit/src/hub.rs
@@ -27,7 +27,7 @@ pub struct IdOpt {
     #[clap(long, short)]
     verbose: bool,
 
-    #[clap(long, hide_short_help=true)]
+    #[clap(long, hide_short_help = true)]
     remote: Option<String>,
 }
 

--- a/crates/smartmodule-development-kit/src/hub.rs
+++ b/crates/smartmodule-development-kit/src/hub.rs
@@ -27,7 +27,7 @@ pub struct IdOpt {
     #[clap(long, short)]
     verbose: bool,
 
-    #[clap(long)]
+    #[clap(long, hide_short_help=true)]
     remote: Option<String>,
 }
 


### PR DESCRIPTION
hides smdk hub id commands:

```
SmartModule Development Kit utility

Usage: smdk <COMMAND>

Commands:
  build     Builds SmartModule into WASM
  generate  Generates a new SmartModule Project
  test      Test SmartModule
  load      Load SmartModule into Fluvio cluster
  publish   Publish SmartModule to Hub
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```