### PR TITLE
[Merged by Bors] - feat: separate custom config from common config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "fluvio-connector-common",
  "proc-macro2",
  "quote",
+ "serde",
  "syn",
  "trybuild 1.0.74",
 ]
@@ -6314,6 +6315,7 @@ dependencies = [
  "fluvio",
  "fluvio-connector-common",
  "futures 0.3.25",
+ "serde",
 ]
 
 [[package]]

--- a/connector/json-test-connector/Connector.toml
+++ b/connector/json-test-connector/Connector.toml
@@ -16,6 +16,7 @@ image = "infinyon/fluvio-connect-json-test-source:0.1.0"
 
 
 [custom]
+name = "json"
 required = ["template", "interval"]
 
 [custom.properties.template]

--- a/connector/json-test-connector/config-example.yaml
+++ b/connector/json-test-connector/config-example.yaml
@@ -1,9 +1,11 @@
-version: 0.1.0
-name: my-json-test-connector
-type: json-test-source
-topic: test-topic
-interval: 10  
-template: '{"template":"test"}'  
+meta:
+  version: 0.1.0
+  name: my-json-test-connector
+  type: json-test-source
+  topic: test-topic
+json:
+  interval: 10  
+  template: '{"template":"test"}'  
 transforms:
   - uses: infinyon/jolt@0.1.0
     with:

--- a/connector/json-test-connector/src/main.rs
+++ b/connector/json-test-connector/src/main.rs
@@ -3,7 +3,6 @@ mod source;
 use fluvio::{TopicProducer, RecordKey};
 use fluvio_connector_common::{Source, connector, Result};
 use futures::StreamExt;
-use serde::Deserialize;
 
 use crate::source::TestJsonSource;
 
@@ -18,7 +17,7 @@ async fn start(config: CustomConfig, producer: TopicProducer) -> Result<()> {
     Ok(())
 }
 
-#[derive(Deserialize)]
+#[connector(config, name = "json")]
 pub(crate) struct CustomConfig {
     pub interval: u64,
     pub template: String,

--- a/connector/sink-test-connector/Cargo.toml
+++ b/connector/sink-test-connector/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { version = "0.1", default-features = false}
 futures = { version = "0.3", default-features = false }
 anyhow = { workspace = true}
 async-std = { version = "1.12",  default-features = false, features = ["attributes"]}
+serde = { version = "1.0", default-features = false, features = ["derive"]}
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }

--- a/connector/sink-test-connector/config-example.yaml
+++ b/connector/sink-test-connector/config-example.yaml
@@ -1,9 +1,8 @@
-version: 0.1.0
-name: my-sink-test-connector
-type: test-sink
-topic: test-topic
-parameters:
-  interval: 10  
+meta:
+  version: 0.1.0
+  name: my-sink-test-connector
+  type: test-sink
+  topic: test-topic
 transforms:
   - uses: infinyon/jolt@0.1.0
     with:

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -1,13 +1,11 @@
 mod sink;
 
-use fluvio_connector_common::{
-    connector, config::ConnectorConfig, Result, consumer::ConsumerStream, Sink,
-};
+use fluvio_connector_common::{connector, Result, consumer::ConsumerStream, Sink};
 use futures::SinkExt;
 use sink::TestSink;
 
 #[connector(sink)]
