### PR TITLE
[Merged by Bors] - feat: make openssl as option to fluvio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,10 @@ jobs:
             rust: stable
             rust-target: armv7-unknown-linux-gnueabihf
             binary: fluvio
-          - os: ubuntu-latest
-            rust: stable
-            rust-target: x86_64-pc-windows-gnu
-            binary: fluvio.exe
+    #      - os: ubuntu-latest
+    #        rust: stable
+    #        rust-target: x86_64-pc-windows-gnu
+    #        binary: fluvio.exe
           - os: macos-12
             rust: stable
             rust-target: x86_64-apple-darwin
@@ -182,10 +182,10 @@ jobs:
             rust: stable
             rust-target: armv7-unknown-linux-gnueabihf
             binary: fluvio-channel
-          - os: ubuntu-latest
-            rust: stable
-            rust-target: x86_64-pc-windows-gnu
-            binary: fluvio-channel.exe
+    #      - os: ubuntu-latest
+    #        rust: stable
+    #        rust-target: x86_64-pc-windows-gnu
+    #        binary: fluvio-channel.exe
           - os: macos-12
             rust: stable
             rust-target: x86_64-apple-darwin
@@ -224,10 +224,10 @@ jobs:
             rust: stable
             rust-target: armv7-unknown-linux-gnueabihf
             binary: fbm
-          - os: ubuntu-latest
-            rust: stable
-            rust-target: x86_64-pc-windows-gnu
-            binary: fbm.exe
+    #      - os: ubuntu-latest
+    #        rust: stable
+    #        rust-target: x86_64-pc-windows-gnu
+    #        binary: fbm.exe
           - os: macos-12
             rust: stable
             rust-target: x86_64-apple-darwin
@@ -1209,8 +1209,8 @@ jobs:
             artifact: smdk
           - rust-target: arm-unknown-linux-gnueabihf
             artifact: smdk
-          - rust-target: x86_64-pc-windows-gnu
-            artifact: smdk.exe
+    #      - rust-target: x86_64-pc-windows-gnu
+    #        artifact: smdk.exe
         include:
           - rust-target: x86_64-unknown-linux-musl
             artifact: fluvio-run
@@ -1218,14 +1218,14 @@ jobs:
             artifact: fluvio-run
           - rust-target: aarch64-apple-darwin
             artifact: fluvio-run
-          - rust-target: x86_64-pc-windows-gnu
-            artifact: fluvio.exe
-          - rust-target: x86_64-pc-windows-gnu
-            artifact: fluvio-channel.exe
+     #     - rust-target: x86_64-pc-windows-gnu
+     #       artifact: fluvio.exe
+     #     - rust-target: x86_64-pc-windows-gnu
+     #       artifact: fluvio-channel.exe
           - rust-target: x86_64-unknown-linux-musl
             artifact: fluvio-test
-          - rust-target: x86_64-pc-windows-gnu
-            artifact: fbm.exe
+      #    - rust-target: x86_64-pc-windows-gnu
+      #      artifact: fbm.exe
     permissions: write-all
     steps:
       #- name: Login GH CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions: read-all
 #permissions:
 #  contents: read
 
-concurrency:
+concurrency: 
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
@@ -568,7 +568,7 @@ jobs:
       TEST_BIN: ~/bin/fluvio-test
       SERVER_LOG: fluvio=info
     strategy:
-      fail-fast: false
+ #     fail-fast: false
       matrix:
         os: [ubuntu-latest]
         rust-target: [x86_64-unknown-linux-musl]
@@ -631,22 +631,22 @@ jobs:
         run: sleep 15
       - name: Validate test harness
         if: matrix.test == 'validate-test-harness'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run : |
           make validate-test-harness
       - name: Run smoke-test
         if: matrix.test == 'smoke-test'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           make smoke-test-local
       - name: Run smoke-test-at-most-once
         if: matrix.test == 'smoke-test-at-most-once'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           make smoke-test-at-most-once
       - name: Run smoke-test-tls
         if: matrix.test == 'smoke-test-tls'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           make smoke-test-tls-root
       #      kubectl get partitions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -989,7 +989,7 @@ jobs:
         timeout-minutes: 5
         run: make FLUVIO_BIN=~/bin/fluvio cli-fluvio-smoke
       - name: Run SMDK smoke tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         if: matrix.cli == 'smdk'
         run: make SMDK_BIN=~/bin/smdk cli-smdk-smoke
       - name: Run diagnostics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-async-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab83884d2a39e57047387dc20a62cf6e28d1e3212591ad64826c4dbb5dfa76"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls 0.20.7",
