### PR TITLE
[Merged by Bors] - feat: fixup fluvio install --hub

### DIFF
--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -79,7 +79,7 @@ impl InstallOpt {
             {
                 None
             } else {
-                Some("https://hub-dev.infinyon.cloud".to_string())
+                Some("https://hub.infinyon.cloud".to_string())
             };
 
             let access = HubAccess::default_load(&access_remote).map_err(|_| {
@@ -243,7 +243,7 @@ impl InstallOpt {
     }
 
     async fn get_binary(&self, bin_name: &str, access: &HubAccess) -> Result<Vec<u8>> {
-        let actiontoken = access.get_download_token().await.map_err(|_| {
+        let actiontoken = access.get_bpkg_get_token().await.map_err(|_| {
             CommonCliError::HttpError(HttpError::InvalidInput("authorization error".into()))
         })?;
 

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -22,7 +22,7 @@ pub const ACTION_LIST_WITH_META: &str = "lwm";
 pub const ACTION_CREATE_HUBID: &str = "chid";
 pub const ACTION_DOWNLOAD: &str = "dl";
 pub const ACTION_PUBLISH: &str = "pbl";
-
+pub const ACTION_BPKG_GET: &str = "bpkg-get";
 pub const INFINYON_HUB_REMOTE: &str = "INFINYON_HUB_REMOTE";
 pub const FLUVIO_HUB_PROFILE_ENV: &str = "FLUVIO_HUB_PROFILE";
 
@@ -90,6 +90,10 @@ impl HubAccess {
             }
         }
         Ok(())
+    }
+
+    pub async fn get_bpkg_get_token(&self) -> Result<String> {
+        self.get_action_auth(ACTION_BPKG_GET).await
     }
 
     pub async fn get_download_token(&self) -> Result<String> {


### PR DESCRIPTION
switch to production hub host by default
use required action request
This will allow blt installs on the latest channel:
$ fluvio install --hub blt