### PR TITLE
[Merged by Bors] - refactor: fix clippy warnings

### DIFF
--- a/crates/fluvio-cli-common/src/install.rs
+++ b/crates/fluvio-cli-common/src/install.rs
@@ -173,7 +173,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     let parent = bin_path
         .parent()
         .ok_or_else(|| IoError::new(ErrorKind::NotFound, "parent directory not found"))?;
-    std::fs::create_dir_all(&parent)?;
+    std::fs::create_dir_all(parent)?;
 
     // Create a temporary dir to write file to
     let tmp_dir = tempdir::TempDir::new_in(parent, "fluvio-tmp")?;
@@ -187,7 +187,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     make_executable(&mut tmp_file)?;
 
     // Rename (atomic move on unix) temp file to destination
-    std::fs::rename(&tmp_path, &bin_path)?;
+    std::fs::rename(&tmp_path, bin_path)?;
 
     Ok(())
 }

--- a/crates/fluvio-cli/build.rs
+++ b/crates/fluvio-cli/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio-cli/src/client/hub/list.rs
+++ b/crates/fluvio-cli/src/client/hub/list.rs
@@ -107,7 +107,7 @@ mod output {
         fn content(&self) -> Vec<Row> {
             self.0
                 .iter()
-                .map(|e| Row::from([Cell::new(&e).set_alignment(CellAlignment::Left)]))
+                .map(|e| Row::from([Cell::new(e).set_alignment(CellAlignment::Left)]))
                 .collect()
         }
     }

