### PR TITLE
[Merged by Bors] - feat: support custom configs in connector SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "fluvio-smartengine",
  "fluvio-types",
  "humantime-serde",
+ "openapiv3",
  "pretty_assertions",
  "serde",
  "serde_yaml 0.8.26",
@@ -4943,6 +4944,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openapiv3"
+version = "1.0.2"
+source = "git+https://github.com/galibey/openapiv3?rev=bdd22f046d2bc19ede257504645d31f835545222#bdd22f046d2bc19ede257504645d31f835545222"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6912,6 +6923,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
+ "serde_yaml 0.8.26",
  "tracing",
 ]
 
@@ -2471,7 +2472,6 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "fluvio-connector-package",
- "tempfile",
  "tracing",
 ]
 
@@ -4206,6 +4206,7 @@ dependencies = [
  "fluvio",
  "fluvio-connector-common",
  "futures 0.3.25",
+ "serde",
  "tokio",
 ]
 

--- a/connector/json-test-connector/Cargo.toml
+++ b/connector/json-test-connector/Cargo.toml
@@ -14,6 +14,7 @@ futures = { version = "0.3", default-features = false }
 anyhow = { workspace = true}
 async-std = { version = "1.12",  default-features = false, features = ["attributes", "tokio1"]}
 tokio = { version = "1.23", default-features = false, features = ["time"]}
+serde = { version = "1.0", default-features = false, features = ["derive"]}
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }

--- a/connector/json-test-connector/Connector.toml
+++ b/connector/json-test-connector/Connector.toml
@@ -15,8 +15,3 @@ source = true
 image = "infinyon/fluvio-connect-json-test-source:0.1.0"
 
 
-
-[[params]]
-name = "template"
-description = "JSON template"
-type = "string"

--- a/connector/json-test-connector/Connector.toml
+++ b/connector/json-test-connector/Connector.toml
@@ -15,3 +15,16 @@ source = true
 image = "infinyon/fluvio-connect-json-test-source:0.1.0"
 
 
+[custom]
+required = ["template", "interval"]
+
+[custom.properties.template]
+title = "template"
+description = "JSON template"
+type = "string"
+
+[custom.properties.interval]
+title = "Interval"
+description = "Interval of producing value"
+type = "integer"
+

--- a/connector/json-test-connector/config-example.yaml
+++ b/connector/json-test-connector/config-example.yaml
@@ -2,9 +2,8 @@ version: 0.1.0
 name: my-json-test-connector
 type: json-test-source
 topic: test-topic
-parameters:
-  interval: 10  
-  template: '{"template":"test"}'  
+interval: 10  
+template: '{"template":"test"}'  
 transforms:
   - uses: infinyon/jolt@0.1.0
     with:

--- a/connector/json-test-connector/src/main.rs
+++ b/connector/json-test-connector/src/main.rs
@@ -1,13 +1,14 @@
 mod source;
 
 use fluvio::{TopicProducer, RecordKey};
-use fluvio_connector_common::{Source, connector, ConnectorConfig, Result};
+use fluvio_connector_common::{Source, connector, Result};
 use futures::StreamExt;
+use serde::Deserialize;
 
 use crate::source::TestJsonSource;
 
 #[connector(source)]
