### PR TITLE
[Merged by Bors] - fix: Add prompt for project group in `smdk generate`

### DIFF
--- a/crates/smartmodule-development-kit/src/generate.rs
+++ b/crates/smartmodule-development-kit/src/generate.rs
@@ -311,10 +311,8 @@ impl GenerateOpt {
             let sm_toml: Value = toml::from_str(&sm_str)?;
 
             if let Value::Table(package) = &sm_toml["package"] {
-                if let Some(config_value) = package.get("group") {
-                    if let Value::String(groupname) = config_value {
-                        set_hubid(&groupname, &mut hub_config)?;
-                    }
+                if let Some(Value::String(groupname)) = package.get("group") {
+                    set_hubid(groupname, &mut hub_config)?;
                 }
             }
         }

--- a/crates/smartmodule-development-kit/src/generate.rs
+++ b/crates/smartmodule-development-kit/src/generate.rs
@@ -27,6 +27,7 @@ pub struct GenerateOpt {
 
     /// SmartModule Project Group Name.
     /// Default to Hub ID, if set. Overrides Hub ID if provided.
+    #[clap(long, env = "SMDK_PROJECT_GROUP", value_name = "GROUP")]
     project_group: Option<String>,
 
     /// Local path to generate the SmartModule project.

--- a/crates/smartmodule-development-kit/src/generate.rs
+++ b/crates/smartmodule-development-kit/src/generate.rs
@@ -199,8 +199,13 @@ impl GenerateOpt {
         let mut hub_config = HubAccess::default_load(&self.hub_remote)?;
 
         let group = if let Some(user_group) = self.project_group {
-            debug!("Using user provided project group: {}", &user_group);
-            Some(user_group)
+            if user_group.is_empty() {
+                debug!("User requesting to be prompted for project group");
+                None
+            } else {
+                debug!("Using user provided project group: {}", &user_group);
+                Some(user_group)
+            }
         } else if hub_config.hubid.is_empty() {
             debug!("No project group value set");
             None

--- a/crates/smartmodule-development-kit/src/generate.rs
+++ b/crates/smartmodule-development-kit/src/generate.rs
@@ -25,6 +25,10 @@ pub struct GenerateOpt {
     /// SmartModule Project Name
     name: String,
 
+    /// SmartModule Project Group Name.
+    /// Default to Hub ID, if set. Overrides Hub ID if provided.
+    project_group: Option<String>,
+
     /// Local path to generate the SmartModule project.
     /// Default to directory with project name, created in current directory
     #[clap(long, env = "SMDK_DESTINATION", value_name = "PATH")]
@@ -192,7 +196,11 @@ impl GenerateOpt {
 
         // Figure out if there's a Hub ID set
         let mut hub_config = HubAccess::default_load(&self.hub_remote)?;
-        let group = if hub_config.hubid.is_empty() {
+
+        let group = if let Some(user_group) = self.project_group {
+            debug!("Using user provided project group: {}", &user_group);
+            Some(user_group)
+        } else if hub_config.hubid.is_empty() {
             debug!("No project group value set");
             None
         } else {

--- a/crates/smartmodule-development-kit/src/hub.rs
+++ b/crates/smartmodule-development-kit/src/hub.rs
@@ -61,7 +61,7 @@ impl IdOpt {
     }
 }
 
-fn set_hubid(hubid: &str, access: &mut HubAccess) -> Result<()> {
+pub fn set_hubid(hubid: &str, access: &mut HubAccess) -> Result<()> {
     // if not: ask server if it exists
     if let Err(e) = run_block_on(access.create_hubid(hubid)) {
         eprintln!("{}", e);

--- a/crates/smartmodule-development-kit/src/load.rs
+++ b/crates/smartmodule-development-kit/src/load.rs
@@ -9,7 +9,7 @@ use fluvio::Fluvio;
 use fluvio_future::task::run_block_on;
 use crate::package::{PackageInfo, PackageOption};
 
-const DEFAULT_META_LOCATION: &str = "SmartModule.toml";
+pub const DEFAULT_META_LOCATION: &str = "SmartModule.toml";
 
 /// Load SmartModule into Fluvio cluster
 #[derive(Debug, Parser)]

--- a/smartmodule/cargo_template/cargo-generate.toml
+++ b/smartmodule/cargo_template/cargo-generate.toml
@@ -2,6 +2,10 @@
 type = "string"
 prompt = "Value of `fluvio-smartmodule` dependency in Cargo.toml"
 
+[placeholders.project-group]
+type = "string"
+prompt = "Please set a group name"
+
 [placeholders.smartmodule-type]
 type = "string"
 prompt = "Which type of SmartModule would you like?"

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -20,7 +20,7 @@ setup_file() {
     SMDK_TEMPLATE_PATH_FLAG="--template-path $(pwd)/smartmodule"
     export SMDK_TEMPLATE_PATH_FLAG
 
-    TESTING_GROUP_NAME_FLAG="--project-name=smdk-smoke-test-group"
+    TESTING_GROUP_NAME_FLAG="--project-group=smdk-smoke-test-group"
     export TESTING_GROUP_NAME_FLAG
 }
 

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -19,6 +19,9 @@ setup_file() {
 
     SMDK_TEMPLATE_PATH_FLAG="--template-path $(pwd)/smartmodule"
     export SMDK_TEMPLATE_PATH_FLAG
+
+    TESTING_GROUP_NAME_FLAG="--project-name=smdk-smoke-test-group"
+    export TESTING_GROUP_NAME_FLAG
 }
 
 ### Using crates.io dependency for `fluvio-smartmodule`
@@ -37,6 +40,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -62,6 +66,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -87,6 +92,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -112,6 +118,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -137,6 +144,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -164,6 +172,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -189,6 +198,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -214,6 +224,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -239,6 +250,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -264,6 +276,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -290,6 +303,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -314,6 +328,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -338,6 +353,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -362,6 +378,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -386,6 +403,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -412,6 +430,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -436,6 +455,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -460,6 +480,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -484,6 +505,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME
@@ -508,6 +530,7 @@ setup_file() {
         $PARAMS_FLAG \
         $SMDK_TEMPLATE_PATH_FLAG \
         $SM_CRATE_PATH_FLAG \
+        $TESTING_GROUP_NAME_FLAG \
         --sm-type $SMDK_SM_TYPE \
         --silent \
         $SM_PACKAGE_NAME


### PR DESCRIPTION
Added prompt to ask for a group name if we don't have one set.

Requires login to InfinyOn Cloud (Tested with with dev instances though)

When asked the first time, we set the hub id with the Hub service. Then future packages will use that value as default.

```
./target/debug/smdk generate \
--with-params \
--sm-crate-path $(pwd)/crates/fluvio-smartmodule \
--template-path $(pwd) \
--destination $(mktemp -d) \
--sm-type map \
--hub-remote https://hub-dev.infinyon.cloud
my-new-sm-package
```

It was hard to test, but I'm certain that if a group name is taken, the Hub will return an error when trying to set the ID

```
Generating new SmartModule project: hellogroup
smartmodule-type => 'map'
smartmodule-params => 'true'
fluvio-smartmodule-cargo-dependency => '{ path = "/Users/telant/Documents/fluvio/crates/fluvio-smartmodule" }'
🔧   Destination: /var/folders/r8/4x6_d2rn283946frzd1gc1pr0000gn/T/tmp.Y7AiGoHa/hellogroup ...
🔧   Generating template ...
🤷   Please set a group name : tj
Ignoring: /var/folders/r8/4x6_d2rn283946frzd1gc1pr0000gn/T/.tmpEyPoIq/smartmodule/cargo_template/cargo-generate.toml
[1/5]   Done: Cargo.toml
[2/5]   Done: README.md
[3/5]   Done: SmartModule.toml
[4/5]   Done: src/lib.rs
[5/5]   Done: src
🔧   Moving generated files into: `/var/folders/r8/4x6_d2rn283946frzd1gc1pr0000gn/T/tmp.Y7AiGoHa/hellogroup`...
💡   Initializing a fresh Git repository
✨   Done! New project created /var/folders/r8/4x6_d2rn283946frzd1gc1pr0000gn/T/tmp.Y7AiGoHa/hellogroup
hub: hubid tj is set
hubid set to tj
```
