### PR TITLE
[Merged by Bors] - feat: check for `Smart.toml` file to be present in cwd

### DIFF
--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -7,7 +7,7 @@ use fluvio_future::task::run_block_on;
 use fluvio_hub_util as hubutil;
 use hubutil::{DEF_HUB_INIT_DIR, HubAccess, PackageMeta};
 
-const SMART_TOML: &str = "Smart.toml";
+const SMARTMODULE_TOML: &str = "SmartModule.toml";
 
 /// Publish SmartModule to SmartModule Hub
 #[derive(Debug, Parser)]
@@ -114,13 +114,13 @@ pub fn init_package_template() -> Result<()> {
 }
 
 fn find_smartmodule_toml() -> Result<PathBuf> {
-    let smartmodule_toml = Path::new(SMART_TOML);
+    let smartmodule_toml = Path::new(SMARTMODULE_TOML);
 
     if smartmodule_toml.exists() {
         return Ok(smartmodule_toml.to_path_buf());
     }
 
-    Err(anyhow::anyhow!("No \"{}\" file found", SMART_TOML))
+    Err(anyhow::anyhow!("No \"{}\" file found", SMARTMODULE_TOML))
 }
 
 #[ignore]
@@ -139,7 +139,7 @@ fn build_sm_toml() {
 fn reference_sm_toml() {
     use fluvio_controlplane_metadata::smartmodule::SmartModuleMetadata;
 
-    let fpath = "../../smartmodule/cargo_template/Smart.toml";
+    let fpath = format!("../../smartmodule/cargo_template/{}", SMARTMODULE_TOML);
     let smart_toml = SmartModuleMetadata::from_toml(fpath);
     assert!(
         smart_toml.is_ok(),

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -92,7 +92,7 @@ pub fn init_package_template() -> Result<()> {
         ..PackageMeta::default()
     };
     let sm_toml_file = find_smartmodule_toml()?;
-    pm.update_from_smartmodule_toml(&sm_toml_file.to_string_lossy().to_string())?;
+    pm.update_from_smartmodule_toml(&sm_toml_file.to_string_lossy())?;
 
     println!("Creating package {}", pm.pkg_name());
     pm.naming_check()?;

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -25,6 +25,7 @@ pub struct PublishOpt {
     #[clap(long, hide_short_help = true)]
     remote: Option<String>,
 }
+
 impl PublishOpt {
     pub(crate) fn process(&self) -> Result<()> {
         let access = HubAccess::default_load(&self.remote)?;
@@ -80,6 +81,7 @@ pub fn package_push(pkgpath: &str, access: &HubAccess) -> Result<()> {
     }
     Ok(())
 }
+
 pub fn init_package_template() -> Result<()> {
     // fill out template w/ defaults
     let pmetapath = hubutil::DEF_HUB_PKG_META;


### PR DESCRIPTION
Checks for the `SmartModule.toml` file to be present in the CWD when running `smdk generate` command.

```bash
➜  smdk publish
Error: No "SmartModule.toml" file found

➜  touch SmartModule.toml
➜  smdk publish
Error: missing field `package`
```

Resolves: https://github.com/infinyon/fluvio/issues/2678