-async fn start(config: ConnectorConfig, mut stream: impl ConsumerStream) -> Result<()> {
+async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<()> {
     let sink = TestSink::new(&config)?;
     let mut sink = sink.connect(None).await?;
     while let Some(item) = stream.next().await {
@@ -16,3 +14,6 @@ async fn start(config: ConnectorConfig, mut stream: impl ConsumerStream) -> Resu
     }
     Ok(())
 }
+
+#[connector(config)]
+struct CustomConfig {}

--- a/connector/sink-test-connector/src/sink.rs
+++ b/connector/sink-test-connector/src/sink.rs
@@ -3,13 +3,15 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use fluvio::Offset;
-use fluvio_connector_common::{config::ConnectorConfig, Sink, LocalBoxSink};
+use fluvio_connector_common::{Sink, LocalBoxSink};
+
+use crate::CustomConfig;
 
 #[derive(Debug)]
 pub(crate) struct TestSink {}
 
 impl TestSink {
-    pub(crate) fn new(_config: &ConnectorConfig) -> Result<Self> {
+    pub(crate) fn new(_config: &CustomConfig) -> Result<Self> {
         Ok(Self {})
     }
 }

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -1,4 +1,5 @@
 pub use fluvio_connector_package::config::ConnectorConfig;
+use tracing::trace;
 
 use std::{path::PathBuf, fs::File};
 
@@ -11,6 +12,14 @@ pub fn value_from_file<P: Into<PathBuf>>(path: P) -> Result<Value> {
     serde_yaml::from_reader(file).context("unable to parse config file into YAML")
 }
 
-pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
+pub fn from_value<T: DeserializeOwned>(value: Value, root: Option<&str>) -> Result<T> {
+    let value = match root {
+        Some(root) => value
+            .get(root)
+            .cloned()
+            .unwrap_or(Value::Mapping(Default::default())),
+        None => value,
+    };
+    trace!("{:#?}", value);
     serde_yaml::from_value(value).context("unable to parse custom config type from YAML")
 }

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -20,14 +20,15 @@ pub async fn consumer_stream_from_config(
     config: &ConnectorConfig,
 ) -> Result<(Fluvio, impl ConsumerStream)> {
     let mut cluster_config = FluvioConfig::load()?;
-    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.name));
+    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta.name));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;
     ensure_topic_exists(config).await?;
     let consumer = fluvio
         .partition_consumer(
-            &config.topic,
+            &config.meta.topic,
             config
+                .meta
                 .consumer
                 .as_ref()
                 .and_then(|c| c.partition)

--- a/crates/fluvio-connector-common/src/lib.rs
+++ b/crates/fluvio-connector-common/src/lib.rs
@@ -38,13 +38,13 @@ pub trait Sink<I> {
 pub async fn ensure_topic_exists(config: &config::ConnectorConfig) -> Result<()> {
     let admin = fluvio::FluvioAdmin::connect().await?;
     let topics = admin
-        .list::<TopicSpec, String>(vec![config.topic.clone()])
+        .list::<TopicSpec, String>(vec![config.meta.topic.clone()])
         .await?;
-    let topic_exists = topics.iter().any(|t| t.name.eq(&config.topic));
+    let topic_exists = topics.iter().any(|t| t.name.eq(&config.meta.topic));
     if !topic_exists {
         let _ = admin
             .create(
-                config.topic.clone(),
+                config.meta.topic.clone(),
                 false,
                 TopicSpec::new_computed(1, 1, Some(false)),
             )

--- a/crates/fluvio-connector-common/src/producer.rs
+++ b/crates/fluvio-connector-common/src/producer.rs
@@ -5,13 +5,13 @@ use crate::{ensure_topic_exists, smartmodule::smartmodule_chain_from_config};
 
 pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, TopicProducer)> {
     let mut cluster_config = FluvioConfig::load()?;
-    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.name));
+    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta.name));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;
     ensure_topic_exists(config).await?;
     let mut config_builder = TopicProducerConfigBuilder::default();
 
