### PR TITLE
[Merged by Bors] - fix: release batches lock

### DIFF
--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -187,19 +187,21 @@ impl PartitionProducer {
             .await?;
 
         let mut batches_ready = vec![];
-        let mut batches = self.batches_lock.batches.lock().await;
-        while !batches.is_empty() {
-            let ready = force
-                || batches.front().map_or(false, |batch| {
-                    batch.is_full() || batch.elapsed() as u128 >= self.config.linger.as_millis()
-                });
-            if ready {
-                if let Some(batch) = batches.pop_front() {
-                    batches_ready.push(batch);
-                    self.batches_lock.control.notify_all();
+        {
+            let mut batches = self.batches_lock.batches.lock().await;
+            while !batches.is_empty() {
+                let ready = force
+                    || batches.front().map_or(false, |batch| {
+                        batch.is_full() || batch.elapsed() as u128 >= self.config.linger.as_millis()
+                    });
+                if ready {
+                    if let Some(batch) = batches.pop_front() {
+                        batches_ready.push(batch);
+                        self.batches_lock.control.notify_all();
+                    }
+                } else {
+                    break;
                 }
-            } else {
-                break;
             }
         }
 


### PR DESCRIPTION
scopes mutex guard in `PartitionProducer` so that mutex is released immediately instead being held while batches are sent.

Means that `TopicProducer::send()` returns quickly instead of blocking while batches are sent.

This change gives almost a 10x improvement on producer throughput when producing to the cloud. Note the regression in latency is beacause all messages get "sent" right away where as previously messages blocked on `send` while waiting for other batches to go out. 

**Config**
```yaml---
matrix_name: ExampleMatrix
topic_name: benchmarking-baingmcvadyojtn
current_profile: cloud
timestamp: "2022-12-01T00:37:15.840379872Z"
worker_timeout:
  secs: 10000
  nanos: 0
num_samples: 100
duration_between_samples:
  secs: 0
  nanos: 300000000
num_records_per_producer_worker_per_batch: 1000
producer_batch_size: 16000
producer_queue_size: 100
producer_linger:
  secs: 0
  nanos: 10000000
producer_server_timeout:
  secs: 5
  nanos: 0
producer_compression: none
consumer_max_bytes: 64000
num_concurrent_producer_workers: 1
num_concurrent_consumers_per_partition: 1
num_partitions: 1
record_size: 1000
record_key_allocation_strategy: NoKey
```

**Per Record E2E Latency**

|Variable|  p0.00  |  p0.50  |  p0.95  |  p0.99  |  p1.00  |
|--------|---------|---------|---------|---------|---------|
|Latency |119.808ms|622.591ms|924.671ms|1.005567s|1.060863s|

**Throughput (Total Produced Bytes / Time)**

|     Variable      |   Min   | Median  |   Max   |                                        Description                                         |
|-------------------|---------|---------|---------|--------------------------------------------------------------------------------------------|
|Producer Throughput|2.165mb/s|2.658mb/s|3.052mb/s|                      First Produced Message <-> Last Produced Message                      |
|Consumer Throughput|1.154mb/s|1.389mb/s|1.563mb/s|First Consumed Message (First Time Consumed) <-> Last Consumed Message (First Time Consumed)|
|Combined Throughput|0.942mb/s|0.989mb/s|1.137mb/s|           First Produced Message <-> Last Consumed Message (First Time Consumed)           |

**Comparision with previous results: cloud @ 2022-12-01 00:24:33.995062094 UTC**

|     Variable      |Change|Previous | Current |P-Value|
|-------------------|------|---------|---------|-------|
|      Latency      |Worse |405.427ms|1.003788s|0.00000|
|Producer Throughput|Better|0.288mb/s|2.626mb/s|0.00000|
|Consumer Throughput|Better|0.249mb/s|1.384mb/s|0.00000|
|Combined Throughput|Better|0.240mb/s|0.996mb/s|0.00000|
