### PR TITLE
[Merged by Bors] - feat: Add Hub support for installing binary packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "current_platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,6 +2332,7 @@ dependencies = [
  "content_inspector",
  "crossterm",
  "ctrlc",
+ "current_platform",
  "dirs",
  "eyre",
  "flate2",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -74,6 +74,7 @@ async-trait = "0.1.21"
 tokio = { version = "1.3.0", features = ["macros"] }
 async-net = "1.7.0"
 anyhow = { workspace = true }
+current_platform = "0.2"
 
 # Fluvio dependencies
 k8-config = { version = "2.0.0", optional = true }

--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -133,7 +133,6 @@ impl InstallOpt {
         Ok(())
     }
 
-    // Error handling hacked together
     async fn install_plugin(&self, agent: &HttpAgent) -> Result<()> {
         let target = fluvio_index::package_target()?;
 
@@ -244,7 +243,7 @@ impl InstallOpt {
             channel = self.get_channel(),
             systuple = self.get_target(),
         );
-        debug!("accessing url: {binurl}");
+        debug!("Downloading binary from hub: {binurl}");
         let mut resp = http::get(binurl)
             .header("Authorization", actiontoken)
             .await
@@ -261,8 +260,6 @@ impl InstallOpt {
                     .unwrap_or_else(|_err| "couldn't fetch error message".to_string());
                 let msg = format!("Status({code}) {body_err_message}");
                 return Err(crate::CliError::HubError(msg).into());
-                //return Err(HubCliError::Cmd(msg));
-                //return Err(CommonCliError::HttpError(HttpError::InvalidInput("authorization error".into())));
             }
         }
         let data = resp

--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -7,6 +7,7 @@ use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 use super::update::should_always_print_available_update;
 
 use fluvio_cli_common::error::CliError as CommonCliError;
