### PR TITLE
[Merged by Bors] - feat: setup benchmark action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,8 +661,14 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
+          # What benchmark tool the output.txt came from
           tool: 'cargo'
+          # Where the output from the benchmark tool is stored
           output-file-path: benchmarks.txt
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable alert commit comment
+          comment-on-alert: true
 
   build_image:
     name: Build Fluvio Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,7 +663,7 @@ jobs:
           key: ${{ runner.os }}-benchmark
 
       - name: Run Benchmarks
-        run: cargo +nightly bench | tee benchmarks.txt
+        run: cargo +nightly bench -p fluvio-protocol | tee benchmarks.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
           # Enable alert commit comment
           comment-on-alert: true
           # Where the previous data file is stored
-           external-data-json-path: ./benches/benchmark-data.json
+          external-data-json-path: ./benches/benchmark-data.json
 
   build_image:
     name: Build Fluvio Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,7 +645,6 @@ jobs:
   unit-benchmark:
     name: Unit Benchmarks
     runs-on: ubuntu-latest
-    needs: check
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
           toolchain: nightly
           profile: minimal
 
-      - name: Download previous benchmark data
+      - name: Setup Cache for Rust and Benchmarks
         uses: Swatinem/rust-cache@v2
         with:
           # Additional non workspace directories, separated by newlines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,6 +642,28 @@ jobs:
           path: diagnostics*.gz
           retention-days: 1
 
+  benchmarks:
+    name: Benchmarks
+    needs: local_cluster_test
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Run Benchmarks
+        run: cargo +nightly bench | tee benchmarks.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: benchmarks.txt
+
   build_image:
     name: Build Fluvio Docker image
     needs: build_primary_binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,13 @@ jobs:
           path: ./cache
           key: ${{ runner.os }}-benchmark
 
+      - name: Install Nightly Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+            components: bench
+
       - name: Run Benchmarks
         run: cargo +nightly bench | tee benchmarks.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,8 +642,8 @@ jobs:
           path: diagnostics*.gz
           retention-days: 1
 
-  benchmarks:
-    name: Benchmarks
+  unit-benchmark:
+    name: Unit Benchmarks
     runs-on: ubuntu-latest
     needs: check
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,22 +645,21 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
+    needs: check
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Download previous benchmark data
-        uses: actions/cache@v1
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
-
-      - name: Install Nightly Toolchain
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
-            override: true
-            components: bench
+          toolchain: nightly
+          profile: minimal
+
+      - name: Download previous benchmark data
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-benchmark
 
       - name: Run Benchmarks
         run: cargo +nightly bench | tee benchmarks.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,7 @@ jobs:
 
   benchmarks:
     name: Benchmarks
-    needs: local_cluster_test
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,11 +655,16 @@ jobs:
           toolchain: nightly
           profile: minimal
 
-      - name: Setup Cache for Rust and Benchmarks
+      - name: Cache Rust Cargo files
         uses: Swatinem/rust-cache@v2
         with:
           # Additional non workspace directories, separated by newlines
-          cache-directories: ./benches
+          key: ${{ runner.os }}-benchmark
+
+      - name: Cache Benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./benches_cache
           key: ${{ runner.os }}-benchmark
 
       - name: Run Benchmarks
@@ -677,7 +682,7 @@ jobs:
           # Leave a commit comment comparing the current branch with the previous
           comment-always: true
           # Where the previous data file is stored
-          external-data-json-path: ./benches/benchmark-data.json
+          external-data-json-path: ./benches_cache/benchmark-data.json
 
   build_image:
     name: Build Fluvio Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,8 +675,8 @@ jobs:
           output-file-path: benchmarks.txt
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable alert commit comment
-          comment-on-alert: true
+          # Leave a commit comment comparing the current branch with the previous
+          comment-always: true
           # Where the previous data file is stored
           external-data-json-path: ./benches/benchmark-data.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,8 @@ jobs:
       - name: Download previous benchmark data
         uses: Swatinem/rust-cache@v2
         with:
+          # Additional non workspace directories, separated by newlines
+          cache-directories: ./benches
           key: ${{ runner.os }}-benchmark
 
       - name: Run Benchmarks
@@ -675,6 +677,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
+          # Where the previous data file is stored
+           external-data-json-path: ./benches/benchmark-data.json
 
   build_image:
     name: Build Fluvio Docker image

