### PR TITLE
[Merged by Bors] - fix: use `localhost` as `proxy-addr` for k8s cluster on macOS

### DIFF
--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -36,7 +36,7 @@ pub async fn process_k8(
         .use_k8_port_forwarding(opt.k8_config.use_k8_port_forwarding);
 
     if cfg!(target_os = "macos") {
-        builder.proxy_addr(opt.proxy_addr.unwrap_or(String::from("localhost")));
+        builder.proxy_addr(opt.proxy_addr.unwrap_or_else(|| String::from("localhost")));
     } else {
         builder.proxy_addr(opt.proxy_addr);
     }

--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -30,11 +30,16 @@ pub async fn process_k8(
         .chart_values(opt.k8_config.chart_values)
         .hide_spinner(false)
         .upgrade(upgrade)
-        .proxy_addr(opt.proxy_addr)
         .spu_config(opt.spu_config.as_spu_config())
         .connector_prefixes(opt.connector_prefix)
         .with_if(opt.skip_checks, |b| b.skip_checks(true))
         .use_k8_port_forwarding(opt.k8_config.use_k8_port_forwarding);
+
+    if cfg!(target_os = "macos") {
+        builder.proxy_addr(opt.proxy_addr.unwrap_or(String::from("localhost")));
+    } else {
+        builder.proxy_addr(opt.proxy_addr);
+    }
 
     if let Some(chart_location) = opt.k8_config.chart_location {
         builder.local_chart(chart_location);


### PR DESCRIPTION
When running `fluvio cluster start` on macOS sets `localhost` as proxy
address by default if no other value is set. For other platforms, behavior
remains the same as of today.

Resolve: https://github.com/infinyon/fluvio/issues/2722