### PR TITLE
[Merged by Bors] - fix: fluvio-test harness bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,6 @@ jobs:
         run: [r1]
         test:
           [
-            validate-test-harness-k8,
             smoke-test-k8,
             smoke-test-k8-tls,
             smoke-test-k8-tls-root-unclean,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,7 +522,7 @@ jobs:
       TEST_BIN: ~/bin/fluvio-test
       SERVER_LOG: fluvio=debug
     strategy:
- #     fail-fast: false
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
@@ -695,7 +695,7 @@ jobs:
       UNINSTALL: noclean
       SERVER_LOG: fluvio=debug
     strategy:
-  #    fail-fast: false
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,7 @@ jobs:
         run: [r1]
         test:
           [
-            validate-test-harness,
+            validate-test-harness-k8,
             smoke-test-k8,
             smoke-test-k8-tls,
             smoke-test-k8-tls-root-unclean,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,7 @@ jobs:
         spu: [2]
         test:
           [
+            validate-test-harness,
             smoke-test,
             smoke-test-tls,
             smoke-test-at-most-once,
@@ -582,6 +583,11 @@ jobs:
           fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}
       - name: sleep
         run: sleep 15
+      - name: Validate test harness
+        if: matrix.test == 'validate-test-harness'
+        timeout-minutes: 5
+        run : |
+          make validate-test-harness
       - name: Run smoke-test
         if: matrix.test == 'smoke-test'
         timeout-minutes: 5
@@ -696,6 +702,7 @@ jobs:
         run: [r1]
         test:
           [
+            validate-test-harness,
             smoke-test-k8,
             smoke-test-k8-tls,
             smoke-test-k8-tls-root-unclean,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
             smoke-test-k8-tls-root-unclean,
           ]
         k8: [k3d, minikube]
-        spu: [3]
+        spu: [1]
     steps:
       - uses: actions/checkout@v3
       # Download artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,7 +707,7 @@ jobs:
             smoke-test-k8-tls-root-unclean,
           ]
         k8: [k3d, minikube]
-        spu: [1]
+        spu: [1,2]
     steps:
       - uses: actions/checkout@v3
       # Download artifacts

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build_long_binaries:
-    name: Test buiild for ${{ matrix.binary }}  on (${{ matrix.os }})
+    name: Test build for ${{ matrix.binary }}  on (${{ matrix.os }})
     if: ${{ false }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -191,6 +191,7 @@ jobs:
             --topic ${{ matrix.topic }} \
             --topic-segment-size ${{ matrix.topic_segment_bytes }} \
             --topic-retention ${{ matrix.topic_retention }} \
+            --expect-timeout
             longevity
 
       ## If the test passed, then copy the data from cluster to store into artifacts

--- a/crates/fluvio-test-util/test_meta/environment.rs
+++ b/crates/fluvio-test-util/test_meta/environment.rs
@@ -264,7 +264,7 @@ pub struct EnvironmentSetup {
     #[clap(long)]
     pub disable_timeout: bool,
 
-    /// Global timeout for a test. Will report as fail when reached
+    /// Global timeout for a test. Will report as fail when reached (unless --expect-timeout)
     /// ex. 30s, 15m, 2h, 1w
     #[clap(long, default_value = "1h", value_parser=parse_duration)]
     pub timeout: Duration,
@@ -276,4 +276,12 @@ pub struct EnvironmentSetup {
     /// K8: use sc address
     #[clap(long)]
     pub proxy_addr: Option<String>,
+
+    /// Will report fail unless test times out
+    #[clap(long, conflicts_with = "expect_fail")]
+    pub expect_timeout: bool,
+
+    /// Expect a test to fail. (fail-> pass. pass or timeout -> fail)
+    #[clap(long, conflicts_with = "expect_timeout")]
+    pub expect_fail: bool,
 }

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -116,14 +116,14 @@ fn run_test(
                 get_current_pid().unwrap(),
             );
             if parent_id == root_pid {
-                println!("test complete, signalling to parent");
+                println!("test complete, signaling to parent");
                 root_process.kill_with(Signal::User1);
             }
             if let Err(err) = status {
                 if environment.expect_fail {
-                    println!("test failed as expected, signalling parent");
+                    println!("test failed as expected, signaling parent");
                 } else {
-                    println!("test failed {:#?}, signalling parent", err);
+                    println!("test failed {:#?}, signaling parent", err);
                 }
                 // This doesn't actually kill root_process, just sends it the signal
                 root_process.kill_with(Signal::User2);

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -176,11 +176,11 @@ fn run_test(
             false
         };
         kill_child_processes(root_process);
-        return TestResult {
+        TestResult {
             success,
             duration: start.elapsed().unwrap(),
             ..std::default::Default::default()
-        };
+        }
     } else if success {
         println!("Test passed");
         TestResult {

--- a/crates/fluvio-test/src/main.rs
+++ b/crates/fluvio-test/src/main.rs
@@ -100,10 +100,7 @@ fn run_test(
     }
     let root_process = sys.process(root_pid).expect("Unable to get root process");
     let _child_pid = match fork::fork() {
-        Ok(fork::Fork::Parent(child_pid)) => {
-            println!("child_pid {child_pid}");
-            child_pid
-        }
+        Ok(fork::Fork::Parent(child_pid)) => child_pid,
         Ok(fork::Fork::Child) => {
             println!("starting test in child process");
             // put panic handler, this shows proper stack trace in the console unlike hook

--- a/crates/fluvio-test/src/tests/expected_fail.rs
+++ b/crates/fluvio-test/src/tests/expected_fail.rs
@@ -1,0 +1,40 @@
+use std::any::Any;
+use std::time::Duration;
+
+use clap::Parser;
+use fluvio_future::timer::sleep;
+use fluvio_test_derive::fluvio_test;
+use fluvio_test_util::test_meta::{TestOption, TestCase};
+use fluvio_test_util::async_process;
+
+#[derive(Debug, Clone)]
+pub struct ExpectedFailTestCase {}
+
+impl From<TestCase> for ExpectedFailTestCase {
+    fn from(_test_case: TestCase) -> Self {
+        ExpectedFailTestCase {}
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(name = "Fluvio Expected Fail Test")]
+pub struct ExpectedFailTestOption {}
+impl TestOption for ExpectedFailTestOption {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[fluvio_test(name = "expected_fail", topic = "unused")]
+pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+    println!("\nStarting example test that fails");
+
+    let fast_fail = async_process!(
+        async {
+            sleep(Duration::from_millis(2000)).await;
+            panic!("This test should fail");
+        },
+        "fast-fail"
+    );
+    fast_fail.join().unwrap();
+}

--- a/crates/fluvio-test/src/tests/expected_fail_join_fail_first.rs
+++ b/crates/fluvio-test/src/tests/expected_fail_join_fail_first.rs
@@ -1,0 +1,48 @@
+use std::any::Any;
+use std::time::Duration;
+
+use clap::Parser;
+use fluvio_future::timer::sleep;
+use fluvio_test_derive::fluvio_test;
+use fluvio_test_util::test_meta::{TestOption, TestCase};
+use fluvio_test_util::async_process;
+
+#[derive(Debug, Clone)]
+pub struct ExpectedFailJoinFailFirstTestCase {}
+
+impl From<TestCase> for ExpectedFailJoinFailFirstTestCase {
+    fn from(_test_case: TestCase) -> Self {
+        ExpectedFailJoinFailFirstTestCase {}
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(name = "Fluvio Expected FailJoinFailFirst Test")]
+pub struct ExpectedFailJoinFailFirstTestOption {}
+impl TestOption for ExpectedFailJoinFailFirstTestOption {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[fluvio_test(name = r#"expected_fail_join_fail_first"#, topic = "unused")]
+pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+    println!("\nStarting example test that fails");
+
+    let success = async_process!(
+        async {
+            sleep(Duration::from_millis(2000)).await;
+        },
+        "success"
+    );
+
+    let fail = async_process!(
+        async {
+            sleep(Duration::from_millis(200)).await;
+            panic!("This test should fail");
+        },
+        "fail"
+    );
+    fail.join().unwrap();
+    success.join().unwrap();
+}

--- a/crates/fluvio-test/src/tests/expected_fail_join_success_first.rs
+++ b/crates/fluvio-test/src/tests/expected_fail_join_success_first.rs
@@ -1,0 +1,48 @@
+use std::any::Any;
+use std::time::Duration;
+
+use clap::Parser;
+use fluvio_future::timer::sleep;
+use fluvio_test_derive::fluvio_test;
+use fluvio_test_util::test_meta::{TestOption, TestCase};
+use fluvio_test_util::async_process;
+
+#[derive(Debug, Clone)]
+pub struct ExpectedFailJoinSuccessFirstTestCase {}
+
+impl From<TestCase> for ExpectedFailJoinSuccessFirstTestCase {
+    fn from(_test_case: TestCase) -> Self {
+        ExpectedFailJoinSuccessFirstTestCase {}
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(name = "Fluvio Expected FailJoinSuccessFirst Test")]
+pub struct ExpectedFailJoinSuccessFirstTestOption {}
+impl TestOption for ExpectedFailJoinSuccessFirstTestOption {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[fluvio_test(name = "expected_fail_join_success_first", topic = "unused")]
+pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+    println!("\nStarting example test that fails");
+
+    let success = async_process!(
+        async {
+            sleep(Duration::from_millis(100)).await;
+        },
+        "success"
+    );
+
+    let fail = async_process!(
+        async {
+            sleep(Duration::from_millis(200)).await;
+            panic!("This test should fail");
+        },
+        "fail"
+    );
+    success.join().unwrap();
+    fail.join().unwrap();
+}

--- a/crates/fluvio-test/src/tests/expected_pass.rs
+++ b/crates/fluvio-test/src/tests/expected_pass.rs
@@ -1,0 +1,37 @@
+use std::any::Any;
+
+use clap::Parser;
+use fluvio_test_derive::fluvio_test;
+use fluvio_test_util::test_meta::{TestOption, TestCase};
+use fluvio_test_util::async_process;
+
+#[derive(Debug, Clone)]
+pub struct ExpectedPassTestCase {}
+
+impl From<TestCase> for ExpectedPassTestCase {
+    fn from(_test_case: TestCase) -> Self {
+        ExpectedPassTestCase {}
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(name = "Fluvio Expected Fail Test")]
+pub struct ExpectedPassTestOption {}
+impl TestOption for ExpectedPassTestOption {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[fluvio_test(name = "expected_pass", topic = "unused")]
+pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+    println!("\nStarting example test that passes");
+
+    let fast_success = async_process!(
+        async {
+            // Do nothing and exit
+        },
+        "fast-success"
+    );
+    fast_success.join().unwrap();
+}

--- a/crates/fluvio-test/src/tests/expected_timeout.rs
+++ b/crates/fluvio-test/src/tests/expected_timeout.rs
@@ -1,0 +1,42 @@
+use std::any::Any;
+use std::time::Duration;
+
+use clap::Parser;
+use fluvio_future::timer::sleep;
+use fluvio_test_derive::fluvio_test;
+use fluvio_test_util::test_meta::{TestOption, TestCase};
+use fluvio_test_util::async_process;
+
+#[derive(Debug, Clone)]
+pub struct ExpectedTimeoutTestCase {}
+
+impl From<TestCase> for ExpectedTimeoutTestCase {
+    fn from(_test_case: TestCase) -> Self {
+        ExpectedTimeoutTestCase {}
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(name = "Fluvio Expected timeout Test")]
+pub struct ExpectedTimeoutTestOption {}
+impl TestOption for ExpectedTimeoutTestOption {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[fluvio_test(name = "expected_timeout", topic = "unused")]
+pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
+    println!("\nStarting example test that timeouts");
+
+    let infinite_loop = async_process!(
+        async {
+            loop {
+                sleep(Duration::from_secs(1)).await
+            }
+            // Do nothing and exit
+        },
+        "infinite loop"
+    );
+    infinite_loop.join().unwrap();
+}

--- a/crates/fluvio-test/src/tests/mod.rs
+++ b/crates/fluvio-test/src/tests/mod.rs
@@ -10,6 +10,11 @@ pub mod producer_fail;
 pub mod reconnection;
 pub mod batching;
 pub mod data_generator;
+pub mod expected_fail;
+pub mod expected_pass;
+pub mod expected_timeout;
+pub mod expected_fail_join_fail_first;
+pub mod expected_fail_join_success_first;
 // pub mod stats;
 
 use serde::{Serialize, Deserialize};

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -139,8 +139,6 @@ test-permission-user1:
 
 # Kubernetes Tests
 
-validate-test-harness-k8: build_k8_image validate-test-harness
-
 smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
 smoke-test-k8: TEST_ARG_TABLE_FORMAT_CONFIG=--table-format-config ./tests/test-table-format-config.yaml
 smoke-test-k8: build_k8_image smoke-test

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -139,6 +139,8 @@ test-permission-user1:
 
 # Kubernetes Tests
 
+validate-test-harness-k8: build_k8_image validate-test-harness
+
 smoke-test-k8: TEST_ARG_EXTRA=$(EXTRA_ARG)
 smoke-test-k8: TEST_ARG_TABLE_FORMAT_CONFIG=--table-format-config ./tests/test-table-format-config.yaml
 smoke-test-k8: build_k8_image smoke-test

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -30,6 +30,8 @@ TEST_ARG_COMMON = ${TEST_ARG_SPU} \
                 ${TEST_ARG_DEVELOP} \
                 ${TEST_ARG_EXTRA}
 
+
+
 ifeq ($(UNINSTALL),noclean)
 clean_cluster:
 	echo "no clean"
@@ -40,6 +42,18 @@ clean_cluster:
 endif
 
 test-setup:	build-test-ci clean_cluster
+
+
+
+validate-test-harness: test-setup
+	$(TEST_BIN) expected_pass ${TEST_ARG_EXTRA}
+	$(TEST_BIN) expected_fail --expect-fail
+	$(TEST_BIN) expected_fail_join_fail_first --expect-fail
+	$(TEST_BIN) expected_fail_join_success_first --expect-fail
+	$(TEST_BIN) expected_timeout --timeout 5sec --expect-timeout
+
+validate-test-harness-local: TEST_ARG_EXTRA=--local  --cluster-start
+validate-test-harness-local: validate-test-harness
 
 # To run a smoke test locally: make smoke-test-local EXTRA_ARG=--cluster-start
 smoke-test: test-setup

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -186,11 +186,11 @@ validate-release-stable:
 ifeq (${CI},true)
 # In CI, we expect all artifacts to already be built and loaded for the script
 longevity-test:
-	$(TEST_BIN) longevity -- --runtime-seconds=1800 --producers 10 --consumers 10
+	$(TEST_BIN) longevity --expect-timeout -- --runtime-seconds=1800 --producers 10 --consumers 10
 else
 # When not in CI (i.e. development), load the dev k8 image before running test
 longevity-test: build-test
-	$(TEST_BIN) longevity -- $(VERBOSE_FLAG) --runtime-seconds=60
+	$(TEST_BIN) longevity --expect-timeout -- $(VERBOSE_FLAG) --runtime-seconds=60
 endif
 
 cli-platform-cross-version-test:


### PR DESCRIPTION
Addresses #2695 

A race condition existed in the logic to evaluate whether or not tests run with `fluvio-test` passed, making it possible for a non-passing-test to appear to succeed. 

Also, tests that timed-out were erroneously set as passing. Note that this effect was obscured as default timeout of one-hour was higher than github action timeout.

1. Added test harness validation tests that "failed to fail" using previous logic.
2. Added `--expect-fail` and `--expect-timeout` flags for tests that are supposed to fail or timeout and added `--expect-timeout` to longevity tests.
3. Tightened up logic so as to eliminate race condition.


**Note: This fix exposes genuine failing tests, so it will not consistently pass CI pipeline.**


### validate-test-harness example output (ignoring stderr)

```
./build-scripts/install_target.sh
cargo build --bin fluvio-test -p fluvio-test   
cargo  build --bin fluvio -p fluvio-cli    
cargo build --bin fluvio-run -p fluvio-run    
echo "clean up previous installation"
clean up previous installation
./target/debug/fluvio cluster delete
./target/debug/fluvio-test expected_pass --local  --cluster-start
Start running fluvio test runner
Starting cluster and testing connection
remove cluster skipped
installing cluster
starting test in child process
Creating the topic: unused
topic "unused" created

Starting example test that passes
test complete, signaling to parent
Test passed
+----------+--------------+
| Pass?    | true         |
|----------+--------------|
| Duration | 827.659539ms |
+----------+--------------+
./target/debug/fluvio-test expected_fail --expect-fail
Start running fluvio test runner
Testing connection to Fluvio cluster in profile
starting test in child process
Creating the topic: unused
topic "unused" already exists

Starting example test that fails
test failed as expected, signaling parent
test complete, signaling to parent
Test passed
+----------+--------------+
| Pass?    | true         |
|----------+--------------|
| Duration | 2.731820019s |
+----------+--------------+
./target/debug/fluvio-test expected_fail_join_fail_first --expect-fail
Start running fluvio test runner
Testing connection to Fluvio cluster in profile
starting test in child process
Creating the topic: unused
topic "unused" already exists

Starting example test that fails
test failed as expected, signaling parent
test complete, signaling to parent
Test passed
+----------+--------------+
| Pass?    | true         |
|----------+--------------|
| Duration | 2.511258335s |
+----------+--------------+
./target/debug/fluvio-test expected_fail_join_success_first --expect-fail
Start running fluvio test runner
Testing connection to Fluvio cluster in profile
starting test in child process
Creating the topic: unused
topic "unused" already exists

Starting example test that fails
test failed as expected, signaling parent
test complete, signaling to parent
Test passed
+----------+--------------+
| Pass?    | true         |
|----------+--------------|
| Duration | 925.028775ms |
+----------+--------------+
./target/debug/fluvio-test expected_timeout --timeout 5sec --expect-timeout
Start running fluvio test runner
Testing connection to Fluvio cluster in profile
starting test in child process
Creating the topic: unused
topic "unused" already exists

Starting example test that timeouts
Test timed out as expected after 5 seconds
killing child test pid 1250657 name fluvio-test
killing child test pid 1250686 name fluvio-test
+----------+--------------+
| Pass?    | true         |
|----------+--------------|
| Duration | 5.405322312s |
+----------+--------------+

```


