### PR TITLE
[Merged by Bors] - feat(cdk): enhance deploy options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "walkdir",
 ]
 
@@ -839,7 +839,7 @@ checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
  "semver 1.0.16",
  "serde",
- "toml",
+ "toml 0.5.11",
  "url",
 ]
 
@@ -874,7 +874,7 @@ checksum = "e72c3ff59e3b7d24630206bb63a73af65da4ed5df1f76ee84dfafb9fee2ba60e"
 dependencies = [
  "serde",
  "serde_derive",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -911,12 +911,16 @@ dependencies = [
  "anyhow",
  "cargo-builder",
  "clap 4.1.4",
+ "comfy-table",
  "fluvio",
  "fluvio-connector-deployer",
  "fluvio-connector-package",
  "fluvio-future",
  "fluvio-hub-util",
+ "serde",
+ "sysinfo",
  "thiserror",
+ "toml 0.7.1",
  "tracing",
 ]
 
@@ -938,7 +942,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "toml-diff",
 ]
 
@@ -2228,7 +2232,7 @@ dependencies = [
  "siphasher",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "wasm-bindgen-test",
 ]
@@ -2288,7 +2292,7 @@ dependencies = [
  "semver 1.0.16",
  "serde",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -2533,7 +2537,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.8.26",
  "tempfile",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -2566,7 +2570,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.9.17",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -2647,7 +2651,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -2678,7 +2682,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "wasmparser",
 ]
@@ -2933,7 +2937,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -4820,6 +4824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6150,6 +6163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6405,7 +6427,7 @@ dependencies = [
  "lib-cargo-crate",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "tracing",
 ]
 
@@ -6950,11 +6972,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml-diff"
 version = "0.0.0"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -7052,7 +7109,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -7499,7 +7556,7 @@ dependencies = [
  "rustix",
  "serde",
  "sha2 0.10.6",
- "toml",
+ "toml 0.5.11",
  "windows-sys",
  "zstd",
 ]

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -23,6 +23,12 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
 cargo-builder = { path = "../cargo-builder"}
 
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+toml = { version = "0.7", default-features = false, features = ["parse", "display", "preserve_order"] }
+comfy-table = { version = "6.1" }
+sysinfo = { version = "0.27", default-features = false }
+
+
 fluvio = { path = "../fluvio"}
 fluvio-connector-deployer = { path = "../fluvio-connector-deployer"}
 fluvio-connector-package = { path = "../fluvio-connector-package", features = ["toml"]}

--- a/crates/cdk/src/build.rs
+++ b/crates/cdk/src/build.rs
@@ -7,7 +7,7 @@ use cargo_builder::{package::PackageInfo, cargo::Cargo};
 
 use crate::cmd::PackageCmd;
 
