### PR TITLE
[Merged by Bors] - Add pre-release input to release_workflow

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -104,6 +104,17 @@ jobs:
       - name: Create K3d cluster
         run: |
           ./k8-util/cluster/reset-k3d.sh
+
+      - name: Set the expected fluvio version
+        run: |
+          if [[ -z "${{ env.USE_VERSION }}" ]]; then
+            echo "EXPECTED_VERSION=$(cat VERSION)" | tee -a $GITHUB_ENV
+          else
+            echo "EXPECTED_VERSION=${{ github.event.inputs.alt_version }}" | tee -a $GITHUB_ENV
+          fi
+          echo "EXPECTED_VERSION: $EXPECTED_VERSION"
+          echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
+
       - name: Install Fluvio
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
@@ -171,6 +182,7 @@ jobs:
             echo "EXPECTED_VERSION=${{ github.event.inputs.alt_version }}" | tee -a $GITHUB_ENV
           fi
           echo "EXPECTED_VERSION: $EXPECTED_VERSION"
+          echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
 
       - name: Install current stable Fluvio CLI and upgrade cluster
         run: |

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -90,7 +90,6 @@ jobs:
 
   start_cluster:
     name: Start cluster test
-    needs: installer_check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -136,7 +135,6 @@ jobs:
 
   upgrade_prev_stable:
     name: Upgrade cluster test
-    needs: installer_check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -113,8 +113,8 @@ jobs:
             echo "EXPECTED_VERSION=${{ github.event.inputs.alt_version }}" | tee -a $GITHUB_ENV
           fi
           echo "EXPECTED_VERSION: $EXPECTED_VERSION"
-          echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
-
+          
+      - run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
       - name: Install Fluvio
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash
@@ -182,8 +182,8 @@ jobs:
             echo "EXPECTED_VERSION=${{ github.event.inputs.alt_version }}" | tee -a $GITHUB_ENV
           fi
           echo "EXPECTED_VERSION: $EXPECTED_VERSION"
-          echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
 
+      - run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
       - name: Install current stable Fluvio CLI and upgrade cluster
         run: |
           curl -fsS https://packages.fluvio.io/v1/install.sh | bash

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,10 +5,7 @@ permissions:
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [Release]
-    branches: [master]
-    types: [completed]
+  workflow_call:
 #env:
 #  USE_COMMIT: ${{ github.event.inputs.commit }}
 #  FORCE_RELEASE: ${{ github.event.inputs.force }}

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,7 +5,17 @@ permissions:
 
 on:
   workflow_dispatch:
+    commit:
+      required: false
+      type: string
+      description: 'Fluvio git commit override (latest `master` by default)'
+      default: ''
   workflow_call:
+    commit:
+      required: false
+      type: string
+      description: 'Fluvio git commit override (latest `master` by default)'
+      default: ''
 #env:
 #  USE_COMMIT: ${{ github.event.inputs.commit }}
 #  FORCE_RELEASE: ${{ github.event.inputs.force }}
@@ -48,6 +58,8 @@ jobs:
           override: true
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.commit || 'master' }}
 
       - name: Run publish script
         env:

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.commit || 'master' }}
+          ref: ${{ github.event.inputs.commit }}
 
       - name: Run publish script
         env:

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -5,17 +5,19 @@ permissions:
 
 on:
   workflow_dispatch:
-    commit:
-      required: false
-      type: string
-      description: 'Fluvio git commit override (latest `master` by default)'
-      default: ''
+    inputs:
+      commit:
+        required: false
+        type: string
+        description: 'Fluvio git commit override (latest `master` by default)'
+        default: ''
   workflow_call:
-    commit:
-      required: false
-      type: string
-      description: 'Fluvio git commit override (latest `master` by default)'
-      default: ''
+    inputs:
+      commit:
+        required: false
+        type: string
+        description: 'Fluvio git commit override (latest `master` by default)'
+        default: ''
 #env:
 #  USE_COMMIT: ${{ github.event.inputs.commit }}
 #  FORCE_RELEASE: ${{ github.event.inputs.force }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ on:
         required: false
         description: ''
         default: ''
