### PR TITLE
fix: segment validation index bug

### DIFF
--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -259,7 +259,6 @@ impl Segment<LogIndex, FileRecordsSlice> {
         let msg_log = FileRecordsSlice::open(base_offset, option.clone()).await?;
         let index = LogIndex::open_from_offset(base_offset, option.clone()).await?;
         let base_offset = msg_log.get_base_offset();
-        let end_offset = msg_log.validate(&index, false, false).await?;
         match msg_log.validate(&index, false, false).await {
             Ok(end_offset) => {
                 debug!(end_offset, base_offset, "base offset from msg_log");

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -275,6 +275,7 @@ impl Segment<LogIndex, FileRecordsSlice> {
                 batch_file_pos,
                 index_position,
                 diff_position,
+                previous_batch_end_offset,
             }) => {
                 error!(
                     offset,
@@ -286,7 +287,20 @@ impl Segment<LogIndex, FileRecordsSlice> {
                     index,
                     option,
                     base_offset,
-                    end_offset,
+                    end_offset: previous_batch_end_offset,
+                })
+            }
+            Err(LogValidationError::InvalidBatch {
+                inner,
+                previous_batch_end_offset,
+            }) => {
+                error!(?inner, "validation error");
+                Ok(Segment {
+                    msg_log,
+                    index,
+                    option,
+                    base_offset,
+                    end_offset: previous_batch_end_offset,
                 })
             }
             Err(err) => {


### PR DESCRIPTION
Attempting to fix https://github.com/infinyon/fluvio/issues/2509

If batch or index is corrupt, uses the previous batch as latest.