### PR TITLE
[Merged by Bors] - refactor: migrate error to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,7 +2302,6 @@ dependencies = [
  "bytesize",
  "clap 4.0.32",
  "clap_complete",
- "color-eyre",
  "colored",
  "comfy-table",
  "content_inspector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
 name = "fluvio"
 version = "0.16.0"
 dependencies = [
+ "anyhow",
  "async-channel",
  "async-lock",
  "async-rwlock",
@@ -2234,6 +2235,7 @@ dependencies = [
 name = "fluvio-benchmark"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-channel",
  "bincode",
  "chrono",
@@ -2293,6 +2295,7 @@ dependencies = [
 name = "fluvio-cli"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-net",
  "async-trait",
  "atty",

--- a/crates/fluvio-benchmark/Cargo.toml
+++ b/crates/fluvio-benchmark/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.103", features = ['derive'] }
 serde_yaml = "0.8"
 statrs = "0.16.0"
 thiserror = { workspace = true }
+anyhow = { workspace = true }
 
 fluvio = { path = "../fluvio" }
 fluvio-cli-common = { path = "../fluvio-cli-common"}

--- a/crates/fluvio-benchmark/src/benchmark_driver.rs
+++ b/crates/fluvio-benchmark/src/benchmark_driver.rs
@@ -1,6 +1,9 @@
 use std::time::Instant;
+
+use anyhow::Result;
 use async_channel::{unbounded, Sender, Receiver};
 use tracing::{debug, info};
+
 use fluvio_future::{task::spawn, future::timeout, timer::sleep};
 use fluvio::{metadata::topic::TopicSpec, FluvioAdmin};
 use crate::{
@@ -127,10 +130,7 @@ impl BenchmarkDriver {
 
         Ok(())
     }
-    pub async fn run_benchmark(
-        config: BenchmarkConfig,
-        all_stats: AllStatsSync,
-    ) -> Result<(), BenchmarkError> {
+    pub async fn run_benchmark(config: BenchmarkConfig, all_stats: AllStatsSync) -> Result<()> {
         // Create topic for this run
 
         let new_topic = TopicSpec::new_computed(config.num_partitions as u32, 1, None);

--- a/crates/fluvio-benchmark/src/bin/fbm.rs
+++ b/crates/fluvio-benchmark/src/bin/fbm.rs
@@ -6,7 +6,10 @@ use std::{
     mem,
     time::Duration,
 };
+
 use clap::{arg, Parser};
+use anyhow::Result;
+
 use fluvio_cli_common::install::fluvio_base_dir;
 use fluvio_future::{task::run_block_on, sync::Mutex, future::timeout};
 use futures_util::FutureExt;
@@ -25,7 +28,7 @@ use fluvio_benchmark::{
     BenchmarkError,
 };
 
-fn main() -> Result<(), BenchmarkError> {
+fn main() -> Result<()> {
     fluvio_future::subscriber::init_logger();
     let args = Args::parse();
 
@@ -108,7 +111,7 @@ fn load_previous_stats() -> Option<AllStats> {
     AllStats::decode(&buffer).ok()
 }
 
-fn write_stats(stats: AllStats) -> Result<(), BenchmarkError> {
+fn write_stats(stats: AllStats) -> Result<()> {
     let encoded = stats.encode();
 
     let mut file = std::fs::OpenOptions::new()

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -46,7 +46,6 @@ clap_complete = "4.0.2"
 dirs = "4.0.0"
 thiserror = { workspace = true }
 eyre = "0.6.1"
-color-eyre = { version = "0.6.0", default-features = false }
 which = "4.0.2"
 sha2 = "0.10.0"
 hex = "0.4.2"

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -74,6 +74,7 @@ indicatif = "0.17.0"
 async-trait = "0.1.21"
 tokio = { version = "1.3.0", features = ["macros"] }
 async-net = "1.7.0"
+anyhow = { workspace = true }
 
 # Fluvio dependencies
 k8-config = { version = "2.0.0", optional = true }

--- a/crates/fluvio-cli/src/bin/main.rs
+++ b/crates/fluvio-cli/src/bin/main.rs
@@ -1,20 +1,18 @@
 use clap::Parser;
-use color_eyre::eyre::Result;
+use anyhow::Result;
+
 use fluvio_cli::{Root, HelpOpt};
 use fluvio_future::task::run_block_on;
 
 fn main() -> Result<()> {
     fluvio_future::subscriber::init_tracer(None);
-    color_eyre::config::HookBuilder::blank()
-        .display_env_section(false)
-        .install()?;
+
     print_help_hack()?;
     let root: Root = Root::parse();
 
     // If the CLI comes back with an error, attempt to handle it
     if let Err(e) = run_block_on(root.process()) {
-        let user_error = e.get_user_error()?;
-        eprintln!("{}", user_error);
+        eprintln!("{}", e);
         std::process::exit(1);
     }
 

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -21,7 +21,6 @@ mod cmd {
     use std::fmt::Debug;
     use std::sync::Arc;
 
-    use fluvio_types::PartitionId;
     use tracing::{debug, trace, instrument};
     use flate2::Compression;
     use flate2::bufread::GzEncoder;
@@ -37,7 +36,9 @@ mod cmd {
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     };
     use handlebars::{self, Handlebars};
+    use anyhow::Result;
 
+    use fluvio_types::PartitionId;
     use fluvio_spu_schema::server::smartmodule::{
         SmartModuleContextData, SmartModuleKind, SmartModuleInvocation, SmartModuleInvocationWasm,
     };
@@ -50,7 +51,7 @@ mod cmd {
 
     use crate::monitoring::init_monitoring;
     use crate::render::ProgressRenderer;
-    use crate::{CliError, Result};
+    use crate::{CliError};
     use crate::common::FluvioExtensionMetadata;
     use crate::util::parse_isolation;
     use crate::common::Terminal;
@@ -246,12 +247,14 @@ mod cmd {
                     }
 
                     if found.is_none() {
-                        return Err(CliError::TableFormatNotFound(tableformat_name.to_string()));
+                        return Err(
+                            CliError::TableFormatNotFound(tableformat_name.to_string()).into()
+                        );
                     }
 
                     found
                 } else {
-                    return Err(CliError::TableFormatNotFound(tableformat_name.to_string()));
+                    return Err(CliError::TableFormatNotFound(tableformat_name.to_string()).into());
                 }
             } else {
                 None
@@ -363,7 +366,8 @@ mod cmd {
                         return Err(CliError::from(FluvioError::CrossingOffsets(
                             start_offset,
                             end_offset,
-                        )));
+                        ))
+                        .into());
                     }
                 }
             }

--- a/crates/fluvio-cli/src/client/derivedstream/create.rs
+++ b/crates/fluvio-cli/src/client/derivedstream/create.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::derivedstream::{DerivedStreamSpec};
 
-use crate::Result;
 use crate::error::CliError;
 
 /// Create a new SmartModule with a given name
@@ -41,7 +41,7 @@ pub struct DerivedStreamCreateConfig {
 }
 
 impl DerivedStreamCreateConfig {
-    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, CliError> {
+    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self> {
         let mut file = File::open(path.into())?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;

--- a/crates/fluvio-cli/src/client/derivedstream/delete.rs
+++ b/crates/fluvio-cli/src/client/derivedstream/delete.rs
@@ -1,9 +1,8 @@
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::derivedstream::DerivedStreamSpec;
-
-use crate::Result;
 
 #[derive(Debug, Parser)]
 pub struct DeleteDerivedStreamOpt {

--- a/crates/fluvio-cli/src/client/derivedstream/list.rs
+++ b/crates/fluvio-cli/src/client/derivedstream/list.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::metadata::derivedstream::DerivedStreamSpec;
 use fluvio::Fluvio;
 
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
-use crate::Result;
 
 /// List all existing SmartModules
 #[derive(Debug, Parser)]
@@ -31,17 +31,15 @@ mod output {
     //! Format Smart Stream response based on output type
 
     use comfy_table::{Row, Cell};
-
     use comfy_table::CellAlignment;
     use tracing::debug;
     use serde::Serialize;
+    use anyhow::Result;
+
     use fluvio_extension_common::output::OutputType;
     use fluvio_extension_common::Terminal;
-
     use fluvio::metadata::objects::Metadata;
     use fluvio::metadata::derivedstream::DerivedStreamSpec;
-
-    use crate::CliError;
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
@@ -56,7 +54,7 @@ mod output {
         out: std::sync::Arc<O>,
         list_smart_streams: Vec<Metadata<DerivedStreamSpec>>,
         output_type: OutputType,
-    ) -> Result<(), CliError> {
+    ) -> Result<()> {
         debug!("derived streams: {:#?}", list_smart_streams);
 
         if !list_smart_streams.is_empty() {

--- a/crates/fluvio-cli/src/client/derivedstream/mod.rs
+++ b/crates/fluvio-cli/src/client/derivedstream/mod.rs
@@ -11,10 +11,10 @@ mod cmd {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
 
-    use crate::Result;
     use crate::client::cmd::ClientCmd;
     use crate::common::output::Terminal;
 

--- a/crates/fluvio-cli/src/client/hub/download.rs
+++ b/crates/fluvio-cli/src/client/hub/download.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use clap::Parser;
+use tracing::info;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::FluvioConfig;
@@ -13,9 +15,8 @@ use fluvio_extension_common::Terminal;
 use fluvio_extension_common::target::ClusterTarget;
 use fluvio_hub_util as hubutil;
 use hubutil::HubAccess;
-use tracing::info;
 
-use crate::{CliError, Result};
+use crate::{CliError};
 use crate::client::cmd::ClientCmd;
 use crate::client::hub::get_hub_access;
 

--- a/crates/fluvio-cli/src/client/hub/mod.rs
+++ b/crates/fluvio-cli/src/client/hub/mod.rs
@@ -10,13 +10,13 @@ mod cmd {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
     use fluvio_extension_common::target::ClusterTarget;
 
     use crate::client::cmd::ClientCmd;
     use crate::common::output::Terminal;
-    use crate::Result;
 
     use super::connector::ConnectorHubSubCmd;
     use super::download::DownloadHubOpt;

--- a/crates/fluvio-cli/src/client/mod.rs
+++ b/crates/fluvio-cli/src/client/mod.rs
@@ -38,12 +38,12 @@ mod cmd {
 
     use clap::{Parser};
     use async_trait::async_trait;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
 
     use crate::common::target::ClusterTarget;
     use crate::common::Terminal;
-    use crate::Result;
 
     use super::derivedstream::DerivedStreamCmd;
     use super::smartmodule::SmartModuleCmd;

--- a/crates/fluvio-cli/src/client/partition/list.rs
+++ b/crates/fluvio-cli/src/client/partition/list.rs
@@ -5,11 +5,11 @@
 //!
 
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::partition::*;
 
-use crate::Result;
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
 

--- a/crates/fluvio-cli/src/client/partition/mod.rs
+++ b/crates/fluvio-cli/src/client/partition/mod.rs
@@ -9,10 +9,10 @@ mod cmd {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
 
-    use crate::Result;
     use crate::client::cmd::ClientCmd;
     use crate::common::output::Terminal;
     use crate::common::FluvioExtensionMetadata;

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -20,6 +20,7 @@ mod cmd {
     use clap::Parser;
     use tracing::{error, warn};
     use humantime::parse_duration;
+    use anyhow::Result;
 
     use fluvio::{
         Compression, Fluvio, FluvioError, TopicProducer, TopicProducerConfigBuilder, RecordKey,
@@ -38,7 +39,6 @@ mod cmd {
 
     use crate::client::cmd::ClientCmd;
     use crate::common::FluvioExtensionMetadata;
-    use crate::Result;
     use crate::monitoring::init_monitoring;
     use crate::util::parse_isolation;
 

--- a/crates/fluvio-cli/src/client/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/create.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use tracing::debug;
 use async_trait::async_trait;
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasm, SmartModuleSpec};
 use fluvio_extension_common::Terminal;
 
-use crate::Result;
 use crate::client::cmd::ClientCmd;
 
 /// Create a new SmartModule with a given name

--- a/crates/fluvio-cli/src/client/smartmodule/list.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/list.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::metadata::smartmodule::SmartModuleSpec;
 use fluvio::Fluvio;
@@ -10,7 +11,6 @@ use fluvio::Fluvio;
 use crate::client::cmd::ClientCmd;
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
-use crate::Result;
 
 /// List all existing SmartModules
 #[derive(Debug, Parser)]
@@ -50,16 +50,16 @@ mod output {
 
     use comfy_table::{Cell, Row};
     use comfy_table::CellAlignment;
-
     use tracing::debug;
     use serde::Serialize;
+    use anyhow::Result;
+
     use fluvio_extension_common::output::OutputType;
     use fluvio_extension_common::Terminal;
 
     use fluvio::metadata::objects::Metadata;
     use fluvio::metadata::smartmodule::SmartModuleSpec;
 
-    use crate::CliError;
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
@@ -75,8 +75,8 @@ mod output {
         out: std::sync::Arc<O>,
         list_smartmodules: Vec<Metadata<SmartModuleSpec>>,
         output_type: OutputType,
-    ) -> Result<(), CliError> {
-        debug!("smartmodules: {:#?}", list_smartmodules);
+    ) -> Result<()> {
+        debug!("smart modules: {:#?}", list_smartmodules);
 
         if !list_smartmodules.is_empty() {
             let smartmodules = ListSmartModules(list_smartmodules);

--- a/crates/fluvio-cli/src/client/smartmodule/mod.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/mod.rs
@@ -12,11 +12,11 @@ mod cmd {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
     use fluvio_extension_common::target::ClusterTarget;
 
-    use crate::Result;
     use crate::client::cmd::ClientCmd;
     use crate::common::output::Terminal;
 

--- a/crates/fluvio-cli/src/client/smartmodule/watch.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/watch.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use clap::Parser;
 use tokio::select;
+use anyhow::Result;
 
 use fluvio::metadata::smartmodule::SmartModuleSpec;
 use fluvio::Fluvio;
@@ -12,7 +13,6 @@ use fluvio_future::io::StreamExt;
 use crate::client::cmd::ClientCmd;
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
-use crate::Result;
 
 /// List all existing SmartModules
 #[derive(Debug, Parser)]

--- a/crates/fluvio-cli/src/client/tableformat/create.rs
+++ b/crates/fluvio-cli/src/client/tableformat/create.rs
@@ -5,13 +5,13 @@
 //!
 
 use std::path::PathBuf;
+
 use clap::Parser;
 use tracing::debug;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::tableformat::TableFormatSpec;
-
-use crate::CliError;
 
 use super::TableFormatConfig;
 
@@ -27,7 +27,7 @@ pub struct CreateTableFormatOpt {
 }
 
 impl CreateTableFormatOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), CliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let config = TableFormatConfig::from_file(self.config)?;
         let tableformat_spec: TableFormatSpec = config.into();
         let name = tableformat_spec.name.clone();

--- a/crates/fluvio-cli/src/client/tableformat/delete.rs
+++ b/crates/fluvio-cli/src/client/tableformat/delete.rs
@@ -4,11 +4,10 @@
 //! CLI tree to generate Delete TableFormat spec
 //!
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::tableformat::TableFormatSpec;
-
-use crate::CliError;
 
 // -----------------------------------
 // CLI Options
@@ -21,7 +20,7 @@ pub struct DeleteTableFormatOpt {
 }
 
 impl DeleteTableFormatOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), CliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
         admin.delete::<TableFormatSpec, _>(&self.name).await?;
         Ok(())

--- a/crates/fluvio-cli/src/client/tableformat/list.rs
+++ b/crates/fluvio-cli/src/client/tableformat/list.rs
@@ -4,14 +4,15 @@
 //!
 
 use std::sync::Arc;
+
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::tableformat::TableFormatSpec;
 
 use fluvio_extension_common::Terminal;
 use fluvio_extension_common::OutputFormat;
-use crate::CliError;
 
 #[derive(Debug, Parser)]
 pub struct ListTableFormatsOpt {
@@ -21,7 +22,7 @@ pub struct ListTableFormatsOpt {
 
 impl ListTableFormatsOpt {
     /// Process list connectors cli request
-    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<(), CliError> {
+    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
         let lists = admin.all::<TableFormatSpec>().await?;
 
@@ -37,16 +38,14 @@ mod output {
 
     use comfy_table::{Row, Cell};
     use comfy_table::CellAlignment;
-
     use tracing::debug;
     use serde::Serialize;
+    use anyhow::Result;
+
     use fluvio_extension_common::output::OutputType;
     use fluvio_extension_common::Terminal;
-
     use fluvio::metadata::objects::Metadata;
     use fluvio::metadata::tableformat::TableFormatSpec;
-
-    use crate::CliError;
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
@@ -62,7 +61,7 @@ mod output {
         out: std::sync::Arc<O>,
         list_tableformats: Vec<Metadata<TableFormatSpec>>,
         output_type: OutputType,
-    ) -> Result<(), CliError> {
+    ) -> Result<()> {
         debug!("tableformats: {:#?}", list_tableformats);
 
         if !list_tableformats.is_empty() {

--- a/crates/fluvio-cli/src/client/tableformat/mod.rs
+++ b/crates/fluvio-cli/src/client/tableformat/mod.rs
@@ -15,15 +15,14 @@ mod cmd {
     use async_trait::async_trait;
     use serde::Deserialize;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
     use fluvio::metadata::tableformat::{DataFormat, TableFormatSpec, TableFormatColumnConfig};
     use fluvio_extension_common::Terminal;
     use fluvio_extension_common::COMMAND_TEMPLATE;
 
-    use crate::CliError;
     use crate::client::cmd::ClientCmd;
-    use crate::Result;
 
     use super::create::CreateTableFormatOpt;
     use super::delete::DeleteTableFormatOpt;
@@ -84,7 +83,7 @@ mod cmd {
     }
 
     impl TableFormatConfig {
-        pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<TableFormatConfig, CliError> {
+        pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<TableFormatConfig> {
             let mut file = File::open(path.into())?;
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -9,12 +9,13 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use fluvio_types::PartitionCount;
-use fluvio_types::ReplicationFactor;
 use tracing::debug;
 use clap::Parser;
 use humantime::parse_duration;
+use anyhow::Result;
 
+use fluvio_types::PartitionCount;
+use fluvio_types::ReplicationFactor;
 use fluvio::metadata::topic::CleanupPolicy;
 use fluvio::metadata::topic::ReplicaSpec;
 use fluvio::metadata::topic::SegmentBasedPolicy;
@@ -25,7 +26,7 @@ use fluvio_sc_schema::topic::validate::valid_topic_name;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
-use crate::{Result, CliError};
+use crate::{CliError};
 
 #[derive(Debug, Parser)]
 pub struct CreateTopicOpt {
@@ -137,7 +138,8 @@ impl CreateTopicOpt {
             return Err(CliError::InvalidArg(
                 "Topic name must only contain lowercase alphanumeric characters or '-'."
                     .to_string(),
-            ));
+            )
+            .into());
         }
 
         let mut topic_spec: TopicSpec = replica_spec.into();

--- a/crates/fluvio-cli/src/client/topic/describe.rs
+++ b/crates/fluvio-cli/src/client/topic/describe.rs
@@ -5,13 +5,14 @@
 //!
 
 use std::sync::Arc;
+
 use tracing::debug;
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
 
-use crate::Result;
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
 

--- a/crates/fluvio-cli/src/client/topic/list.rs
+++ b/crates/fluvio-cli/src/client/topic/list.rs
@@ -8,13 +8,13 @@ use std::sync::Arc;
 
 use clap::Parser;
 use tracing::debug;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
 
 use crate::common::output::Terminal;
 use crate::common::OutputFormat;
-use crate::Result;
 
 // -----------------------------------
 // CLI Options

--- a/crates/fluvio-cli/src/client/topic/mod.rs
+++ b/crates/fluvio-cli/src/client/topic/mod.rs
@@ -12,10 +12,10 @@ mod cmd {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use anyhow::Result;
 
     use fluvio::Fluvio;
 
-    use crate::Result;
     use crate::client::cmd::ClientCmd;
     use crate::common::COMMAND_TEMPLATE;
     use crate::common::output::Terminal;

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -105,16 +105,6 @@ impl CliError {
         Self::InvalidArg(reason.into())
     }
 
-    pub fn into_report(self) -> color_eyre::Report {
-        use color_eyre::Report;
-
-        match self {
-            #[cfg(feature = "k8s")]
-            CliError::ClusterCliError(cluster) => cluster.into_report(),
-            _ => Report::from(self),
-        }
-    }
-
     /// Looks at the error value and attempts to create a user facing error message
     ///
     /// Sometimes, specific errors require specific user-facing error messages.

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::Infallible,
-    io::{Error as IoError, ErrorKind},
+    io::{ErrorKind},
 };
 
 use semver::Version;
@@ -22,8 +22,6 @@ pub type Result<T, E = CliError> = core::result::Result<T, E>;
 #[derive(thiserror::Error, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub enum CliError {
-    #[error(transparent)]
-    IoError(#[from] IoError),
     #[error(transparent)]
     OutputError(#[from] OutputError),
     #[error("Failed to parse format string")]

--- a/crates/fluvio-cli/src/install/mod.rs
+++ b/crates/fluvio-cli/src/install/mod.rs
@@ -1,6 +1,2 @@
 pub mod update;
 pub mod plugins;
-
-fn error_convert(err: fluvio_cli_common::error::CliError) -> crate::error::CliError {
-    crate::error::CliError::FluvioInstall(err)
-}

--- a/crates/fluvio-cli/src/install/update.rs
+++ b/crates/fluvio-cli/src/install/update.rs
@@ -1,18 +1,19 @@
 use std::path::{Path, PathBuf};
+
 use clap::Parser;
+use tracing::{debug, instrument};
+use semver::Version;
+use anyhow::Result;
+
 use fluvio_channel::{LATEST_CHANNEL_NAME, FLUVIO_RELEASE_CHANNEL};
 use fluvio_cli_common::FLUVIO_ALWAYS_CHECK_UPDATES;
-use tracing::{debug, instrument};
-
-use semver::Version;
 use fluvio_index::{PackageId, HttpAgent};
-use crate::Result;
 use fluvio_cli_common::error::CliError as CommonCliError;
 use fluvio_cli_common::install::{
     fetch_latest_version, fetch_package_file, install_bin, install_println, fluvio_extensions_dir,
 };
+
 use crate::metadata::subcommand_metadata;
-use super::error_convert;
 
 const FLUVIO_CLI_PACKAGE_ID: &str = "fluvio/fluvio";
 const FLUVIO_CHANNEL_PACKAGE_ID: &str = "fluvio/fluvio-channel";
@@ -116,7 +117,7 @@ impl UpdateOpt {
                 ));
                 return Ok(());
             }
-            Err(other) => return Err(error_convert(other)),
+            Err(other) => return Err(other.into()),
         };
         install_println("🔑 Downloaded and verified package file");
 
@@ -168,7 +169,7 @@ impl UpdateOpt {
                 ));
                 return Ok(());
             }
-            Err(other) => return Err(error_convert(other)),
+            Err(other) => return Err(other.into()),
         };
         install_println("🔑 Downloaded and verified package file");
 

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -33,6 +33,7 @@ mod root {
     use clap::{Parser, Command as ClapCommand, CommandFactory};
     use clap_complete::{generate, Shell};
     use tracing::debug;
+    use anyhow::Result;
 
     #[cfg(feature = "k8s")]
     use fluvio_cluster::cli::ClusterCmd;
@@ -48,8 +49,6 @@ mod root {
     use crate::common::target::ClusterTarget;
     use crate::common::COMMAND_TEMPLATE;
     use crate::common::PrintTerminal;
-
-    use super::Result;
 
     /// Fluvio Command Line Interface
     #[derive(Parser, Debug)]

--- a/crates/fluvio-cli/src/profile/mod.rs
+++ b/crates/fluvio-cli/src/profile/mod.rs
@@ -4,9 +4,6 @@
 //! CLI command for Profile operation
 //!
 
-use std::sync::Arc;
-use clap::Parser;
-
 mod sync;
 mod current;
 mod switch;
@@ -16,7 +13,11 @@ mod delete_cluster;
 mod list;
 mod export;
 
-use crate::Result;
+use std::sync::Arc;
+
+use clap::Parser;
+use anyhow::Result;
+
 use crate::common::output::Terminal;
 use crate::profile::current::CurrentOpt;
 use crate::profile::delete_cluster::DeleteClusterOpt;

--- a/crates/fluvio-cli/src/profile/sync/local.rs
+++ b/crates/fluvio-cli/src/profile/sync/local.rs
@@ -1,9 +1,11 @@
 use std::convert::TryInto;
+
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::FluvioConfig;
 use fluvio::config::{ConfigFile, LOCAL_PROFILE, Profile};
-use crate::Result;
+
 use crate::common::tls::TlsClientOpt;
 
 #[derive(Debug, Default, Parser)]

--- a/crates/fluvio-cli/src/profile/sync/mod.rs
+++ b/crates/fluvio-cli/src/profile/sync/mod.rs
@@ -1,10 +1,10 @@
-use clap::Parser;
-
 #[cfg(feature = "k8s")]
 mod k8;
 mod local;
 
-use crate::Result;
+use clap::Parser;
+use anyhow::Result;
+
 use crate::common::COMMAND_TEMPLATE;
 use crate::profile::sync::local::LocalOpt;
 #[cfg(feature = "k8s")]

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = "0.1.21"
 colored = "2.0.0"
 semver = "1.0.3"
 url = "2.1.1"
-
 serde = "1.0.115"
 serde_json = "1.0.57"
 serde_yaml = "0.9.0"
@@ -46,7 +45,7 @@ directories = "4.0.0"
 tempfile = "3.2"
 include_dir = "0.7.2"
 tempdir = "0.3.7"
-anyhow = "1.0.44"
+anyhow = { workspace = true }
 async-channel = "1.6.1"
 bytesize = { version = "1.1.0", features = ['serde'] }
 indicatif = "0.17.0"

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use duct::cmd;
 use sysinfo::{System, SystemExt, NetworkExt, ProcessExt, DiskExt, PidExt};
 use which::which;
+use anyhow::Result;
 
 use fluvio::config::ConfigFile;
 use fluvio::metadata::{topic::TopicSpec, partition::PartitionSpec, spg::SpuGroupSpec, spu::SpuSpec};
@@ -15,8 +16,6 @@ use fluvio_sc_schema::objects::Metadata;
 use crate::cli::ClusterCliError;
 use crate::cli::start::get_log_directory;
 use crate::start::local::DEFAULT_DATA_DIR as DEFAULT_LOCAL_DIR;
-
-type Result<T, E = ClusterCliError> = core::result::Result<T, E>;
 
 #[derive(Debug)]
 enum ProfileType {

--- a/crates/fluvio-cluster/src/cli/group/create.rs
+++ b/crates/fluvio-cluster/src/cli/group/create.rs
@@ -6,11 +6,10 @@
 
 use tracing::debug;
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::spg::*;
-
-use crate::cli::ClusterCliError;
 
 // -----------------------------------
 // CLI Options
@@ -40,7 +39,7 @@ pub struct CreateManagedSpuGroupOpt {
 }
 
 impl CreateManagedSpuGroupOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), ClusterCliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let (name, spec) = self.validate();
         debug!("creating spg: {}, spec: {:#?}", name, spec);
 

--- a/crates/fluvio-cluster/src/cli/group/delete.rs
+++ b/crates/fluvio-cluster/src/cli/group/delete.rs
@@ -4,11 +4,10 @@
 //! CLI tree to generate Delete Managed SPU Groups
 //!
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::spg::SpuGroupSpec;
-
-use crate::cli::ClusterCliError;
 
 // -----------------------------------
 // CLI Options
@@ -22,7 +21,7 @@ pub struct DeleteManagedSpuGroupOpt {
 }
 
 impl DeleteManagedSpuGroupOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), ClusterCliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
         admin.delete::<SpuGroupSpec, _>(&self.name).await?;
         Ok(())

--- a/crates/fluvio-cluster/src/cli/group/list.rs
+++ b/crates/fluvio-cluster/src/cli/group/list.rs
@@ -4,14 +4,15 @@
 //!
 
 use std::sync::Arc;
+
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio_controlplane_metadata::spg::SpuGroupSpec;
 
 use crate::cli::common::output::Terminal;
 use crate::cli::common::OutputFormat;
-use crate::cli::ClusterCliError;
 
 #[derive(Debug, Parser)]
 pub struct ListManagedSpuGroupsOpt {
@@ -21,11 +22,7 @@ pub struct ListManagedSpuGroupsOpt {
 
 impl ListManagedSpuGroupsOpt {
     /// Process list spus cli request
-    pub async fn process<O: Terminal>(
-        self,
-        out: Arc<O>,
-        fluvio: &Fluvio,
-    ) -> Result<(), ClusterCliError> {
+    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
         let lists = admin.all::<SpuGroupSpec>().await?;
 
@@ -44,11 +41,11 @@ mod output {
     use comfy_table::CellAlignment;
     use tracing::debug;
     use serde::Serialize;
+    use anyhow::Result;
 
     use fluvio::metadata::objects::Metadata;
     use fluvio_controlplane_metadata::spg::SpuGroupSpec;
 
-    use crate::cli::ClusterCliError;
     use crate::cli::common::output::{OutputType, TableOutputHandler, Terminal};
     use crate::cli::common::t_println;
 
@@ -64,7 +61,7 @@ mod output {
         out: std::sync::Arc<O>,
         list_spu_groups: Vec<Metadata<SpuGroupSpec>>,
         output_type: OutputType,
-    ) -> Result<(), ClusterCliError> {
+    ) -> Result<()> {
         debug!("groups: {:#?}", list_spu_groups);
 
         if !list_spu_groups.is_empty() {

--- a/crates/fluvio-cluster/src/cli/group/mod.rs
+++ b/crates/fluvio-cluster/src/cli/group/mod.rs
@@ -5,8 +5,9 @@ mod create;
 mod delete;
 mod list;
 
+use anyhow::Result;
+
 use fluvio::Fluvio;
-use crate::cli::ClusterCliError;
 use crate::cli::common::output::Terminal;
 use crate::cli::common::COMMAND_TEMPLATE;
 
@@ -39,11 +40,7 @@ pub enum SpuGroupCmd {
 }
 
 impl SpuGroupCmd {
-    pub async fn process<O: Terminal>(
-        self,
-        out: Arc<O>,
-        fluvio: &Fluvio,
-    ) -> Result<(), ClusterCliError> {
+    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         match self {
             Self::Create(create) => {
                 create.process(fluvio).await?;

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -28,6 +28,8 @@ use shutdown::ShutdownOpt;
 
 pub use self::error::ClusterCliError;
 
+use anyhow::Result;
+
 use fluvio_extension_common as common;
 use common::target::ClusterTarget;
 use common::output::Terminal;
@@ -94,7 +96,7 @@ impl ClusterCmd {
         out: Arc<O>,
         platform_version: Version,
         target: ClusterTarget,
-    ) -> Result<(), ClusterCliError> {
+    ) -> Result<()> {
         match self {
             Self::Start(mut start) => {
                 if let Ok(tag_strategy_value) = std::env::var(FLUVIO_IMAGE_TAG_STRATEGY) {

--- a/crates/fluvio-cluster/src/cli/spu/list.rs
+++ b/crates/fluvio-cluster/src/cli/spu/list.rs
@@ -5,14 +5,15 @@
 //!
 
 use std::sync::Arc;
+
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio_controlplane_metadata::spu::SpuSpec;
 use fluvio::metadata::customspu::CustomSpuSpec;
 use fluvio::metadata::objects::Metadata;
 
-use crate::cli::ClusterCliError;
 use crate::cli::common::output::Terminal;
 use crate::cli::common::OutputFormat;
 use crate::cli::spu::display::format_spu_response_output;
@@ -29,11 +30,7 @@ pub struct ListSpusOpt {
 
 impl ListSpusOpt {
     /// Process list spus cli request
-    pub async fn process<O: Terminal>(
-        self,
-        out: Arc<O>,
-        fluvio: &Fluvio,
-    ) -> Result<(), ClusterCliError> {
+    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
 
         let spus = if self.custom {

--- a/crates/fluvio-cluster/src/cli/spu/mod.rs
+++ b/crates/fluvio-cluster/src/cli/spu/mod.rs
@@ -6,15 +6,15 @@ mod display;
 mod register;
 mod unregister;
 
-use fluvio::Fluvio;
-// pub use display::*;
+use anyhow::Result;
 
-use crate::cli::ClusterCliError;
-use super::common::COMMAND_TEMPLATE;
-use super::common::output::Terminal;
+use fluvio::Fluvio;
 use list::ListSpusOpt;
 use register::RegisterCustomSpuOpt;
 use unregister::UnregisterCustomSpuOpt;
+
+use super::common::COMMAND_TEMPLATE;
+use super::common::output::Terminal;
 
 #[derive(Debug, Parser)]
 pub enum SpuCmd {
@@ -41,11 +41,7 @@ pub enum SpuCmd {
 }
 
 impl SpuCmd {
-    pub async fn process<O: Terminal>(
-        self,
-        out: Arc<O>,
-        fluvio: &Fluvio,
-    ) -> Result<(), ClusterCliError> {
+    pub async fn process<O: Terminal>(self, out: Arc<O>, fluvio: &Fluvio) -> Result<()> {
         match self {
             Self::Register(register) => {
                 register.process(fluvio).await?;

--- a/crates/fluvio-cluster/src/cli/spu/register.rs
+++ b/crates/fluvio-cluster/src/cli/spu/register.rs
@@ -5,7 +5,9 @@
 //!
 
 use std::convert::TryFrom;
+
 use clap::Parser;
+use anyhow::Result;
 
 use fluvio::Fluvio;
 use fluvio::metadata::customspu::CustomSpuSpec;
@@ -36,7 +38,7 @@ pub struct RegisterCustomSpuOpt {
 }
 
 impl RegisterCustomSpuOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), ClusterCliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let (name, spec) = self.validate()?;
         let admin = fluvio.admin().await;
         admin.create(name, false, spec).await?;

--- a/crates/fluvio-cluster/src/cli/spu/unregister.rs
+++ b/crates/fluvio-cluster/src/cli/spu/unregister.rs
@@ -5,6 +5,8 @@
 //!
 use std::io::Error as IoError;
 use std::io::ErrorKind;
+
+use anyhow::Result;
 use clap::Parser;
 
 use fluvio::Fluvio;
@@ -33,7 +35,7 @@ pub struct UnregisterCustomSpuOpt {
 }
 
 impl UnregisterCustomSpuOpt {
-    pub async fn process(self, fluvio: &Fluvio) -> Result<(), ClusterCliError> {
+    pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let delete_key = self.validate()?;
         let admin = fluvio.admin().await;
         admin.delete::<CustomSpuSpec, _>(delete_key).await?;

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -1,16 +1,18 @@
 use std::{fmt, str::FromStr};
 use std::path::PathBuf;
-use fluvio_controlplane_metadata::spg::{SpuConfig, StorageConfig};
+
 use clap::Parser;
-use fluvio_types::defaults::{TLS_SERVER_SECRET_NAME, TLS_CLIENT_SECRET_NAME};
 use semver::Version;
+use anyhow::Result;
+
+use fluvio_controlplane_metadata::spg::{SpuConfig, StorageConfig};
+use fluvio_types::defaults::{TLS_SERVER_SECRET_NAME, TLS_CLIENT_SECRET_NAME};
 
 mod local;
 mod k8;
 mod sys;
 mod tls;
 
-use crate::cli::ClusterCliError;
 use tls::TlsOpt;
 
 #[cfg(target_os = "macos")]
@@ -174,11 +176,7 @@ pub struct StartOpt {
 }
 
 impl StartOpt {
-    pub async fn process(
-        self,
-        platform_version: Version,
-        upgrade: bool,
-    ) -> Result<(), ClusterCliError> {
+    pub async fn process(self, platform_version: Version, upgrade: bool) -> Result<()> {
         use crate::cli::start::local::process_local;
         use crate::cli::start::sys::process_sys;
         use crate::cli::start::k8::process_k8;
@@ -202,7 +200,7 @@ pub struct UpgradeOpt {
 }
 
 impl UpgradeOpt {
-    pub async fn process(self, platform_version: Version) -> Result<(), ClusterCliError> {
+    pub async fn process(self, platform_version: Version) -> Result<()> {
         self.start.process(platform_version, true).await?;
         Ok(())
     }

--- a/crates/fluvio-cluster/src/cli/status.rs
+++ b/crates/fluvio-cluster/src/cli/status.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
+use anyhow::{Result, anyhow};
+
 use fluvio::{Fluvio, FluvioAdmin, FluvioConfig};
 use fluvio::config::ConfigFile;
 use fluvio_controlplane_metadata::partition::PartitionSpec;
@@ -23,16 +25,12 @@ macro_rules! pad_format {
 }
 
 impl StatusOpt {
-    pub async fn process(self, target: ClusterTarget) -> Result<(), ClusterCliError> {
+    pub async fn process(self, target: ClusterTarget) -> Result<()> {
         let pb_factory = ProgressBarFactory::new(false);
 
         let pb = match pb_factory.create() {
             Ok(pb) => pb,
-            Err(_) => {
-                return Err(ClusterCliError::Other(
-                    "Failed to create progress bar".to_string(),
-                ))
-            }
+            Err(_) => return Err(anyhow!("Failed to create progress bar")),
         };
 
         let fluvio_config = target.load()?;
@@ -108,10 +106,7 @@ impl StatusOpt {
         }
     }
 
-    async fn check_spus(
-        pb: &ProgressRenderer,
-        fluvio_config: &FluvioConfig,
-    ) -> Result<(), ClusterCliError> {
+    async fn check_spus(pb: &ProgressRenderer, fluvio_config: &FluvioConfig) -> Result<()> {
         pb.set_message(pad_format!(format!("{} Checking {}", "📝".bold(), "SPUs")));
 
         match FluvioAdmin::connect_with_config(fluvio_config).await {
@@ -151,7 +146,7 @@ impl StatusOpt {
                     "❌".bold(),
                 )));
 
-                Err(ClusterCliError::ClientError(e))
+                Err(e)
             }
         }
     }
@@ -164,10 +159,7 @@ impl StatusOpt {
             .to_string()
     }
 
-    async fn check_topics(
-        pb: &ProgressRenderer,
-        fluvio_config: &FluvioConfig,
-    ) -> Result<(), ClusterCliError> {
+    async fn check_topics(pb: &ProgressRenderer, fluvio_config: &FluvioConfig) -> Result<()> {
         pb.set_message(pad_format!(format!(
             "{} Checking {}",
             "📝".bold(),
@@ -201,7 +193,7 @@ impl StatusOpt {
                     "❌".bold(),
                 )));
 
-                Err(ClusterCliError::ClientError(e))
+                Err(e)
             }
         }
     }

--- a/crates/fluvio-cluster/src/error.rs
+++ b/crates/fluvio-cluster/src/error.rs
@@ -36,12 +36,6 @@ pub enum ClusterError {
 /// Errors that may occur while trying to install Fluvio on Kubernetes
 #[derive(thiserror::Error, Debug)]
 pub enum K8InstallError {
-    /// An IO error occurred, such as opening a file or running a command.
-    #[error(transparent)]
-    IoError(#[from] IoError),
-    /// An error occurred with the Fluvio client.
-    #[error("Fluvio client error")]
-    FluvioError(#[from] FluvioError),
     /// An error occurred with the Kubernetes config.
     #[error("Kubernetes config error")]
     K8ConfigError(#[from] K8ConfigError),
@@ -93,11 +87,6 @@ pub enum K8InstallError {
     /// Attempted to construct a Config object without all required fields
     #[error("Missing required config option {0}")]
     MissingRequiredConfig(String),
-    /// A different kind of error occurred.
-    #[error("An unknown error occurred: {0}")]
-    Other(String),
-    #[error(transparent)]
-    ClusterCheckError(#[from] ClusterCheckError),
     /// Kubectl not found
     #[error("kubectl not found")]
     KubectlNotFoundError(IoError),

--- a/crates/fluvio-cluster/src/lib.rs
+++ b/crates/fluvio-cluster/src/lib.rs
@@ -9,9 +9,9 @@
 //! To install a basic Fluvio cluster, just do the following:
 //!
 //! ```
-//! use fluvio_cluster::{ClusterInstaller, ClusterConfig, ClusterError};
+//! use fluvio_cluster::{ClusterInstaller, ClusterConfig};
 //! use semver::Version;
-//! # async fn example() -> Result<(), ClusterError> {
+//! # async fn example() -> anyhow::Result<()> {
 //! let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
 //! let installer = ClusterInstaller::from_config(config)?;
 //! installer.install_fluvio().await?;

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -11,7 +11,13 @@ use std::time::Duration;
 use std::env;
 use std::time::SystemTime;
 
+use anyhow::{anyhow, Result};
 use derive_builder::Builder;
+use tracing::{info, warn, debug, instrument};
+use once_cell::sync::Lazy;
+use tempfile::NamedTempFile;
+use semver::Version;
+
 use fluvio::FluvioAdmin;
 use fluvio_controlplane_metadata::spg::SpuConfig;
 use fluvio_sc_schema::objects::CommonCreateRequest;
@@ -22,11 +28,6 @@ use k8_client::load_and_share;
 use k8_metadata_client::NameSpace;
 use k8_types::K8Obj;
 use k8_types::app::deployment::DeploymentSpec;
-use tracing::{info, warn, debug, instrument};
-use once_cell::sync::Lazy;
-use tempfile::NamedTempFile;
-use semver::Version;
-
 use fluvio::{Fluvio, FluvioConfig};
 use fluvio::metadata::spg::SpuGroupSpec;
 use fluvio::metadata::spu::SpuSpec;
@@ -648,7 +649,7 @@ impl ClusterInstaller {
         skip(self),
         fields(namespace = &*self.config.namespace),
     )]
-    pub async fn install_fluvio(&self) -> Result<StartStatus, K8InstallError> {
+    pub async fn install_fluvio(&self) -> Result<StartStatus> {
         if !self.config.skip_checks {
             self.preflight_check(true).await?;
         }
@@ -687,7 +688,7 @@ impl ClusterInstaller {
         let fluvio =
             match try_connect_to_sc(&cluster_config, &self.config.platform_version, &pb).await {
                 Some(fluvio) => fluvio,
-                None => return Err(K8InstallError::SCServiceTimeout),
+                None => return Err(K8InstallError::SCServiceTimeout.into()),
             };
         pb.println(format!("✅ Connected to SC: {}", install_host_and_port));
         pb.finish_and_clear();
@@ -718,7 +719,7 @@ impl ClusterInstaller {
 
     /// Install Fluvio Core chart on the configured cluster
     #[instrument(skip(self))]
-    async fn install_app(&self) -> Result<(), K8InstallError> {
+    async fn install_app(&self) -> Result<()> {
         debug!(
             "Installing fluvio with the following configuration: {:#?}",
             &self.config
@@ -800,11 +801,7 @@ impl ClusterInstaller {
                         node_addr
                             .iter()
                             .find(|a| a.r#type == "InternalIP")
-                            .ok_or_else(|| {
-                                K8InstallError::Other(
-                                    "No nodes with ExternalIP or InternalIP set".into(),
-                                )
-                            })?
+                            .ok_or_else(|| anyhow!("No nodes with ExternalIP or InternalIP set"))?
                     }
                 };
                 anode.address.clone()
@@ -822,8 +819,7 @@ impl ClusterInstaller {
 
             debug!(?helm_lb_config, "helm_lb_config");
 
-            serde_yaml::to_writer(&np_addr_fd, &helm_lb_config)
-                .map_err(|err| K8InstallError::Other(err.to_string()))?;
+            serde_yaml::to_writer(&np_addr_fd, &helm_lb_config)?;
             Some((np_addr_fd, np_conf_path))
         } else {
             None
@@ -888,11 +884,7 @@ impl ClusterInstaller {
     }
 
     /// Uploads TLS secrets to Kubernetes
-    fn upload_tls_secrets(
-        &self,
-        server_tls: &TlsConfig,
-        client_tls: &TlsConfig,
-    ) -> Result<(), K8InstallError> {
+    fn upload_tls_secrets(&self, server_tls: &TlsConfig, client_tls: &TlsConfig) -> Result<()> {
         let server_paths: Cow<TlsPaths> = tls_config_to_cert_paths(server_tls)?;
         let client_paths: Cow<TlsPaths> = tls_config_to_cert_paths(client_tls)?;
         self.upload_tls_secrets_from_files(server_paths.as_ref(), client_paths.as_ref())?;
@@ -905,7 +897,7 @@ impl ClusterInstaller {
         &self,
         service: &K8Obj<ServiceSpec>,
         pb: &ProgressRenderer,
-    ) -> Result<(String, u16, Child), K8InstallError> {
+    ) -> Result<(String, u16, Child)> {
         let pf_host_name = "localhost";
 
         let pf_port = portpicker::pick_unused_port().expect("No local ports available");
@@ -937,7 +929,7 @@ impl ClusterInstaller {
                 let error_msg = format!("kubectl port-forward error: {}", buf);
                 pb.println(error_msg);
 
-                return Err(K8InstallError::PortForwardingFailed(status));
+                return Err(K8InstallError::PortForwardingFailed(status).into());
             }
             None => {
                 info!("Port forwarding process started");
@@ -1051,7 +1043,7 @@ impl ClusterInstaller {
     async fn discover_sc_external_host_and_port(
         &self,
         service: &K8Obj<ServiceSpec>,
-    ) -> Result<(String, u16), K8InstallError> {
+    ) -> Result<(String, u16)> {
         let target_port = ClusterInstaller::target_port_for_service(service)?;
 
         let node_port = service
@@ -1069,13 +1061,12 @@ impl ClusterInstaller {
             .spec
             .r#type
             .as_ref()
-            .ok_or_else(|| K8InstallError::Other("Load Balancer Type".into()))?;
+            .ok_or_else(|| anyhow!("Load Balancer Type"))?;
 
         match k8_load_balancer_type {
             LoadBalancerType::ClusterIP => Ok((service.spec.cluster_ip.clone(), target_port)),
             LoadBalancerType::NodePort => {
-                let node_port = node_port
-                    .ok_or_else(|| K8InstallError::Other("Expecting a NodePort port".into()))?;
+                let node_port = node_port.ok_or_else(|| anyhow!("Expecting a NodePort port"))?;
 
                 let host_addr = if let Some(addr) = &self.config.proxy_addr {
                     debug!(?addr, "using proxy");
@@ -1102,9 +1093,7 @@ impl ClusterInstaller {
                                 .iter()
                                 .find(|a| a.r#type == "InternalIP")
                                 .ok_or_else(|| {
-                                    K8InstallError::Other(
-                                        "No nodes with ExternalIP or InternalIP set".into(),
-                                    )
+                                    anyhow!("No nodes with ExternalIP or InternalIP set",)
                                 })?
                                 .address
                         }
@@ -1127,7 +1116,7 @@ impl ClusterInstaller {
                     debug!(%ingress_host,"found lb address");
                     Ok((ingress_host.to_owned(), target_port))
                 } else {
-                    Err(K8InstallError::SCIngressNotValid)
+                    Err(K8InstallError::SCIngressNotValid.into())
                 }
             }
             LoadBalancerType::ExternalName => {
@@ -1136,7 +1125,7 @@ impl ClusterInstaller {
         }
     }
 
-    fn target_port_for_service(service: &K8Obj<ServiceSpec>) -> Result<u16, K8InstallError> {
+    fn target_port_for_service(service: &K8Obj<ServiceSpec>) -> Result<u16> {
         service
             .spec
             .ports
@@ -1147,16 +1136,12 @@ impl ClusterInstaller {
                 None => None,
             })
             .next()
-            .ok_or_else(|| K8InstallError::Other("target port should be there".into()))
+            .ok_or_else(|| anyhow!("target port should be there"))
     }
 
     /// Wait until all SPUs are ready and have ingress
     #[instrument(skip(self, admin))]
-    async fn wait_for_spu(
-        &self,
-        admin: &FluvioAdmin,
-        pb: &ProgressRenderer,
-    ) -> Result<bool, K8InstallError> {
+    async fn wait_for_spu(&self, admin: &FluvioAdmin, pb: &ProgressRenderer) -> Result<bool> {
         let expected_spu = self.config.spu_replicas as usize;
         let timeout_duration = Duration::from_secs(*MAX_PROVISION_TIME_SEC as u64);
         let time = SystemTime::now();
@@ -1200,7 +1185,7 @@ impl ClusterInstaller {
             }
         }
 
-        Err(K8InstallError::SPUTimeout)
+        Err(K8InstallError::SPUTimeout.into())
     }
 
     /// Install server-side TLS by uploading secrets to kubernetes
@@ -1209,7 +1194,7 @@ impl ClusterInstaller {
         &self,
         server_paths: &TlsPaths,
         client_paths: &TlsPaths,
-    ) -> Result<(), K8InstallError> {
+    ) -> Result<()> {
         let ca_cert = server_paths
             .ca_cert
             .to_str()
@@ -1296,7 +1281,7 @@ impl ClusterInstaller {
     }
 
     /// Updates the Fluvio configuration with the newly installed cluster info.
-    fn update_profile(&self, external_addr: &str) -> Result<(), K8InstallError> {
+    fn update_profile(&self, external_addr: &str) -> Result<()> {
         let pb = self.pb_factory.create()?;
         pb.set_message(format!("Creating K8 profile for: {}", external_addr));
 
@@ -1313,14 +1298,12 @@ impl ClusterInstaller {
     }
 
     /// Determines a profile name from the name of the active Kubernetes context
-    fn compute_profile_name(&self) -> Result<String, K8InstallError> {
+    fn compute_profile_name(&self) -> Result<String> {
         let k8_config = K8Config::load()?;
 
         let kc_config = match k8_config {
             K8Config::Pod(_) => {
-                return Err(K8InstallError::Other(
-                    "Pod config is not valid here".to_owned(),
-                ));
+                return Err(anyhow!("Pod config is not valid here"));
             }
             K8Config::KubeConfig(config) => config,
         };
@@ -1328,13 +1311,13 @@ impl ClusterInstaller {
         kc_config
             .config
             .current_context()
-            .ok_or_else(|| K8InstallError::Other("No context fount".to_owned()))
+            .ok_or_else(|| anyhow!("No context fount"))
             .map(|ctx| ctx.name.to_owned())
     }
 
     /// Provisions a SPU group for the given cluster according to internal config
     #[instrument(skip(self, fluvio))]
-    async fn create_managed_spu_group(&self, fluvio: &Fluvio) -> Result<(), K8InstallError> {
+    async fn create_managed_spu_group(&self, fluvio: &Fluvio) -> Result<()> {
         let pb = self.pb_factory.create()?;
         let spg_name = self.config.group_name.clone();
         pb.set_message(format!("📝 Checking for existing SPU Group: {}", spg_name));

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -553,8 +553,8 @@ impl ClusterConfigBuilder {
 /// # Example
 ///
 /// ```
-/// # use fluvio_cluster::{ClusterInstaller, ClusterConfig, ClusterError};
-/// # async fn example() -> Result<(), ClusterError> {
+/// # use fluvio_cluster::{ClusterInstaller, ClusterConfig};
+/// # async fn example() -> anyhow::Result<()> {
 /// use semver::Version;
 /// let config = ClusterConfig::builder(Version::parse("0.7.0-alpha.1").unwrap()).build()?;
 /// let installer = ClusterInstaller::from_config(config)?;

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -25,14 +25,60 @@ pub mod errors {
 pub use fluvio_controlplane_metadata::core;
 pub use fluvio_controlplane_metadata::store;
 pub use fluvio_controlplane_metadata::message;
+pub use error::ApiError;
+mod error {
 
-/// Error from api call
-#[derive(thiserror::Error, Debug)]
-pub enum ApiError {
-    #[error("Received error code: {0:#?} ({1:?})")]
-    Code(crate::errors::ErrorCode, Option<String>),
-    #[error("No resource found: {0}")]
-    NoResourceFound(String),
+    use std::fmt::Display;
+    use std::fmt::Formatter;
+
+    use super::errors::ErrorCode;
+
+    /// Error from api call
+    #[derive(thiserror::Error, Debug)]
+    pub enum ApiError {
+        Code(crate::errors::ErrorCode, Option<String>),
+        NoResourceFound(String),
+    }
+
+    impl Display for ApiError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ApiError::Code(ErrorCode::TopicAlreadyExists, _) => {
+                    write!(f, "Topic already exists")
+                }
+                ApiError::Code(ErrorCode::ManagedConnectorAlreadyExists, _) => {
+                    write!(f, "Connector already exists")
+                }
+                ApiError::Code(ErrorCode::TopicNotFound, _) => {
+                    write!(f, "Topic not found")
+                }
+                ApiError::Code(ErrorCode::SmartModuleNotFound { name: _ }, _) => {
+                    write!(f, "SmartModule not found")
+                }
+                ApiError::Code(ErrorCode::ManagedConnectorNotFound, _) => {
+                    write!(f, "Connector not found")
+                }
+                ApiError::Code(ErrorCode::TopicInvalidName, _) => {
+                    write!(f,"Invalid topic name: topic name may only include lowercase letters (a-z), numbers (0-9), and hyphens (-).")
+                }
+                ApiError::Code(ErrorCode::TableFormatAlreadyExists, _) => {
+                    write!(f, "TableFormat already exists")
+                }
+                ApiError::Code(ErrorCode::TableFormatNotFound, _) => {
+                    write!(f, "TableFormat not found")
+                }
+                ApiError::Code(_, Some(msg)) => {
+                    write!(f, "{}", msg)
+                }
+                ApiError::Code(code, None) => {
+                    write!(f, "{}", code)
+                }
+                ApiError::NoResourceFound(name) => {
+                    write!(f, "No resource found: {}", name)
+                }
+            }
+        }
+    }
 }
 
 mod admin {

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -97,7 +97,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         return Status::new(
             name.to_string(),
             ErrorCode::TopicAlreadyExists,
-            Some(format!("topic '{}' already defined", name)),
+            Some(format!("Topic '{}' already exists", name)),
         );
     }
 

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -40,7 +40,7 @@ pin-project-lite = "0.2"
 siphasher = "0.3.5"
 cfg-if = "1.0.0"
 async-trait = "0.1.51"
-
+anyhow = "1.0.38" 
 
 # Fluvio dependencies
 fluvio-future = { version = "0.4.2", features = [

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -3,12 +3,13 @@ use std::fmt::{Display, Debug};
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
+use futures_util::{Stream, StreamExt};
+use tracing::{debug, trace, instrument};
+use anyhow::{Result, anyhow};
+
 use fluvio_protocol::{Decoder, Encoder};
 use fluvio_protocol::api::{Request, RequestMessage};
 use fluvio_future::net::DomainConnector;
-use futures_util::{Stream, StreamExt};
-use tracing::{debug, trace, instrument};
-
 use fluvio_sc_schema::objects::{
     CommonCreateRequest, DeleteRequest, ObjectApiCreateRequest, ObjectApiDeleteRequest,
     ObjectApiListRequest, ObjectApiListResponse, ObjectApiWatchRequest, Metadata, ListFilter,
@@ -17,7 +18,7 @@ use fluvio_sc_schema::objects::{
 use fluvio_sc_schema::{AdminSpec, DeletableAdminSpec, CreatableAdminSpec};
 use fluvio_socket::{SocketError, ClientConfig, VersionedSerialSocket, SerialFrame, MultiplexerSocket};
 
-use crate::{FluvioError, FluvioConfig};
+use crate::FluvioConfig;
 use crate::metadata::objects::{ListResponse, ListRequest};
 use crate::config::ConfigFile;
 use crate::sync::MetadataStores;
@@ -88,7 +89,7 @@ impl FluvioAdmin {
     ///
     /// [`connect_with_config`]: ./struct.FluvioAdmin.html#method.connect_with_config
     #[instrument]
-    pub async fn connect() -> Result<Self, FluvioError> {
+    pub async fn connect() -> Result<Self> {
         let config_file = ConfigFile::load_default_or_new()?;
         let cluster_config = config_file.config().current_cluster()?;
         Self::connect_with_config(cluster_config).await
@@ -113,7 +114,7 @@ impl FluvioAdmin {
     /// # }
     /// ```
     #[instrument(skip(config))]
-    pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self, FluvioError> {
+    pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self> {
         let connector = DomainConnector::try_from(config.tls.clone())?;
         let client_config =
             ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);
@@ -131,7 +132,7 @@ impl FluvioAdmin {
                 metadata,
             })
         } else {
-            Err(FluvioError::Other("WatchApi version not found".to_string()))
+            Err(anyhow!("WatchApi version not found"))
         }
     }
 
@@ -145,7 +146,7 @@ impl FluvioAdmin {
 
     /// Create new object
     #[instrument(skip(self, name, dry_run, spec))]
-    pub async fn create<S>(&self, name: String, dry_run: bool, spec: S) -> Result<(), FluvioError>
+    pub async fn create<S>(&self, name: String, dry_run: bool, spec: S) -> Result<()>
     where
         S: CreatableAdminSpec + Sync + Send,
         ObjectApiCreateRequest: From<(CommonCreateRequest, S)>,
@@ -160,11 +161,7 @@ impl FluvioAdmin {
     }
 
     #[instrument(skip(self, config, spec))]
-    pub async fn create_with_config<S>(
-        &self,
-        config: CommonCreateRequest,
-        spec: S,
-    ) -> Result<(), FluvioError>
+    pub async fn create_with_config<S>(&self, config: CommonCreateRequest, spec: S) -> Result<()>
     where
         S: CreatableAdminSpec + Sync + Send,
         ObjectApiCreateRequest: From<(CommonCreateRequest, S)>,
@@ -181,7 +178,7 @@ impl FluvioAdmin {
     /// Delete object by key
     /// key is depend on spec, most are string but some allow multiple types
     #[instrument(skip(self, key))]
-    pub async fn delete<S, K>(&self, key: K) -> Result<(), FluvioError>
+    pub async fn delete<S, K>(&self, key: K) -> Result<()>
     where
         S: DeletableAdminSpec + Sync + Send,
         K: Into<S::DeleteKey>,
@@ -198,7 +195,7 @@ impl FluvioAdmin {
 
     /// return all instance of this spec
     #[instrument(skip(self))]
-    pub async fn all<S>(&self) -> Result<Vec<Metadata<S>>, FluvioError>
+    pub async fn all<S>(&self) -> Result<Vec<Metadata<S>>>
     where
         S: AdminSpec,
         ObjectApiListRequest: From<ListRequest<S>>,
@@ -211,7 +208,7 @@ impl FluvioAdmin {
 
     /// return all instance of this spec by filter
     #[instrument(skip(self, filters))]
-    pub async fn list<S, F>(&self, filters: Vec<F>) -> Result<Vec<Metadata<S>>, FluvioError>
+    pub async fn list<S, F>(&self, filters: Vec<F>) -> Result<Vec<Metadata<S>>>
     where
         S: AdminSpec,
         ListFilter: From<F>,
@@ -228,7 +225,7 @@ impl FluvioAdmin {
         &self,
         filters: Vec<F>,
         summary: bool,
-    ) -> Result<Vec<Metadata<S>>, FluvioError>
+    ) -> Result<Vec<Metadata<S>>>
     where
         S: AdminSpec,
         ListFilter: From<F>,
@@ -255,9 +252,7 @@ impl FluvioAdmin {
     /// Watch stream of changes for metadata
     /// There is caching, this is just pass through
     #[instrument(skip(self))]
-    pub async fn watch<S>(
-        &self,
-    ) -> Result<impl Stream<Item = Result<WatchResponse<S>, IoError>>, FluvioError>
+    pub async fn watch<S>(&self) -> Result<impl Stream<Item = Result<WatchResponse<S>, IoError>>>
     where
         S: AdminSpec,
         ObjectApiWatchRequest: From<WatchRequest<S>>,

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -80,8 +80,8 @@ impl FluvioAdmin {
     /// # Example
     ///
     /// ```no_run
-    /// # use fluvio::{FluvioAdmin, FluvioError};
-    /// # async fn do_connect() -> Result<(), FluvioError> {
+    /// # use fluvio::FluvioAdmin;
+    /// # async fn do_connect() -> anyhow::Result<()> {
     /// let admin = FluvioAdmin::connect().await?;
     /// # Ok(())
     /// # }
@@ -104,9 +104,9 @@ impl FluvioAdmin {
     /// # Example
     ///
     /// ```no_run
-    /// # use fluvio::{FluvioAdmin, FluvioError};
+    /// # use fluvio::FluvioAdmin;
     /// use fluvio::config::ConfigFile;
-    /// #  async fn do_connect_with_config() -> Result<(), FluvioError> {
+    /// #  async fn do_connect_with_config() -> anyhow::Result<()> {
     /// let config_file = ConfigFile::load_default_or_new()?;
     /// let fluvio_config = config_file.config().current_cluster().unwrap();
     /// let admin = FluvioAdmin::connect_with_config(fluvio_config).await?;


### PR DESCRIPTION
Migrate to use `anyhow` for Result.  This removes the error wrapping business, leading to more straightforward error handling by making error flat.

Move the previous `eyer` error message to a specific error display conversion to make it compatible with existing code and tests.  We will keep the existing error structure even though some fields are unnecessary.  They will be removed in future versions once the rest of the ecosystem is migrated.