+      pre_release:
+        type: boolean
+        required: true
+        description: ''
+        default: true
+
   workflow_call:
     inputs:
       commit:
@@ -246,6 +252,7 @@ jobs:
     needs: [setup_job, release_github, release_docker, release_fluvio]
     #permissions: write-all
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.pre_release }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,12 +247,17 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
 
+  publish_crates:
+    name: Publish Crates
+    if: ${{ !github.event.inputs.pre_release }}
+    uses: ./.github/workflows/publish_crates.yml
+
   bump_stable_fluvio:
     name: Bump stable Fluvio
     needs: [setup_job, release_github, release_docker, release_fluvio]
     #permissions: write-all
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.pre_release }}
+    if: ${{ !github.event.inputs.pre_release }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.setup_job.outputs.VERSION }}
-      TARGET_SHA: ${{ env.TARGET_SHA }}
+      TARGET_SHA: ${{ needs.setup_job.outputs.TARGET_SHA }}
     steps:
       - uses: actions/checkout@v3
       - name: Attempt to pull image tag in docker registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,6 @@ jobs:
     outputs:
       VERSION: ${{ steps.version_step.outputs.VERSION }}
       TARGET_SHA: ${{ steps.version_step.outputs.GIT_SHA }}
-      LATEST_TAG: ${{ steps.docker_step.outputs.LATEST_TAG }}
-      RELEASE_TAG: ${{ steps.docker_step.outputs.RELEASE_TAG }}
       INSTALLER_URL: ${{ steps.installer_step.outputs.INSTALLER_URL }}
     steps:
       - name: Set target sha and Fluvio version
@@ -75,11 +73,6 @@ jobs:
             echo "GIT_SHA=${{ github.event.inputs.commit }}" | tee -a $GITHUB_ENV
             echo "::set-output name=GIT_SHA::${{ github.event.inputs.commit }}"
           fi
-      - name: Set Docker tag related env vars
-        id: docker_step
-        run: |
-          echo "::set-output name=LATEST_TAG::infinyon/fluvio:${{ env.VERSION }}-${{ env.GIT_SHA }}"
-          echo "::set-output name=RELEASE_TAG::infinyon/fluvio:${{ env.VERSION }}"
       - name: Set Installer URL
         id: installer_step
         run: |
@@ -163,9 +156,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.setup_job.outputs.VERSION }}
-      RELEASE_TAG: ${{ needs.setup_job.outputs.RELEASE_TAG }}
-      LATEST_TAG: ${{ needs.setup_job.outputs.LATEST_TAG }}
-      DEV_VERSION_TAG: ${{ needs.setup_job.outputs.VERSION }}-${{ github.event.inputs.commit }}
     steps:
       - uses: actions/checkout@v3
       - name: Attempt to pull image tag in docker registry
@@ -173,6 +163,7 @@ jobs:
         continue-on-error: true
         env:
           DOCKER_IMAGE_TAG: ${{ env.VERSION }}
+          TARGET_SHA: ${{ env.TARGET_SHA }}
         run: |
           make docker-hub-check-image-exists
 
@@ -184,6 +175,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_IMAGE_TAG: ${{ env.VERSION }}
           CHANNEL_TAG: stable
+          DEV_VERSION_TAG: ${{ env.VERSION }}-${{ env.TARGET_SHA }}
         run: |
           make docker-push-manifest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ on:
         default: 'stable'
 
 env:
