### PR TITLE
[Merged by Bors] - fix: Standardize reading records from CLI input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,6 @@ dependencies = [
  "async-net",
  "async-trait",
  "atty",
- "bytes 1.2.1",
  "bytesize",
  "clap 4.0.18",
  "clap_complete",
@@ -2159,7 +2158,6 @@ name = "fluvio-cli-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bytes 1.2.1",
  "fluvio",
  "fluvio-future",
  "fluvio-package-index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "async-net",
  "async-trait",
  "atty",
+ "bytes 1.2.1",
  "bytesize",
  "clap 4.0.18",
  "clap_complete",
@@ -2157,8 +2158,12 @@ dependencies = [
 name = "fluvio-cli-common"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "bytes 1.2.1",
+ "fluvio",
  "fluvio-future",
  "fluvio-package-index",
+ "fluvio-protocol",
  "fluvio-types",
  "futures 0.3.25",
  "hex",
@@ -2168,6 +2173,7 @@ dependencies = [
  "semver 1.0.14",
  "sha2 0.10.6",
  "tempdir",
+ "tempfile",
  "thiserror",
  "tracing",
 ]
@@ -5794,6 +5800,7 @@ name = "smartmodule-development-kit"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes 1.2.1",
  "cargo-generate",
  "cargo_metadata",
  "clap 4.0.18",
@@ -5801,6 +5808,7 @@ dependencies = [
  "dirs",
  "enum-display",
  "fluvio",
+ "fluvio-cli-common",
  "fluvio-controlplane-metadata",
  "fluvio-extension-common",
  "fluvio-future",

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -26,9 +26,14 @@ thiserror = "1.0.20"
 http = { version = "0.2", default-features = false}
 isahc = { version = "1.7", default-features = false, features = ["static-curl"] }
 futures = { version = "0.3" , default-features = false, features = ["std", "io-compat"]}
+tempfile = "3.3.0"
+anyhow = { version = "1.0.38" }
+bytes = { version = "1" }
 
 fluvio-package-index = { path = "../fluvio-package-index", features = ["http_agent"] }
 fluvio-types = { path = "../fluvio-types", optional = true }
+fluvio = { path = "../fluvio", default-features = false }
+fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }
 
 [dev-dependencies]
 fluvio-future = { version = "0.4.0", features = ["fs", "io", "subscriber", "native2_tls", "fixture"] }

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["fluvio-types"]
-file-records = ["fluvio-protocol"]
+file-records = ["fluvio-protocol/record", "fluvio-protocol/api"]
 
 [dependencies]
 tracing = "0.1.19"
@@ -33,7 +33,7 @@ fluvio-package-index = { path = "../fluvio-package-index", features = ["http_age
 fluvio-types = { path = "../fluvio-types", optional = true }
 
 fluvio = { path = "../fluvio", default-features = false, optional = true }
-fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"], optional = true }
+fluvio-protocol = { path = "../fluvio-protocol", optional = true }
 
 [dev-dependencies]
 fluvio-future = { version = "0.4.0", features = ["fs", "io", "subscriber", "native2_tls", "fixture"] }

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["fluvio-types"]
+file-records = ["fluvio-protocol"]
 
 [dependencies]
 tracing = "0.1.19"
@@ -26,14 +27,14 @@ thiserror = "1.0.20"
 http = { version = "0.2", default-features = false}
 isahc = { version = "1.7", default-features = false, features = ["static-curl"] }
 futures = { version = "0.3" , default-features = false, features = ["std", "io-compat"]}
-tempfile = "3.3.0"
 anyhow = { version = "1.0.38" }
-bytes = { version = "1" }
 
 fluvio-package-index = { path = "../fluvio-package-index", features = ["http_agent"] }
 fluvio-types = { path = "../fluvio-types", optional = true }
-fluvio = { path = "../fluvio", default-features = false }
-fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }
+
+fluvio = { path = "../fluvio", default-features = false, optional = true }
+fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"], optional = true }
 
 [dev-dependencies]
 fluvio-future = { version = "0.4.0", features = ["fs", "io", "subscriber", "native2_tls", "fixture"] }
+tempfile = "3.3.0"

--- a/crates/fluvio-cli-common/src/install.rs
+++ b/crates/fluvio-cli-common/src/install.rs
@@ -5,10 +5,14 @@ use tracing::{debug, instrument};
 use semver::Version;
 use fluvio_index::{HttpAgent, PackageId, Target, WithVersion, PackageVersion};
 use crate::FLUVIO_EXTENSIONS_DIR;
-use fluvio_types::defaults::CLI_CONFIG_PATH;
 use crate::error::{Result, CliError};
 
 pub const FLUVIO_DIR: &str = "FLUVIO_DIR";
+
+#[cfg(feature = "default")]
+use fluvio_types::defaults::CLI_CONFIG_PATH;
+#[cfg(not(feature = "default"))]
+pub const CLI_CONFIG_PATH: &str = ".fluvio";
 
 fn fluvio_base_dir() -> Result<PathBuf> {
     if let Ok(dir) = std::env::var(FLUVIO_DIR) {

--- a/crates/fluvio-cli-common/src/lib.rs
+++ b/crates/fluvio-cli-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod http;
 pub mod install;
 pub mod error;
+pub mod user_input;
 
 // Environment vars for Channels
 pub const FLUVIO_RELEASE_CHANNEL: &str = "FLUVIO_RELEASE_CHANNEL";

--- a/crates/fluvio-cli-common/src/lib.rs
+++ b/crates/fluvio-cli-common/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod http;
 pub mod install;
 pub mod error;
+
+#[cfg(feature = "file-records")]
 pub mod user_input;
 
 // Environment vars for Channels

--- a/crates/fluvio-cli-common/src/user_input.rs
+++ b/crates/fluvio-cli-common/src/user_input.rs
@@ -3,9 +3,9 @@ use std::io::{self, BufRead};
 use std::path::PathBuf;
 
 use anyhow::{self, Result};
-use bytes::Bytes;
 
 use fluvio_protocol::record::{Record, RecordData};
+use fluvio_protocol::bytes::Bytes;
 
 pub enum UserInputType {
     Text { key: Option<Bytes>, data: Bytes },

--- a/crates/fluvio-cli-common/src/user_input.rs
+++ b/crates/fluvio-cli-common/src/user_input.rs
@@ -165,7 +165,6 @@ mod file_tests {
 
     #[test]
     fn file_whole() -> Result<(), ()> {
-        // Create a file inside of `std::env::temp_dir()`.
         let mut file = NamedTempFile::new().unwrap();
 
         let data = vec!["123", "abc", "📼🍅🐊"];

--- a/crates/fluvio-cli-common/src/user_input.rs
+++ b/crates/fluvio-cli-common/src/user_input.rs
@@ -1,0 +1,195 @@
+use std::fs::File;
+use std::io::{self, BufRead};
+use std::path::PathBuf;
+
+use anyhow::{self, Result};
+use bytes::Bytes;
+
+use fluvio_protocol::record::{Record, RecordData};
+
+pub enum UserInputType {
+    Text { key: Option<Bytes>, data: Bytes },
+    File { key: Option<Bytes>, path: PathBuf },
+    FileByLine { key: Option<Bytes>, path: PathBuf },
+}
+
+#[derive(Debug, Default)]
+pub struct UserInputRecords {
+    key: Option<Bytes>,
+    data: Vec<RecordData>,
+    size: usize,
+}
+
+impl UserInputRecords {
+    pub fn key(&self) -> Option<Bytes> {
+        self.key.clone()
+    }
+
+    pub fn data(&self) -> Vec<RecordData> {
+        self.data.clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
+impl From<UserInputRecords> for RecordData {
+    fn from(input: UserInputRecords) -> Self {
+        let mut data: Vec<u8> = Vec::new();
+
+        for r in input.data {
+            let v: Vec<u8> = r.as_ref().to_vec();
+            data.extend(v.iter());
+        }
+
+        RecordData::from(data)
+    }
+}
+
+impl From<UserInputRecords> for Vec<Record> {
+    fn from(input: UserInputRecords) -> Self {
+        if let Some(key) = input.key {
+            input
+                .data
+                .into_iter()
+                .map(|r| Record::new_key_value(key.clone(), r))
+                .collect()
+        } else {
+            input.data.into_iter().map(Record::new).collect()
+        }
+    }
+}
+
+impl From<String> for UserInputRecords {
+    fn from(input: String) -> Self {
+        let data = RecordData::from(input.as_bytes());
+        let size = data.len();
+        UserInputRecords {
+            key: None,
+            data: vec![data],
+            size,
+        }
+    }
+}
+
+impl TryFrom<UserInputType> for UserInputRecords {
+    type Error = anyhow::Error;
+    fn try_from(input: UserInputType) -> Result<Self> {
+        match input {
+            UserInputType::Text { key, data } => Ok(UserInputRecords {
+                key,
+                size: data.len(),
+                data: vec![RecordData::from(data)],
+            }),
+            UserInputType::File { key, path } => {
+                let data: Vec<u8> = std::fs::read(path)?;
+                let size = data.len();
+
+                Ok(UserInputRecords {
+                    key,
+                    data: vec![RecordData::from(data)],
+                    size,
+                })
+            }
+            UserInputType::FileByLine { key, path } => {
+                let file = File::open(path)?;
+                let buf = io::BufReader::new(file).lines();
+                let mut size = 0;
+
+                let mut data: Vec<RecordData> = Vec::new();
+
+                for line in buf.flatten() {
+                    let l = line.as_bytes();
+
+                    size += l.len();
+                    data.push(RecordData::from(line));
+                }
+
+                Ok(UserInputRecords { key, data, size })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod file_tests {
+    use super::{UserInputRecords, UserInputType, Bytes};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn text_only() -> Result<(), ()> {
+        let key = "hello123 🚅 👴 🍡 🎰 🛂 🔣 🏂 ⚗ 📰 🏸 🙇 🔊 🖊 🐝";
+        let data = "datadata1234Ⓜ️ 🎉 ☣ 💯 🆑 🌠 🐌 📠 😅 🏹 🐺 ⏸ 7️⃣ 🎯";
+
+        let d = UserInputRecords::try_from(UserInputType::Text {
+            key: Some(Bytes::from(key)),
+            data: Bytes::from(data),
+        })
+        .unwrap();
+
+        assert_eq!(d.data().len(), 1);
+        assert_eq!(d.len(), data.len());
+        assert_eq!(std::str::from_utf8(d.key().as_ref().unwrap()).unwrap(), key);
+        assert_eq!(std::str::from_utf8(d.data()[0].as_ref()).unwrap(), data);
+
+        Ok(())
+    }
+    #[test]
+    fn file_lines() -> Result<(), ()> {
+        let mut file = NamedTempFile::new().unwrap();
+        let data = vec!["123", "abc", "📼🍅🐊"];
+
+        writeln!(file, "{}", data[0]).unwrap();
+        writeln!(file, "{}", data[1]).unwrap();
+        writeln!(file, "{}", data[2]).unwrap();
+
+        let d = UserInputRecords::try_from(UserInputType::FileByLine {
+            key: None,
+            path: file.path().to_path_buf(),
+        })
+        .unwrap();
+
+        assert_eq!(d.data().len(), 3);
+        assert_eq!(d.len(), data.iter().map(|d| d.len()).sum::<usize>());
+        assert_eq!(std::str::from_utf8(d.data()[0].as_ref()).unwrap(), data[0]);
+        assert_eq!(std::str::from_utf8(d.data()[1].as_ref()).unwrap(), data[1]);
+        assert_eq!(std::str::from_utf8(d.data()[2].as_ref()).unwrap(), data[2]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_whole() -> Result<(), ()> {
+        // Create a file inside of `std::env::temp_dir()`.
+        let mut file = NamedTempFile::new().unwrap();
+
+        let data = vec!["123", "abc", "📼🍅🐊"];
+
+        writeln!(file, "{}", data[0]).unwrap();
+        writeln!(file, "{}", data[1]).unwrap();
+        writeln!(file, "{}", data[2]).unwrap();
+
+        let d = UserInputRecords::try_from(UserInputType::File {
+            key: None,
+            path: file.path().to_path_buf(),
+        })
+        .unwrap();
+
+        assert_eq!(d.data().len(), 1);
+        assert_eq!(
+            d.len(),
+            data.iter().map(|d| format!("{}\n", d).len()).sum::<usize>()
+        );
+        assert_eq!(
+            std::str::from_utf8(d.data()[0].as_ref()).unwrap(),
+            format!("{}\n", data.join("\n"))
+        );
+
+        Ok(())
+    }
+}

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -73,6 +73,7 @@ indicatif = "0.17.0"
 async-trait = "0.1.21"
 tokio = { version = "1.3.0", features = ["macros"] }
 async-net = "1.7.0"
+bytes = { version = "1" }
 
 # Fluvio dependencies
 k8-config = { version = "2.0.0", optional = true }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/main.rs"
 doc = false
 
 [features]
-default = ["consumer", "k8s"]
+default = ["consumer", "k8s", "producer-file-io"]
 consumer = [
     "atty",
     "ctrlc",
@@ -35,6 +35,7 @@ k8s = [
     "fluvio-cluster",
 ]
 smartengine = ["fluvio-smartengine"]
+producer-file-io = ["fluvio-cli-common/file-records"]
 
 [dependencies]
 tracing = "0.1.19"
@@ -73,7 +74,6 @@ indicatif = "0.17.0"
 async-trait = "0.1.21"
 tokio = { version = "1.3.0", features = ["macros"] }
 async-net = "1.7.0"
-bytes = { version = "1" }
 
 # Fluvio dependencies
 k8-config = { version = "2.0.0", optional = true }

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -343,8 +343,6 @@ mod cmd {
             // Avoid writing duplicate data to disk
             let mut stats_dataframe_check = 0;
 
-            //match &self.file {
-
             #[cfg(feature = "producer-file-io")]
             if let Some(path) = &self.file {
                 let reader = BufReader::new(File::open(path)?);
@@ -388,49 +386,6 @@ mod cmd {
 
             #[cfg(not(feature = "producer-file-io"))]
             self.producer_stdin(&producer).await?;
-
-            //    None => {
-            //        let mut lines = BufReader::new(std::io::stdin()).lines();
-            //        if self.interactive_mode() {
-            //            eprint!("> ");
-            //        }
-
-            //        while let Some(Ok(line)) = lines.next() {
-            //            let produce_output = self.produce_line(&producer, &line).await?;
-
-            //            if let Some(produce_output) = produce_output {
-            //                if self.delivery_semantic != DeliverySemantic::AtMostOnce {
-            //                    // ensure it was properly sent
-            //                    produce_output.wait().await?;
-            //                }
-            //            }
-
-            //            #[cfg(feature = "stats")]
-            //            if self.is_stats_collect() {
-            //                if self.is_print_live_stats() {
-            //                    self.update_stats_bar(maybe_stats_bar, &producer, &line);
-            //                }
-
-            //                stats_dataframe_check = write_csv_dataframe(
-            //                    &producer,
-            //                    stats_dataframe_check,
-            //                    maybe_stats_file.as_mut(),
-            //                )
-            //                .await?;
-            //            }
-
-            //            if self.interactive_mode() {
-            //                #[cfg(feature = "stats")]
-            //                if let Some(file) = maybe_stats_file.as_mut() {
-            //                    file.flush()?;
-            //                }
-
-            //                print_cli_ok!();
-            //                eprint!("> ");
-            //            }
-            //        }
-            //    }
-            //};
 
             #[cfg(feature = "stats")]
             if let Some(file) = maybe_stats_file.as_mut() {

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -236,12 +236,6 @@ mod cmd {
 
             if self.raw {
                 let key = self.key.clone().map(Bytes::from);
-                //let key = if let Some(k) = self.key {
-                //    RecordKey::from(k)
-                //} else {
-                //    RecordKey::NULL
-                //};
-
                 // Read all input and send as one record
                 let buffer = match &self.file {
                     Some(path) => UserInputRecords::try_from(UserInputType::File {
@@ -253,7 +247,6 @@ mod cmd {
                     None => {
                         let mut buffer = Vec::new();
                         std::io::Read::read_to_end(&mut std::io::stdin(), &mut buffer)?;
-                        //buffer
                         UserInputRecords::try_from(UserInputType::Text {
                             key: key.clone(),
                             data: Bytes::from(buffer),
@@ -262,12 +255,13 @@ mod cmd {
                     }
                 };
 
-                let data: RecordData = buffer.into();
-                let key = if let Some(key) = key {
+                let key = if let Some(key) = buffer.key() {
                     RecordKey::from(key)
                 } else {
                     RecordKey::NULL
                 };
+
+                let data: RecordData = buffer.into();
 
                 let produce_output = producer.send(key, data).await?;
 

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -27,6 +27,7 @@ include_dir = "0.7.2"
 tempfile = "3.3.0"
 enum-display = "0.1.3"
 lib-cargo-crate = "0.1.6"
+bytes = { version = "1" }
 
 fluvio = { path = "../fluvio", default-features = false }
 fluvio-hub-util = { path = "../fluvio-hub-util" }
@@ -36,3 +37,4 @@ fluvio-smartengine = { path = "../fluvio-smartengine" }
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-smartmodule = { path = "../fluvio-smartmodule",  default-features = false }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
+fluvio-cli-common = { path = "../fluvio-cli-common" }

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -13,10 +13,6 @@ name = "smdk"
 path = "src/main.rs"
 doc = false
 
-[features]
-default = ["test-file-io"]
-test-file-io = ["fluvio-cli-common/file-records"]
-
 [dependencies]
 tracing = "0.1.19"
 clap = { version = "4.0.10", features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
@@ -41,4 +37,4 @@ fluvio-smartengine = { path = "../fluvio-smartengine" }
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-smartmodule = { path = "../fluvio-smartmodule",  default-features = false }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
-fluvio-cli-common = { path = "../fluvio-cli-common", optional = true}
+fluvio-cli-common = { path = "../fluvio-cli-common", features = ["file-records"]}

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -13,6 +13,10 @@ name = "smdk"
 path = "src/main.rs"
 doc = false
 
+[features]
+default = ["test-file-io"]
+test-file-io = ["fluvio-cli-common/file-records"]
+
 [dependencies]
 tracing = "0.1.19"
 clap = { version = "4.0.10", features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
@@ -37,4 +41,4 @@ fluvio-smartengine = { path = "../fluvio-smartengine" }
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-smartmodule = { path = "../fluvio-smartmodule",  default-features = false }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
-fluvio-cli-common = { path = "../fluvio-cli-common" }
+fluvio-cli-common = { path = "../fluvio-cli-common", optional = true}

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{self, BufRead};
 
 use clap::Parser;
-use anyhow::Result;
+use anyhow::{self, Result};
 use fluvio_smartengine::metrics::SmartModuleChainMetrics;
 use tracing::debug;
 
@@ -31,6 +31,11 @@ pub struct TestOpt {
     #[clap(long, action, requires = "TestFile")]
     file_single: bool,
 
+    /// Key to use with the test record(s)
+    key: Option<String>,
+
+    // TODO read in from topic, delete for PR
+    // topic
     #[clap(flatten)]
     package: PackageOption,
 
@@ -81,52 +86,193 @@ impl TestOpt {
 
         let mut chain = chain_builder.initialize(&engine)?;
 
-        let mut input_size = 0;
-        let test_record: Vec<Record> = if let Some(input) = self.text {
-            debug!(input, "input string");
-            input.as_bytes().to_vec();
+        let key = self.key;
 
-            let input_bytes = input.as_bytes().to_vec();
-
-            input_size += input_bytes.len();
-
-            vec![Record::new_key_value(RecordKey::NULL, input_bytes)]
-        } else if let Some(test_file) = &self.file {
+        let test_record: UserInputData = if let Some(data) = self.text {
+            UserInputData::try_from(UserInputType::Text { key, data })?
+        } else if let Some(test_file_path) = &self.file {
+            let path = test_file_path.to_path_buf();
             if self.file_single {
-                let f: Vec<u8> = std::fs::read(test_file)?;
-                input_size += f.len();
-                vec![Record::new_key_value(RecordKey::NULL, f)]
+                UserInputData::try_from(UserInputType::File { key, path })?
             } else {
-                let file = File::open(test_file)?;
-                let buf = io::BufReader::new(file).lines();
-
-                let mut records: Vec<Record> = Vec::new();
-
-                for line in buf.flatten() {
-                    let l = line.as_bytes();
-
-                    input_size += l.len();
-                    records.push(Record::new_key_value(RecordKey::NULL, line.as_bytes()));
-                }
-
-                records
+                UserInputData::try_from(UserInputType::FileByLine { key, path })?
             }
         } else {
             return Err(anyhow::anyhow!("No valid input provided"));
         };
-
-        debug!(len = input_size, "input data");
-
-        let entries = test_record;
+        debug!(len = &test_record.len(), "input data");
 
         let metrics = SmartModuleChainMetrics::default();
-        let output = chain.process(SmartModuleInput::try_from(entries)?, &metrics)?;
+        let output = chain.process(SmartModuleInput::try_from(test_record.data())?, &metrics)?;
 
         println!("{:?} records outputed", output.successes.len());
         for output_record in output.successes {
             let output_value = output_record.value.as_str()?;
             println!("{}", output_value);
         }
+
+        Ok(())
+    }
+}
+
+enum UserInputType {
+    Text { key: Option<String>, data: String },
+    File { key: Option<String>, path: PathBuf },
+    FileByLine { key: Option<String>, path: PathBuf },
+}
+
+#[derive(Debug, Default)]
+struct UserInputData {
+    data: Vec<Record>,
+    size: usize,
+}
+
+impl UserInputData {
+    pub fn data(&self) -> Vec<Record> {
+        self.data.clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.size
+    }
+}
+
+impl From<String> for UserInputData {
+    fn from(input: String) -> Self {
+        let input_bytes = input.as_bytes().to_vec();
+        let size = input_bytes.len();
+        UserInputData {
+            data: vec![Record::new_key_value(RecordKey::NULL, input_bytes)],
+            size,
+        }
+    }
+}
+
+impl TryFrom<UserInputType> for UserInputData {
+    type Error = anyhow::Error;
+    fn try_from(input: UserInputType) -> Result<Self> {
+        match input {
+            UserInputType::Text { key, data } => {
+                let key = if let Some(k) = key {
+                    RecordKey::from(k)
+                } else {
+                    RecordKey::NULL
+                };
+                Ok(UserInputData {
+                    size: data.len(),
+                    data: vec![Record::new_key_value(key, data)],
+                })
+            }
+            UserInputType::File { key, path } => {
+                let key = if let Some(k) = key {
+                    RecordKey::from(k)
+                } else {
+                    RecordKey::NULL
+                };
+                let f: Vec<u8> = std::fs::read(path)?;
+                let size = f.len();
+
+                Ok(UserInputData {
+                    data: vec![Record::new_key_value(key, f)],
+                    size,
+                })
+            }
+            UserInputType::FileByLine { key, path } => {
+                let file = File::open(path)?;
+                let buf = io::BufReader::new(file).lines();
+                let mut size = 0;
+
+                let mut data: Vec<Record> = Vec::new();
+
+                for line in buf.flatten() {
+                    let key = if let Some(k) = key.clone() {
+                        RecordKey::from(k)
+                    } else {
+                        RecordKey::NULL
+                    };
+                    let l = line.as_bytes();
+
+                    size += l.len();
+                    data.push(Record::new_key_value(key, line.as_bytes()));
+                }
+
+                Ok(UserInputData { data, size })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod file_tests {
+    use super::{UserInputData, UserInputType};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn text_only() -> Result<(), ()> {
+        let key = "hello 🚅 👴 🍡 🎰 🛂 🔣 🏂 ⚗ 📰 🏸 🙇 🔊 🖊 🐝";
+        let data = "Ⓜ️ 🎉 ☣ 💯 🆑 🌠 🐌 📠 😅 🏹 🐺 ⏸ 7️⃣ 🎯";
+
+        let d = UserInputData::try_from(UserInputType::Text {
+            key: Some(key.to_string()),
+            data: data.to_string(),
+        })
+        .unwrap();
+
+        let r = d.data();
+
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].key().unwrap().as_str().unwrap(), key);
+        assert_eq!(r[0].value().to_string(), data.to_string());
+
+        Ok(())
+    }
+    #[test]
+    fn file_lines() -> Result<(), ()> {
+        let mut file = NamedTempFile::new().unwrap();
+        let data = vec!["123", "abc", "📼🍅🐊"];
+
+        writeln!(file, "{}", data[0]).unwrap();
+        writeln!(file, "{}", data[1]).unwrap();
+        writeln!(file, "{}", data[2]).unwrap();
+
+        let d = UserInputData::try_from(UserInputType::FileByLine {
+            key: None,
+            path: file.path().to_path_buf(),
+        })
+        .unwrap();
+
+        let r = d.data();
+
+        assert_eq!(r.len(), 3);
+        assert_eq!(r[0].value().to_string(), data[0].to_string());
+        assert_eq!(r[1].value().to_string(), data[1].to_string());
+        assert_eq!(r[2].value().to_string(), data[2].to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn file_whole() -> Result<(), ()> {
+        // Create a file inside of `std::env::temp_dir()`.
+        let mut file = NamedTempFile::new().unwrap();
+
+        let data = vec!["123", "abc", "📼🍅🐊"];
+
+        writeln!(file, "{}", data[0]).unwrap();
+        writeln!(file, "{}", data[1]).unwrap();
+        writeln!(file, "{}", data[2]).unwrap();
+
+        let d = UserInputData::try_from(UserInputType::File {
+            key: None,
+            path: file.path().to_path_buf(),
+        })
+        .unwrap();
+
+        let r = d.data();
+
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].value().to_string(), format!("{}\n", data.join("\n")));
 
         Ok(())
     }

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -1,18 +1,17 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
 use std::fmt::Debug;
-use std::fs::File;
-use std::io::{self, BufRead};
 
+use bytes::Bytes;
 use clap::Parser;
 use anyhow::{self, Result};
 use fluvio_smartengine::metrics::SmartModuleChainMetrics;
 use tracing::debug;
 
-use fluvio::RecordKey;
-use fluvio_protocol::record::Record;
 use fluvio_smartengine::{SmartEngine, SmartModuleChainBuilder, SmartModuleConfig};
 use fluvio_smartmodule::dataplane::smartmodule::SmartModuleInput;
+use fluvio_protocol::record::Record;
+use fluvio_cli_common::user_input::{UserInputRecords, UserInputType};
 
 use crate::package::{PackageInfo, PackageOption};
 
@@ -29,7 +28,7 @@ pub struct TestOpt {
 
     /// Read the file as single record
     #[clap(long, action, requires = "TestFile")]
-    file_single: bool,
+    raw: bool,
 
     /// Key to use with the test record(s)
     key: Option<String>,
@@ -86,193 +85,34 @@ impl TestOpt {
 
         let mut chain = chain_builder.initialize(&engine)?;
 
-        let key = self.key;
+        let key = self.key.map(Bytes::from);
 
-        let test_record: UserInputData = if let Some(data) = self.text {
-            UserInputData::try_from(UserInputType::Text { key, data })?
+        let test_data: UserInputRecords = if let Some(data) = self.text {
+            UserInputRecords::try_from(UserInputType::Text {
+                key,
+                data: Bytes::from(data),
+            })?
         } else if let Some(test_file_path) = &self.file {
             let path = test_file_path.to_path_buf();
-            if self.file_single {
-                UserInputData::try_from(UserInputType::File { key, path })?
+            if self.raw {
+                UserInputRecords::try_from(UserInputType::File { key, path })?
             } else {
-                UserInputData::try_from(UserInputType::FileByLine { key, path })?
+                UserInputRecords::try_from(UserInputType::FileByLine { key, path })?
             }
         } else {
             return Err(anyhow::anyhow!("No valid input provided"));
         };
-        debug!(len = &test_record.len(), "input data");
+        debug!(len = &test_data.len(), "input data");
 
         let metrics = SmartModuleChainMetrics::default();
-        let output = chain.process(SmartModuleInput::try_from(test_record.data())?, &metrics)?;
+        let test_records: Vec<Record> = test_data.into();
+        let output = chain.process(SmartModuleInput::try_from(test_records)?, &metrics)?;
 
         println!("{:?} records outputed", output.successes.len());
         for output_record in output.successes {
             let output_value = output_record.value.as_str()?;
             println!("{}", output_value);
         }
-
-        Ok(())
-    }
-}
-
-enum UserInputType {
-    Text { key: Option<String>, data: String },
-    File { key: Option<String>, path: PathBuf },
-    FileByLine { key: Option<String>, path: PathBuf },
-}
-
-#[derive(Debug, Default)]
-struct UserInputData {
-    data: Vec<Record>,
-    size: usize,
-}
-
-impl UserInputData {
-    pub fn data(&self) -> Vec<Record> {
-        self.data.clone()
-    }
-
-    pub fn len(&self) -> usize {
-        self.size
-    }
-}
-
-impl From<String> for UserInputData {
-    fn from(input: String) -> Self {
-        let input_bytes = input.as_bytes().to_vec();
-        let size = input_bytes.len();
-        UserInputData {
-            data: vec![Record::new_key_value(RecordKey::NULL, input_bytes)],
-            size,
-        }
-    }
-}
-
-impl TryFrom<UserInputType> for UserInputData {
-    type Error = anyhow::Error;
-    fn try_from(input: UserInputType) -> Result<Self> {
-        match input {
-            UserInputType::Text { key, data } => {
-                let key = if let Some(k) = key {
-                    RecordKey::from(k)
-                } else {
-                    RecordKey::NULL
-                };
-                Ok(UserInputData {
-                    size: data.len(),
-                    data: vec![Record::new_key_value(key, data)],
-                })
-            }
-            UserInputType::File { key, path } => {
-                let key = if let Some(k) = key {
-                    RecordKey::from(k)
-                } else {
-                    RecordKey::NULL
-                };
-                let f: Vec<u8> = std::fs::read(path)?;
-                let size = f.len();
-
-                Ok(UserInputData {
-                    data: vec![Record::new_key_value(key, f)],
-                    size,
-                })
-            }
-            UserInputType::FileByLine { key, path } => {
-                let file = File::open(path)?;
-                let buf = io::BufReader::new(file).lines();
-                let mut size = 0;
-
-                let mut data: Vec<Record> = Vec::new();
-
-                for line in buf.flatten() {
-                    let key = if let Some(k) = key.clone() {
-                        RecordKey::from(k)
-                    } else {
-                        RecordKey::NULL
-                    };
-                    let l = line.as_bytes();
-
-                    size += l.len();
-                    data.push(Record::new_key_value(key, line.as_bytes()));
-                }
-
-                Ok(UserInputData { data, size })
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod file_tests {
-    use super::{UserInputData, UserInputType};
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
-    #[test]
-    fn text_only() -> Result<(), ()> {
-        let key = "hello 🚅 👴 🍡 🎰 🛂 🔣 🏂 ⚗ 📰 🏸 🙇 🔊 🖊 🐝";
-        let data = "Ⓜ️ 🎉 ☣ 💯 🆑 🌠 🐌 📠 😅 🏹 🐺 ⏸ 7️⃣ 🎯";
-
-        let d = UserInputData::try_from(UserInputType::Text {
-            key: Some(key.to_string()),
-            data: data.to_string(),
-        })
-        .unwrap();
-
-        let r = d.data();
-
-        assert_eq!(r.len(), 1);
-        assert_eq!(r[0].key().unwrap().as_str().unwrap(), key);
-        assert_eq!(r[0].value().to_string(), data.to_string());
-
-        Ok(())
-    }
-    #[test]
-    fn file_lines() -> Result<(), ()> {
-        let mut file = NamedTempFile::new().unwrap();
-        let data = vec!["123", "abc", "📼🍅🐊"];
-
-        writeln!(file, "{}", data[0]).unwrap();
-        writeln!(file, "{}", data[1]).unwrap();
-        writeln!(file, "{}", data[2]).unwrap();
-
-        let d = UserInputData::try_from(UserInputType::FileByLine {
-            key: None,
-            path: file.path().to_path_buf(),
-        })
-        .unwrap();
-
-        let r = d.data();
-
-        assert_eq!(r.len(), 3);
-        assert_eq!(r[0].value().to_string(), data[0].to_string());
-        assert_eq!(r[1].value().to_string(), data[1].to_string());
-        assert_eq!(r[2].value().to_string(), data[2].to_string());
-
-        Ok(())
-    }
-
-    #[test]
-    fn file_whole() -> Result<(), ()> {
-        // Create a file inside of `std::env::temp_dir()`.
-        let mut file = NamedTempFile::new().unwrap();
-
-        let data = vec!["123", "abc", "📼🍅🐊"];
-
-        writeln!(file, "{}", data[0]).unwrap();
-        writeln!(file, "{}", data[1]).unwrap();
-        writeln!(file, "{}", data[2]).unwrap();
-
-        let d = UserInputData::try_from(UserInputType::File {
-            key: None,
-            path: file.path().to_path_buf(),
-        })
-        .unwrap();
-
-        let r = d.data();
-
-        assert_eq!(r.len(), 1);
-        assert_eq!(r[0].value().to_string(), format!("{}\n", data.join("\n")));
 
         Ok(())
     }

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -33,8 +33,6 @@ pub struct TestOpt {
     /// Key to use with the test record(s)
     key: Option<String>,
 
-    // TODO read in from topic, delete for PR
-    // topic
     #[clap(flatten)]
     package: PackageOption,
 

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -11,8 +11,6 @@ use tracing::debug;
 use fluvio_smartengine::{SmartEngine, SmartModuleChainBuilder, SmartModuleConfig};
 use fluvio_smartmodule::dataplane::smartmodule::SmartModuleInput;
 use fluvio_protocol::record::Record;
-
-#[cfg(feature = "test-file-io")]
 use fluvio_cli_common::user_input::{UserInputRecords, UserInputType};
 
 use crate::package::{PackageInfo, PackageOption};
@@ -24,12 +22,10 @@ pub struct TestOpt {
     #[clap(long, group = "TestInput")]
     text: Option<String>,
 
-    #[cfg(feature = "test-file-io")]
     /// Path to test file. Default: Read file line by line
     #[clap(long, groups = ["TestInput", "TestFile"])]
     file: Option<PathBuf>,
 
-    #[cfg(feature = "test-file-io")]
     /// Read the file as single record
     #[clap(long, action, requires = "TestFile")]
     raw: bool,
@@ -89,15 +85,6 @@ impl TestOpt {
 
         let key = self.key.map(Bytes::from);
 
-        #[cfg(not(feature = "test-file-io"))]
-        let test_data = if let Some(input) = self.text {
-            debug!(input, "input string");
-            input.as_bytes().to_vec()
-        } else {
-            return Err(anyhow::anyhow!("No valid input provided"));
-        };
-
-        #[cfg(feature = "test-file-io")]
         let test_data: UserInputRecords = if let Some(data) = self.text {
             UserInputRecords::try_from(UserInputType::Text {
                 key,
@@ -117,18 +104,7 @@ impl TestOpt {
 
         let metrics = SmartModuleChainMetrics::default();
 
-        #[cfg(feature = "test-file-io")]
         let test_records: Vec<Record> = test_data.into();
-
-        #[cfg(not(feature = "test-file-io"))]
-        let test_records: Vec<Record> = if let Some(k) = key {
-            vec![Record::new_key_value(
-                fluvio_protocol::record::RecordKey::from(k),
-                test_data,
-            )]
-        } else {
-            vec![Record::new(test_data)]
-        };
 
         let output = chain.process(SmartModuleInput::try_from(test_records)?, &metrics)?;
 

--- a/smartmodule/regex-filter/Cargo.lock
+++ b/smartmodule/regex-filter/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "thiserror",
  "tracing",


### PR DESCRIPTION
Resolves #2755 

`smdk test --file <file>` by default will read in file and treat each line as a separate record.

If you want to read file as a single record, you need to pass in additional flag `--raw`