### PR TITLE
[Merged by Bors] - Update segment.rs

### DIFF
--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -133,6 +133,7 @@ where
                 );
                 match max_offset_opt {
                     Some(max_offset) => {
+                        let max_offset = std::cmp::min(max_offset, self.get_end_offset());
                         // check if max offset same as segment end
                         if max_offset == self.get_end_offset() {
                             debug!("max offset is same as end offset, reading to end");

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -133,7 +133,7 @@ where
                 );
                 match max_offset_opt {
                     Some(max_offset) => {
-                        // max_offset comes from HW, which could be greater than segment end.
+                        // max_offset comes from HW, which could be greater than current segment end.
                         let max_offset = std::cmp::min(max_offset, self.get_end_offset());
                         // check if max offset same as segment end
                         if max_offset == self.get_end_offset() {
@@ -669,5 +669,13 @@ mod tests {
         next_batch.base_offset = 1000;
         assert!(seg_sink.append_batch(&mut next_batch).await.is_ok());
         assert_eq!(seg_sink.get_end_offset(), 50);
+
+        let _records = seg_sink
+            .records_slice(44, Some(52))
+            .await
+            .expect(
+                "failed to get records using max offset larger than current end offset in segment",
+            )
+            .expect("failed to get records");
     }
 }

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -133,6 +133,7 @@ where
                 );
                 match max_offset_opt {
                     Some(max_offset) => {
+                        // max_offset comes from HW, which could be greater than segment end.
                         let max_offset = std::cmp::min(max_offset, self.get_end_offset());
                         // check if max offset same as segment end
                         if max_offset == self.get_end_offset() {


### PR DESCRIPTION
Currently when using `Isolation::ReadCommitted`, we read records until current HW. https://github.com/infinyon/fluvio/blob/934544dec2403cd65113eda5c2a6fb6b509793d4/crates/fluvio-storage/src/replica.rs#L106

Here, there are two scenarios. If Start offset is greater or equal than base offset of current active segment. Then read_records is call in that segment. If HW is greater than last offset in that segment it will fail. (I think that this scenario should not happen since current active segment should be ok)
https://github.com/infinyon/fluvio/blob/934544dec2403cd65113eda5c2a6fb6b509793d4/crates/fluvio-storage/src/replica.rs#L348

On the other hand, if the start offset is in a old segment, it calls find_slice, that first checks in which segment is the start offset and then call `read_records` there. This read_records will fail if that HW offset is not in the current segment.

https://github.com/infinyon/fluvio/blob/934544dec2403cd65113eda5c2a6fb6b509793d4/crates/fluvio-storage/src/replica.rs#L361

This PR updates read_records to truncate max_offset to end_offset of current segment if it is larger than that so we can read records of that segment without failures