-  USE_COMMIT: ${{ github.event.inputs.commit }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RELEASE: true # Needed so `make` targets make public changes
 
@@ -63,7 +62,7 @@ jobs:
       - name: Set target sha and Fluvio version
         id: version_step
         run: |
-          if [[ -z "${{ env.USE_COMMIT }}" ]]; then
+          if [[ -z "${{ github.event.inputs.commit }}" ]]; then
             export GITHUB_VERSION=$(curl -fsS https://raw.githubusercontent.com/infinyon/fluvio/${{ github.sha }}/VERSION)
             echo "VERSION=${GITHUB_VERSION}" | tee -a $GITHUB_ENV
             echo "::set-output name=VERSION::${GITHUB_VERSION}"
@@ -252,6 +251,8 @@ jobs:
     name: Publish Crates
     if: ${{ !github.event.inputs.pre_release }}
     uses: ./.github/workflows/publish_crates.yml
+    with:
+      commit: ${{ github.event.inputs.commit }}
     secrets: inherit
 
   bump_stable_fluvio:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.setup_job.outputs.VERSION }}
+      TARGET_SHA: ${{ env.TARGET_SHA }}
     steps:
       - uses: actions/checkout@v3
       - name: Attempt to pull image tag in docker registry
@@ -163,7 +164,6 @@ jobs:
         continue-on-error: true
         env:
           DOCKER_IMAGE_TAG: ${{ env.VERSION }}
-          TARGET_SHA: ${{ env.TARGET_SHA }}
         run: |
           make docker-hub-check-image-exists
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
         if: ${{ steps.release_check.outcome == 'failure' }}
         env:
           CHANNEL_TAG: ${{ env.VERSION }}
+          PRE_RELEASE: ${{ github.event.inputs.pre_release }}
         run: make create-gh-release
 
       - name: Slack Notification
@@ -251,6 +252,7 @@ jobs:
     name: Publish Crates
     if: ${{ !github.event.inputs.pre_release }}
     uses: ./.github/workflows/publish_crates.yml
+    secrets: inherit
 
   bump_stable_fluvio:
     name: Bump stable Fluvio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
       VERSION: ${{ needs.setup_job.outputs.VERSION }}
       RELEASE_TAG: ${{ needs.setup_job.outputs.RELEASE_TAG }}
       LATEST_TAG: ${{ needs.setup_job.outputs.LATEST_TAG }}
+      DEV_VERSION_TAG: ${{ needs.setup_job.outputs.VERSION }}-${{ github.event.inputs.commit }}
     steps:
       - uses: actions/checkout@v3
       - name: Attempt to pull image tag in docker registry

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -39,6 +39,12 @@ DOCKER_IMAGE_TAG?=$(REPO_VERSION)
 GH_TOKEN?=
 GH_RELEASE_TAG?=dev
 
+ifeq ($(PRE_RELEASE),true)
+GH_PRE_RELEASE_FLAG=--prerelease
+else
+GH_PRE_RELEASE_FLAG=
+endif
+
 # Allow using local `gh` auth token for local testing
 #ifeq ($(CI), true)
 #ifndef GH_TOKEN
@@ -223,6 +229,7 @@ build-release-notes:
 
 create-gh-release: download-fluvio-release build-release-notes
 	$(DRY_RUN_ECHO) gh release create -R infinyon/fluvio \
+		$(GH_PRE_RELEASE_FLAG) \
 		--title="v$(VERSION)" \
 		-F /tmp/release_notes \
 		"v$(VERSION)" \

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -122,7 +122,7 @@ install-fluvio-package:
 
 # Requires GH_TOKEN set or `gh auth login`
 download-fluvio-release:
-	gh release download $(GH_RELEASE_TAG) -R infinyon/fluvio --skip-existing
+	$(DRY_RUN_ECHO) gh release download $(GH_RELEASE_TAG) -R infinyon/fluvio --skip-existing
 
 unzip-gh-release-artifacts: download-fluvio-release
 	@echo "unzip stuff"


### PR DESCRIPTION
Only change that it does is to prevent from update `stable` tag for fluvio-cli, not sure which other things are needed. This won't prevent crates publishing workflow from running