--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -42,7 +42,6 @@ mod bench {
         let value: Vec<u8> = vec![0x10, 0x11, 0x12, 0x10, 0x11, 0x12, 0x10, 0x11];
 
         b.iter(|| {
-            // Inner closure, the actual test
             for i in 1..100 {
                 let mut dest = vec![];
 

--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -1,0 +1,22 @@
+#![feature(test)]
+
+extern crate test;
+
+#[cfg(test)]
+mod bench {
+  use test::{Bencher, black_box};
+
+  #[bench]
+  fn bench_pow(b: &mut Bencher) {
+    // Optionally include some setup
+    let x: f64 = 211.0 * 11.0;
+    let y: f64 = 301.0 * 103.0;
+
+    b.iter(|| {
+        // Inner closure, the actual test
+        for i in 1..100 {
+            black_box(x.powf(y).powf(x));
+        }
+    });
+  }
+}

--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -13,12 +13,13 @@ mod bench {
     fn bench_encode_vecu8(b: &mut Bencher) {
         let value: Vec<u8> = vec![0x10, 0x11, 0x12, 0x10, 0x11, 0x12, 0x10, 0x11];
 
+        #[allow(unused_must_use)]
         b.iter(|| {
-            for i in 1..100 {
+            for _i in 1..100 {
                 let mut dest = vec![];
 
                 black_box(|| {
-                    value.encode(&mut dest, 0);
+                    value.encode(&mut dest, 0).unwrap();
                 });
             }
         });
@@ -30,12 +31,15 @@ mod bench {
             0x00, 0x00, 0x00, 0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
         ];
 
+        #[allow(unused_must_use)]
         b.iter(|| {
-            for i in 1..100 {
+            for _i in 1..100 {
                 let mut decoded_vecu8: Vec<u8> = vec![];
 
                 black_box(|| {
-                    decoded_vecu8.decode(&mut Cursor::new(&encoded_expect), 0);
+                    decoded_vecu8
+                        .decode(&mut Cursor::new(&encoded_expect), 0)
+                        .unwrap();
                 });
             }
         });

--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -10,34 +10,6 @@ mod bench {
     use test::{Bencher, black_box};
 
     #[bench]
-    fn bench_decode_bool(b: &mut Bencher) {
-        b.iter(|| {
-            for i in 1..100 {
-                let data = [0x1];
-                let mut value: bool = false;
-
-                black_box(|| {
-                    value.decode(&mut Cursor::new(&data), 0);
-                });
-            }
-        });
-    }
-
-    #[bench]
-    fn bench_encode_bool(b: &mut Bencher) {
-        b.iter(|| {
-            for i in 1..100 {
-                let mut dest = vec![];
-                let value = true;
-
-                black_box(|| {
-                    value.encode(&mut dest, 0);
-                });
-            }
-        });
-    }
-
-    #[bench]
     fn bench_encode_vecu8(b: &mut Bencher) {
         let value: Vec<u8> = vec![0x10, 0x11, 0x12, 0x10, 0x11, 0x12, 0x10, 0x11];
 

--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -4,19 +4,69 @@ extern crate test;
 
 #[cfg(test)]
 mod bench {
-  use test::{Bencher, black_box};
+    use std::io::Cursor;
 
-  #[bench]
-  fn bench_pow(b: &mut Bencher) {
-    // Optionally include some setup
-    let x: f64 = 211.0 * 11.0;
-    let y: f64 = 301.0 * 103.0;
+    use fluvio_protocol::{Decoder, Encoder};
+    use test::{Bencher, black_box};
 
-    b.iter(|| {
-        // Inner closure, the actual test
-        for i in 1..100 {
-            black_box(x.powf(y).powf(x));
-        }
-    });
-  }
+    #[bench]
+    fn bench_decode_bool(b: &mut Bencher) {
+        b.iter(|| {
+            for i in 1..100 {
+                let data = [0x1];
+                let mut value: bool = false;
+
+                black_box(|| {
+                    value.decode(&mut Cursor::new(&data), 0);
+                });
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_encode_bool(b: &mut Bencher) {
+        b.iter(|| {
+            for i in 1..100 {
+                let mut dest = vec![];
+                let value = true;
+
+                black_box(|| {
+                    value.encode(&mut dest, 0);
+                });
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_encode_vecu8(b: &mut Bencher) {
+        let value: Vec<u8> = vec![0x10, 0x11, 0x12, 0x10, 0x11, 0x12, 0x10, 0x11];
+
+        b.iter(|| {
+            // Inner closure, the actual test
+            for i in 1..100 {
+                let mut dest = vec![];
+
+                black_box(|| {
+                    value.encode(&mut dest, 0);
+                });
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_decode_vecu8(b: &mut Bencher) {
+        let encoded_expect: [u8; 14] = [
+            0x00, 0x00, 0x00, 0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+        ];
+
+        b.iter(|| {
+            for i in 1..100 {
+                let mut decoded_vecu8: Vec<u8> = vec![];
+
+                black_box(|| {
+                    decoded_vecu8.decode(&mut Cursor::new(&encoded_expect), 0);
+                });
+            }
+        });
+    }
 }


### PR DESCRIPTION
Setups Benchmarks as part of the CI workflow using the [benchmark-action][1].
Benchmarks will be executed after running tests with the `local_cluster_test`
action.

Previous benchmarks are stored using `actions/cache` action with the goal of
comparing them on every change to measure improvements on performance.

[1]: https://github.com/benchmark-action/github-action-benchmark