+use fluvio_cli_common::error::HttpError;
 use fluvio_cli_common::install::{
     fetch_latest_version, fetch_package_file, fluvio_extensions_dir, install_bin, install_println,
     fluvio_bin_dir,
@@ -19,7 +20,7 @@ use crate::install::update::{
 #[derive(Parser, Debug)]
 pub struct InstallOpt {
     /// The ID of a package to install, e.g. "fluvio/fluvio-cloud".
-    package: PackageId<MaybeVersion>,
+    package: Option<PackageId<MaybeVersion>>,
     /// Used for testing. Specifies alternate package location, e.g. "test/"
     #[clap(hide = true, long)]
     prefix: Option<String>,
@@ -28,70 +29,164 @@ pub struct InstallOpt {
     /// If the package ID contains a version (e.g. `fluvio/fluvio:0.6.0`), this is ignored
     #[clap(long)]
     pub develop: bool,
+
+    /// When this flag is provided, use the hub. Dev-only
+    #[clap(long)]
+    pub hub: bool,
+}
+
+// Copied from hub-tool (rough hacks to error handling to make this work)
+use fluvio_hub_util as hubutil;
+use hubutil::http;
+use hubutil::http::StatusCode;
+use hubutil::HubAccess;
+pub const HUB_API_BPKG_AUTH: &str = "hub/v0/bpkg-auth"; // copied from hub-tool
+async fn get_binary(
+    channel: &str,
+    systuple: &str,
+    binname: &str,
+    access: &HubAccess,
+) -> Result<Vec<u8>> {
+    let actiontoken = access.get_download_token().await.map_err(|_| {
+        CommonCliError::HttpError(HttpError::InvalidInput("authorization error".into()))
+    })?;
+
+    let binurl = format!(
+        "{}/{HUB_API_BPKG_AUTH}/{channel}/{systuple}/{binname}",
+        access.remote
+    );
+    debug!("accessing url: {binurl}");
+    let mut resp = http::get(binurl)
+        .header("Authorization", actiontoken)
+        .await
+        .map_err(|_| {
+            CommonCliError::HttpError(HttpError::InvalidInput("authorization error".into()))
+        })?;
+
+    match resp.status() {
+        StatusCode::Ok => {}
+        code => {
+            let body_err_message = resp
+                .body_string()
+                .await
+                .unwrap_or_else(|_err| "couldn't fetch error message".to_string());
+            let msg = format!("Status({code}) {body_err_message}");
+            return Err(crate::CliError::HubError(msg).into());
+            //return Err(HubCliError::Cmd(msg));
+            //return Err(CommonCliError::HttpError(HttpError::InvalidInput("authorization error".into())));
+        }
+    }
+    let data = resp
+        .body_bytes()
+        .await
+        .map_err(|_| crate::CliError::HubError("Data unpack failure".into()))?;
+    Ok(data)
 }
 
 impl InstallOpt {
     pub async fn process(self) -> Result<()> {
-        let agent = match &self.prefix {
-            Some(prefix) => HttpAgent::with_prefix(prefix)?,
-            None => HttpAgent::default(),
-        };
+        if self.hub {
+            debug!("Using the hub to install");
 
-        // Before any "install" type command, check if the CLI needs updating.
-        // This may be the case if the index schema has updated.
-        let require_update = check_update_required(&agent).await?;
-        if require_update {
-            prompt_required_update(&agent).await?;
-            return Ok(());
-        }
+            let channel = "latest";
+            let systuple = "aarch64-apple-darwin";
+            let binname = "sample-bin-script";
 
-        match self.install_plugin(&agent).await {
-            Ok(_) => (),
-            Err(err) => match err.downcast_ref::<CliError>() {
-                Some(crate::CliError::IndexError(fluvio_index::Error::MissingTarget(target))) => {
-                    install_println(format!(
-                        "❕ Package '{}' is not available for target {}, skipping",
-                        self.package.name(),
-                        target
-                    ));
-                    install_println("❕ Consider filing an issue to add support for this platform using the link below! 👇");
-                    install_println(format!(
-                            "❕   https://github.com/infinyon/fluvio/issues/new?title=Support+fluvio-cloud+on+target+{}",
+            let access =
+                HubAccess::default_load(&Some("https://hub-dev.infinyon.cloud".to_string()))
+                    .map_err(|_| {
+                        crate::CliError::Other(
+                            "Something happened getting hub dev info".to_string(),
+                        )
+                    })?;
+            let data = get_binary(channel, systuple, binname, &access).await?;
+            std::fs::write(binname, data)?;
+        } else {
+            let agent = match &self.prefix {
+                Some(prefix) => HttpAgent::with_prefix(prefix)?,
+                None => HttpAgent::default(),
+            };
+
+            // Before any "install" type command, check if the CLI needs updating.
+            // This may be the case if the index schema has updated.
+            let require_update = check_update_required(&agent).await?;
+            if require_update {
+                prompt_required_update(&agent).await?;
+                return Ok(());
+            }
+
+            let result = self.install_plugin(&agent).await;
+            match result {
+                Ok(_) => (),
+                Err(err) => match err.downcast_ref::<CliError>() {
+                    Some(crate::CliError::IndexError(fluvio_index::Error::MissingTarget(
+                        target,
+                    ))) => {
+                        install_println(format!(
+                            "❕ Package '{}' is not available for target {}, skipping",
+                            self.package
+                                .ok_or(crate::CliError::Other(
+                                    "Package name not provided".to_string(),
+                                ))?
+                                .name(),
                             target
                         ));
-                    return Ok(());
-                }
-                _ => return Err(err),
-            },
-        }
+                        install_println("❕ Consider filing an issue to add support for this platform using the link below! 👇");
+                        install_println(format!(
+                    "❕   https://github.com/infinyon/fluvio/issues/new?title=Support+fluvio-cloud+on+target+{}",
+                    target
+                ));
+                        return Ok(());
+                    }
+                    _ => return Err(err),
+                },
+            }
 
-        // After any "install" command, check if the CLI has an available update,
-        // i.e. one that is not required, but present.
-        // Sometimes this is printed at the beginning, so we don't print it again here
-        if !should_always_print_available_update() {
-            let update_result = check_update_available(&agent, false).await;
-            if let Ok(Some(latest_version)) = update_result {
-                prompt_available_update(&latest_version);
+            // After any "install" command, check if the CLI has an available update,
+            // i.e. one that is not required, but present.
+            // Sometimes this is printed at the beginning, so we don't print it again here
+            if !should_always_print_available_update() {
+                let update_result = check_update_available(&agent, false).await;
+                if let Ok(Some(latest_version)) = update_result {
+                    prompt_available_update(&latest_version);
+                }
             }
         }
         Ok(())
     }
 
+    // Error handling hacked together
     async fn install_plugin(&self, agent: &HttpAgent) -> Result<()> {
         let target = fluvio_index::package_target()?;
 
         // If a version is given in the package ID, use it. Otherwise, use latest
-        let id = match self.package.maybe_version() {
+        let id = match self
+            .package
+            .clone()
+            .ok_or(crate::CliError::Other(
+                "Package name not provided".to_string(),
+            ))?
+            .maybe_version()
+        {
             Some(version) => {
                 install_println(format!(
                     "⏳ Downloading package with provided version: {}...",
-                    &self.package
+                    &self.package.clone().ok_or(crate::CliError::Other(
+                        "Package name not provided".to_string(),
+                    ))?
                 ));
                 let version = version.clone();
-                self.package.clone().into_versioned(version)
+                self.package
+                    .clone()
+                    .ok_or(crate::CliError::Other(
+                        "Package name not provided".to_string(),
+                    ))?
+                    .into_versioned(version)
             }
             None => {
-                let id = &self.package;
+                let id = &self.package.clone().ok_or(crate::CliError::Other(
+                    "Package name not provided".to_string(),
+                ))?;
                 install_println(format!("🎣 Fetching latest version for package: {}...", id));
                 let version = fetch_latest_version(agent, id, &target, self.develop).await?;
                 let id = id.clone().into_versioned(version.into());

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -23,8 +23,8 @@ pub const ACTION_CREATE_HUBID: &str = "chid";
 pub const ACTION_DOWNLOAD: &str = "dl";
 pub const ACTION_PUBLISH: &str = "pbl";
 
-const INFINYON_HUB_REMOTE: &str = "INFINYON_HUB_REMOTE";
-const FLUVIO_HUB_PROFILE_ENV: &str = "FLUVIO_HUB_PROFILE";
+pub const INFINYON_HUB_REMOTE: &str = "INFINYON_HUB_REMOTE";
+pub const FLUVIO_HUB_PROFILE_ENV: &str = "FLUVIO_HUB_PROFILE";
 
 #[derive(Serialize, Deserialize)]
 pub struct HubAccess {


### PR DESCRIPTION
Resolves #2894 

Adds `--hub` feature flag to `fluvio install`. CLI fetches binaries from the hub instead of packages.fluvio.io

example command installs executable binary `sample-bin-script` to `~/.fluvio/bin/`

```shell
fluvio install sample-bin-script --hub
```

```shell
% sample-bin-script
hello world
```