### PR TITLE
[Merged by Bors] - chore: remove unneeded fluvio crate compile triggers

### DIFF
--- a/crates/fluvio-cli/build.rs
+++ b/crates/fluvio-cli/build.rs
@@ -2,7 +2,12 @@ use std::process::Command;
 
 fn main() {
     // Copy VERSION file. Do not fail e.g. when built via `cargo publish`
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")

--- a/crates/fluvio-cluster/build.rs
+++ b/crates/fluvio-cluster/build.rs
@@ -1,7 +1,12 @@
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../k8-util/helm/pkg_sys/fluvio-chart-sys.tgz");
     println!("cargo:rerun-if-changed=../../k8-util/helm/pkg_app/fluvio-chart-app.tgz");
 

--- a/crates/fluvio-run/build.rs
+++ b/crates/fluvio-run/build.rs
@@ -2,7 +2,12 @@ use std::process::Command;
 
 fn main() {
     // Copy VERSION file. Do not fail e.g. when built via `cargo publish`
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")

--- a/crates/fluvio-sc/build.rs
+++ b/crates/fluvio-sc/build.rs
@@ -1,7 +1,12 @@
 fn main() {
     use std::process::Command;
 
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")

--- a/crates/fluvio-socket/build.rs
+++ b/crates/fluvio-socket/build.rs
@@ -4,7 +4,12 @@ fn main() {
     built::write_built_file().expect("Failed to acquire build-time information");
 
     // Copy VERSION file. Do not fail e.g. when built via `cargo publish`
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")

--- a/crates/fluvio-spu/build.rs
+++ b/crates/fluvio-spu/build.rs
@@ -1,7 +1,12 @@
 fn main() {
     use std::process::Command;
 
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")

--- a/crates/fluvio/build.rs
+++ b/crates/fluvio/build.rs
@@ -2,7 +2,12 @@ use std::process::Command;
 
 fn main() {
     // Copy VERSION file. Do not fail e.g. when built via `cargo publish`
-    println!("cargo:rerun-if-changed=../../VERSION");
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+    println!("cargo:rerun-if-changed=build.rs");
 
     // Fetch current git hash to print version output
     let git_version_output = Command::new("git")


### PR DESCRIPTION
In workspace, builds work fine, but any builds out of the workspace, dependent on the fluvio crate, triggered a relink step every time due to a reference to ../../VERSION.

Only emit cargo:rerun-in-changed=../../VERSION if detected in workspace.