### PR TITLE
[Merged by Bors] - chore: pin to specific rust release

### DIFF
--- a/toolchain.toml
+++ b/toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable-2023-01-24"

--- a/toolchain.toml
+++ b/toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable-2023-01-24"
+channel = "stable-2023-03-06"


### PR DESCRIPTION
Instead of building to being broken every rust release, pin to specific release until code is caught up