### PR TITLE
feat(cli): add download connector package command

### DIFF
--- a/crates/fluvio-cli/src/client/hub/connector.rs
+++ b/crates/fluvio-cli/src/client/hub/connector.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::fmt::Debug;
 
@@ -6,22 +7,28 @@ use clap::Parser;
 use fluvio_extension_common::Terminal;
 use fluvio_hub_util::HUB_API_CONN_LIST;
 
-use crate::Result;
+use crate::{Result, error::CliError};
 use crate::common::OutputFormat;
 
-use super::get_pkg_list;
+use super::{get_pkg_list, get_hub_access};
 
 /// List available Connectors in the hub
 #[derive(Debug, Parser)]
 pub enum ConnectorHubSubCmd {
+    /// List all available SmartConnectors
     #[clap(name = "list")]
     List(ConnectorHubListOpts),
+
+    /// Download SmartConnector to the local folder
+    #[clap(name = "download")]
+    Download(ConnectorHubDownloadOpts),
 }
 
 impl ConnectorHubSubCmd {
     pub async fn process<O: Terminal + Debug + Send + Sync>(self, out: Arc<O>) -> Result<()> {
         match self {
             ConnectorHubSubCmd::List(opts) => opts.process(out).await,
+            ConnectorHubSubCmd::Download(opts) => opts.process(out).await,
         }
     }
 }
@@ -39,6 +46,64 @@ impl ConnectorHubListOpts {
     pub async fn process<O: Terminal + Debug + Send + Sync>(self, out: Arc<O>) -> Result<()> {
         let pl = get_pkg_list(HUB_API_CONN_LIST, &self.remote).await?;
         output::tableformat(out, pl.packages, self.output.format)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct ConnectorHubDownloadOpts {
+    /// SmartConnector name: e.g. infinyon/salesforce-sink@v0.0.1
+    #[clap(value_name = "name", required = true)]
+    package_name: String,
+
+    /// Target local folder or file name
+    #[clap(short, long, value_name = "PATH")]
+    output: Option<PathBuf>,
+
+    #[clap(long, hide_short_help = true)]
+    remote: Option<String>,
+}
+
+impl ConnectorHubDownloadOpts {
+    pub async fn process<O: Terminal + Debug + Send + Sync>(self, _out: Arc<O>) -> Result<()> {
+        let access = get_hub_access(&self.remote)?;
+
+        let package_name = self.package_name;
+        let file_name = fluvio_hub_util::cli_pkgname_to_filename(&package_name).map_err(|_| {
+            CliError::HubError(format!(
+                "invalid package name format {package_name}, is it the form infinyon/json-sql@0.1.0"
+            ))
+        })?;
+
+        let file_path = if let Some(mut output) = self.output {
+            if output.is_dir() {
+                output.push(file_name);
+            }
+            output
+        } else {
+            PathBuf::from(file_name)
+        };
+        println!(
+            "downloading {package_name} to {}",
+            file_path.to_string_lossy()
+        );
+
+        let url = fluvio_hub_util::cli_conn_pkgname_to_url(&package_name, &access.remote)
+            .map_err(|_| CliError::HubError(format!("invalid pkgname {package_name}")))?;
+
+        let data = fluvio_hub_util::get_package(&url, &access)
+            .await
+            .map_err(|err| {
+                CliError::HubError(format!("downloading {package_name} failed\nServer: {err}"))
+            })?;
+
+        std::fs::write(file_path, data).map_err(|err| {
+            CliError::Other(format!(
+                "unable to write downloaded package to the disk: {}",
+                err
+            ))
+        })?;
+        println!("... downloading complete");
         Ok(())
     }
 }

--- a/crates/fluvio-cli/src/client/hub/download.rs
+++ b/crates/fluvio-cli/src/client/hub/download.rs
@@ -16,7 +16,7 @@ use fluvio_extension_common::target::ClusterTarget;
 use fluvio_hub_util as hubutil;
 use hubutil::HubAccess;
 
-use crate::{CliError};
+use crate::CliError;
 use crate::client::cmd::ClientCmd;
 use crate::client::hub::get_hub_access;
 

--- a/crates/fluvio-hub-util/src/utils.rs
+++ b/crates/fluvio-hub-util/src/utils.rs
@@ -52,6 +52,18 @@ pub fn cli_pkgname_to_url(pkgname: &str, remote: &str) -> Result<String> {
     Ok(urlstring)
 }
 
+/// Returns url string on sucess or Err(InvalidPackageName)
+pub fn cli_conn_pkgname_to_url(pkgname: &str, remote: &str) -> Result<String> {
+    let (org, pkg, ver) = cli_pkgname_split(pkgname)?;
+    // buildup something like: https://hub.infinyon.cloud/connector/pkg/v0/sm/example/0.0.1
+    let urlstring = if org.is_empty() {
+        format!("{remote}/{HUB_API_CONN_PKG}/{pkg}/{ver}")
+    } else {
+        format!("{remote}/{HUB_API_CONN_PKG}/{org}/{pkg}/{ver}")
+    };
+    Ok(urlstring)
+}
+
 /// Returns filename on sucess or Err(InvalidPackageName)
 pub fn cli_pkgname_to_filename(pkgname: &str) -> Result<String> {
     let (org, pkg, ver) = cli_pkgname_split(pkgname)?;


### PR DESCRIPTION
Download connector package from the Hub using fluvio-cli:
```
fluvio hub connector download infinyon/some-connector-name@0.1.0
```
The downloaded file can be used to run connector locally using:
```
cdk deploy local --ipkg ...
```

Related #2832