### PR TITLE
[Merged by Bors] - feat: Retry monitoring if there is a failure

### DIFF
--- a/crates/fluvio-spu/src/monitoring.rs
+++ b/crates/fluvio-spu/src/monitoring.rs
@@ -60,5 +60,8 @@ async fn start_monitoring(ctx: DefaultSharedGlobalContext) -> Result<(), IoError
             let bytes = serde_json::to_vec_pretty(metrics)?;
             stream.write_all(&bytes).await?;
         }
+
+        info!("monitoring socket closed. Trying to reconnect in 5 seconds");
+        fluvio_future::timer::sleep(std::time::Duration::from_secs(5)).await;
     }
 }


### PR DESCRIPTION
Also add error logs if there is an issue.

Right now, 
```
    while let Some(stream) = incoming.next().await {
        let mut stream = stream?;
```

could finish if there is an error like broken pipe,

```
2023-02-09T17:56:39.649123Z ERROR fluvio_spu::monitoring: error running monitoring: Broken pipe (os error 32)
```

This adds changes to retry to create the unix socket if there is a failure