### PR TITLE
[Merged by Bors] - feat(smartmodule): added chain support to producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "anymap2"
@@ -174,7 +174,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -513,9 +513,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -732,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93123a31e37accdbf3872120a09f11be29b3fa1f148bc552269123d2a2ebb04e"
 dependencies = [
  "anyhow",
- "clap 3.2.22",
+ "clap 3.2.23",
  "console",
  "dialoguer",
  "dirs",
@@ -784,15 +784,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.14",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -837,7 +838,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "check-crate-version"
 version = "0.0.0"
 dependencies = [
- "clap 4.0.17",
+ "clap 4.0.18",
  "flate2",
  "reqwest",
  "semver 1.0.14",
@@ -886,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
  "clap_derive 3.2.18",
@@ -900,13 +901,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.17"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 4.0.13",
+ "clap_derive 4.0.18",
  "clap_lex 0.3.0",
  "once_cell",
  "strsim",
@@ -920,7 +921,7 @@ version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
 dependencies = [
- "clap 4.0.17",
+ "clap 4.0.18",
 ]
 
 [[package]]
@@ -938,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1123,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
- "base64 0.13.0",
+ "base64 0.13.1",
  "hkdf",
  "hmac",
  "percent-encoding",
@@ -1498,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1510,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1525,15 +1526,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2005,7 +2006,7 @@ dependencies = [
  "async-rwlock",
  "async-std",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "built",
  "bytes 1.2.1",
  "cfg-if",
@@ -2026,7 +2027,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "pin-project-lite",
- "rand 0.8.5",
  "semver 1.0.14",
  "serde",
  "serde_json",
@@ -2062,7 +2062,7 @@ name = "fluvio-channel"
 version = "0.0.0"
 dependencies = [
  "cfg-if",
- "clap 4.0.17",
+ "clap 4.0.18",
  "color-eyre",
  "dirs",
  "fluvio-types",
@@ -2079,7 +2079,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "cfg-if",
- "clap 4.0.17",
+ "clap 4.0.18",
  "color-eyre",
  "colored",
  "dirs",
@@ -2101,7 +2101,7 @@ dependencies = [
  "async-trait",
  "atty",
  "bytesize",
- "clap 4.0.17",
+ "clap 4.0.18",
  "clap_complete",
  "color-eyre",
  "colored",
@@ -2142,7 +2142,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml 0.9.14",
  "sha2 0.10.6",
  "static_assertions",
  "sysinfo",
@@ -2182,7 +2182,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "chrono",
- "clap 4.0.17",
+ "clap 4.0.18",
  "color-eyre",
  "colored",
  "comfy-table",
@@ -2214,7 +2214,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml 0.9.14",
  "sysinfo",
  "tar",
  "tempdir",
@@ -2264,7 +2264,7 @@ name = "fluvio-controlplane-metadata"
 version = "0.19.0"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes 1.2.1",
  "flate2",
  "fluvio-future",
@@ -2275,7 +2275,7 @@ dependencies = [
  "lenient_semver",
  "semver 1.0.14",
  "serde",
- "serde_yaml 0.9.13",
+ "serde_yaml 0.9.14",
  "thiserror",
  "toml",
  "tracing",
@@ -2286,7 +2286,7 @@ name = "fluvio-extension-common"
 version = "0.9.0"
 dependencies = [
  "async-trait",
- "clap 4.0.17",
+ "clap 4.0.18",
  "comfy-table",
  "fluvio",
  "fluvio-package-index",
@@ -2294,7 +2294,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml 0.9.14",
  "thiserror",
  "tracing",
 ]
@@ -2426,7 +2426,7 @@ dependencies = [
 name = "fluvio-run"
 version = "0.0.0"
 dependencies = [
- "clap 4.0.17",
+ "clap 4.0.18",
  "fluvio-extension-common",
  "fluvio-future",
  "fluvio-sc",
@@ -2446,9 +2446,9 @@ dependencies = [
  "async-channel",
  "async-lock",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "cfg-if",
- "clap 4.0.17",
+ "clap 4.0.18",
  "event-listener",
  "fluvio-auth",
  "fluvio-controlplane",
@@ -2586,7 +2586,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "cfg-if",
- "clap 4.0.17",
+ "clap 4.0.18",
  "derive_builder",
  "event-listener",
  "flate2",
@@ -2648,7 +2648,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "bytes 1.2.1",
- "clap 4.0.17",
+ "clap 4.0.18",
  "derive_builder",
  "fluvio-controlplane-metadata",
  "fluvio-future",
@@ -2714,7 +2714,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bytes 1.2.1",
- "clap 4.0.17",
+ "clap 4.0.18",
  "comfy-table",
  "crc",
  "crossbeam-channel",
@@ -2741,7 +2741,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serde_yaml 0.9.13",
+ "serde_yaml 0.9.14",
  "signal-hook",
  "sysinfo",
  "tokio",
@@ -2763,7 +2763,7 @@ dependencies = [
 name = "fluvio-test-derive"
 version = "0.0.0"
 dependencies = [
- "clap 4.0.17",
+ "clap 4.0.18",
  "crossbeam-channel",
  "fluvio",
  "fluvio-future",
@@ -2797,7 +2797,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes 1.2.1",
- "clap 4.0.17",
+ "clap 4.0.18",
  "comfy-table",
  "dyn-clone",
  "fluvio",
@@ -3357,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes 1.2.1",
  "fnv",
@@ -3403,7 +3403,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -3526,7 +3526,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-std",
- "base64 0.13.0",
+ "base64 0.13.1",
  "cookie",
  "futures-lite",
  "infer",
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
 dependencies = [
  "libc",
  "windows-sys 0.36.1",
@@ -3890,7 +3890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab958be0d11da969be0522c572f09762ab40a30432fdd23e506541cceb624"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes 1.2.1",
  "cfg-if",
  "fluvio-future",
@@ -4052,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
 
 [[package]]
 name = "libgit2-sys"
@@ -4145,7 +4145,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -4170,7 +4170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time 0.3.15",
+ "time 0.3.16",
  "unicode-segmentation",
 ]
 
@@ -4312,14 +4312,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4552,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.76"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -4676,7 +4676,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4788,9 +4788,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -5192,7 +5192,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
@@ -5313,9 +5313,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.11"
+version = "0.35.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+checksum = "985947f9b6423159c4726323f373be0a21bdb514c5af06a849cb3d2dce2d01e8"
 dependencies = [
  "bitflags",
  "errno",
@@ -5358,7 +5358,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5523,9 +5523,9 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -5541,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5618,9 +5618,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5797,7 +5797,7 @@ dependencies = [
  "anyhow",
  "cargo-generate",
  "cargo_metadata",
- "clap 4.0.17",
+ "clap 4.0.18",
  "convert_case",
  "dirs",
  "enum-display",
@@ -5993,9 +5993,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6123,9 +6123,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -6184,15 +6184,23 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "time-macros 0.2.4",
+ "serde",
+ "time-core",
+ "time-macros 0.2.5",
 ]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
@@ -6206,9 +6214,12 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "time-macros-impl"
@@ -6862,7 +6873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c2101b211d9db7db8bcfb2ffa69e119fa99a20266d0e5f19bb989cb6c3280d7"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -7387,7 +7398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs",
- "base64 0.13.0",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -7395,7 +7406,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bytes 1.2.1",
  "educe",

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -26,5 +26,5 @@ futures-lite = { version = "1.7.0" }
 thiserror = "1.0.20"
 semver = { version = "1.0.0", features = ["serde"] }
 
-fluvio = { version = "0.14.0", path = "../fluvio", optional = true }
+fluvio = { path = "../fluvio", optional = true }
 fluvio-package-index = { version = "0.7.0", path = "../fluvio-package-index" }

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/src/engine.rs
+++ b/crates/fluvio-smartengine/src/engine.rs
@@ -1,10 +1,9 @@
-use std::ops::{Deref, DerefMut};
 use std::fmt::{self, Debug};
 
-use anyhow::{Error, Result};
+use anyhow::Result;
 use derive_builder::Builder;
 use tracing::debug;
-use wasmtime::{Engine, Module, IntoFunc, Store, Instance, AsContextMut};
+use wasmtime::{Engine, Module};
 
 use fluvio_smartmodule::dataplane::smartmodule::{
     SmartModuleExtraParams, SmartModuleInput, SmartModuleOutput,
@@ -14,6 +13,7 @@ use crate::init::SmartModuleInit;
 use crate::instance::{SmartModuleInstance, SmartModuleInstanceContext};
 
 use crate::metrics::SmartModuleChainMetrics;
+use crate::state::WasmState;
 use crate::transforms::create_transform;
 
 const DEFAULT_SMARTENGINE_VERSION: i16 = 17;
@@ -26,36 +26,9 @@ impl SmartEngine {
     pub fn new() -> Self {
         Self(Engine::default())
     }
-}
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "wasi")] {
-
-        pub(crate) type State = wasmtime_wasi::WasiCtx;
-        impl SmartEngine {
-            /// create new chain builder
-            pub fn builder(&self) -> SmartModuleChainBuilder {
-                let wasi = wasmtime_wasi::WasiCtxBuilder::new()
-                    .inherit_stderr()
-                    .inherit_stdout()
-                    .build();
-                SmartModuleChainBuilder {
-                    store: Store::new(&self.0, wasi),
-                    instances: vec![],
-                }
-            }
-        }
-    } else  {
-        pub(crate) type State = ();
-        impl SmartEngine {
-            /// create new chain builder
-            pub fn builder(&self) -> SmartModuleChainBuilder {
-                SmartModuleChainBuilder {
-                    store: Store::new(&self.0,()),
-                    instances: vec![],
-                }
-            }
-        }
+    pub(crate) fn new_state(&self) -> WasmState {
+        WasmState::new(&self.0)
     }
 }
 
@@ -65,131 +38,61 @@ impl Debug for SmartEngine {
     }
 }
 
-pub type WasmState = Store<State>;
-
 /// Building SmartModule
+#[derive(Default)]
 pub struct SmartModuleChainBuilder {
-    store: Store<State>,
-    instances: Vec<SmartModuleInstance>,
-}
-
-impl Deref for SmartModuleChainBuilder {
-    type Target = Store<State>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.store
-    }
-}
-
-impl DerefMut for SmartModuleChainBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.store
-    }
-}
-
-cfg_if::cfg_if! {
-    if #[cfg(feature = "wasi")] {
-        impl SmartModuleChainBuilder {
-            pub(crate) fn instantiate<Params, Args>(
-                &mut self,
-                module: &Module,
-                host_fn: impl IntoFunc<State, Params, Args>,
-            ) -> Result<Instance, Error> {
-                let mut linker = wasmtime::Linker::new(self.store.engine());
-                wasmtime_wasi::add_to_linker(&mut linker, |c| c)?;
-                let copy_records_fn_import = module
-                    .imports()
-                    .find(|import| import.name().eq("copy_records"))
-                    .ok_or_else(|| Error::msg("At least one import is required"))?;
-                linker.func_wrap(
-                    copy_records_fn_import.module(),
-                    copy_records_fn_import.name(),
-                    host_fn,
-                )?;
-                linker.instantiate(self.as_context_mut(), module)
-            }
-        }
-    } else  {
-        impl SmartModuleChainBuilder {
-
-            pub(crate) fn instantiate<Params, Args>(
-                &mut self,
-                module: &Module,
-                host_fn: impl IntoFunc<State, Params, Args>,
-            ) -> Result<Instance, Error> {
-
-                use wasmtime::Func;
-
-                let func = Func::wrap(self.as_context_mut(), host_fn);
-                Instance::new(self.as_context_mut(), module, &[func.into()])
-            }
-
-
-
-        }
-    }
+    smart_modules: Vec<(SmartModuleConfig, Vec<u8>)>,
 }
 
 impl SmartModuleChainBuilder {
-    #[cfg(test)]
-    pub(crate) fn instances(&self) -> &Vec<SmartModuleInstance> {
-        &self.instances
-    }
-
     /// Add SmartModule with a single transform and init
-    pub fn add_smart_module(
-        &mut self,
-        config: SmartModuleConfig,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        let module = Module::new(self.store.engine(), bytes)?;
-
-        let version = config.version();
-        let params = config.params;
-        let initial_data = config.initial_data;
-        let ctx = SmartModuleInstanceContext::instantiate(module, self, params, version)?;
-        let init = SmartModuleInit::try_instantiate(&ctx, &mut self.as_context_mut())?;
-        let transform = create_transform(&ctx, initial_data, &mut self.as_context_mut())?;
-        self.instances
-            .push(SmartModuleInstance::new(ctx, init, transform));
-        Ok(())
+    pub fn add_smart_module(&mut self, config: SmartModuleConfig, bytes: Vec<u8>) {
+        self.smart_modules.push((config, bytes))
     }
 
     /// stop adding smart module and return SmartModuleChain that can be executed
-    pub fn initialize(mut self) -> Result<SmartModuleChainInstance> {
-        for instance in self.instances.iter_mut() {
-            instance.init(&mut self.store)?;
+    pub fn initialize(self, engine: &SmartEngine) -> Result<SmartModuleChainInstance> {
+        let mut instances = Vec::with_capacity(self.smart_modules.len());
+        let mut state = engine.new_state();
+        for (config, bytes) in self.smart_modules {
+            let module = Module::new(&engine.0, bytes)?;
+            let version = config.version();
+            let ctx = SmartModuleInstanceContext::instantiate(
+                &mut state,
+                module,
+                config.params,
+                version,
+            )?;
+            let init = SmartModuleInit::try_instantiate(&ctx, &mut state)?;
+            let transform = create_transform(&ctx, config.initial_data, &mut state)?;
+            let mut instance = SmartModuleInstance::new(ctx, init, transform);
+            instance.init(&mut state)?;
+            instances.push(instance);
         }
         Ok(SmartModuleChainInstance {
-            store: self.store,
-            instances: self.instances,
+            store: state,
+            instances,
         })
+    }
+}
+
+impl<T: Into<Vec<u8>>> From<(SmartModuleConfig, T)> for SmartModuleChainBuilder {
+    fn from(pair: (SmartModuleConfig, T)) -> Self {
+        let mut result = Self::default();
+        result.add_smart_module(pair.0, pair.1.into());
+        result
     }
 }
 
 /// SmartModule Chain Instance that can be executed
 pub struct SmartModuleChainInstance {
-    store: Store<State>,
+    store: WasmState,
     instances: Vec<SmartModuleInstance>,
 }
 
 impl Debug for SmartModuleChainInstance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SmartModuleChainInstance")
-    }
-}
-
-impl Deref for SmartModuleChainInstance {
-    type Target = Store<State>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.store
-    }
-}
-
-impl DerefMut for SmartModuleChainInstance {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.store
     }
 }
 
@@ -324,7 +227,8 @@ mod chaining_test {
     };
 
     use crate::{
-        SmartEngine, SmartModuleConfig, SmartModuleInitialData, metrics::SmartModuleChainMetrics,
+        SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, SmartModuleInitialData,
+        metrics::SmartModuleChainMetrics,
     };
 
     const SM_FILTER_INIT: &str = "fluvio_smartmodule_filter_init";
@@ -336,27 +240,25 @@ mod chaining_test {
     #[test]
     fn test_chain_filter_map() {
         let engine = SmartEngine::new();
-        let mut chain_builder = engine.builder();
+        let mut chain_builder = SmartModuleChainBuilder::default();
         let metrics = SmartModuleChainMetrics::default();
 
-        chain_builder
-            .add_smart_module(
-                SmartModuleConfig::builder()
-                    .param("key", "a")
-                    .build()
-                    .unwrap(),
-                read_wasm_module(SM_FILTER_INIT),
-            )
-            .expect("failed to create filter");
+        chain_builder.add_smart_module(
+            SmartModuleConfig::builder()
+                .param("key", "a")
+                .build()
+                .unwrap(),
+            read_wasm_module(SM_FILTER_INIT),
+        );
 
-        chain_builder
-            .add_smart_module(
-                SmartModuleConfig::builder().build().unwrap(),
-                read_wasm_module(SM_MAP),
-            )
-            .expect("failed to create map");
+        chain_builder.add_smart_module(
+            SmartModuleConfig::builder().build().unwrap(),
+            read_wasm_module(SM_MAP),
+        );
 
-        let mut chain = chain_builder.initialize().expect("failed to build chain");
+        let mut chain = chain_builder
+            .initialize(&engine)
+            .expect("failed to build chain");
         assert_eq!(chain.instances().len(), 2);
 
         let input = vec![Record::new("hello world")];
@@ -384,32 +286,30 @@ mod chaining_test {
     #[test]
     fn test_chain_filter_aggregate() {
         let engine = SmartEngine::new();
-        let mut chain_builder = engine.builder();
+        let mut chain_builder = SmartModuleChainBuilder::default();
         let metrics = SmartModuleChainMetrics::default();
 
-        chain_builder
-            .add_smart_module(
-                SmartModuleConfig::builder()
-                    .param("key", "a")
-                    .build()
-                    .unwrap(),
-                read_wasm_module(SM_FILTER_INIT),
-            )
-            .expect("failed to create filter");
+        chain_builder.add_smart_module(
+            SmartModuleConfig::builder()
+                .param("key", "a")
+                .build()
+                .unwrap(),
+            read_wasm_module(SM_FILTER_INIT),
+        );
 
-        chain_builder
-            .add_smart_module(
-                SmartModuleConfig::builder()
-                    .initial_data(SmartModuleInitialData::with_aggregate(
-                        "zero".to_string().as_bytes().to_vec(),
-                    ))
-                    .build()
-                    .unwrap(),
-                read_wasm_module(SM_AGGEGRATE),
-            )
-            .expect("failed to create aggegrate");
+        chain_builder.add_smart_module(
+            SmartModuleConfig::builder()
+                .initial_data(SmartModuleInitialData::with_aggregate(
+                    "zero".to_string().as_bytes().to_vec(),
+                ))
+                .build()
+                .unwrap(),
+            read_wasm_module(SM_AGGEGRATE),
+        );
 
-        let mut chain = chain_builder.initialize().expect("failed to build chain");
+        let mut chain = chain_builder
+            .initialize(&engine)
+            .expect("failed to build chain");
         assert_eq!(chain.instances().len(), 2);
 
         let input = vec![
@@ -445,8 +345,10 @@ mod chaining_test {
     fn test_empty_chain() {
         //given
         let engine = SmartEngine::new();
-        let chain_builder = engine.builder();
-        let mut chain = chain_builder.initialize().expect("failed to build chain");
+        let chain_builder = SmartModuleChainBuilder::default();
+        let mut chain = chain_builder
+            .initialize(&engine)
+            .expect("failed to build chain");
         let record = vec![Record::new("input")];
         let input = SmartModuleInput::try_from(record).expect("valid input record");
         let metrics = SmartModuleChainMetrics::default();

--- a/crates/fluvio-smartengine/src/init.rs
+++ b/crates/fluvio-smartengine/src/init.rs
@@ -7,10 +7,7 @@ use fluvio_smartmodule::dataplane::smartmodule::{
 };
 use wasmtime::{AsContextMut, TypedFunc};
 
-use crate::{
-    instance::{SmartModuleInstanceContext},
-    WasmState,
-};
+use crate::instance::SmartModuleInstanceContext;
 
 pub(crate) const INIT_FN_NAME: &str = "init";
 type WasmInitFn = TypedFunc<(i32, i32, u32), i32>;
@@ -46,7 +43,7 @@ impl SmartModuleInit {
         &mut self,
         input: SmartModuleInitInput,
         ctx: &mut SmartModuleInstanceContext,
-        store: &mut WasmState,
+        store: &mut impl AsContextMut,
     ) -> Result<()> {
         let slice = ctx.write_input(&input, &mut *store)?;
         let init_output = self.0.call(&mut *store, slice)?;

--- a/crates/fluvio-smartengine/src/lib.rs
+++ b/crates/fluvio-smartengine/src/lib.rs
@@ -14,3 +14,5 @@ pub type Version = i16;
 
 #[cfg(test)]
 mod fixture;
+
+mod state;

--- a/crates/fluvio-smartengine/src/state.rs
+++ b/crates/fluvio-smartengine/src/state.rs
@@ -1,0 +1,76 @@
+use anyhow::Error;
+use wasmtime::{
+    AsContext, AsContextMut, Engine, Instance, IntoFunc, Module, Store, StoreContext,
+    StoreContextMut,
+};
+
+#[cfg(not(feature = "wasi"))]
+pub type WasmState = WasmStore<()>;
+
+#[cfg(feature = "wasi")]
+pub type WasmState = WasmStore<wasmtime_wasi::WasiCtx>;
+
+#[derive(Debug)]
+pub struct WasmStore<T>(Store<T>);
+
+impl<T> AsContext for WasmStore<T> {
+    type Data = T;
+
+    fn as_context(&self) -> StoreContext<'_, Self::Data> {
+        self.0.as_context()
+    }
+}
+
+impl<T> AsContextMut for WasmStore<T> {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::Data> {
+        self.0.as_context_mut()
+    }
+}
+
+#[cfg(not(feature = "wasi"))]
+impl WasmStore<()> {
+    pub(crate) fn new(engine: &Engine) -> Self {
+        Self(Store::new(engine, ()))
+    }
+
+    pub(crate) fn instantiate<Params, Args>(
+        &mut self,
+        module: &Module,
+        host_fn: impl IntoFunc<<Self as AsContext>::Data, Params, Args>,
+    ) -> Result<Instance, Error> {
+        use wasmtime::Func;
+
+        let func = Func::wrap(&mut *self, host_fn);
+        Instance::new(self, module, &[func.into()])
+    }
+}
+
+#[cfg(feature = "wasi")]
+impl WasmStore<wasmtime_wasi::WasiCtx> {
+    pub(crate) fn new(engine: &Engine) -> Self {
+        let wasi = wasmtime_wasi::WasiCtxBuilder::new()
+            .inherit_stderr()
+            .inherit_stdout()
+            .build();
+        Self(Store::new(engine, wasi))
+    }
+
+    pub(crate) fn instantiate<Params, Args>(
+        &mut self,
+        module: &Module,
+        host_fn: impl IntoFunc<<Self as AsContext>::Data, Params, Args>,
+    ) -> Result<Instance, Error> {
+        let mut linker = wasmtime::Linker::new(module.engine());
+        wasmtime_wasi::add_to_linker(&mut linker, |c| c)?;
+        let copy_records_fn_import = module
+            .imports()
+            .find(|import| import.name().eq("copy_records"))
+            .ok_or_else(|| Error::msg("At least one import is required"))?;
+        linker.func_wrap(
+            copy_records_fn_import.module(),
+            copy_records_fn_import.name(),
+            host_fn,
+        )?;
+        linker.instantiate(self, module)
+    }
+}

--- a/crates/fluvio-smartengine/src/transforms/filter_map.rs
+++ b/crates/fluvio-smartengine/src/transforms/filter_map.rs
@@ -9,7 +9,7 @@ use wasmtime::{AsContextMut, TypedFunc};
 
 use crate::{
     instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    WasmState,
+    state::WasmState,
 };
 
 const FILTER_MAP_FN_NAME: &str = "filter_map";
@@ -77,7 +77,9 @@ mod test {
         Record,
     };
 
-    use crate::{SmartEngine, SmartModuleConfig, metrics::SmartModuleChainMetrics};
+    use crate::{
+        SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, metrics::SmartModuleChainMetrics,
+    };
 
     const SM_FILTER_MAP: &str = "fluvio_smartmodule_filter_map";
 
@@ -87,26 +89,21 @@ mod test {
     #[test]
     fn test_filter_map() {
         let engine = SmartEngine::new();
-        let mut chain_builder = engine.builder();
+        let mut chain_builder = SmartModuleChainBuilder::default();
 
-        chain_builder
-            .add_smart_module(
-                SmartModuleConfig::builder().build().unwrap(),
-                read_wasm_module(SM_FILTER_MAP),
-            )
-            .expect("failed to create filter map");
-
-        assert_eq!(
-            chain_builder
-                .instances()
-                .first()
-                .expect("first")
-                .transform()
-                .name(),
-            super::FILTER_MAP_FN_NAME
+        chain_builder.add_smart_module(
+            SmartModuleConfig::builder().build().unwrap(),
+            read_wasm_module(SM_FILTER_MAP),
         );
 
-        let mut chain = chain_builder.initialize().expect("failed to build chain");
+        let mut chain = chain_builder
+            .initialize(&engine)
+            .expect("failed to build chain");
+
+        assert_eq!(
+            chain.instances().first().expect("first").transform().name(),
+            super::FILTER_MAP_FN_NAME
+        );
 
         let metrics = SmartModuleChainMetrics::default();
         let input = vec![Record::new("10"), Record::new("11")];

--- a/crates/fluvio-smartengine/src/transforms/join.rs
+++ b/crates/fluvio-smartengine/src/transforms/join.rs
@@ -7,7 +7,7 @@ use wasmtime::{AsContextMut, TypedFunc};
 
 use crate::{
     instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    WasmState,
+    state::WasmState,
 };
 
 pub(crate) const JOIN_FN_NAME: &str = "join";

--- a/crates/fluvio-smartengine/src/transforms/join_stream.rs
+++ b/crates/fluvio-smartengine/src/transforms/join_stream.rs
@@ -10,7 +10,7 @@ use wasmtime::{AsContextMut, TypedFunc};
 
 use crate::{
     instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    WasmState,
+    state::WasmState,
 };
 
 pub(crate) const JOIN_FN_NAME: &str = "join";

--- a/crates/fluvio-smartengine/src/transforms/mod.rs
+++ b/crates/fluvio-smartengine/src/transforms/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use instance::create_transform;
 mod instance {
 
     use anyhow::{Result};
-    use wasmtime::{AsContextMut};
+    use wasmtime::AsContextMut;
 
     use crate::{
         instance::{SmartModuleInstanceContext, DowncastableTransform},

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/server/smartmodule.rs
+++ b/crates/fluvio-spu-schema/src/server/smartmodule.rs
@@ -173,6 +173,14 @@ impl SmartModuleWasmCompressed {
             Self::Gzip(gzipped) => Cow::Owned(unzip(gzipped.as_ref())?),
         })
     }
+
+    /// consume and get the raw bytes of the WASM module
+    pub fn into_raw(self) -> io::Result<Vec<u8>> {
+        Ok(match self {
+            Self::Raw(raw) => raw,
+            Self::Gzip(gzipped) => unzip(gzipped.as_ref())?,
+        })
+    }
 }
 
 impl Default for SmartModuleWasmCompressed {

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -1046,7 +1046,7 @@ const FLUVIO_WASM_MAP_DOUBLE: &str = "fluvio_wasm_map_double";
 #[fluvio_future::test(ignore)]
 async fn test_stream_fetch_map_adhoc() {
     adhoc_test(
-        "test_stream_fetch_map_error_adhoc",
+        "test_stream_fetch_map_adhoc",
         FLUVIO_WASM_MAP_DOUBLE,
         SmartModuleKind::Map,
         test_stream_fetch_map,
@@ -2310,10 +2310,8 @@ async fn test_stream_fetch_invalid_smartmodule(
         .expect("response should be Ok");
 
     match response.partition.error_code {
-        ErrorCode::SmartModuleInvalidExports { error: _, kind } => {
-            assert_eq!(kind, "filter");
-        }
-        _ => panic!("expected an InvalidSmartModule error"),
+        ErrorCode::SmartModuleChainInitError { .. } => {}
+        _ => panic!("expected an SmartModuleChainInitError error"),
     }
 
     server_end_event.notify();

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -65,7 +65,7 @@ fluvio-smartmodule = { path = "../fluvio-smartmodule", version = "0.3.0", defaul
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = "4.0.0"
 chrono = {version =  "0.4", default-features = false, features = ["clock"]}
-fluvio-smartengine = { path = "../fluvio-smartengine", version = "0.4.0",  optional = true}
+fluvio-smartengine = { path = "../fluvio-smartengine", version = "0.5.0",  optional = true}
 
 [target.'cfg(unix)'.dependencies]
 fluvio-spu-schema = { version = "0.10.0", path = "../fluvio-spu-schema", features = [

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use fluvio::RecordKey;
 use fluvio_protocol::record::{RecordData, Record};
-use fluvio_smartengine::{SmartEngine, SmartModuleConfig};
+use fluvio_smartengine::{SmartEngine, SmartModuleChainBuilder, SmartModuleConfig};
 use fluvio_smartmodule::dataplane::smartmodule::SmartModuleInput;
 
 use crate::package::{PackageInfo, PackageOption};
@@ -65,15 +65,15 @@ impl TestOpt {
         let param: BTreeMap<String, String> = self.params.into_iter().collect();
 
         let engine = SmartEngine::new();
-        let mut chain_builder = engine.builder();
+        let mut chain_builder = SmartModuleChainBuilder::default();
         chain_builder.add_smart_module(
             SmartModuleConfig::builder().params(param.into()).build()?,
             raw,
-        )?;
+        );
 
         debug!("SmartModule chain created");
 
-        let mut chain = chain_builder.initialize()?;
+        let mut chain = chain_builder.initialize(&engine)?;
 
         // get raw json in one of other ways
         let raw_input = if let Some(input) = self.text {


### PR DESCRIPTION
This PR is a step towards supporting `transform` section for all types of connectors. Specifically, here we add support of the chain of smartmodules to Fluvio Producer.
Main changes in this PR:
1. Decouple the creation and filling of the chain builder from the engine. Now it is required only in the instantiation phase. 
2. Fluvio Producer can be built with the chain builder passed from external. 