### PR TITLE
[Merged by Bors] - feat: use `content: write` permission for benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 permissions:
-  pull-requests: write
+  content: write
 
 jobs:
   unit_fluvio_protocol:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Cache Benchmark data
         uses: actions/cache@v1
+        if: github.ref == 'refs/heads/master'
         with:
           path: ./benches_cache
           key: benches-${{ runner.os }}-unit_fluvio_protocol
@@ -82,6 +83,7 @@ jobs:
 
       - name: Cache Benchmark data
         uses: actions/cache@v1
+        if: github.ref == 'refs/heads/master'
         with:
           path: ./benches_cache
           key: benches-${{ runner.os }}-unit_fluvio_smartmodule


### PR DESCRIPTION
Provides the `content: write` permission for the `GITHUB_TOKEN` used in the
benchmarks action.

---

Based on permissions required for commenting benchmarks in commits
using the [Benchmark Action][1], the [`GITHUB_TOKEN`][2] is configured
to have the `content: write` permission, which is required by the [Create Commit Comment][3]
endpoint from the GitHub API. The list of permissions required for each endpoint
can be found [here][4].

[1]: https://github.com/benchmark-action/github-action-benchmark
[2]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
[3]: https://docs.github.com/en/rest/commits/comments#create-a-commit-comment
[4]: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#contents