### PR TITLE
[Merged by Bors] - feat(cdk): support secrets from env and file

### DIFF
--- a/connector/sink-test-connector/config-example.yaml
+++ b/connector/sink-test-connector/config-example.yaml
@@ -3,6 +3,10 @@ meta:
   name: my-sink-test-connector
   type: test-sink
   topic: test-topic
+custom: 
+  api_key: 
+    secret:
+      name: TEST_API_KEY
 transforms:
   - uses: infinyon/jolt@0.1.0
     with:

--- a/connector/sink-test-connector/secrets.txt
+++ b/connector/sink-test-connector/secrets.txt
@@ -1,0 +1,1 @@
+TEST_API_KEY=test value

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -1,6 +1,6 @@
 mod sink;
 
-use fluvio_connector_common::{connector, Result, consumer::ConsumerStream, Sink};
+use fluvio_connector_common::{connector, Result, consumer::ConsumerStream, Sink, secret::SecretString};
 use futures::SinkExt;
 use sink::TestSink;
 
@@ -16,4 +16,6 @@ async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<
 }
 
 #[connector(config)]
-struct CustomConfig {}
+struct CustomConfig {
+    api_key: SecretString,
+}

--- a/connector/sink-test-connector/src/sink.rs
+++ b/connector/sink-test-connector/src/sink.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use fluvio::Offset;
-use fluvio_connector_common::{Sink, LocalBoxSink};
+use fluvio_connector_common::{Sink, LocalBoxSink, tracing::debug};
 
 use crate::CustomConfig;
 
@@ -11,7 +11,10 @@ use crate::CustomConfig;
 pub(crate) struct TestSink {}
 
 impl TestSink {
-    pub(crate) fn new(_config: &CustomConfig) -> Result<Self> {
+    pub(crate) fn new(config: &CustomConfig) -> Result<Self> {
+        debug!(?config.api_key);
+        let resolved = config.api_key.resolve()?;
+        debug!(resolved);
         Ok(Self {})
     }
 }

--- a/crates/cdk/src/test.rs
+++ b/crates/cdk/src/test.rs
@@ -14,8 +14,13 @@ pub struct TestCmd {
     #[clap(flatten)]
     package: PackageCmd,
 
+    /// Path to configuration file in YAML format
     #[clap(short, long, value_name = "PATH")]
     config: PathBuf,
+
+    /// Path to file with secrets. Secrets are 'key=value' pairs separated by the new line character. Optional
+    #[clap(short, long, value_name = "PATH")]
+    secrets: Option<PathBuf>,
 
     /// Extra arguments to be passed to cargo
     #[clap(raw = true)]
@@ -43,6 +48,7 @@ impl TestCmd {
         builder
             .executable(executable)
             .config(self.config)
+            .secrets(self.secrets)
             .pkg(connector_metadata)
             .deployment_type(DeploymentType::Local { output_file: None });
         builder.deploy()?;

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -8,9 +8,6 @@ use derive_builder::Builder;
 use fluvio_connector_package::metadata::ConnectorMetadata;
 
 #[derive(Clone)]
-pub struct Secret(String);
-
-#[derive(Clone)]
 pub enum DeploymentType {
     Local { output_file: Option<PathBuf> },
 }
@@ -20,7 +17,7 @@ pub enum DeploymentType {
 pub struct Deployment {
     pub executable: PathBuf, // path to executable
     #[builder(default)]
-    pub secrets: Vec<Secret>, // List of Secrets
+    pub secrets: Option<PathBuf>, // path to secrets file
     pub config: PathBuf,     // Configuration to pass along,
     pub pkg: ConnectorMetadata, // Connector pkg definition
     pub deployment_type: DeploymentType, // deployment type


### PR DESCRIPTION
Added support for secrets to `cdk`:
```bash
cdk test --config config-example.yaml --secrets secrets.txt

cdk deploy start --config config-example.yaml --secrets secrets.txt
```
If secrets file is not specified, env variables will be used as secret store.

Fixes #2984 