-    if let Some(producer_params) = &config.producer {
+    if let Some(producer_params) = &config.meta.producer {
         // Linger
         if let Some(linger) = producer_params.linger {
             config_builder = config_builder.linger(linger)
@@ -30,7 +30,7 @@ pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, T
 
     let producer_config = config_builder.build()?;
     let producer = fluvio
-        .topic_producer_with_config(&config.topic, producer_config)
+        .topic_producer_with_config(&config.meta.topic, producer_config)
         .await?;
 
     if let Some(chain) = smartmodule_chain_from_config(config).await? {

--- a/crates/fluvio-connector-derive/Cargo.toml
+++ b/crates/fluvio-connector-derive/Cargo.toml
@@ -21,5 +21,6 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 trybuild = { version = "1.0" }
+serde = { version = "1.0", features = ["derive"]}
 fluvio = { path = "../fluvio", default-features = false}
 fluvio-connector-common = { path = "../fluvio-connector-common/", features = ["derive"] }

--- a/crates/fluvio-connector-derive/src/lib.rs
+++ b/crates/fluvio-connector-derive/src/lib.rs
@@ -1,21 +1,31 @@
 mod ast;
 mod generator;
 
-use ast::{ConnectorDirection, ConnectorFn};
-use generator::generate_connector;
+use ast::{ConnectorDirection, ConnectorFn, ConnectorConfigStruct};
+use generator::{generate_connector, generate_connector_config};
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, AttributeArgs, ItemFn};
+use syn::{parse_macro_input, AttributeArgs, ItemFn, Item, ItemStruct, Error, spanned::Spanned};
 
 #[proc_macro_attribute]
 pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as AttributeArgs);
+    let input = parse_macro_input!(input as Item);
 
+    match input {
+        Item::Fn(item_fn) => connector_func(args, item_fn),
+        Item::Struct(item_struct) => connector_config(args, item_struct),
+        _ => Error::new(input.span(), "macro supports only functions and structs")
+            .into_compile_error()
+            .into(),
+    }
+}
+
+fn connector_func(args: AttributeArgs, func: ItemFn) -> TokenStream {
     let direction = match ConnectorDirection::from_ast(&args) {
         Ok(dir) => dir,
         Err(e) => return e.into_compile_error().into(),
     };
 
-    let func = parse_macro_input!(input as ItemFn);
     let func = match ConnectorFn::from_ast(&func) {
         Ok(func) => func,
         Err(e) => return e.into_compile_error().into(),
@@ -23,5 +33,14 @@ pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let output = generate_connector(direction, &func);
 
+    output.into()
+}
+
+fn connector_config(args: AttributeArgs, item: ItemStruct) -> TokenStream {
+    let item = match ConnectorConfigStruct::from_ast(&args, &item) {
+        Ok(it) => it,
+        Err(e) => return e.into_compile_error().into(),
+    };
+    let output = generate_connector_config(&item);
     output.into()
 }

--- a/crates/fluvio-connector-derive/tests/mod.rs
+++ b/crates/fluvio-connector-derive/tests/mod.rs
@@ -3,8 +3,11 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/wrong_direction.rs");
     t.compile_fail("tests/ui/wrong_input_len.rs");
+    t.compile_fail("tests/ui/wrong_rust_type.rs");
     t.compile_fail("tests/ui/not_async.rs");
     t.compile_fail("tests/ui/invalid_config_type.rs");
     t.compile_fail("tests/ui/config_input_self.rs");
-    t.compile_fail("tests/ui/config_not_deserialized.rs");
+    t.compile_fail("tests/ui/config_use_reserved_name_fluvio.rs");
+    t.compile_fail("tests/ui/config_use_reserved_name_transforms.rs");
+    t.compile_fail("tests/ui/struct_without_config.rs");
 }

--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.rs
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.rs
@@ -1,0 +1,7 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+async fn start_fn(config: CustomConfig, producer: ()) {}
+
+#[connector(config, name = "meta")]
+struct CustomConfig {}

--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.stderr
@@ -1,0 +1,52 @@
+error: Custom config name conflicts with reserved names: 'meta' and 'transforms'
+ --> tests/ui/config_use_reserved_name_fluvio.rs:7:1
+  |
+7 | struct CustomConfig {}
+  | ^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `CustomConfig`
+ --> tests/ui/config_use_reserved_name_fluvio.rs:4:27
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ use of undeclared type `CustomConfig`
+
+error[E0412]: cannot find type `CustomConfig` in this scope
+ --> tests/ui/config_use_reserved_name_fluvio.rs:4:27
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+ --> tests/ui/config_use_reserved_name_fluvio.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `fluvio::producer::TopicProducer`
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          -------- arguments to this function are incorrect
+  |
+note: function defined here
+ --> tests/ui/config_use_reserved_name_fluvio.rs:4:10
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          ^^^^^^^^                       ------------
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+ --> tests/ui/config_use_reserved_name_fluvio.rs:3:20
+  |
+3 | #[connector(source)]
+  | -------------------^
+  | |                  |
+  | |                  cannot use the `?` operator in an async block that returns `()`
+  | this function should return `Result` or `Option` to accept `?`
+  |
+  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+ --> tests/ui/config_use_reserved_name_fluvio.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  |
+  = help: the trait `Try` is not implemented for `()`

--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.rs
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.rs
@@ -1,0 +1,7 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+async fn start_fn(config: CustomConfig, producer: ()) {}
+
+#[connector(config, name = "transforms")]
+struct CustomConfig {}

--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.stderr
@@ -1,0 +1,52 @@
+error: Custom config name conflicts with reserved names: 'meta' and 'transforms'
+ --> tests/ui/config_use_reserved_name_transforms.rs:7:1
+  |
+7 | struct CustomConfig {}
+  | ^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `CustomConfig`
+ --> tests/ui/config_use_reserved_name_transforms.rs:4:27
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ use of undeclared type `CustomConfig`
+
+error[E0412]: cannot find type `CustomConfig` in this scope
+ --> tests/ui/config_use_reserved_name_transforms.rs:4:27
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+ --> tests/ui/config_use_reserved_name_transforms.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `fluvio::producer::TopicProducer`
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          -------- arguments to this function are incorrect
+  |
+note: function defined here
+ --> tests/ui/config_use_reserved_name_transforms.rs:4:10
+  |
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |          ^^^^^^^^                       ------------
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+ --> tests/ui/config_use_reserved_name_transforms.rs:3:20
+  |
+3 | #[connector(source)]
+  | -------------------^
+  | |                  |
+  | |                  cannot use the `?` operator in an async block that returns `()`
+  | this function should return `Result` or `Option` to accept `?`
+  |
+  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the `?` operator can only be applied to values that implement `Try`
+ --> tests/ui/config_use_reserved_name_transforms.rs:3:1
+  |
+3 | #[connector(source)]
+  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  |
+  = help: the trait `Try` is not implemented for `()`

--- a/crates/fluvio-connector-derive/tests/ui/struct_without_config.rs
+++ b/crates/fluvio-connector-derive/tests/ui/struct_without_config.rs
@@ -3,4 +3,5 @@ use fluvio_connector_common::connector;
 #[connector(source)]
 async fn start_fn(config: CustomConfig, producer: ()) {}
 
+#[connector]
 struct CustomConfig {}

--- a/crates/fluvio-connector-derive/tests/ui/struct_without_config.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/struct_without_config.stderr
@@ -1,29 +1,23 @@
-error[E0277]: the trait bound `for<'de> CustomConfig: serde::de::Deserialize<'de>` is not satisfied
- --> tests/ui/config_not_deserialized.rs:3:1
+error: struct must be annotated as config, e.g. '#[connector(config)]'
+ --> tests/ui/struct_without_config.rs:7:1
   |
-3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `CustomConfig`
+7 | struct CustomConfig {}
+  | ^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `CustomConfig`
+ --> tests/ui/struct_without_config.rs:4:27
   |
-  = help: the following other types implement trait `serde::de::Deserialize<'de>`:
-            &'a Path
-            &'a [u8]
-            &'a str
-            ()
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-            (T0, T1, T2, T3, T4)
-          and $N others
-  = note: required for `CustomConfig` to implement `serde::de::DeserializeOwned`
-note: required by a bound in `from_value`
- --> $WORKSPACE/crates/fluvio-connector-common/src/config.rs
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ use of undeclared type `CustomConfig`
+
+error[E0412]: cannot find type `CustomConfig` in this scope
+ --> tests/ui/struct_without_config.rs:4:27
   |
-  | pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T> {
-  |                      ^^^^^^^^^^^^^^^^ required by this bound in `from_value`
-  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
+4 | async fn start_fn(config: CustomConfig, producer: ()) {}
+  |                           ^^^^^^^^^^^^ not found in this scope
 
 error[E0308]: mismatched types
- --> tests/ui/config_not_deserialized.rs:3:1
+ --> tests/ui/struct_without_config.rs:3:1
   |
 3 | #[connector(source)]
   | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `fluvio::producer::TopicProducer`
@@ -31,14 +25,14 @@ error[E0308]: mismatched types
   |          -------- arguments to this function are incorrect
   |
 note: function defined here
- --> tests/ui/config_not_deserialized.rs:4:10
+ --> tests/ui/struct_without_config.rs:4:10
   |
 4 | async fn start_fn(config: CustomConfig, producer: ()) {}
   |          ^^^^^^^^                       ------------
   = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
- --> tests/ui/config_not_deserialized.rs:3:20
+ --> tests/ui/struct_without_config.rs:3:20
   |
 3 | #[connector(source)]
   | -------------------^
@@ -50,7 +44,7 @@ error[E0277]: the `?` operator can only be used in an async block that returns `
   = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
- --> tests/ui/config_not_deserialized.rs:3:1
+ --> tests/ui/struct_without_config.rs:3:1
   |
 3 | #[connector(source)]
   | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`

--- a/crates/fluvio-connector-derive/tests/ui/wrong_rust_type.rs
+++ b/crates/fluvio-connector-derive/tests/ui/wrong_rust_type.rs
@@ -1,0 +1,4 @@
+use fluvio_connector_common::connector;
+
+#[connector(source)]
+mod start {}

--- a/crates/fluvio-connector-derive/tests/ui/wrong_rust_type.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/wrong_rust_type.stderr
@@ -1,0 +1,11 @@
+error: macro supports only functions and structs
+ --> tests/ui/wrong_rust_type.rs:4:1
+  |
+4 | mod start {}
+  | ^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/wrong_rust_type.rs:4:13
+  |
+4 | mod start {}
+  |             ^ consider adding a `main` function to `$DIR/tests/ui/wrong_rust_type.rs`

--- a/crates/fluvio-connector-package/test-data/connectors/error-batchsize.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-batchsize.yaml
@@ -1,7 +1,8 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
-producer:
-  batch-size: 1aoeu
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  producer:
+    batch-size: 1aoeu

--- a/crates/fluvio-connector-package/test-data/connectors/error-compression.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-compression.yaml
@@ -1,7 +1,8 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
-producer:
-  compression: gzipaoeu
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  producer:
+    compression: gzipaoeu

--- a/crates/fluvio-connector-package/test-data/connectors/error-linger.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-linger.yaml
@@ -1,7 +1,8 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
-producer:
-  linger: 1
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  producer:
+    linger: 1

--- a/crates/fluvio-connector-package/test-data/connectors/error-version.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-version.yaml
@@ -1,4 +1,5 @@
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
+meta:
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false

--- a/crates/fluvio-connector-package/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/full-config.yaml
@@ -1,31 +1,32 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
-parameters:
-  param_1: "mqtt.hsl.fi"
-  param_2:
-    - "foo:baz"
-    - "bar"
-  param_3:
-    foo: bar
-    bar: 10.0
-    linger.ms: 10
-  param_4: true
-  param_5: 10.0
-  param_6:
-  - -10
-  - -10.0
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  parameters:
+    param_1: "mqtt.hsl.fi"
+    param_2:
+      - "foo:baz"
+      - "bar"
+    param_3:
+      foo: bar
+      bar: 10.0
+      linger.ms: 10
+    param_4: true
+    param_5: 10.0
+    param_6:
+    - -10
+    - -10.0
 
-secrets:
-  foo: bar
-producer:
-  linger: 1ms
-  batch-size: '44.0 MB'
-  compression: gzip
-consumer:
-  partition: 10
+  secrets:
+    foo: bar
+  producer:
+    linger: 1ms
+    batch-size: '44.0 MB'
+    compression: gzip
+  consumer:
+    partition: 10
 transforms:
   - uses: infinyon/json-sql
     with:

--- a/crates/fluvio-connector-package/test-data/connectors/simple.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/simple.yaml
@@ -1,5 +1,6 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false

--- a/crates/fluvio-connector-package/test-data/connectors/with_transform.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/with_transform.yaml
@@ -1,8 +1,9 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
 transforms:
   - uses: infinyon/sql
     with:

--- a/crates/fluvio-connector-package/test-data/connectors/with_transform_many.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/with_transform_many.yaml
@@ -1,8 +1,9 @@
-version: 0.1.0
-name: my-test-mqtt
-type: mqtt
-topic: my-mqtt
-create_topic: false
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
 transforms:
   - uses: infinyon/json-sql
     with:


### PR DESCRIPTION
This PR changes the shape of the connector's config separating fields for custom user-defined config from `ConnectorConfig`. For example:
```yaml
meta:
  version: 0.1.0
  name: my-json-test-connector
  type: json-test-source
  topic: test-topic
json:
  interval: 10  
  template: '{"template":"test"}'  
transforms:
  - uses: infinyon/jolt@0.1.0
    with:
```
sections `meta` and `transforms` go to `ConnectorConfig`, `json` goes to custom config (the name is configurable, by default  is `custom`). If the name of the custom config is overridden, need to specify it in the package metadata also.