--- a/crates/fluvio-cluster/build.rs
+++ b/crates/fluvio-cluster/build.rs
@@ -12,7 +12,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio-cluster/src/charts/location.rs
+++ b/crates/fluvio-cluster/src/charts/location.rs
@@ -162,7 +162,7 @@ mod inline {
                 let mut builder = DirBuilder::new();
                 builder.recursive(true);
                 builder
-                    .create(&debug_chart_path)
+                    .create(debug_chart_path)
                     .expect("FLV_INLINE_CHART_DIR not exists");
                 let mut debug_file = File::create(debug_chart_path.join(inline_file.path()))
                     .expect("chart cant' be created");

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -368,7 +368,7 @@ impl ClusterConfigBuilder {
     pub fn development(&mut self) -> Result<&mut Self, ClusterError> {
         // look at git version instead of compiling git version which may not be same as image version
         let git_version_output = Command::new("git")
-            .args(&["rev-parse", "HEAD"])
+            .args(["rev-parse", "HEAD"])
             .output()
             .expect("should run 'git rev-parse HEAD' to get git hash");
         let git_hash = String::from_utf8(git_version_output.stdout)
@@ -1224,48 +1224,48 @@ impl ClusterInstaller {
 
         // Try uninstalling secrets first to prevent duplication error
         Command::new("kubectl")
-            .args(&["delete", "secret", "fluvio-ca", "--ignore-not-found=true"])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["delete", "secret", "fluvio-ca", "--ignore-not-found=true"])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 
         Command::new("kubectl")
-            .args(&["delete", "secret", "fluvio-tls", "--ignore-not-found=true"])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["delete", "secret", "fluvio-tls", "--ignore-not-found=true"])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 
         Command::new("kubectl")
-            .args(&[
+            .args([
                 "delete",
                 "secret",
                 "fluvio-client-tls",
                 "--ignore-not-found=true",
             ])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 
         Command::new("kubectl")
-            .args(&["create", "secret", "generic", "fluvio-ca"])
-            .args(&["--from-file", ca_cert])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["create", "secret", "generic", "fluvio-ca"])
+            .args(["--from-file", ca_cert])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 
         Command::new("kubectl")
-            .args(&["create", "secret", "tls", "fluvio-tls"])
-            .args(&["--cert", server_cert])
-            .args(&["--key", server_key])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["create", "secret", "tls", "fluvio-tls"])
+            .args(["--cert", server_cert])
+            .args(["--key", server_key])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 
         Command::new("kubectl")
-            .args(&["create", "secret", "tls", "fluvio-client-tls"])
-            .args(&["--cert", client_cert])
-            .args(&["--key", client_key])
-            .args(&["--namespace", &self.config.namespace])
+            .args(["create", "secret", "tls", "fluvio-client-tls"])
+            .args(["--cert", client_cert])
+            .args(["--key", client_key])
+            .args(["--namespace", &self.config.namespace])
             .inherit()
             .result()?;
 

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -175,7 +175,7 @@ impl HubAccess {
             profile
         } else {
             let profile_ptr_path = base_path.as_ref().join(ACCESS_FILE_PTR);
-            if let Ok(profile) = std::fs::read_to_string(&profile_ptr_path.as_path()) {
+            if let Ok(profile) = std::fs::read_to_string(profile_ptr_path.as_path()) {
                 profile
             } else {
                 info!("Creating initial hub credentials");

--- a/crates/fluvio-hub-util/src/infinyon_tok.rs
+++ b/crates/fluvio-hub-util/src/infinyon_tok.rs
@@ -57,11 +57,11 @@ impl Credentials {
     }
 
     fn load(cred_path: &Path) -> Result<Self, InfinyonCredentialError> {
-        let file_str = fs::read_to_string(&cred_path).map_err(|_| {
+        let file_str = fs::read_to_string(cred_path).map_err(|_| {
             let strpath = cred_path.to_string_lossy().to_string();
             InfinyonCredentialError::Read(strpath)
         })?;
-        let creds: Credentials = toml::from_str(&*file_str)
+        let creds: Credentials = toml::from_str(&file_str)
             .map_err(|_| InfinyonCredentialError::UnableToParseCredentials)?;
         Ok(creds)
     }

--- a/crates/fluvio-hub-util/src/keymgmt.rs
+++ b/crates/fluvio-hub-util/src/keymgmt.rs
@@ -110,7 +110,7 @@ impl Keypair {
     /// ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIACGeGHWvt/E60k/FLuDsCkArLAIa4lvwk1wg3nJIGJl sshkey@example.com
     pub fn from_ssh(env_val: &str) -> Result<Keypair> {
         let sshprivkey =
-            ssh_key::PrivateKey::from_openssh(&env_val).map_err(|_| HubUtilError::KeyVerify)?;
+            ssh_key::PrivateKey::from_openssh(env_val).map_err(|_| HubUtilError::KeyVerify)?;
         let keypair = sshprivkey
             .key_data()
             .ed25519()

--- a/crates/fluvio-hub-util/src/package.rs
+++ b/crates/fluvio-hub-util/src/package.rs
@@ -82,7 +82,7 @@ fn package_assemble(pkgmeta: &str, outdir: Option<&str>) -> Result<String> {
         let just_fname = fname.file_name().ok_or_else(|| {
             HubUtilError::ManifestInvalidFile(fname.to_string_lossy().to_string())
         })?;
-        tf.append_path_with_name(&fname, just_fname)?;
+        tf.append_path_with_name(fname, just_fname)?;
         let just_fname = just_fname.to_string_lossy().to_string();
         pm_clean.manifest.push(just_fname);
     }
@@ -152,7 +152,7 @@ impl PackageSignatureBulder {
 
         let fsig = FileSig {
             name: String::from(fname),
-            hash: hex::encode(&sha),
+            hash: hex::encode(sha),
             len: buf.len() as u64,
             sig: hex::encode(sig.to_bytes()),
         };
@@ -227,9 +227,9 @@ pub fn package_sign(in_pkgfile: &str, key: &Keypair, out_pkgfile: &str) -> Resul
     drop(signedpkg);
     signedfile.flush()?;
     let sf_path = signedfile.path().to_path_buf();
-    if let Err(e) = signedfile.persist(&out_pkgfile) {
+    if let Err(e) = signedfile.persist(out_pkgfile) {
         warn!("{}, falling back to copy", e);
-        std::fs::copy(sf_path, &out_pkgfile).map_err(|e| {
+        std::fs::copy(sf_path, out_pkgfile).map_err(|e| {
             warn!("copy failure {}", e);
             HubUtilError::PackageSigning(format!(
                 "{in_pkgfile}: fault creating signed package\n{e}"
@@ -478,7 +478,7 @@ pub fn package_verify_with_readio<R: std::io::Read + std::io::Seek>(
 ) -> Result<()> {
     // locate sig that matches the public key in cred
     let sigs = package_getsigs_with_readio(readio, pkgfile)?;
-    let string_pubkey = hex::encode(&pubkey.to_bytes());
+    let string_pubkey = hex::encode(pubkey.to_bytes());
     let sig = sigs
         .iter()
         .find_map(|rec| {

--- a/crates/fluvio-hub-util/src/packagemeta.rs
+++ b/crates/fluvio-hub-util/src/packagemeta.rs
@@ -129,7 +129,7 @@ impl PackageMeta {
 
     pub fn write<P: AsRef<Path>>(&self, pmetapath: P) -> Result<()> {
         let serialized = serde_yaml::to_string(&self)?;
-        fs::write(pmetapath, &serialized.as_bytes())?;
+        fs::write(pmetapath, serialized.as_bytes())?;
         Ok(())
     }
 
@@ -376,7 +376,7 @@ fn hub_package_meta_t_write_then_read() {
         ..PackageMeta::default()
     };
 
-    pm.write(&testfile).expect("error writing package file");
+    pm.write(testfile).expect("error writing package file");
     let pm_read = PackageMeta::read_from_file(testfile).expect("error reading package file");
     assert_eq!(pm, pm_read);
 }

--- a/crates/fluvio-hub-util/src/utils.rs
+++ b/crates/fluvio-hub-util/src/utils.rs
@@ -62,7 +62,7 @@ pub fn cli_pkgname_to_filename(pkgname: &str) -> Result<String> {
 /// returns recommended name and data
 pub async fn get_package(pkgurl: &str, access: &HubAccess) -> Result<Vec<u8>> {
     let actiontoken = access.get_download_token().await?;
-    let mut resp = surf::get(&pkgurl)
+    let mut resp = surf::get(pkgurl)
         .header("Authorization", actiontoken)
         .await
         .map_err(|_| HubUtilError::PackageDownload("authorization error".into()))?;
@@ -92,7 +92,7 @@ pub async fn get_package(pkgurl: &str, access: &HubAccess) -> Result<Vec<u8>> {
 // deprecated, but keep for reference for a bit
 pub async fn get_package_noauth(pkgurl: &str) -> Result<Vec<u8>> {
     //todo use auth
-    let mut resp = surf::get(&pkgurl)
+    let mut resp = surf::get(pkgurl)
         .await
         .map_err(|_| HubUtilError::PackageDownload("".into()))?;
     match resp.status() {

--- a/crates/fluvio-package-index/src/package_id.rs
+++ b/crates/fluvio-package-index/src/package_id.rs
@@ -205,7 +205,7 @@ impl<T> PackageId<T> {
     pub fn registry(&self) -> &Registry {
         match self.registry.as_ref() {
             Some(registry) => registry,
-            None => &*DEFAULT_REGISTRY,
+            None => &DEFAULT_REGISTRY,
         }
     }
 
@@ -213,7 +213,7 @@ impl<T> PackageId<T> {
     pub fn group(&self) -> &GroupName {
         match self.group.as_ref() {
             Some(group) => group,
-            None => &*DEFAULT_GROUP,
+            None => &DEFAULT_GROUP,
         }
     }
 

--- a/crates/fluvio-run/build.rs
+++ b/crates/fluvio-run/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio-sc/build.rs
+++ b/crates/fluvio-sc/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio-sc/src/k8/objects/managed_connector_deployment.rs
+++ b/crates/fluvio-sc/src/k8/objects/managed_connector_deployment.rs
@@ -92,7 +92,7 @@ mod extended {
                 trace!("converting k8 managed connector: {:#?}", k8_obj);
                 default_convert_from_k8(k8_obj, multi_namespace_context)
             } else {
-                Err(K8ConvertError::Skip(k8_obj))
+                Err(K8ConvertError::Skip(Box::new(k8_obj)))
             }
         }
     }

--- a/crates/fluvio-sc/src/k8/objects/spg_service.rs
+++ b/crates/fluvio-sc/src/k8/objects/spg_service.rs
@@ -97,7 +97,7 @@ mod extended {
                 trace!(
                     name = %k8_obj.metadata.name,
                     "skipping non spg service");
-                Err(K8ConvertError::Skip(k8_obj))
+                Err(K8ConvertError::Skip(Box::new(k8_obj)))
             }
         }
     }

--- a/crates/fluvio-sc/src/k8/objects/spu_k8_config.rs
+++ b/crates/fluvio-sc/src/k8/objects/spu_k8_config.rs
@@ -242,7 +242,7 @@ mod extended {
                 trace!(
                     name = %k8_obj.metadata.name,
                     "skipping non spu service");
-                Err(K8ConvertError::Skip(k8_obj))
+                Err(K8ConvertError::Skip(Box::new(k8_obj)))
             }
         }
     }

--- a/crates/fluvio-sc/src/k8/objects/spu_service.rs
+++ b/crates/fluvio-sc/src/k8/objects/spu_service.rs
@@ -123,7 +123,7 @@ mod extended {
                 trace!(
                     name = %k8_obj.metadata.name,
                     "skipping non spu service");
-                Err(K8ConvertError::Skip(k8_obj))
+                Err(K8ConvertError::Skip(Box::new(k8_obj)))
             }
         }
     }

--- a/crates/fluvio-spu/build.rs
+++ b/crates/fluvio-spu/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -656,7 +656,7 @@ mod tests {
 
         assert_eq!(replica.get_log_start_offset(), START_OFFSET);
         let replica_dir = &option.base_dir.join("test-1");
-        let dir_contents = fs::read_dir(&replica_dir).expect("read_dir");
+        let dir_contents = fs::read_dir(replica_dir).expect("read_dir");
         assert_eq!(dir_contents.count(), 5, "should be 5 files");
 
         let seg2_file = replica_dir.join(TEST_SE2_NAME);

--- a/crates/fluvio-stream-model/src/store/k8.rs
+++ b/crates/fluvio-stream-model/src/store/k8.rs
@@ -146,7 +146,7 @@ where
     S: K8Spec,
 {
     /// skip, this object, it is not considered valid object  
-    Skip(K8Obj<S>),
+    Skip(Box<K8Obj<S>>),
     /// Converting error
     KeyConvertionError(IoError),
     Other(IoError),

--- a/crates/fluvio-test-util/setup/environment/k8.rs
+++ b/crates/fluvio-test-util/setup/environment/k8.rs
@@ -30,7 +30,7 @@ impl EnvironmentDriver for K8EnvironmentDriver {
     }
 
     async fn start_cluster(&self) -> StartStatus {
-        let version = semver::Version::parse(&*crate::VERSION).unwrap();
+        let version = semver::Version::parse(&crate::VERSION).unwrap();
         let mut builder = ClusterConfig::builder(version);
         if self.option.develop_mode() {
             builder.development().expect("should test in develop mode");

--- a/crates/fluvio-test-util/setup/environment/local.rs
+++ b/crates/fluvio-test-util/setup/environment/local.rs
@@ -20,7 +20,7 @@ impl LocalEnvDriver {
     }
 
     fn load_config(option: &EnvironmentSetup) -> LocalConfig {
-        let version = semver::Version::parse(&*crate::VERSION).unwrap();
+        let version = semver::Version::parse(&crate::VERSION).unwrap();
         let mut builder = LocalConfig::builder(version);
         builder.spu_replicas(option.spu()).hide_spinner(false);
 

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -106,7 +106,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
                     // Add a connector CRD
                     let admin = test_driver.client().admin().await;
                     // Create a managed connector
-                    let config = ConnectorConfig::from_file(&connector_config).unwrap();
+                    let config = ConnectorConfig::from_file(connector_config).unwrap();
                     let spec: ManagedConnectorSpec = config.clone().into();
                     let name = spec.name.clone();
 

--- a/crates/fluvio/build.rs
+++ b/crates/fluvio/build.rs
@@ -8,7 +8,7 @@ fn main() {
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("should run 'git rev-parse HEAD' to get git hash");
     let git_hash = String::from_utf8(git_version_output.stdout)

--- a/crates/fluvio/src/config/tls.rs
+++ b/crates/fluvio/src/config/tls.rs
@@ -65,8 +65,8 @@ impl TlsConfig {
     /// Returns the domain which this TLS configuration is valid for
     pub fn domain(&self) -> &str {
         match self {
-            TlsConfig::Files(TlsPaths { domain, .. }) => &**domain,
-            TlsConfig::Inline(TlsCerts { domain, .. }) => &**domain,
+            TlsConfig::Files(TlsPaths { domain, .. }) => domain,
+            TlsConfig::Inline(TlsCerts { domain, .. }) => domain,
         }
     }
 }

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -105,7 +105,7 @@ pub fn init_package_template() -> Result<()> {
         return Err(anyhow::anyhow!("package hub directory exists already"));
     }
     std::fs::create_dir(pkgdir)?;
-    pm.write(&pmetapath)?;
+    pm.write(pmetapath)?;
 
     println!(".. fill out info in {pmetapath}");
     Ok(())


### PR DESCRIPTION
Fixed using `cargo clippy --fix` and using `Box` in `Skip` variant of `K8ConvertError` enum