### PR TITLE
[Merged by Bors] - fix: benchmarking tool behaviour on timeout

### DIFF
--- a/crates/fluvio-benchmark/src/bin/fbm.rs
+++ b/crates/fluvio-benchmark/src/bin/fbm.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
     mem,
+    time::Duration,
 };
 use clap::{arg, Parser};
 use fluvio_cli_common::install::fluvio_base_dir;

--- a/crates/fluvio-benchmark/src/bin/fbm.rs
+++ b/crates/fluvio-benchmark/src/bin/fbm.rs
@@ -50,7 +50,8 @@ fn main() -> Result<(), BenchmarkError> {
         println!("## Matrix: {}", matrix.shared_config.matrix_name);
         for (i, config) in matrix.into_iter().enumerate() {
             run_block_on(timeout(
-                config.worker_timeout,
+                // Give time for workers to clean up if workers timeout.
+                config.worker_timeout + Duration::from_secs(10),
                 BenchmarkDriver::run_benchmark(config.clone(), all_stats.clone()),
             ))??;
             println!("### {}: Iteration {:3.0}", config.matrix_name, i);


### PR DESCRIPTION
Currently workers and driver use same timeout, that means that driver times out before workers so the cleanup routine following worker timeout gets short circuited.