-/// Builds the Connector in the current working directory
+/// Build the Connector in the current working directory
 #[derive(Debug, Parser)]
 pub struct BuildCmd {
     #[clap(flatten)]

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -18,14 +18,14 @@ use crate::cmd::PackageCmd;
 
 const CONNECTOR_METADATA_FILE_NAME: &str = "Connector.toml";
 
-/// Deploys the Connector from the current working directory
+/// Deploy the Connector from the current working directory
 #[derive(Debug, Parser)]
 pub struct DeployCmd {
     #[clap(flatten)]
     package: PackageCmd,
 
     #[command(subcommand)]
-    deployment_type: DeploymentTypeCmd,
+    operation: DeployOperationCmd,
 
     /// Extra arguments to be passed to cargo
     #[clap(raw = true)]
@@ -33,7 +33,22 @@ pub struct DeployCmd {
 }
 
 #[derive(Debug, Subcommand)]
-enum DeploymentTypeCmd {
+enum DeployOperationCmd {
+    #[command(flatten)]
+    Start(DeployStartCmd),
+    #[command(flatten)]
+    Shutdown(DeployShutdownCmd),
+    #[command(flatten)]
+    List(DeployListCmd),
+    #[command(flatten)]
+    Log(DeployLogCmd),
+}
+
+#[derive(Debug, Subcommand)]
+enum DeployStartCmd {
+    /// Start new deployment for the given connector config
+    // As long as there is only one deployment type, we omit to specify its name
+    #[command(name = "start")]
     Local {
         #[clap(short, long, value_name = "PATH")]
         config: PathBuf,
@@ -44,17 +59,86 @@ enum DeploymentTypeCmd {
     },
 }
 
+#[derive(Debug, Subcommand)]
+enum DeployShutdownCmd {
+    /// Shutdown the Connector's deployment
+    // As long as there is only one deployment type, we omit to specify its name
+    #[command(name = "shutdown")]
+    Local {
+        #[clap(value_name = "CONNECTOR_NAME")]
+        name: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum DeployListCmd {
+    /// Print the list of all deployed connectors
+    // As long as there is only one deployment type, we omit to specify its name
+    #[command(name = "list")]
+    Local,
+}
+
+#[derive(Debug, Subcommand)]
+enum DeployLogCmd {
+    /// Print the connector's logs
+    // As long as there is only one deployment type, we omit to specify its name
+    #[command(name = "log")]
+    Local {
+        #[clap(value_name = "CONNECTOR_NAME")]
+        name: String,
+    },
+}
+
 impl DeployCmd {
     pub(crate) fn process(self) -> Result<()> {
         let DeployCmd {
             package,
-            deployment_type,
-            extra_arguments: _,
+            operation,
+            extra_arguments,
         } = self;
-        match deployment_type {
-            DeploymentTypeCmd::Local { config, ipkg_file } => {
-                deploy_local(package, config, ipkg_file)
-            }
+        operation.process(package, extra_arguments)
+    }
+}
+
+impl DeployOperationCmd {
+    pub(crate) fn process(self, package: PackageCmd, _extra_arguments: Vec<String>) -> Result<()> {
+        match self {
+            Self::Start(deployment_type) => deployment_type.process(package),
+            Self::Shutdown(deployment_type) => deployment_type.process(),
+            Self::List(deployment_type) => deployment_type.process(),
+            Self::Log(deployment_type) => deployment_type.process(),
+        }
+    }
+}
+
+impl DeployStartCmd {
+    pub(crate) fn process(self, package: PackageCmd) -> Result<()> {
+        match self {
+            Self::Local { config, ipkg_file } => deploy_local(package, config, ipkg_file),
+        }
+    }
+}
+
+impl DeployListCmd {
+    pub(crate) fn process(self) -> Result<()> {
+        match self {
+            Self::Local => local_index::print(),
+        }
+    }
+}
+
+impl DeployShutdownCmd {
+    pub(crate) fn process(self) -> Result<()> {
+        match self {
+            Self::Local { name } => local_index::delete_by_name(&name),
+        }
+    }
+}
+
+impl DeployLogCmd {
+    pub(crate) fn process(self) -> Result<()> {
+        match self {
+            Self::Local { name } => local_index::print_log(&name),
         }
     }
 }
@@ -82,7 +166,8 @@ fn deploy_local(
         .deployment_type(DeploymentType::Local {
             output_file: Some(log_path),
         });
-    builder.deploy()
+    let result = builder.deploy()?;
+    local_index::store(result)
 }
 
 pub(crate) fn from_cargo_package(package_cmd: PackageCmd) -> Result<(PathBuf, ConnectorMetadata)> {
@@ -149,4 +234,434 @@ fn set_exec_permissions(f: &mut File) -> Result<()> {
 #[cfg(not(unix))]
 fn set_exec_permissions(f: &mut File) -> Result<()> {
     Ok(())
+}
+
+mod local_index {
+
+    use std::{
+        path::{PathBuf, Path},
+        fmt::Display,
+        io::Write,
+    };
+    use comfy_table::Table;
+    use serde::{Serialize, Deserialize};
+
+    use anyhow::Result;
+    use fluvio_connector_deployer::DeploymentResult;
+    use sysinfo::{SystemExt, Pid, PidExt, ProcessExt};
+    use tracing::debug;
+
+    const LOCAL_INDEX_FILE_NAME: &str = "fluvio_cdk_deploy_index.toml";
+    const LIST_TABLE_HEADERS: [&str; 2] = ["NAME", "STATUS"];
+
+    #[derive(Debug, Serialize, Deserialize, Default)]
+    struct LocalIndex<T: ConnectorOperator> {
+        entries: Vec<Entry>,
+        #[serde(skip)]
+        path: PathBuf,
+        #[serde(skip)]
+        operator: T,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum Entry {
+        Local {
+            process_id: u32,
+            name: String,
+            log_file: Option<PathBuf>,
+        },
+    }
+
+    enum ConnectorStatus {
+        Running,
+        Stopped,
+    }
+
+    trait ConnectorOperator: Default {
+        fn status(&self, entry: &Entry) -> Result<ConnectorStatus>;
+
+        fn kill(&self, entry: &Entry) -> Result<()>;
+    }
+
+    struct LocalProcesses {
+        system: sysinfo::System,
+    }
+
+    impl<T: ConnectorOperator> LocalIndex<T> {
+        fn load<P: AsRef<Path>>(index_path: P) -> Result<Self> {
+            let index_path = index_path.as_ref();
+            debug!(?index_path, "loading");
+            let mut index: Self =
+                match std::fs::read_to_string(index_path).map(|content| toml::from_str(&content)) {
+                    Ok(Ok(index)) => index,
+                    Ok(Err(err)) => {
+                        debug!(?err, "index file parsing failed");
+                        Default::default()
+                    }
+                    Err(err) => {
+                        debug!(?err, "index file read failed");
+                        Default::default()
+                    }
+                };
+            index.path = index_path.to_owned();
+            Ok(index)
+        }
+
+        fn insert(&mut self, entry: Entry) {
+            self.entries.push(entry)
+        }
+
+        fn remove(&mut self, index: usize) -> Result<()> {
+            let entry = self.entries.remove(index);
+            self.operator.kill(&entry)
+        }
+
+        fn find_by_name(&self, connector_name: &str) -> Option<(usize, &Entry)> {
+            self.entries.iter().enumerate().find(|(_, entry)| {
+                let Entry::Local {
+                    process_id: _,
+                    name,
+                    log_file: _,
+                } = entry;
+
+                name.eq(connector_name)
+            })
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            let index_path = &self.path;
+            debug!(?index_path, "flushing");
+            let content = toml::to_string(self)?;
+            Ok(std::fs::write(index_path, content)?)
+        }
+
+        fn print_table<W: Write>(self, mut writer: W) -> Result<()> {
+            if self.entries.is_empty() {
+                writeln!(writer, "No connectors found")?;
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table.load_preset(comfy_table::presets::NOTHING);
+            table.set_header(LIST_TABLE_HEADERS);
+
+            let mut system = sysinfo::System::new();
+            system.refresh_processes();
+            for connector in self.entries {
+                let status = self.operator.status(&connector)?;
+                let Entry::Local {
+                    process_id: _,
+                    name,
+                    log_file: _,
+                } = connector;
+
+                table.add_row(vec![name, status.to_string()]);
+            }
+            writeln!(writer, "{table}")?;
+            Ok(())
+        }
+    }
+
+    impl ConnectorOperator for LocalProcesses {
+        fn status(&self, entry: &Entry) -> Result<ConnectorStatus> {
+            let Entry::Local {
+                process_id,
+                name: _,
+                log_file: _,
+            } = entry;
+            let status = if self.system.process(Pid::from_u32(*process_id)).is_some() {
+                ConnectorStatus::Running
+            } else {
+                ConnectorStatus::Stopped
+            };
+            Ok(status)
+        }
+
+        fn kill(&self, entry: &Entry) -> Result<()> {
+            let Entry::Local {
+                process_id,
+                name: _,
+                log_file: _,
+            } = entry;
+
+            if let Some(process) = self.system.process(Pid::from_u32(*process_id)) {
+                process.kill();
+            }
+
+            Ok(())
+        }
+    }
+
+    impl Default for LocalProcesses {
+        fn default() -> Self {
+            let mut system: sysinfo::System = Default::default();
+            system.refresh_processes();
+            Self { system }
+        }
+    }
+
+    impl From<DeploymentResult> for Entry {
+        fn from(value: DeploymentResult) -> Self {
+            match value {
+                DeploymentResult::Local {
+                    process_id,
+                    name,
+                    log_file,
+                } => Entry::Local {
+                    process_id,
+                    name,
+                    log_file,
+                },
+            }
+        }
+    }
+
+    impl Display for ConnectorStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let str = match self {
+                Self::Running => "Running",
+                Self::Stopped => "Stopped",
+            };
+            write!(f, "{str}")
+        }
+    }
+
+    pub(super) fn store(deployment: DeploymentResult) -> Result<()> {
+        let mut index = load()?;
+        index.insert(deployment.into());
+        index.flush()
+    }
+
+    pub(super) fn print() -> Result<()> {
+        let index = load()?;
+        index.print_table(std::io::stdout())
+    }
+
+    pub(super) fn delete_by_name(connector_name: &str) -> Result<()> {
+        let mut index = load()?;
+        if let Some((i, _)) = index.find_by_name(connector_name) {
+            index.remove(i)?;
+        }
+        index.flush()
+    }
+
+    pub(super) fn print_log(connector_name: &str) -> Result<()> {
+        let index = load()?;
+        if let Some((
+            _,
+            Entry::Local {
+                process_id: _,
+                name: _,
+                log_file: Some(log_file),
+            },
+        )) = index.find_by_name(connector_name)
+        {
+            let mut buf_reader = std::io::BufReader::new(std::fs::File::open(log_file)?);
+            std::io::copy(&mut buf_reader, &mut std::io::stdout())?;
+        };
+
+        Ok(())
+    }
+
+    fn load() -> Result<LocalIndex<LocalProcesses>> {
+        let mut index_path = std::env::temp_dir();
+        index_path.push(LOCAL_INDEX_FILE_NAME);
+        LocalIndex::load(index_path)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::{io::Cursor, time::SystemTime};
+
+        use super::*;
+
+        #[test]
+        fn test_load_from_non_existing_file() -> Result<()> {
+            //given
+            let file_path = "non_existing_file";
+
+            //when
+            let index: LocalIndex<NoopOperator> = LocalIndex::load(file_path)?;
+
+            let mut output = Cursor::new(Vec::new());
+            index.print_table(&mut output)?;
+            let output = String::from_utf8_lossy(output.get_ref());
+
+            //then
+            assert_eq!(output, "No connectors found\n");
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_load_from_empty_file() -> Result<()> {
+            //given
+            let file_path = TestFile::new();
+            std::fs::write(&file_path, [])?;
+
+            //when
+            let result = LocalIndex::load(&file_path);
+            let index: LocalIndex<NoopOperator> = result?;
+
+            let mut output = Cursor::new(Vec::new());
+            index.print_table(&mut output)?;
+            let output = String::from_utf8_lossy(output.get_ref());
+
+            //then
+            assert_eq!(output, "No connectors found\n");
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_load_empty_add_and_flush() -> Result<()> {
+            //given
+            let file_path = TestFile::new();
+
+            //when
+            let mut index: LocalIndex<NoopOperator> = LocalIndex::load(&file_path)?;
+            index.insert(Entry::Local {
+                process_id: 1,
+                name: "test_connector".to_owned(),
+                log_file: None,
+            });
+            index.flush()?;
+
+            //then
+            let mut output = Cursor::new(Vec::new());
+            index.print_table(&mut output)?;
+            let output = String::from_utf8_lossy(output.get_ref());
+
+            assert_eq!(
+                output,
+                " NAME            STATUS  \n test_connector  Running \n"
+            );
+
+            assert_eq!(
+                std::fs::read_to_string(file_path)?,
+                "[[entries]]\ntype = \"local\"\nprocess_id = 1\nname = \"test_connector\"\n"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_load_add_and_flush() -> Result<()> {
+            //given
+            let file_path = TestFile::new();
+            std::fs::write(
+                &file_path,
+                b"[[entries]]\ntype = \"local\"\nprocess_id = 1\nname = \"test_connector\"\n",
+            )?;
+
+            //when
+            let mut index: LocalIndex<NoopOperator> = LocalIndex::load(&file_path)?;
+            assert!(index.find_by_name("test_connector").is_some());
+
+            index.insert(Entry::Local {
+                process_id: 2,
+                name: "test_connector2".to_owned(),
+                log_file: None,
+            });
+            index.flush()?;
+
+            //then
+            let mut output = Cursor::new(Vec::new());
+            index.print_table(&mut output)?;
+            let output = String::from_utf8_lossy(output.get_ref());
+
+            assert_eq!(
+                output,
+                " NAME             STATUS  \n test_connector   Running \n test_connector2  Running \n"
+            );
+
+            assert_eq!(
+                std::fs::read_to_string(file_path)?,
+                "[[entries]]\ntype = \"local\"\nprocess_id = 1\nname = \"test_connector\"\n\n[[entries]]\ntype = \"local\"\nprocess_id = 2\nname = \"test_connector2\"\n"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_remove() -> Result<()> {
+            //given
+            let file_path = TestFile::new();
+            std::fs::write(
+                &file_path,
+                b"[[entries]]\ntype = \"local\"\nprocess_id = 1\nname = \"test_connector\"\n\n[[entries]]\ntype = \"local\"\nprocess_id = 2\nname = \"test_connector2\"\n",
+            )?;
+
+            //when
+            let mut index: LocalIndex<NoopOperator> = LocalIndex::load(&file_path)?;
+            assert!(index.find_by_name("test_connector2").is_some());
+            let (i, _) = index
+                .find_by_name("test_connector")
+                .expect("connector not found");
+
+            index.remove(i)?;
+            assert!(index.find_by_name("test_connector").is_none());
+
+            index.flush()?;
+
+            //then
+            let mut output = Cursor::new(Vec::new());
+            index.print_table(&mut output)?;
+            let output = String::from_utf8_lossy(output.get_ref());
+
+            assert_eq!(
+                output,
+                " NAME             STATUS  \n test_connector2  Running \n"
+            );
+
+            assert_eq!(
+                std::fs::read_to_string(file_path)?,
+                "[[entries]]\ntype = \"local\"\nprocess_id = 2\nname = \"test_connector2\"\n"
+            );
+
+            Ok(())
+        }
+
+        #[derive(Default)]
+        struct NoopOperator;
+
+        impl ConnectorOperator for NoopOperator {
+            fn status(&self, _entry: &Entry) -> Result<ConnectorStatus> {
+                Ok(ConnectorStatus::Running)
+            }
+
+            fn kill(&self, _entry: &Entry) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        struct TestFile(PathBuf);
+
+        impl TestFile {
+            fn new() -> Self {
+                let mut file_path = std::env::temp_dir();
+                file_path.push(
+                    SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .expect("system time broken")
+                        .as_nanos()
+                        .to_string(),
+                );
+                Self(file_path)
+            }
+        }
+
+        impl Drop for TestFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+
+        impl AsRef<Path> for TestFile {
+            fn as_ref(&self) -> &Path {
+                self.0.as_ref()
+            }
+        }
+    }
 }

--- a/crates/cdk/src/test.rs
+++ b/crates/cdk/src/test.rs
@@ -8,7 +8,7 @@ use fluvio_connector_deployer::{Deployment, DeploymentType};
 
 use crate::{cmd::PackageCmd, deploy::from_cargo_package};
 
-/// Builds and runs the Connector in the current working directory
+/// Build and run the Connector in the current working directory
 #[derive(Debug, Parser)]
 pub struct TestCmd {
     #[clap(flatten)]
@@ -45,6 +45,7 @@ impl TestCmd {
             .config(self.config)
             .pkg(connector_metadata)
             .deployment_type(DeploymentType::Local { output_file: None });
-        builder.deploy()
+        builder.deploy()?;
+        Ok(())
     }
 }

--- a/crates/fluvio-connector-deployer/src/local.rs
+++ b/crates/fluvio-connector-deployer/src/local.rs
@@ -10,7 +10,7 @@ use crate::Deployment;
 pub(crate) fn deploy_local<P: AsRef<Path>>(
     deployment: &Deployment,
     output_file: Option<P>,
-) -> Result<()> {
+) -> Result<u32> {
     let (stdout, stderr, wait) = if let Some(log_path) = output_file {
         println!("Log file: {}", log_path.as_ref().to_string_lossy());
         let log_file = std::fs::File::create(log_path)?;
@@ -39,5 +39,5 @@ pub(crate) fn deploy_local<P: AsRef<Path>>(
     if wait {
         child.wait()?;
     }
-    Ok(())
+    Ok(child.id())
 }

--- a/crates/fluvio-connector-package/src/metadata.rs
+++ b/crates/fluvio-connector-package/src/metadata.rs
@@ -264,7 +264,7 @@ impl ConnectorMetadata {
 }
 
 impl ConnectorMetadata {
-    pub fn validate_config<R: std::io::Read>(&self, reader: R) -> anyhow::Result<()> {
+    pub fn validate_config<R: std::io::Read>(&self, reader: R) -> anyhow::Result<ConnectorConfig> {
         let value =
             serde_yaml::from_reader(reader).context("unable to parse config into YAML format")?;
         validate_custom_config(&self.custom_config, &value)
@@ -274,7 +274,7 @@ impl ConnectorMetadata {
         validate_direction(&self.direction, &config)?;
         validate_deployment(&self.deployment, &config)?;
         validate_secrets(&self.secrets, &config)?;
-        Ok(())
+        Ok(config)
     }
 }
 

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -44,7 +44,7 @@ setup_file() {
 
     # Deploy
     cd $CONNECTOR_DIR
-    run $CDK_BIN deploy local \
+    run $CDK_BIN deploy start \
         $CONFIG_FILE_FLAG 
     assert_success
 


### PR DESCRIPTION
Added `cdk deploy start` for starting connectors, `cdk deploy shutdown` for stopping, `cdk deploy list` for listing and `cdk deploy log` for printing logs of connectors.

Closes #2964