### PR TITLE
[Merged by Bors] - Refactor look up version: from O(N) to O(1)

### DIFF
--- a/crates/fluvio-protocol/benches/bench.rs
+++ b/crates/fluvio-protocol/benches/bench.rs
@@ -36,7 +36,7 @@ fn bench_decode_vecu8(c: &mut Criterion) {
 
 fn bench_encode_bytebuf(c: &mut Criterion) {
     let bytes = read(EXAMPLE_WASM_FILE).unwrap();
-    let bytebuf: ByteBuf = ByteBuf::from(bytes.clone());
+    let bytebuf: ByteBuf = ByteBuf::from(bytes);
 
     c.bench_function("bytebuf encoding", |b| {
         b.iter(|| {

--- a/crates/fluvio/src/sockets.rs
+++ b/crates/fluvio/src/sockets.rs
@@ -196,12 +196,10 @@ impl Versions {
         for version in &self.api_versions {
             if version.api_key == R::API_KEY as i16 {
                 // try to find most latest maximum version
-                for client_version in (R::MIN_API_VERSION..=R::MAX_API_VERSION).rev() {
-                    if version.min_version <= client_version
-                        && version.max_version >= client_version
-                    {
-                        return Some(client_version);
-                    }
+                if version.max_version >= R::MIN_API_VERSION
+                    && version.min_version <= R::MAX_API_VERSION
+                {
+                    return Some(R::MAX_API_VERSION.min(version.max_version));
                 }
             }
         }


### PR DESCRIPTION
`Versions::lookup_version` is based on a simple `if` instead of `for-if`.