### PR TITLE
feat: add getter for client metrics in producer and consumer strucs

### DIFF
--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -73,6 +73,11 @@ where
         self.partition
     }
 
+    /// Return a shared instance of `ClientMetrics`
+    pub fn metrics(&self) -> Arc<ClientMetrics> {
+        self.metrics.clone()
+    }
+
     /// Continuously streams events from a particular offset in the consumer's partition
     ///
     /// Streaming is one of the two ways to consume events in Fluvio.

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -483,6 +483,11 @@ impl TopicProducer {
         self.inner.clear_errors().await;
     }
 
+    /// Return a shared instance of `ClientMetrics`
+    pub fn metrics(&self) -> Arc<ClientMetrics> {
+        self.metrics.clone()
+    }
+
     #[cfg(feature = "stats")]
     /// Return a `ClientStatsDataFrame` to represent the current recorded client stats
     pub fn stats(&self) -> Option<ClientStatsDataFrame> {


### PR DESCRIPTION
This is just in order to be able to get metrics from `TopicProducer` and `PartitionConsumer` so we can get them in connectors