### PR TITLE
[Merged by Bors] - feat: setup cargo-vet for auditing crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
   cargo-vet:
     name: Vet Dependencies
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     env:
       CARGO_VET_VERSION: 0.3.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
 
       - name: Cache Cargo Vet
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,34 @@ jobs:
           path: ${{ env.RUST_BIN_DIR }}/${{ matrix.binary }}
           retention-days: 1
 
+  cargo-vet:
+    name: Vet Dependencies
+    runs-on: ubuntu-latest
+    env:
+      CARGO_VET_VERSION: 0.3.0
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+
+      - name: Cache Cargo Vet
+        uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-vet
+          key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
+
+      - name: Add "cargo vet" from cache to PATH
+        run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+
+      - name: Ensure "cargo vet" is present
+        run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+
+      - name: Invoke cargo-vet
+        run: cargo vet --locked
+
   # Run all checks and unit test. This always run on debug mode
   check:
     name: Rust check ${{ matrix.check }} (${{ matrix.rust-target }})

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,5 @@
+
+# cargo-vet audits file
+
+[audits]
+

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,2632 @@
+
+# cargo-vet config file
+
+[policy.fluvio-compression]
+audit-as-crates-io = false
+
+[policy.fluvio-extension-common]
+audit-as-crates-io = false
+
+[policy.fluvio-package-index]
+audit-as-crates-io = false
+
+[policy.fluvio-protocol]
+audit-as-crates-io = false
+
+[policy.fluvio-protocol-derive]
+audit-as-crates-io = false
+
+[policy.fluvio-smartmodule]
+audit-as-crates-io = false
+
+[policy.fluvio-smartmodule-derive]
+audit-as-crates-io = false
+
+[policy.fluvio-socket]
+audit-as-crates-io = false
+
+[policy.fluvio-stream-dispatcher]
+audit-as-crates-io = false
+
+[policy.fluvio-stream-model]
+audit-as-crates-io = false
+
+[policy.trybuild]
+audit-as-crates-io = false
+
+[[exemptions.adaptive_backoff]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.addr2line]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.adler]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.aead]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes-gcm]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes-soft]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.aesni]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ahash]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.ahash]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.aho-corasick]]
+version = "0.7.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.ambient-authority]]
+version = "0.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.android_system_properties]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.anes]]
+version = "0.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.anyhow]]
+version = "1.0.66"
+criteria = "safe-to-deploy"
+
+[[exemptions.anymap2]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.arrayvec]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.arrayvec]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.asn1-rs]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.asn1-rs-derive]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.asn1-rs-impl]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.assert_cmd]]
+version = "2.0.6"
+criteria = "safe-to-run"
+
+[[exemptions.async-attributes]]
+version = "1.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-channel]]
+version = "1.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-dup]]
+version = "1.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-executor]]
+version = "1.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-fs]]
+version = "1.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-global-executor]]
+version = "2.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-h1]]
+version = "2.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-io]]
+version = "1.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-lock]]
+version = "2.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-mutex]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-native-tls]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-net]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-process]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-rwlock]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-std]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-task]]
+version = "4.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-tls]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-trait]]
+version = "0.1.58"
+criteria = "safe-to-deploy"
+
+[[exemptions.async_io_stream]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.atomic-waker]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.atty]]
+version = "0.2.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.autocfg]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.backtrace]]
+version = "0.3.66"
+criteria = "safe-to-deploy"
+
+[[exemptions.base-x]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64ct]]
+version = "1.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitflags]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.block-buffer]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.block-buffer]]
+version = "0.10.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.blocking]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bstr]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.bstr]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.btoi]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.built]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bumpalo]]
+version = "3.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.byte-unit]]
+version = "4.0.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.byteorder]]
+version = "1.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytes]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytes]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytesize]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cache-padded]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.camino]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-fs-ext]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-primitives]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-rand]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-std]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-time-ext]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-generate]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-lock]]
+version = "7.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo-platform]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo_metadata]]
+version = "0.15.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cargo_toml]]
+version = "0.11.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.cassowary]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cast]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.castaway]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cc]]
+version = "1.0.74"
+criteria = "safe-to-deploy"
+
+[[exemptions.cfg-if]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.chrono]]
+version = "0.4.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.chrono-humanize]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ciborium]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.ciborium-io]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.ciborium-ll]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.cipher]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap]]
+version = "3.2.23"
+criteria = "safe-to-run"
+
+[[exemptions.clap]]
+version = "4.0.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_complete]]
+version = "4.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "4.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_lex]]
+version = "0.2.4"
+criteria = "safe-to-run"
+
+[[exemptions.clap_lex]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.codespan-reporting]]
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.color-eyre]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.colored]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.comfy-table]]
+version = "6.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.concurrent-queue]]
+version = "1.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.config]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.console]]
+version = "0.15.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.console_error_panic_hook]]
+version = "0.1.7"
+criteria = "safe-to-run"
+
+[[exemptions.const-oid]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.const_fn]]
+version = "0.4.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.const_format]]
+version = "0.2.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.const_format_proc_macros]]
+version = "0.2.29"
+criteria = "safe-to-deploy"
+
+[[exemptions.content_inspector]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.convert_case]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cookie]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation]]
+version = "0.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation-sys]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpp_demangle]]
+version = "0.3.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpufeatures]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpuid-bool]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-bforest]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen-meta]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-codegen-shared]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-entity]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-frontend]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-isle]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-native]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cranelift-wasm]]
+version = "0.89.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.crates_io_api]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc]]
+version = "3.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc-catalog]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32c]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32fast]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.criterion]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-deque]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-epoch]]
+version = "0.9.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-queue]]
+version = "0.3.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossterm]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossterm_winapi]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-common]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-mac]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ctor]]
+version = "0.1.26"
+criteria = "safe-to-deploy"
+
+[[exemptions.ctr]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ctrlc]]
+version = "3.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.curl]]
+version = "0.4.44"
+criteria = "safe-to-deploy"
+
+[[exemptions.curl-sys]]
+version = "0.4.59+curl-7.86.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.curve25519-dalek]]
+version = "3.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cxx]]
+version = "1.0.80"
+criteria = "safe-to-deploy"
+
+[[exemptions.cxx-build]]
+version = "1.0.80"
+criteria = "safe-to-deploy"
+
+[[exemptions.cxxbridge-flags]]
+version = "1.0.80"
+criteria = "safe-to-deploy"
+
+[[exemptions.cxxbridge-macro]]
+version = "1.0.80"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_core]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.dashmap]]
+version = "5.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.data-encoding]]
+version = "2.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.deadpool]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.der]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.der-parser]]
+version = "8.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_builder]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_builder_core]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_builder_macro]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.dialoguer]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.difflib]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.digest]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.digest]]
+version = "0.10.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.directories]]
+version = "4.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.directories-next]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs]]
+version = "4.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys-next]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.discard]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.displaydoc]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.doc-comment]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.duct]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.dyn-clone]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519]]
+version = "1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519-dalek]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.educe]]
+version = "0.4.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.either]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.encode_unicode]]
+version = "0.3.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.encoding_rs]]
+version = "0.8.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.enum-display]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.enum-display-macro]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.enum-ordinalize]]
+version = "3.1.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_logger]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.errno]]
+version = "0.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.errno-dragonfly]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener]]
+version = "2.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.eyre]]
+version = "0.6.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.fallible-iterator]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fastrand]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.file-per-thread-logger]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.filetime]]
+version = "0.2.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.flate2]]
+version = "1.0.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.float-cmp]]
+version = "0.9.0"
+criteria = "safe-to-run"
+
+[[exemptions.fluvio-command]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fluvio-future]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.fluvio-helm]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.fluvio-test-derive]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fluvio-wasm-timer]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.fluvio_ws_stream_wasm]]
+version = "0.7.0"
+criteria = "safe-to-run"
+
+[[exemptions.flv-tls-proxy]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.flv-util]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.fnv]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.foreign-types]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.foreign-types-shared]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fork]]
+version = "0.1.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.form_urlencoded]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fs-set-times]]
+version = "0.17.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fuchsia-cprng]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures]]
+version = "0.1.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-channel]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-core]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-executor]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-io]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-lite]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-sink]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-task]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-util]]
+version = "0.3.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.fxhash]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.14.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.ghash]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ghost]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.gimli]]
+version = "0.26.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-actor]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-config]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-config-value]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-date]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-features]]
+version = "0.23.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-glob]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-hash]]
+version = "0.9.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-lock]]
+version = "2.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-object]]
+version = "0.22.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-path]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-ref]]
+version = "0.18.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-sec]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-tempfile]]
+version = "2.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.git-validate]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.git2]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.glob]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.globset]]
+version = "0.4.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.gloo-timers]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.h2]]
+version = "0.3.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.half]]
+version = "1.8.2"
+criteria = "safe-to-run"
+
+[[exemptions.handlebars]]
+version = "4.3.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.hashbrown]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.hdrhistogram]]
+version = "7.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.heck]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.1.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.2.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.hex]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.hkdf]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hmac]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.home]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.hostfile]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.http]]
+version = "0.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.http-body]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.http-client]]
+version = "6.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.http-types]]
+version = "2.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.httparse]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.httpdate]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.humantime]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper]]
+version = "0.14.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-rustls]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-tls]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.iana-time-zone]]
+version = "0.1.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.iana-time-zone-haiku]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ident_case]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.idna]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ignore]]
+version = "0.4.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.include_dir]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.include_dir_macros]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.indenter]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.indexmap]]
+version = "1.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.indicatif]]
+version = "0.17.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.infer]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.inflections]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.instant]]
+version = "0.1.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.inventory]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.io-extras]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.io-lifetimes]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.iovec]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ipnet]]
+version = "2.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.is-terminal]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.isahc]]
+version = "1.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.10.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.itoa]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ittapi]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ittapi-sys]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jobserver]]
+version = "0.1.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.js-sys]]
+version = "0.3.60"
+criteria = "safe-to-deploy"
+
+[[exemptions.k8-client]]
+version = "8.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.k8-config]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.k8-diff]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.k8-metadata-client]]
+version = "5.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.k8-types]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.kstring]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.kv-log-macro]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.lazy_static]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.leb128]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.lenient_semver]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.lenient_semver_parser]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.lenient_semver_version_builder]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-core]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.lib-cargo-crate]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.libc]]
+version = "0.2.137"
+criteria = "safe-to-deploy"
+
+[[exemptions.libgit2-sys]]
+version = "0.14.0+1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.libssh2-sys]]
+version = "0.2.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.libz-sys]]
+version = "1.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.link-cplusplus]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.linked-hash-map]]
+version = "0.5.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.linux-raw-sys]]
+version = "0.0.46"
+criteria = "safe-to-deploy"
+
+[[exemptions.liquid]]
+version = "0.26.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.liquid-core]]
+version = "0.26.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.liquid-derive]]
+version = "0.26.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.liquid-lib]]
+version = "0.26.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lock_api]]
+version = "0.4.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.log]]
+version = "0.4.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.lz4_flex]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.mach]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.matchers]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.maybe-owned]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.md-5]]
+version = "0.10.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.memchr]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.memfd]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.memmap]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.memmap2]]
+version = "0.5.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.memoffset]]
+version = "0.6.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.mime]]
+version = "0.3.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.mime_guess]]
+version = "2.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.minimal-lexical]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.miniz_oxide]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.mio]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.names]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.native-tls]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.nix]]
+version = "0.24.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.nix]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nom]]
+version = "5.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.nom]]
+version = "7.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.normalize-line-endings]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.ntapi]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nu-ansi-term]]
+version = "0.46.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-integer]]
+version = "0.1.45"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-traits]]
+version = "0.2.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_cpus]]
+version = "1.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_threads]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.number_prefix]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.object]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.oid-registry]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.once_cell]]
+version = "1.16.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.oorandom]]
+version = "11.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.opaque-debug]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl]]
+version = "0.10.42"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-macros]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-probe]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-src]]
+version = "111.24.0+1.1.1s"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-sys]]
+version = "0.9.77"
+criteria = "safe-to-deploy"
+
+[[exemptions.os_pipe]]
+version = "0.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.os_str_bytes]]
+version = "6.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.overload]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.owo-colors]]
+version = "3.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot_core]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot_core]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.paste]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.path-absolutize]]
+version = "3.0.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.path-dedot]]
+version = "3.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem-rfc7468]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.percent-encoding]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pest]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pest_derive]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pest_generator]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pest_meta]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pharos]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project]]
+version = "1.0.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project-internal]]
+version = "1.0.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project-lite]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-utils]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkg-config]]
+version = "0.3.26"
+criteria = "safe-to-deploy"
+
+[[exemptions.plotters]]
+version = "0.3.4"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-backend]]
+version = "0.3.4"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-svg]]
+version = "0.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.polling]]
+version = "2.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.polyval]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.portpicker]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.predicates]]
+version = "2.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.predicates-core]]
+version = "1.0.4"
+criteria = "safe-to-run"
+
+[[exemptions.predicates-tree]]
+version = "1.0.6"
+criteria = "safe-to-run"
+
+[[exemptions.proc-macro-error]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-error-attr]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-hack]]
+version = "0.5.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro2]]
+version = "1.0.47"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-quote]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-quote-impl]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.psm]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.pure-rust-locales]]
+version = "0.5.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.quick-error]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.quote]]
+version = "1.0.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_chacha]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_chacha]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_hc]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon]]
+version = "1.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon-core]]
+version = "1.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rdrand]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_syscall]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_users]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.regalloc2]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-automata]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-syntax]]
+version = "0.6.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.remove_dir_all]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.remove_dir_all]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.reqwest]]
+version = "0.11.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.rhai]]
+version = "1.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rhai_codegen]]
+version = "1.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ring]]
+version = "0.16.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc-demangle]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc_version]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc_version]]
+version = "0.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.rustc_version]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rusticata-macros]]
+version = "4.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustix]]
+version = "0.35.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls]]
+version = "0.18.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls]]
+version = "0.20.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-pemfile]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustversion]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.ryu]]
+version = "1.0.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.same-file]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sanitize-filename]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.schannel]]
+version = "0.1.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.scoped-tls]]
+version = "1.0.1"
+criteria = "safe-to-run"
+
+[[exemptions.scopeguard]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.scratch]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.sct]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.sct]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sec1]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework]]
+version = "2.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework-sys]]
+version = "2.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.semver]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.semver]]
+version = "0.11.0"
+criteria = "safe-to-run"
+
+[[exemptions.semver]]
+version = "1.0.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.semver-parser]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.semver-parser]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.send_wrapper]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde]]
+version = "1.0.147"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_bytes]]
+version = "0.11.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_derive]]
+version = "1.0.147"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_json]]
+version = "1.0.87"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_path_to_error]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_qs]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_qs]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_urlencoded]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_yaml]]
+version = "0.8.26"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_yaml]]
+version = "0.9.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.10.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1_smol]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha2]]
+version = "0.9.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha2]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sharded-slab]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.shared_child]]
+version = "0.3.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.shellexpand]]
+version = "2.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook]]
+version = "0.3.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook-mio]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.signal-hook-registry]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.signature]]
+version = "1.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.simple-mutex]]
+version = "1.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.siphasher]]
+version = "0.3.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.slab]]
+version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.slice-group-by]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sluice]]
+version = "0.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.smallvec]]
+version = "1.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.smartstring]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.snap]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.socket2]]
+version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ssh-key]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.standback]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.static_assertions]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.stdweb]]
+version = "0.4.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.stdweb-derive]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.stdweb-internal-macros]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.stdweb-internal-runtime]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.strsim]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.strum]]
+version = "0.24.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.strum_macros]]
+version = "0.24.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.subtle]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.surf]]
+version = "2.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "1.0.103"
+criteria = "safe-to-deploy"
+
+[[exemptions.synstructure]]
+version = "0.12.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sysinfo]]
+version = "0.26.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-interface]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tar]]
+version = "0.4.38"
+criteria = "safe-to-deploy"
+
+[[exemptions.target-lexicon]]
+version = "0.12.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.tempdir]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.tempfile]]
+version = "3.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.termcolor]]
+version = "1.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.terminal_size]]
+version = "0.1.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.terminal_size]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.termtree]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.textwrap]]
+version = "0.16.0"
+criteria = "safe-to-run"
+
+[[exemptions.thiserror]]
+version = "1.0.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror-impl]]
+version = "1.0.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.thread_local]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.time]]
+version = "0.1.44"
+criteria = "safe-to-deploy"
+
+[[exemptions.time]]
+version = "0.2.27"
+criteria = "safe-to-deploy"
+
+[[exemptions.time]]
+version = "0.3.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-core]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros-impl]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinytemplate]]
+version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.tinyvec]]
+version = "1.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinyvec_macros]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio]]
+version = "1.21.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-io]]
+version = "0.1.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-macros]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-native-tls]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-rustls]]
+version = "0.23.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-util]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml]]
+version = "0.5.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-service]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing]]
+version = "0.1.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-attributes]]
+version = "0.1.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-core]]
+version = "0.1.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-futures]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-log]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-subscriber]]
+version = "0.3.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.try-lock]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.trybuild]]
+version = "1.0.71"
+criteria = "safe-to-run"
+
+[[exemptions.tui]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.twox-hash]]
+version = "1.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.typenum]]
+version = "1.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ucd-trie]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicase]]
+version = "2.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-bidi]]
+version = "0.3.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-bom]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-ident]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-normalization]]
+version = "0.1.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-segmentation]]
+version = "1.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-width]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-xid]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.universal-hash]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.unsafe-libyaml]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.untrusted]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.url]]
+version = "2.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.utf8-width]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.uuid]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.valuable]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.value-bag]]
+version = "1.0.0-alpha.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.vcpkg]]
+version = "0.2.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.version_check]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.wait-timeout]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.waker-fn]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.walkdir]]
+version = "2.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.want]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.9.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.10.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.11.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi-cap-std-sync]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi-common]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.83"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-backend]]
+version = "0.2.83"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-futures]]
+version = "0.4.33"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.83"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.83"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.83"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-test]]
+version = "0.3.33"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-test-macro]]
+version = "0.3.33"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-encoder]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmparser]]
+version = "0.92.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmparser]]
+version = "0.93.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-asm-macros]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-cache]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-cranelift]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-environ]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-fiber]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-jit]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-jit-debug]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-runtime]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-types]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtime-wasi]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wast]]
+version = "35.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.wast]]
+version = "48.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wat]]
+version = "1.0.50"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-sys]]
+version = "0.3.60"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki]]
+version = "0.21.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki]]
+version = "0.22.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-roots]]
+version = "0.20.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-roots]]
+version = "0.22.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.wepoll-ffi]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.which]]
+version = "4.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wiggle]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wiggle-generate]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wiggle-macro]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-util]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.40.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winreg]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.winx]]
+version = "0.33.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.witx]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ws_stream_wasm]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.x509-parser]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.xattr]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.yaml-rust]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize_derive]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd]]
+version = "0.11.2+zstd.1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-safe]]
+version = "5.0.2+zstd.1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-sys]]
+version = "2.0.1+zstd.1.5.2"
+criteria = "safe-to-deploy"
+

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,5 @@
+
+# cargo-vet imports lock
+
+[audits]
+


### PR DESCRIPTION
Setups and initializes cargo vet in the project.

Resolves: https://github.com/infinyon/fluvio/issues/2593

---

By default cargo-vet uses the [safe-to-run](https://mozilla.github.io/cargo-vet/built-in-criteria.html#safe-to-run) and [safe-to-deploy](https://mozilla.github.io/cargo-vet/built-in-criteria.html#safe-to-deploy) criteria OOTB, so this [audit criteria][1] is already active. [More details here](https://mozilla.github.io/cargo-vet/specifying-policies.html).

If this gets merged it would be nice to also add this audit to [The Registry][2].

[1]: https://mozilla.github.io/cargo-vet/audit-criteria.html#audit-criteria
[2]: https://mozilla.github.io/cargo-vet/importing-audits.html#the-registry