### PR TITLE
cli: don't print in stdout warnings about new version available in `latest` channel

### DIFF
--- a/crates/fluvio-cli/src/install/update.rs
+++ b/crates/fluvio-cli/src/install/update.rs
@@ -282,9 +282,9 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<()> {
     debug!(%target, %id, "Fetching latest package version:");
     let latest_version = fetch_latest_version(agent, &id, &target, false).await?;
 
-    println!("⚠️ A major update to Fluvio has been detected!");
-    println!("⚠️ You must complete this update before using any 'install' command");
-    println!(
+    eprintln!("⚠️ A major update to Fluvio has been detected!");
+    eprintln!("⚠️ You must complete this update before using any 'install' command");
+    eprintln!(
         "⚠️     Run 'fluvio update' to install v{} of Fluvio",
         &latest_version
     );
@@ -293,9 +293,9 @@ pub async fn prompt_required_update(agent: &HttpAgent) -> Result<()> {
 
 /// Prompt the user about a new available version of the Fluvio CLI
 pub fn prompt_available_update(latest_version: &Version) {
-    println!();
-    println!("💡 An update to Fluvio is available!");
-    println!(
+    eprintln!();
+    eprintln!("💡 An update to Fluvio is available!");
+    eprintln!(
         "💡     Run 'fluvio update' to install v{} of Fluvio",
         &latest_version
     );

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -305,13 +305,13 @@ mod root {
             None => {
                 match fluvio_extensions_dir() {
                     Ok(fluvio_dir) => {
-                        println!(
+                        eprintln!(
                             "Unable to find plugin '{}'. Make sure it is installed in {:?}.",
                             &subcommand, fluvio_dir,
                         );
                     }
                     Err(_) => {
-                        println!(
+                        eprintln!(
                             "Unable to find plugin '{}'. Make sure it is in your PATH.",
                             &subcommand,
                         );
@@ -343,7 +343,7 @@ mod root {
             // https://doc.rust-lang.org/std/os/unix/process/trait.ExitStatusExt.html
             use std::os::unix::process::ExitStatusExt;
             if let Some(signal) = status.signal() {
-                println!("Extension killed via {} signal", signal);
+                eprintln!("Extension killed via {} signal", signal);
                 std::process::exit(signal);
             }
         }

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -377,13 +377,13 @@ mod root {
 // Checks for an update if channel is latest or ALWAYS_CHECK is set
 async fn check_for_channel_update() {
     if should_always_print_available_update() {
-        println!("🔍 Checking for new version");
+        eprintln!("🔍 Checking for new version");
         let agent = HttpAgent::default();
         let update_result = check_update_available(&agent, false).await;
         if let Ok(Some(latest_version)) = update_result {
             prompt_available_update(&latest_version);
         } else {
-            println!("✅ fluvio-cli is up to date");
+            eprintln!("✅ fluvio-cli is up to date");
         }
     }
 }


### PR DESCRIPTION
in fluvio-connectors we use:

```
fluvio partition list -O json | jq ".[] | select ...
```

But `jq` fails due to those texts are printed to stdout