### PR TITLE
[Merged by Bors] - ci: Remove a step in docker manifest publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,6 @@ jobs:
           DOCKER_IMAGE_TAG: ${{ env.VERSION }}
           CHANNEL_TAG: stable
         run: |
-          make docker-create-manifest
           make docker-push-manifest
 
       - name: Slack Notification


### PR DESCRIPTION
The make targets try to create a manifest twice, causing issue