### PR TITLE
[Merged by Bors] - feat: add connector metadata visibility and binary to deployment

### DIFF
--- a/crates/fluvio-connector-package/tests/Connector.toml
+++ b/crates/fluvio-connector-package/tests/Connector.toml
@@ -6,12 +6,13 @@ apiVersion = "0.1.0"
 fluvio = "0.10.0"
 description = "Generate JSON generator"
 license = "Apache-2.0"
+visibility = "public"
 
 [direction]
 source = true
 
 [deployment]
-image = "fluvio/json-test-connector:0.1.0"
+binary = "json-test-connector"
 
 [secret.password]
 type = "env"

--- a/crates/fluvio-connector-package/tests/mod.rs
+++ b/crates/fluvio-connector-package/tests/mod.rs
@@ -16,9 +16,7 @@ fn test_read_from_toml_file() {
         metadata,
         ConnectorMetadata {
             direction: Direction::source(),
-            deployment: Deployment {
-                image: "fluvio/json-test-connector:0.1.0".to_string()
-            },
+            deployment: Deployment::from_binary_name("json-test-connector"),
             package: ConnectorPackage {
                 name: "json-test-connector".into(),
                 group: "fluvio".into(),
@@ -26,7 +24,8 @@ fn test_read_from_toml_file() {
                 fluvio: FluvioSemVersion::parse("0.10.0").unwrap(),
                 api_version: FluvioSemVersion::parse("0.1.0").unwrap(),
                 description: Some("Generate JSON generator".into()),
-                license: Some("Apache-2.0".into())
+                license: Some("Apache-2.0".into()),
+                visibility: ConnectorVisibility::Public,
             },
             parameters: Parameters::from(vec![Parameter {
                 name: "template".into(),
@@ -77,12 +76,13 @@ fluvio = "0.10.0"
 apiVersion = "0.1.0"
 description = "Generate JSON generator"
 license = "Apache-2.0"
+visibility = "public"
 
 [direction]
 source = true
 
 [deployment]
-image = "fluvio/json-test-connector:0.1.0"
+binary = "json-test-connector"
 [secret.my_cert]
 type = "file"
 mount = "/mydata/secret1"


### PR DESCRIPTION
Added `visibility` property to connector package metadata.

Also, added an option to specify a binary name in the `deployment` section of connector package metadata.