### PR TITLE
[Merged by Bors] - fix: use `master` over `main` for benchmark step

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         with:
           # What benchmark tool the output.txt came from
           tool: 'cargo'


### PR DESCRIPTION
Replaces `main` with `master` when filtering the Update Benchmarks job
execution.