### PR TITLE
fix: recover from invalid segments

### DIFF
--- a/crates/fluvio-spu/src/replication/follower/state.rs
+++ b/crates/fluvio-spu/src/replication/follower/state.rs
@@ -12,7 +12,7 @@ use fluvio_storage::config::ReplicaConfig;
 use fluvio_controlplane_metadata::partition::{Replica, ReplicaKey};
 use fluvio_protocol::record::RecordSet;
 use fluvio_protocol::record::Offset;
-use fluvio_storage::{FileReplica, StorageError, ReplicaStorage, ReplicaStorageConfig};
+use fluvio_storage::{FileReplica, ReplicaStorage, ReplicaStorageConfig};
 use fluvio_types::SpuId;
 
 use crate::replication::leader::ReplicaOffsetRequest;
@@ -209,7 +209,7 @@ where
         &self,
         records: &mut RecordSet<R>,
         leader_hw: Offset,
-    ) -> Result<bool, StorageError> {
+    ) -> Result<bool> {
         let mut changes = false;
 
         if records.total_records() > 0 {
@@ -245,10 +245,7 @@ where
 
     /// try to write records
     /// ensure records has correct baseoffset
-    async fn write_recordsets<R: BatchRecords>(
-        &self,
-        records: &mut RecordSet<R>,
-    ) -> Result<bool, StorageError> {
+    async fn write_recordsets<R: BatchRecords>(&self, records: &mut RecordSet<R>) -> Result<bool> {
         let storage_leo = self.leo();
         if records.base_offset() != storage_leo {
             // this could happened if records were sent from leader before hw was sync

--- a/crates/fluvio-spu/src/replication/leader/replica_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/replica_state.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use fluvio_protocol::record::{RecordSet, Offset, ReplicaKey, BatchRecords};
 use fluvio_controlplane_metadata::partition::{Replica, ReplicaStatus, PartitionStatus};
 use fluvio_controlplane::LrsRequest;
-use fluvio_storage::{FileReplica, StorageError, ReplicaStorage, OffsetInfo, ReplicaStorageConfig};
+use fluvio_storage::{FileReplica, ReplicaStorage, OffsetInfo, ReplicaStorageConfig};
 use fluvio_types::{SpuId};
 use fluvio_spu_schema::Isolation;
 
@@ -315,7 +315,7 @@ where
         &self,
         records: &mut RecordSet<R>,
         notifiers: &FollowerNotifier,
-    ) -> Result<(Offset, Offset, usize), StorageError> {
+    ) -> Result<(Offset, Offset, usize)> {
         let offsets = self
             .storage
             .write_record_set(records, self.in_sync_replica == 1)
@@ -742,7 +742,7 @@ mod test_leader {
             &mut self,
             records: &mut fluvio_protocol::record::RecordSet<R>,
             update_highwatermark: bool,
-        ) -> Result<usize, fluvio_storage::StorageError> {
+        ) -> Result<usize> {
             self.pos.leo = records.last_offset().unwrap();
             if update_highwatermark {
                 self.pos.hw = self.pos.leo;

--- a/crates/fluvio-spu/src/storage/mod.rs
+++ b/crates/fluvio-spu/src/storage/mod.rs
@@ -133,7 +133,7 @@ where
         &self,
         records: &mut RecordSet<R>,
         hw_update: bool,
-    ) -> Result<(Offset, Offset, usize), StorageError> {
+    ) -> Result<(Offset, Offset, usize)> {
         debug!(
             replica = %self.id,
             leo = self.leo(),

--- a/crates/fluvio-storage/src/batch.rs
+++ b/crates/fluvio-storage/src/batch.rs
@@ -5,9 +5,9 @@ use std::marker::PhantomData;
 use std::path::Path;
 
 use fluvio_protocol::record::BatchHeader;
+use tracing::error;
 use tracing::instrument;
 use tracing::trace;
-use tracing::debug;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -20,7 +20,7 @@ use fluvio_protocol::record::Size;
 
 use crate::file::FileBytesIterator;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 /// Outer batch representation
 /// It's either sucessfully decoded into actual batch or not enough bytes to decode
 pub enum BatchHeaderError {
@@ -228,9 +228,9 @@ where
         match FileBatchPos::read_from(&mut self.byte_iterator).await {
             Ok(batch_res) => Ok(batch_res),
             Err(err) => {
-                debug!("error getting batch: {}", err);
+                error!("error getting batch: {}, invalidating", err);
                 self.invalid = true;
-                Err(anyhow!("error decoding batch: {}", err))
+                Err(err)
             }
         }
     }

--- a/crates/fluvio-storage/src/bin/cli.rs
+++ b/crates/fluvio-storage/src/bin/cli.rs
@@ -171,12 +171,6 @@ pub(crate) struct SegmentValidateOpt {
 
     #[clap(long, default_value = "0")]
     base_offset: Offset,
-
-    #[clap(long)]
-    skip_errors: bool,
-
-    #[clap(long)]
-    verbose: bool,
 }
 
 pub(crate) async fn validate_segment(opt: SegmentValidateOpt) -> Result<()> {
@@ -196,9 +190,7 @@ pub(crate) async fn validate_segment(opt: SegmentValidateOpt) -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let last_offset = active_segment
-        .validate(opt.skip_errors, opt.verbose)
-        .await?;
+    let last_offset = active_segment.validate().await?;
 
     let duration = start.elapsed().as_secs_f32();
 

--- a/crates/fluvio-storage/src/bin/cli.rs
+++ b/crates/fluvio-storage/src/bin/cli.rs
@@ -190,7 +190,7 @@ pub(crate) async fn validate_segment(opt: SegmentValidateOpt) -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let last_offset = active_segment.validate().await?;
+    let last_offset = active_segment.validate_and_repair().await?;
 
     let duration = start.elapsed().as_secs_f32();
 

--- a/crates/fluvio-storage/src/cleaner.rs
+++ b/crates/fluvio-storage/src/cleaner.rs
@@ -140,12 +140,13 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use anyhow::Result;
+
     use fluvio_future::timer::sleep;
     use flv_util::fixture::ensure_new_dir;
     use fluvio_protocol::fixture::create_batch;
     use fluvio_protocol::record::Offset;
 
-    use crate::StorageError;
     use crate::config::SharedReplicaConfig;
     use crate::segment::MutableSegment;
     use crate::segment::ReadSegment;
@@ -253,7 +254,7 @@ mod tests {
         option: Arc<SharedReplicaConfig>,
         start: Offset,
         end_offset: Offset,
-    ) -> Result<ReadSegment, StorageError> {
+    ) -> Result<ReadSegment> {
         let mut mut_segment = MutableSegment::create(start, option).await?;
         mut_segment.append_batch(&mut create_batch()).await?;
         mut_segment.set_end_offset(end_offset);

--- a/crates/fluvio-storage/src/lib.rs
+++ b/crates/fluvio-storage/src/lib.rs
@@ -159,7 +159,7 @@ mod inner {
             &mut self,
             records: &mut RecordSet<R>,
             update_highwatermark: bool,
-        ) -> Result<usize, StorageError>;
+        ) -> Result<usize>;
 
         async fn update_high_watermark(&mut self, offset: Offset) -> Result<bool, StorageError>;
 

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -24,6 +24,7 @@ use fluvio_protocol::record::{Offset, Size, Size64};
 use fluvio_protocol::Encoder;
 
 use crate::config::SharedReplicaConfig;
+use crate::file::FileBytesIterator;
 use crate::mut_index::MutLogIndex;
 use crate::util::generate_file_name;
 use crate::validator::LogValidationError;
@@ -112,7 +113,13 @@ impl MutFileRecords {
         skip_errors: bool,
         verbose: bool,
     ) -> Result<LogValidator> {
-        LogValidator::validate(&self.path, Some(index), skip_errors, verbose).await
+        LogValidator::validate::<_, FileBytesIterator>(
+            &self.path,
+            Some(index),
+            skip_errors,
+            verbose,
+        )
+        .await
     }
 
     /// get current file position

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -106,7 +106,14 @@ impl MutFileRecords {
         self.base_offset
     }
 
-    pub async fn validate(&mut self, index: &MutLogIndex) -> Result<LogValidator> {
+    /// readjust to new length
+    pub(crate) async fn set_len(&mut self, len: u32) -> Result<()> {
+        self.file.set_len(len as u64).await?;
+        self.len = len;
+        Ok(())
+    }
+
+    pub(crate) async fn validate(&mut self, index: &MutLogIndex) -> Result<LogValidator> {
         LogValidator::default_validate(&self.path, Some(index)).await
     }
 

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -106,13 +106,8 @@ impl MutFileRecords {
         self.base_offset
     }
 
-    pub async fn validate(
-        &mut self,
-        index: &MutLogIndex,
-        skip_errors: bool,
-        verbose: bool,
-    ) -> Result<LogValidator> {
-        LogValidator::default_validate(&self.path, Some(index), skip_errors, verbose).await
+    pub async fn validate(&mut self, index: &MutLogIndex) -> Result<LogValidator> {
+        LogValidator::default_validate(&self.path, Some(index)).await
     }
 
     /// get current file position

--- a/crates/fluvio-storage/src/mut_records.rs
+++ b/crates/fluvio-storage/src/mut_records.rs
@@ -24,7 +24,6 @@ use fluvio_protocol::record::{Offset, Size, Size64};
 use fluvio_protocol::Encoder;
 
 use crate::config::SharedReplicaConfig;
-use crate::file::FileBytesIterator;
 use crate::mut_index::MutLogIndex;
 use crate::util::generate_file_name;
 use crate::validator::LogValidationError;
@@ -113,13 +112,7 @@ impl MutFileRecords {
         skip_errors: bool,
         verbose: bool,
     ) -> Result<LogValidator> {
-        LogValidator::validate::<_, FileBytesIterator>(
-            &self.path,
-            Some(index),
-            skip_errors,
-            verbose,
-        )
-        .await
+        LogValidator::default_validate(&self.path, Some(index), skip_errors, verbose).await
     }
 
     /// get current file position

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -88,13 +88,8 @@ impl FileRecordsSlice {
         self.base_offset
     }
 
-    pub async fn validate(
-        &self,
-        index: &LogIndex,
-        skip_errors: bool,
-        verbose: bool,
-    ) -> Result<LogValidator> {
-        LogValidator::default_validate(&self.path, Some(index), skip_errors, verbose).await
+    pub async fn validate(&self, index: &LogIndex) -> Result<LogValidator> {
+        LogValidator::default_validate(&self.path, Some(index)).await
     }
 
     pub fn modified_time_elapsed(&self) -> Result<Duration, SystemTimeError> {

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -23,7 +23,6 @@ use fluvio_protocol::record::{Offset, Size, Size64};
 
 use crate::LogIndex;
 use crate::config::SharedReplicaConfig;
-use crate::file::FileBytesIterator;
 use crate::util::generate_file_name;
 use crate::validator::LogValidator;
 use crate::StorageError;
@@ -95,13 +94,7 @@ impl FileRecordsSlice {
         skip_errors: bool,
         verbose: bool,
     ) -> Result<LogValidator> {
-        LogValidator::validate::<_, FileBytesIterator>(
-            &self.path,
-            Some(index),
-            skip_errors,
-            verbose,
-        )
-        .await
+        LogValidator::default_validate(&self.path, Some(index), skip_errors, verbose).await
     }
 
     pub fn modified_time_elapsed(&self) -> Result<Duration, SystemTimeError> {

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -23,6 +23,7 @@ use fluvio_protocol::record::{Offset, Size, Size64};
 
 use crate::LogIndex;
 use crate::config::SharedReplicaConfig;
+use crate::file::FileBytesIterator;
 use crate::util::generate_file_name;
 use crate::validator::LogValidator;
 use crate::StorageError;
@@ -94,7 +95,13 @@ impl FileRecordsSlice {
         skip_errors: bool,
         verbose: bool,
     ) -> Result<LogValidator> {
-        LogValidator::validate(&self.path, Some(index), skip_errors, verbose).await
+        LogValidator::validate::<_, FileBytesIterator>(
+            &self.path,
+            Some(index),
+            skip_errors,
+            verbose,
+        )
+        .await
     }
 
     pub fn modified_time_elapsed(&self) -> Result<Duration, SystemTimeError> {

--- a/crates/fluvio-storage/src/records.rs
+++ b/crates/fluvio-storage/src/records.rs
@@ -24,7 +24,7 @@ use fluvio_protocol::record::{Offset, Size, Size64};
 use crate::LogIndex;
 use crate::config::SharedReplicaConfig;
 use crate::util::generate_file_name;
-use crate::validator::validate;
+use crate::validator::LogValidator;
 use crate::StorageError;
 
 pub const MESSAGE_LOG_EXTENSION: &str = "log";
@@ -93,8 +93,8 @@ impl FileRecordsSlice {
         index: &LogIndex,
         skip_errors: bool,
         verbose: bool,
-    ) -> Result<Offset> {
-        validate(&self.path, Some(index), skip_errors, verbose).await
+    ) -> Result<LogValidator> {
+        LogValidator::validate(&self.path, Some(index), skip_errors, verbose).await
     }
 
     pub fn modified_time_elapsed(&self) -> Result<Duration, SystemTimeError> {

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -233,7 +233,7 @@ impl FileReplica {
             debug!(last_offset, "last segment found, validating offsets");
             let mut last_segment =
                 MutableSegment::open_for_write(last_offset, shared_config.clone()).await?;
-            last_segment.validate(false, false).await?;
+            last_segment.validate().await?;
             info!(
                 end_offset = last_segment.get_end_offset(),
                 "existing segment validated with last offset",

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -233,7 +233,7 @@ impl FileReplica {
             debug!(last_offset, "last segment found, validating offsets");
             let mut last_segment =
                 MutableSegment::open_for_write(last_offset, shared_config.clone()).await?;
-            last_segment.validate().await?;
+            last_segment.validate_and_repair().await?;
             info!(
                 end_offset = last_segment.get_end_offset(),
                 "existing segment validated with last offset",

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -625,7 +625,7 @@ mod tests {
 
         // open replica
         let replica2 = create_replica("test", 0, option).await;
-        assert_eq!(replica2.get_leo(), START_OFFSET + 4);
+        assert_eq!(replica2.get_leo(), START_OFFSET + 4); // should be 24 since we added 4 records
     }
 
     const TEST_REPLICA_DIR: &str = "test_replica";

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -265,13 +265,13 @@ impl Segment<LogIndex, FileRecordsSlice> {
                     return Err(err.into());
                 }
 
-                info!(end_offset = val.last_valid_offset, base_offset = val.base_offset, time_ms = %val.duration.as_millis(), "segment validated");
+                info!(end_offset = val.leo(), base_offset = val.base_offset, time_ms = %val.duration.as_millis(), "segment validated");
                 Ok(Segment {
                     msg_log,
                     index,
                     option,
                     base_offset,
-                    end_offset: val.last_valid_offset,
+                    end_offset: val.leo(),
                 })
             }
             Err(err) => {
@@ -350,7 +350,7 @@ impl Segment<MutLogIndex, MutFileRecords> {
             .msg_log
             .validate(&self.index, skip_errors, verbose)
             .await?
-            .last_valid_offset;
+            .leo();
         Ok(self.end_offset)
     }
 

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -257,7 +257,7 @@ impl Segment<LogIndex, FileRecordsSlice> {
         let msg_log = FileRecordsSlice::open(base_offset, option.clone()).await?;
         let index = LogIndex::open_from_offset(base_offset, option.clone()).await?;
         let base_offset = msg_log.get_base_offset();
-        match msg_log.validate(&index, false, false).await {
+        match msg_log.validate(&index).await {
             Ok(val) => {
                 // check if validation is successful
                 if let Some(err) = val.error {
@@ -345,12 +345,8 @@ impl Segment<MutLogIndex, MutFileRecords> {
     }
 
     /// validate the segment and load last offset
-    pub async fn validate(&mut self, skip_errors: bool, verbose: bool) -> Result<Offset> {
-        self.end_offset = self
-            .msg_log
-            .validate(&self.index, skip_errors, verbose)
-            .await?
-            .leo();
+    pub async fn validate(&mut self) -> Result<Offset> {
+        self.end_offset = self.msg_log.validate(&self.index).await?.leo();
         Ok(self.end_offset)
     }
 

--- a/crates/fluvio-storage/src/segments.rs
+++ b/crates/fluvio-storage/src/segments.rs
@@ -274,11 +274,12 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use anyhow::Result;
+
     use flv_util::fixture::ensure_new_dir;
     use fluvio_protocol::fixture::create_batch;
     use fluvio_protocol::record::Offset;
 
-    use crate::StorageError;
     use crate::config::SharedReplicaConfig;
     use crate::segment::MutableSegment;
     use crate::segment::ReadSegment;
@@ -291,7 +292,7 @@ mod tests {
         option: Arc<SharedReplicaConfig>,
         start: Offset,
         end_offset: Offset,
-    ) -> Result<ReadSegment, StorageError> {
+    ) -> Result<ReadSegment> {
         let mut mut_segment = MutableSegment::create(start, option).await?;
         mut_segment.append_batch(&mut create_batch()).await?;
         mut_segment.set_end_offset(end_offset); // only used for testing

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -310,7 +310,7 @@ mod tests {
         let validator = LogValidator::default_validate::<LogIndex>(&log_path, None, false, false)
             .await
             .expect("validate");
-        assert_eq!(validator.last_valid_offset, BASE_OFFSET);
+        assert_eq!(validator.leo(), BASE_OFFSET);
     }
 
     #[fluvio_future::test]
@@ -348,7 +348,7 @@ mod tests {
         let validator = LogValidator::default_validate::<LogIndex>(&log_path, None, false, true)
             .await
             .expect("validate");
-        assert_eq!(validator.last_valid_offset, BASE_OFFSET + 5);
+        assert_eq!(validator.leo(), BASE_OFFSET + 5);
     }
 
     #[fluvio_future::test]

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -20,7 +20,6 @@ use crate::batch_header::FileEmptyRecords;
 use crate::file::FileBytesIterator;
 use crate::index::Index;
 use crate::util::log_path_get_offset;
-use crate::util::OffsetError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum LogValidationError {
@@ -28,17 +27,11 @@ pub enum LogValidationError {
     InvalidExtension,
     #[error("Batch decoding error: {0}")]
     BatchDecoding(#[from] BatchHeaderError),
-    #[error("Invalid log name")]
-    LogName(#[from] OffsetError),
     #[error("batch offset is less than base offset: {invalid_batch_offset}")]
     InvalidBaseOffsetMinimum { invalid_batch_offset: Offset },
-    #[error("Offset not ordered")]
-    OffsetNotOrdered,
-    #[error("No batches")]
-    NoBatches,
-    #[error("Batch already exists")]
-    ExistingBatch,
 }
+
+impl LogValidationError {}
 
 #[derive(Debug, thiserror::Error)]
 #[error("Invalid Index: {offset} pos: {batch_file_pos} offset: {index_position}")]

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -226,17 +226,9 @@ impl LogValidator {
         Ok(())
     }
 
-    fn next_offset(&self) -> Offset {
-        if self.last_valid_offset == -1 {
-            return self.base_offset;
-        }
-
-        self.last_valid_offset + 1
-    }
-
-    /// generalized validation using byte iterator
+    /// used by test
     #[instrument(skip(index, path))]
-    pub(crate) async fn validate_segment<I, S>(
+    async fn validate_segment<I, S>(
         path: impl AsRef<Path>,
         index: Option<&I>,
         skip_errors: bool,
@@ -248,7 +240,13 @@ impl LogValidator {
     {
         match Self::validate_core::<I, S, FileEmptyRecords>(path, index, skip_errors, verbose).await
         {
-            Ok(val) => Ok(val.next_offset()),
+            Ok(val) => {
+                if val.last_valid_offset == -1 {
+                    Ok(val.base_offset)
+                } else {
+                    Ok(val.last_valid_offset + 1)
+                }
+            }
             Err(err) => Err(err),
         }
     }

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -31,8 +31,6 @@ pub enum LogValidationError {
     InvalidBaseOffsetMinimum { invalid_batch_offset: Offset },
 }
 
-impl LogValidationError {}
-
 #[derive(Debug, thiserror::Error)]
 #[error("Invalid Index: {offset} pos: {batch_file_pos} offset: {index_position}")]
 pub struct InvalidIndexError {

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -7,11 +7,13 @@ use fluvio_protocol::record::BatchRecords;
 use tracing::error;
 use tracing::info;
 use tracing::instrument;
+use tracing::trace;
 use tracing::{debug};
 use anyhow::{Result, anyhow};
 
 use fluvio_protocol::record::Offset;
 
+use crate::batch::BatchHeaderError;
 use crate::batch::FileBatchStream;
 use crate::batch::StorageBytesIterator;
 use crate::batch_header::FileEmptyRecords;
@@ -24,6 +26,8 @@ use crate::util::OffsetError;
 pub enum LogValidationError {
     #[error("Invalid extension")]
     InvalidExtension,
+    #[error("Batch decoding error: {0}")]
+    BatchDecoding(#[from] BatchHeaderError),
     #[error("Invalid log name")]
     LogName(#[from] OffsetError),
     #[error("batch offset is less than base offset: {invalid_batch_offset}")]
@@ -34,33 +38,32 @@ pub enum LogValidationError {
     NoBatches,
     #[error("Batch already exists")]
     ExistingBatch,
-    #[error("Invalid Index: {offset} pos: {batch_file_pos} offset: {index_position}")]
-    InvalidIndex {
-        offset: Offset,
-        batch_file_pos: u32,
-        index_position: u32,
-        diff_position: u32,
-    },
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid Index: {offset} pos: {batch_file_pos} offset: {index_position}")]
+pub struct InvalidIndexError {
+    offset: Offset,
+    batch_file_pos: u32,
+    index_position: u32,
+    diff_position: u32,
 }
 
 /// Validation Log file is consistent with index file
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LogValidator {
     pub base_offset: Offset,
     file_path: PathBuf,
     pub batches: u32,
     last_valid_offset: Offset,
+    pub last_valid_file_pos: u32,
     pub duration: Duration,
     pub error: Option<LogValidationError>,
+    pub index_error: Option<InvalidIndexError>,
 }
 
 impl LogValidator {
-    async fn validate_core<I, S, R>(
-        path: impl AsRef<Path>,
-        index: Option<&I>,
-        skip_errors: bool,
-        verbose: bool,
-    ) -> Result<Self>
+    async fn validate_core<I, S, R>(path: impl AsRef<Path>, index: Option<&I>) -> Result<Self>
     where
         I: Index,
         S: StorageBytesIterator,
@@ -71,9 +74,7 @@ impl LogValidator {
             base_offset: log_path_get_offset(&file_path)?,
             last_valid_offset: -1,
             file_path,
-            batches: 0,
-            duration: Duration::ZERO,
-            error: None,
+            ..Default::default()
         };
 
         info!(
@@ -94,21 +95,32 @@ impl LogValidator {
             },
         };
 
-        val.validate_with_stream(batch_stream, index, skip_errors, verbose)
-            .await?;
+        // find recoverable error
 
-        val.duration = start_time.elapsed();
-        Ok(val)
+        if let Err(err) = val.validate_with_stream(batch_stream, index).await {
+            error!(%err, "found error from stream");
+            error!("{:#?} debug", err);
+            val.duration = start_time.elapsed();
+            match err.downcast_ref::<BatchHeaderError>() {
+                Some(header_error) => {
+                    error!(%header_error, "found batch header error, turn into recoverable error");
+                    val.error = Some(LogValidationError::BatchDecoding(header_error.clone()));
+                    Ok(val)
+                }
+                _ => Err(err.into()),
+            }
+        } else {
+            val.duration = start_time.elapsed();
+            Ok(val)
+        }
     }
 
     /// validate log file
-    #[instrument(skip(self, index, skip_errors, verbose, batch_stream))]
+    #[instrument(skip(self, index, batch_stream))]
     async fn validate_with_stream<I, R, S>(
         &mut self,
         mut batch_stream: FileBatchStream<R, S>,
         index: Option<&I>,
-        skip_errors: bool,
-        verbose: bool,
     ) -> Result<()>
     where
         I: Index,
@@ -116,83 +128,85 @@ impl LogValidator {
         R: BatchRecords + Default + std::fmt::Debug,
     {
         let mut last_index_pos = 0;
-        let mut last_batch_pos = 0;
-
-        if batch_stream.is_invalid() {
-            return Err(anyhow!("invalid batch stream"));
-        }
 
         while let Some(batch_pos) = batch_stream.try_next().await? {
-            let pos = batch_pos.get_pos();
-            let batch = batch_pos.inner();
+            let current_batch_pos = batch_pos.get_pos();
+            let current_batch = batch_pos.inner();
 
-            let batch_offset = batch.get_base_offset();
+            let current_batch_offset = current_batch.get_base_offset();
 
-            let header = batch.get_header();
+            let header = current_batch.get_header();
             let offset_delta = header.last_offset_delta;
 
-            if verbose {
-                let diff_pos = pos - last_batch_pos;
-                println!("found batch offset = {batch_offset}, pos = {pos}, diff_pos = {diff_pos}");
-            }
-
-            // offset relative to segment
-            let delta_offset = batch_offset - self.base_offset;
-
-            if let Some(index) = index {
-                if let Some((offset, index_pos)) = index.find_offset(delta_offset as u32) {
-                    if offset == delta_offset as u32 {
-                        if verbose {
-                            let diff_pos = index_pos - last_index_pos;
-                            println!(
-                                        "index offset = {offset}, idx_pos = {index_pos}, diff_pos={diff_pos}"
-                                    );
-                        }
-
-                        if index_pos != pos {
-                            if verbose {
-                                let diff_index_batch_pos = index_pos - pos;
-                                let diff_index_pos = index_pos - last_index_pos;
-                                println!(
-                                            "-- index mismatch: diff pos = {diff_index_batch_pos}, diff from prev index pos={diff_index_pos}"
-                                        );
-                            }
-
-                            if !skip_errors {
-                                self.error = Some(LogValidationError::InvalidIndex {
-                                    offset: batch_offset,
-                                    batch_file_pos: pos,
-                                    index_position: index_pos,
-                                    diff_position: index_pos - pos,
-                                });
-                                return Ok(());
-                            }
-                        } else {
-                            last_index_pos = index_pos;
-                        }
-                    } else {
-                        /*
-                        trace!(
-                            delta_offset,
-                            offset,
-                            index_pos,
-                            "- different offset from index, skipping"
-                        );
-                        */
-                    }
-                } else {
-                    //  trace!(delta_offset, "no index found");
-                }
-            }
-
-            if batch_offset < self.base_offset {
+            // if current batch offset is less than base offset, it's invalid, we abort
+            if current_batch_offset < self.base_offset {
+                error!(
+                    last_valid_offset = self.last_valid_offset,
+                    last_valid_pos = self.last_valid_file_pos,
+                    current_batch_offset,
+                    base_offset = self.base_offset,
+                    "found offset less than base offset,aborting"
+                );
                 self.error = Some(LogValidationError::InvalidBaseOffsetMinimum {
-                    invalid_batch_offset: batch_offset,
+                    invalid_batch_offset: current_batch_offset,
                 });
                 return Ok(());
             }
 
-            last_batch_pos = pos;
+            // set high watermark for validating batches
+            self.last_valid_offset = current_batch_offset + offset_delta as Offset;
+            self.last_valid_file_pos = current_batch_pos;
+            self.batches += 1;
+
+            // self.last_valid_file_pos = file
+
+            // perform index validation
+            if self.index_error.is_none() {
+                trace!(
+                    diff_pos = current_batch_pos - self.last_valid_file_pos,
+                    "found batch offset"
+                );
+
+                // offset relative to segment
+                let delta_offset = current_batch_offset - self.base_offset;
+
+                if let Some(index) = index {
+                    if let Some((offset, index_pos)) = index.find_offset(delta_offset as u32) {
+                        if offset == delta_offset as u32 {
+                            trace!(diff_pos = index_pos - last_index_pos, "found index offset");
+
+                            if index_pos != current_batch_pos {
+                                error!(
+                                    diff_index_batch_pos = index_pos - current_batch_pos,
+                                    diff_index_pos = index_pos - last_index_pos,
+                                    "index mismatch"
+                                );
+
+                                // found index error
+                                self.index_error = Some(InvalidIndexError {
+                                    offset: current_batch_offset,
+                                    batch_file_pos: current_batch_pos,
+                                    index_position: index_pos,
+                                    diff_position: index_pos - current_batch_pos,
+                                });
+                            } else {
+                                last_index_pos = index_pos;
+                            }
+                        } else {
+                            /*
+                            trace!(
+                                delta_offset,
+                                offset,
+                                index_pos,
+                                "- different offset from index, skipping"
+                            );
+                            */
+                        }
+                    } else {
+                        //  trace!(delta_offset, "no index found");
+                    }
+                }
+            }
 
             /*
             // test converting batch to slice
@@ -212,16 +226,12 @@ impl LogValidator {
                 }
             }
             */
-
-            // last successfull offset
-            self.last_valid_offset = batch_offset + offset_delta as Offset;
-
-            // perform a simple json decoding
-
-            self.batches += 1;
         }
 
-        debug!(self.last_valid_offset, "found last offset");
+        debug!(
+            self.last_valid_offset,
+            "validation completed, found last offset"
+        );
 
         Ok(())
     }
@@ -237,30 +247,23 @@ impl LogValidator {
 
     /// public facing entry point
     #[instrument(skip(index, path))]
-    pub(crate) async fn validate<I, S>(
-        path: impl AsRef<Path>,
-        index: Option<&I>,
-        skip_errors: bool,
-        verbose: bool,
-    ) -> Result<Self>
+    pub(crate) async fn validate<I, S>(path: impl AsRef<Path>, index: Option<&I>) -> Result<Self>
     where
         I: Index,
         S: StorageBytesIterator,
     {
-        Self::validate_core::<I, S, FileEmptyRecords>(path, index, skip_errors, verbose).await
+        Self::validate_core::<I, S, FileEmptyRecords>(path, index).await
     }
 
     #[instrument(skip(index, path))]
     pub(crate) async fn default_validate<I>(
         path: impl AsRef<Path>,
         index: Option<&I>,
-        skip_errors: bool,
-        verbose: bool,
     ) -> Result<Self>
     where
         I: Index,
     {
-        Self::validate::<I, FileBytesIterator>(path, index, skip_errors, verbose).await
+        Self::validate::<I, FileBytesIterator>(path, index).await
     }
 }
 
@@ -275,8 +278,6 @@ mod tests {
     use flv_util::fixture::ensure_new_dir;
     use futures_lite::io::AsyncWriteExt;
 
-    use fluvio_future::fs::BoundedFileSink;
-    use fluvio_future::fs::BoundedFileOption;
     use fluvio_protocol::record::Offset;
 
     use crate::LogIndex;
@@ -307,7 +308,7 @@ mod tests {
         let log_path = log_records.get_path().to_owned();
         drop(log_records);
 
-        let validator = LogValidator::default_validate::<LogIndex>(&log_path, None, false, false)
+        let validator = LogValidator::default_validate::<LogIndex>(&log_path, None)
             .await
             .expect("validate");
         assert_eq!(validator.leo(), BASE_OFFSET);
@@ -342,17 +343,19 @@ mod tests {
             .await
             .expect("write");
 
+        // at this point, we have written 5 records
+
         let log_path = msg_sink.get_path().to_owned();
         drop(msg_sink);
 
-        let validator = LogValidator::default_validate::<LogIndex>(&log_path, None, false, true)
+        let validator = LogValidator::default_validate::<LogIndex>(&log_path, None)
             .await
             .expect("validate");
         assert_eq!(validator.leo(), BASE_OFFSET + 5);
     }
 
     #[fluvio_future::test]
-    async fn test_validate_invalid_contents() {
+    async fn test_fix_invalid_contents() {
         const OFFSET: i64 = 501;
 
         let test_dir = temp_dir().join("validate_invalid_contents");
@@ -374,25 +377,62 @@ mod tests {
             .build()
             .expect("build");
 
+        // write a batch with 3 records
+        // each batch is 88 bytes long
         msg_sink
-            .write_batch(&builder.batch())
+            .write_batch(&builder.batch_records(3))
             .await
-            .expect("create batch");
+            .expect("write");
 
-        let test_file = msg_sink.get_path().to_owned();
-
-        // add some junk
-        let mut f_sink = BoundedFileSink::create(&test_file, BoundedFileOption::default())
+        // write a batch with 3 records
+        msg_sink
+            .write_batch(&builder.batch_records(3))
             .await
-            .expect("open batch file");
+            .expect("write");
+
+        msg_sink.flush().await.expect("flush");
+        let test_fs_path = msg_sink.get_path().to_owned();
+        drop(msg_sink);
+
+        let validator = LogValidator::default_validate::<LogIndex>(&test_fs_path, None)
+            .await
+            .expect("validate");
+
+        // we have written 3 records, leo = 3 + 1
+        assert_eq!(validator.leo(), OFFSET + 6);
+        drop(validator);
+
+        // get size of the file
+        let original_fs_len = std::fs::metadata(&test_fs_path)
+            .expect("get metadata")
+            .len();
+
+        // append some junk
+        let mut file = fluvio_future::fs::util::open_read_append(&test_fs_path)
+            .await
+            .expect("opening log file");
         let bytes = vec![0x01, 0x02, 0x03];
-        f_sink.write_all(&bytes).await.expect("write some junk");
-        f_sink.flush().await.expect("flush");
-        assert!(
-            LogValidator::default_validate::<LogIndex>(&test_file, None, false, false)
+        file.write_all(&bytes).await.expect("write some junk");
+        file.flush().await.expect("flush");
+        drop(file);
+
+        let invalid_fs_len = std::fs::metadata(&test_fs_path)
+            .expect("get metadata")
+            .len();
+        // assert_eq!(invalid_fs_len, original_fs_len + 3);
+
+        /*
+        debug!("checking invalid contents");
+        let validator =
+            LogValidator::default_validate::<LogIndex>(&test_fs_path, None, false, false)
                 .await
-                .is_err()
-        );
+                .expect("validate");
+
+        assert_eq!(validator.leo(), OFFSET + 6);  // should have same leo as successfull validation
+        assert_eq!(validator.last_valid_file_pos, original_fs_len);
+        let err = validator.error.expect("error");
+        assert!(matches!(err, LogValidationError::BatchDecoding(_)));
+        */
     }
 }
 
@@ -413,7 +453,7 @@ mod perf {
 
         println!("starting test");
         let header_time = Instant::now();
-        let msm_result = LogValidator::default_validate::<LogIndex>(TEST_PATH, None, false, false)
+        let msm_result = LogValidator::default_validate::<LogIndex>(TEST_PATH, None)
             .await
             .expect("validate");
         println!("header only took: {:#?}", header_time.elapsed());

--- a/crates/fluvio-storage/src/validator.rs
+++ b/crates/fluvio-storage/src/validator.rs
@@ -56,8 +56,8 @@ pub struct LogValidator {
     file_path: PathBuf,
     pub batches: u32,
     last_valid_offset: Offset,
-    pub last_valid_batch_pos: u32,
-    pub last_valid_file_pos: u32,
+    pub last_valid_batch_pos: u32, // starting position of last successful batch
+    pub last_valid_file_pos: u32,  // end position of last successful batch
     pub duration: Duration,
     pub error: Option<LogValidationError>,
     pub index_error: Option<InvalidIndexError>,
@@ -108,7 +108,7 @@ impl LogValidator {
                     val.error = Some(LogValidationError::BatchDecoding(header_error.clone()));
                     Ok(val)
                 }
-                _ => Err(err.into()),
+                _ => Err(err),
             }
         } else {
             val.duration = start_time.elapsed();


### PR DESCRIPTION
resolves #2509.

Recover from invalid logs due to incorrect batch encoding.  It does this by setting log size to last correct batches.