### PR TITLE
[Merged by Bors] - chore: add rust-toolchain.toml to smdk template

### DIFF
--- a/smartmodule/cargo_template/rust-toolchain.toml
+++ b/smartmodule/cargo_template/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
So that the wasm target can be automatically added by rustup:

```
> smdk build                    
info: syncing channel updates for 'stable-aarch64-apple-darwin'
warning: Signature verification failed for 'https://static.rust-lang.org/dist/channel-rust-stable.toml'
info: latest update on 2023-02-09, rust version 1.67.1 (d5a82bbd2 2023-02-07)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
info: installing component 'rust-std'
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
info: installing component 'rustc'
info: installing component 'rustfmt'
```