### PR TITLE
[Merged by Bors] - fix: fluvio cli update is too frequent

### DIFF
--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -24,7 +24,6 @@ pub use root::{Root, HelpOpt};
 pub use client::TableFormatConfig;
 
 mod root {
-
     use crate::check_for_channel_update;
     use std::sync::Arc;
     use std::path::PathBuf;
@@ -62,6 +61,7 @@ mod root {
     impl Root {
         pub async fn process(self) -> Result<()> {
             if command_triggers_update_check(&self.command) {
+                tracing::info!("Triggered a Fluvio Update Check");
                 check_for_channel_update().await;
             }
 


### PR DESCRIPTION
Uses `fluvio version` and `fluvio update` as commands that triggers
Fluvio CLI update checks instead.

---

## Demo

With changes introduced the `fluvio` command will check for updates only
when using `fluvio version` and/or `fluvio update`.


https://user-images.githubusercontent.com/34756077/215342166-223612ad-1f7c-49a2-80cb-16dcea6545b0.mov


> `./fluvio` is the `target/debug/fluvio` file outputted by the `cargo build` command. Corresponds to the version included in this PR

The current version checks for updates on ever command execution instead.

https://user-images.githubusercontent.com/34756077/215342243-14535a2c-d62e-4a11-b86b-8e15db73649b.mov