-async fn start(config: ConnectorConfig, producer: TopicProducer) -> Result<()> {
+async fn start(config: CustomConfig, producer: TopicProducer) -> Result<()> {
     let source = TestJsonSource::new(&config)?;
     let mut stream = source.connect(None).await?;
     while let Some(item) = stream.next().await {
@@ -15,4 +16,10 @@ async fn start(config: ConnectorConfig, producer: TopicProducer) -> Result<()> {
         producer.send(RecordKey::NULL, item).await?;
     }
     Ok(())
+}
+
+#[derive(Deserialize)]
+pub(crate) struct CustomConfig {
+    pub interval: u64,
+    pub template: String,
 }

--- a/connector/json-test-connector/src/source.rs
+++ b/connector/json-test-connector/src/source.rs
@@ -8,10 +8,12 @@ use anyhow::Result;
 
 use async_trait::async_trait;
 use fluvio::Offset;
-use fluvio_connector_common::{Source, ConnectorConfig};
+use fluvio_connector_common::Source;
 use futures::{stream::LocalBoxStream, Stream, StreamExt};
 
 use tokio::time::Interval;
+
+use crate::CustomConfig;
 
 #[derive(Debug)]
 pub(crate) struct TestJsonSource {
@@ -20,18 +22,11 @@ pub(crate) struct TestJsonSource {
 }
 
 impl TestJsonSource {
-    pub(crate) fn new(config: &ConnectorConfig) -> Result<Self> {
-        let interval = match config.parameters.get("interval") {
-            Some(value) => value.as_u32()?,
-            None => anyhow::bail!("interval not found"),
-        };
-        let template = match config.parameters.get("template") {
-            Some(value) => value.as_string()?,
-            None => anyhow::bail!("template not found"),
-        };
+    pub(crate) fn new(config: &CustomConfig) -> Result<Self> {
+        let CustomConfig { interval, template } = config;
         Ok(Self {
-            interval: tokio::time::interval(Duration::from_secs(interval as u64)),
-            template,
+            interval: tokio::time::interval(Duration::from_secs(*interval)),
+            template: template.clone(),
         })
     }
 }

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -1,6 +1,8 @@
 mod sink;
 
-use fluvio_connector_common::{connector, ConnectorConfig, Result, consumer::ConsumerStream, Sink};
+use fluvio_connector_common::{
+    connector, config::ConnectorConfig, Result, consumer::ConsumerStream, Sink,
+};
 use futures::SinkExt;
 use sink::TestSink;
 

--- a/connector/sink-test-connector/src/sink.rs
+++ b/connector/sink-test-connector/src/sink.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use fluvio::Offset;
-use fluvio_connector_common::{ConnectorConfig, Sink, LocalBoxSink};
+use fluvio_connector_common::{config::ConnectorConfig, Sink, LocalBoxSink};
 
 #[derive(Debug)]
 pub(crate) struct TestSink {}

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -1,14 +1,11 @@
-use std::{
-    fmt::Debug,
-    path::{PathBuf, Path},
-};
+use std::{fmt::Debug, path::PathBuf};
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use cargo_builder::package::PackageInfo;
 use fluvio_connector_deployer::{Deployment, DeploymentType};
-use fluvio_connector_package::{config::ConnectorConfig, metadata::ConnectorMetadata};
+use fluvio_connector_package::metadata::ConnectorMetadata;
 
 use crate::cmd::PackageCmd;
 
@@ -47,7 +44,7 @@ impl DeployCmd {
         let mut builder = Deployment::builder();
         builder
             .executable(p.target_bin_path()?)
-            .config(ConnectorConfig::from_file(self.config())?)
+            .config(self.config())
             .pkg(connector_metadata)
             .deployment_type(self.deployment_type.into());
         builder.deploy()?;
@@ -55,9 +52,9 @@ impl DeployCmd {
         Ok(())
     }
 
-    fn config(&self) -> &Path {
+    fn config(&self) -> PathBuf {
         match &self.deployment_type {
-            DeploymentTypeCmd::Local { config } => config.as_path(),
+            DeploymentTypeCmd::Local { config } => config.clone(),
         }
     }
 }

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -21,6 +21,7 @@ async-net = { version = "1.7", default-features = false }
 futures-util = { version = "0.3", features = ["sink"], default-features = false }
 serde = { version = "1", features = ["derive", "rc"], default-features = false }
 serde_json = { version = "1" }
+serde_yaml = { version = "0.8" }
 
 fluvio = { path = "../fluvio/", features = ["smartengine"]}
 fluvio-connector-package = { path = "../fluvio-connector-package/" }

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -1,0 +1,16 @@
+pub use fluvio_connector_package::config::ConnectorConfig;
+
+use std::{path::PathBuf, fs::File};
+
+use serde::de::DeserializeOwned;
+use anyhow::{Result, Context};
+use serde_yaml::Value;
+
+pub fn value_from_file<P: Into<PathBuf>>(path: P) -> Result<Value> {
+    let file = File::open(path.into())?;
+    serde_yaml::from_reader(file).context("unable to parse config file into YAML")
+}
+
+pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
+    serde_yaml::from_value(value).context("unable to parse custom config type from YAML")
+}

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -2,7 +2,7 @@ use fluvio::{FluvioConfig, Fluvio};
 use fluvio::dataplane::record::ConsumerRecord;
 use fluvio_sc_schema::errors::ErrorCode;
 use futures::StreamExt;
-use crate::{ConnectorConfig, Result};
+use crate::{config::ConnectorConfig, Result};
 use crate::ensure_topic_exists;
 use crate::smartmodule::smartmodule_vec_from_config;
 

--- a/crates/fluvio-connector-common/src/lib.rs
+++ b/crates/fluvio-connector-common/src/lib.rs
@@ -2,11 +2,10 @@ pub mod producer;
 pub mod smartmodule;
 pub mod monitoring;
 pub mod consumer;
+pub mod config;
 
 #[cfg(feature = "derive")]
 pub use fluvio_connector_derive::connector;
-
-pub use fluvio_connector_package::config::ConnectorConfig;
 
 use fluvio::{Offset, metadata::topic::TopicSpec};
 use futures::stream::LocalBoxStream;
@@ -36,7 +35,7 @@ pub trait Sink<I> {
     async fn connect(self, offset: Option<Offset>) -> Result<LocalBoxSink<I>>;
 }
 
-pub async fn ensure_topic_exists(config: &ConnectorConfig) -> Result<()> {
+pub async fn ensure_topic_exists(config: &config::ConnectorConfig) -> Result<()> {
     let admin = fluvio::FluvioAdmin::connect().await?;
     let topics = admin
         .list::<TopicSpec, String>(vec![config.topic.clone()])

--- a/crates/fluvio-connector-common/src/producer.rs
+++ b/crates/fluvio-connector-common/src/producer.rs
@@ -1,5 +1,5 @@
 use fluvio::{FluvioConfig, Fluvio, TopicProducer, TopicProducerConfigBuilder};
-use crate::{ConnectorConfig, Result};
+use crate::{config::ConnectorConfig, Result};
 
 use crate::{ensure_topic_exists, smartmodule::smartmodule_chain_from_config};
 

--- a/crates/fluvio-connector-common/src/smartmodule.rs
+++ b/crates/fluvio-connector-common/src/smartmodule.rs
@@ -1,5 +1,5 @@
 use fluvio::{FluvioConfig, SmartModuleInvocation, SmartModuleKind};
-use crate::{ConnectorConfig, Result};
+use crate::{config::ConnectorConfig, Result};
 use fluvio_smartengine::transformation::TransformationConfig;
 
 pub async fn smartmodule_chain_from_config(

--- a/crates/fluvio-connector-deployer/Cargo.toml
+++ b/crates/fluvio-connector-deployer/Cargo.toml
@@ -14,6 +14,4 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 derive_builder = { workspace = true }
 
-tempfile = {version = "3.3", default-features = false}
-
 fluvio-connector-package = { path = "../fluvio-connector-package" }

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Deployment {
     pub executable: PathBuf, // path to executable
     #[builder(default)]
     pub secrets: Vec<Secret>, // List of Secrets
-    pub config: ConnectorConfig, // Configuration to pass along,
+    pub config: PathBuf,     // Configuration to pass along,
     pub pkg: ConnectorMetadata, // Connector pkg definition
     pub deployment_type: DeploymentType, // deployment type
 }
@@ -37,7 +37,9 @@ impl Deployment {
 impl DeploymentBuilder {
     pub fn deploy(self) -> Result<()> {
         let deployment = self.build()?;
-        deployment.pkg.validate_config(&deployment.config)?;
+        deployment
+            .pkg
+            .validate_config(&ConnectorConfig::from_file(&deployment.config)?)?;
         match deployment.deployment_type {
             DeploymentType::Local => local::deploy_local(&deployment)?,
             DeploymentType::K8 => {

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use anyhow::Result;
 use derive_builder::Builder;
 
-use fluvio_connector_package::config::ConnectorConfig;
 use fluvio_connector_package::metadata::ConnectorMetadata;
 
 #[derive(Clone)]
@@ -37,9 +36,8 @@ impl Deployment {
 impl DeploymentBuilder {
     pub fn deploy(self) -> Result<()> {
         let deployment = self.build()?;
-        deployment
-            .pkg
-            .validate_config(&ConnectorConfig::from_file(&deployment.config)?)?;
+        let config_file = std::fs::File::open(&deployment.config)?;
+        deployment.pkg.validate_config(config_file)?;
         match deployment.deployment_type {
             DeploymentType::Local => local::deploy_local(&deployment)?,
             DeploymentType::K8 => {

--- a/crates/fluvio-connector-deployer/src/local.rs
+++ b/crates/fluvio-connector-deployer/src/local.rs
@@ -1,15 +1,11 @@
 use std::process::{Command, Stdio};
 
 use anyhow::{Result, anyhow};
-use tempfile::NamedTempFile;
 use crate::Deployment;
 
 pub(crate) fn deploy_local(deployment: &Deployment) -> Result<()> {
-    let (_, config_path) = NamedTempFile::new()?.keep()?;
-    deployment.config.write_to_file(&config_path)?;
-
     let mut log_path = std::env::current_dir()?;
-    log_path.push(&deployment.config.name);
+    log_path.push(&deployment.pkg.package.name);
     log_path.set_extension("log");
     let log_file = std::fs::File::create(log_path.as_path())?;
 
@@ -19,7 +15,8 @@ pub(crate) fn deploy_local(deployment: &Deployment) -> Result<()> {
     cmd.stderr(log_file);
     cmd.arg("--config");
     cmd.arg(
-        config_path
+        deployment
+            .config
             .to_str()
             .ok_or_else(|| anyhow!("illegal path of temp config file"))?,
     );

--- a/crates/fluvio-connector-derive/tests/mod.rs
+++ b/crates/fluvio-connector-derive/tests/mod.rs
@@ -4,4 +4,7 @@ fn ui() {
     t.compile_fail("tests/ui/wrong_direction.rs");
     t.compile_fail("tests/ui/wrong_input_len.rs");
     t.compile_fail("tests/ui/not_async.rs");
+    t.compile_fail("tests/ui/invalid_config_type.rs");
+    t.compile_fail("tests/ui/config_input_self.rs");
+    t.compile_fail("tests/ui/config_not_deserialized.rs");
 }

--- a/crates/fluvio-connector-derive/tests/ui/config_input_self.rs
+++ b/crates/fluvio-connector-derive/tests/ui/config_input_self.rs
@@ -1,0 +1,4 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+async fn start_fn(self, producer: ()) {}

--- a/crates/fluvio-connector-derive/tests/ui/config_input_self.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_input_self.stderr
@@ -1,0 +1,11 @@
+error: config input argument must not be self
+ --> tests/ui/config_input_self.rs:4:19
+  |
+4 | async fn start_fn(self, producer: ()) {}
+  |                   ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/config_input_self.rs:4:41
+  |
+4 | async fn start_fn(self, producer: ()) {}
+  |                                         ^ consider adding a `main` function to `$DIR/tests/ui/config_input_self.rs`

--- a/crates/fluvio-connector-derive/tests/ui/config_not_deserialized.rs
+++ b/crates/fluvio-connector-derive/tests/ui/config_not_deserialized.rs
@@ -1,0 +1,6 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+async fn start_fn(config: CustomConfig, producer: ()) {}
+
+struct CustomConfig {}

--- a/crates/fluvio-connector-derive/tests/ui/config_not_deserialized.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_not_deserialized.stderr
@@ -1,0 +1,58 @@
+error[E0277]: the trait bound `for<'de> CustomConfig: serde::de::Deserialize<'de>` is not satisfied
+ --> tests/ui/config_not_deserialized.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `CustomConfig`
+  |
+  = help: the following other types implement trait `serde::de::Deserialize<'de>`:
+            &'a Path
+            &'a [u8]
+            &'a str
+            ()
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
+            (T0, T1, T2, T3, T4)
+          and $N others
+  = note: required for `CustomConfig` to implement `serde::de::DeserializeOwned`
+note: required by a bound in `from_value`
+ --> $WORKSPACE/crates/fluvio-connector-common/src/config.rs
+  |
+  | pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
+  |                      ^^^^^^^^^^^^^^^^ required by this bound in `from_value`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/ui/config_not_deserialized.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `fluvio::producer::TopicProducer`
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          -------- arguments to this function are incorrect
+  |
+note: function defined here
+ --> tests/ui/config_not_deserialized.rs:4:10
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          ^^^^^^^^                       ------------
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+ --> tests/ui/config_not_deserialized.rs:3:20
+  |
+3 | #[connector(source)]
+  | -------------------^
+  | |                  |
+  | |                  cannot use the `?` operator in an async block that returns `()`
+  | this function should return `Result` or `Option` to accept `?`
+  |
+  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+ --> tests/ui/config_not_deserialized.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  |
+  = help: the trait `Try` is not implemented for `()`

--- a/crates/fluvio-connector-derive/tests/ui/invalid_config_type.rs
+++ b/crates/fluvio-connector-derive/tests/ui/invalid_config_type.rs
@@ -1,0 +1,4 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+async fn start_fn(config: &[i32], producer: ()) {}

--- a/crates/fluvio-connector-derive/tests/ui/invalid_config_type.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/invalid_config_type.stderr
@@ -1,0 +1,11 @@
+error: config type must valid path of owned type
+ --> tests/ui/invalid_config_type.rs:4:19
+  |
+4 | async fn start_fn(config: &[i32], producer: ()) {}
+  |                   ^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/invalid_config_type.rs:4:51
+  |
+4 | async fn start_fn(config: &[i32], producer: ()) {}
+  |                                                   ^ consider adding a `main` function to `$DIR/tests/ui/invalid_config_type.rs`

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -15,7 +15,7 @@ bytesize = "1.1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_yaml = "0.8.18"
 humantime-serde = "1.1.1"
-toml = { version = "0.5", default-features = false, optional = true }
+toml = { version = "0.5", default-features = false, optional = true, features = ["preserve_order"] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata/", default-features = false, features = [
     "use_serde",
 ] }
@@ -27,6 +27,7 @@ fluvio-types = { path = "../fluvio-types" }
 
 tracing = { workspace = true }
 anyhow = { workspace = true }
+openapiv3 = { git = "https://github.com/galibey/openapiv3", rev = "bdd22f046d2bc19ede257504645d31f835545222", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/crates/fluvio-connector-package/tests/Connector.toml
+++ b/crates/fluvio-connector-package/tests/Connector.toml
@@ -21,7 +21,10 @@ type = "env"
 type = "file"
 mount = "/mydata/secret1"
 
-[[params]]
-name = "template"
+[custom]
+required = ["template"]
+
+[custom.properties.template]
+title = "template"
 description = "JSON template"
 type = "string"

--- a/crates/fluvio-connector-package/tests/mod.rs
+++ b/crates/fluvio-connector-package/tests/mod.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use fluvio_controlplane_metadata::smartmodule::FluvioSemVersion;
 use fluvio_connector_package::metadata::*;
+use openapiv3::SchemaData;
 
 #[test]
 fn test_read_from_toml_file() {
@@ -27,11 +28,22 @@ fn test_read_from_toml_file() {
                 license: Some("Apache-2.0".into()),
                 visibility: ConnectorVisibility::Public,
             },
-            parameters: Parameters::from(vec![Parameter {
-                name: "template".into(),
-                description: Some("JSON template".into()),
-                ty: ParameterType::String
-            }]),
+            custom_config: CustomConfigSchema::with(
+                [(
+                    "template",
+                    openapiv3::Schema {
+                        schema_data: SchemaData {
+                            title: Some("template".to_owned()),
+                            description: Some("JSON template".to_owned()),
+                            ..Default::default()
+                        },
+                        schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                            Default::default()
+                        ))
+                    }
+                )],
+                ["template"]
+            ),
             secrets: Secrets::from(BTreeMap::from([
                 (
                     "password".into(),
@@ -90,8 +102,10 @@ mount = "/mydata/secret1"
 [secret.password]
 type = "env"
 
-[[params]]
-name = "template"
+[custom]
+required = ["template"]
+[custom.properties.template]
+title = "template"
 description = "JSON template"
 type = "string"
 "#


### PR DESCRIPTION
`connector` macro will support any custom configs for connectors.

It is done in the following way:
1. Config file is read and parsed to `serde_yaml::Value`.
2. `ConnectorConfig` is parsed from the yaml value and used to initialize Producer/Consumer.
3. User-defined config is parsed from the yaml value and passed to the user-defined function.

Validation on the deployer side is done only for `ConnectorConfig` type.

Each connector will be responsible for the validation of its own configs. 