+ "rustls-pemfile",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
 name = "fluvio-auth"
 version = "0.0.0"
 dependencies = [
@@ -2579,6 +2593,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "cfg-if",
+ "fluvio-async-tls",
  "fluvio-test-derive 0.1.1",
  "fluvio-wasm-timer",
  "futures-lite",
@@ -2591,9 +2606,12 @@ dependencies = [
  "openssl-sys",
  "pin-project",
  "pin-utils",
+ "rustls 0.20.7",
+ "rustls-pemfile",
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "webpki 0.22.0",
  "ws_stream_wasm",
 ]
 

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -14,7 +14,7 @@ name = "fluvio"
 path = "src/lib.rs"
 
 [features]
-default = ["openssl_tls"]
+default = ["rust_tls"]
 admin = ["fluvio-sc-schema/use_serde"]
 smartengine = ["fluvio-smartengine"]
 openssl_tls = ["fluvio-future/openssl_tls"]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -14,9 +14,11 @@ name = "fluvio"
 path = "src/lib.rs"
 
 [features]
-default = []
+default = ["openssl_tls"]
 admin = ["fluvio-sc-schema/use_serde"]
 smartengine = ["fluvio-smartengine"]
+openssl_tls = ["fluvio-future/openssl_tls"]
+rust_tls = ["fluvio-future/rust_tls"]
 unstable = []
 
 [dependencies]
@@ -45,7 +47,6 @@ anyhow = "1.0.38"
 # Fluvio dependencies
 fluvio-future = { version = "0.4.2", features = [
     "task",
-    "openssl_tls",
     "task_unstable",
     "retry",
     "sync"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -14,7 +14,7 @@ name = "fluvio"
 path = "src/lib.rs"
 
 [features]
-default = ["rust_tls"]
+default = ["openssl_tls"]
 admin = ["fluvio-sc-schema/use_serde"]
 smartengine = ["fluvio-smartengine"]
 openssl_tls = ["fluvio-future/openssl_tls"]

--- a/crates/fluvio/src/config/tls.rs
+++ b/crates/fluvio/src/config/tls.rs
@@ -4,8 +4,6 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::fmt::{Debug, self};
 
-use fluvio_future::rust_tls::TlsAnonymousConnector;
-use fluvio_future::rust_tls::TlsDomainConnector;
 use tracing::info;
 use serde::{Deserialize, Serialize};
 use fluvio_future::net::{DomainConnector, DefaultDomainConnector};
@@ -277,7 +275,8 @@ cfg_if::cfg_if! {
 
 
                 use fluvio_future::rust_tls:: ConnectorBuilder;
-
+                use fluvio_future::rust_tls::TlsAnonymousConnector;
+                use fluvio_future::rust_tls::TlsDomainConnector;
 
                 match config {
                     TlsPolicy::Disabled => Ok(Box::new(DefaultDomainConnector::new())),
@@ -292,6 +291,9 @@ cfg_if::cfg_if! {
                     TlsPolicy::Verified(TlsConfig::Files(tls)) => {
                         info!(
                             domain = &*tls.domain,
+                            ca_cert_path = ?tls.ca_cert,
+                            client.cert = ?tls.cert,
+                            client.key = ?tls.key,
                             "Using verified TLS with certificates from paths"
                         );
 

--- a/crates/fluvio/src/config/tls.rs
+++ b/crates/fluvio/src/config/tls.rs
@@ -4,6 +4,8 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::fmt::{Debug, self};
 
+use fluvio_future::rust_tls::TlsAnonymousConnector;
+use fluvio_future::rust_tls::TlsDomainConnector;
 use tracing::info;
 use serde::{Deserialize, Serialize};
 use fluvio_future::net::{DomainConnector, DefaultDomainConnector};
@@ -183,7 +185,7 @@ cfg_if::cfg_if! {
             }
         }
 
-    } else {
+    } else if #[cfg(feature = "openssl_tls")] {
 
         impl TryFrom<TlsPolicy> for DomainConnector {
             type Error = IoError;
@@ -266,6 +268,74 @@ cfg_if::cfg_if! {
                 }
             }
         }
+    }  else if #[cfg(feature = "rust_tls")] {
+
+        impl TryFrom<TlsPolicy> for DomainConnector {
+            type Error = IoError;
+
+            fn try_from(config: TlsPolicy) -> Result<Self, Self::Error> {
+
+
+                use fluvio_future::rust_tls:: ConnectorBuilder;
+
+
+                match config {
+                    TlsPolicy::Disabled => Ok(Box::new(DefaultDomainConnector::new())),
+                    TlsPolicy::Anonymous => {
+                        info!("Using anonymous TLS");
+                        let rust_tls_connnector: TlsAnonymousConnector = ConnectorBuilder::with_safe_defaults()
+                        .no_cert_verification()
+                        .build().into();
+                        Ok(Box::new(rust_tls_connnector))
+
+                    }
+                    TlsPolicy::Verified(TlsConfig::Files(tls)) => {
+                        info!(
+                            domain = &*tls.domain,
+                            "Using verified TLS with certificates from paths"
+                        );
+
+                        let connector = ConnectorBuilder::with_safe_defaults()
+                        .load_ca_cert(&tls.ca_cert)?
+                        .load_client_certs(&tls.cert, &tls.key)?
+                        .build();
+
+
+                        Ok(Box::new(TlsDomainConnector::new(
+                            connector,
+                            tls.domain
+                        )))
+                    }
+                    TlsPolicy::Verified(TlsConfig::Inline(tls)) => {
+                        info!(
+                            domain = &*tls.domain,
+                            "Using verified TLS with inline certificates"
+                        );
+                        let connector = ConnectorBuilder::with_safe_defaults()
+                        .load_ca_cert_from_bytes(tls.ca_cert.as_bytes())?
+                        .load_client_certs_from_bytes(tls.cert.as_bytes(),tls.key.as_bytes())?
+                        .build();
+
+
+                        Ok(Box::new(TlsDomainConnector::new(
+                            connector,
+                            tls.domain
+                        )))
+                    }
+                }
+            }
+        }
+    } else {
+        // by default, no TLS
+        impl TryFrom<TlsPolicy> for DomainConnector {
+            type Error = IoError;
+
+            fn try_from(_config: TlsPolicy) -> Result<Self, Self::Error> {
+                info!("Using Default Domain connector for wasm");
+                Ok(Box::new(DefaultDomainConnector::new()))
+            }
+        }
+
     }
 
 }

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -25,8 +25,8 @@ k8-set-k8-profile-tls:
 install-local-tls:
 	$(FLUVIO_BIN) cluster start --local  \
 		--tls --server-cert tls/certs/server.crt --server-key tls/certs/server.key \
-		--ca-cert tls/certs/ca.crt --client-cert tls/certs/client.crt	\
-		--client-key tls/certs/client.key --domain fluvio.local
+		--ca-cert tls/certs/ca.crt --client-cert tls/certs/client-root.crt	\
+		--client-key tls/certs/client-root.key --domain fluvio.local
 	
 uninstall-local:
 	$(FLUVIO_BIN) cluster delete --local
@@ -34,8 +34,8 @@ uninstall-local:
 install-k8-tls:
 	$(FLUVIO_BIN) cluster start --develop \
 		--tls --server-cert tls/certs/server.crt --server-key tls/certs/server.key \
-		--ca-cert tls/certs/ca.crt --client-cert tls/certs/client.crt	\
-		--client-key tls/certs/client.key --domain fluvio.local
+		--ca-cert tls/certs/ca.crt --client-cert tls/certs/client-root.crt	\
+		--client-key tls/certs/client-root.key --domain fluvio.local
 
 uninstall-k8:
 	$(FLUVIO_BIN) cluster delete


### PR DESCRIPTION
address part of #2921.
Don't hard code `openssl` as hard dependency.   Instead, it will be turn into optional dependency.  Also introduce `rustls` as another optional dependency.

However, `rustls` doesn't work.
