### PR TITLE
fix: cargo vet registry imports and exemptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
   cargo-vet:
     name: Vet Dependencies
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     env:
       CARGO_VET_VERSION: 0.3.0
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,6 +1,15 @@
 
 # cargo-vet config file
 
+[imports.bytecodealliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.embark]
+url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
+
+[imports.firefox]
+url = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [policy.fluvio-compression]
 audit-as-crates-io = false
 
@@ -136,6 +145,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.async-executor]]
 version = "1.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-executor]]
+version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-fs]]


### PR DESCRIPTION
Currently `cargo vet` is not configured to allow certain dependencies
without _cargo vet_ audition. We also lack of audition databases we could
extend from other sources to reduce registry work.

This PR adds imports used in the [Cargo Vet Official Repository from Mozilla][1],
and also reviews exemptions. Without this, cargo vet is not able to determine which
packages to allow [pass audition on PR merging][2].

[1]: https://github.com/mozilla/cargo-vet/blob/56ebfded2d27d6c28a56832aaae1dc99b41c4311/supply-chain/config.toml#L4
[2]: https://github.com/infinyon/fluvio/actions/runs/3449126540/jobs/5756774360#step:7:18