### PR TITLE
ci: Add pr labeler to CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,7 @@
 "CLI:fluvio":
   - "crates/fluvio-cli/**"
 
-"fluvio-cli-common":
+"CLI:misc":
   - "crates/fluvio-cli-common/**"
 
 "fluvio-cluster":
@@ -103,6 +103,9 @@
 "CLI:smdk":
   - "crates/smartmodule-development-kit/**"
 
+"CLI:fvm":
+  - "crates/fluvio-version-manager/**"
+
 # Additional groups
 
 "Smartmodule":
@@ -117,6 +120,7 @@
   - "install.sh"
   - "crates/fluvio-cli-common/src/install.rs"
   - "crates/fluvio-cli/src/install/**"
+  - "crates/fluvio-version-manager/**"
 
 "CI":
   - ".github/**"
@@ -145,6 +149,7 @@
   - "RELEASE.md"
   - "examples/**"
   - "dev-tools/**"
+  - "rust-toolchain.toml"
 
 "Repo-related":
   - "LICENSE"
@@ -154,3 +159,4 @@
   - ".cargo/**"
   - ".github/ISSUE_TEMPLATE"
   - ".github/PULL_REQUEST_TEMPLATE"
+  - ".gitignore"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,156 @@
+# All crates
+# Group up where it makes sense
+# Labels to help PR reviewers see scope before looking at code
+"cargo-builder":
+  - "crates/cargo-builder/**"
+
+"CLI:cdk":
+  - "crates/cdk"
+  - "crates/fluvio-connector-common/**"
+  - "crates/fluvio-connector-deployer/**"
+  - "crates/fluvio-connector-derive/**"
+  - "crates/fluvio-connector-package/**"
+
+"fluvio":
+  - "crates/fluvio/**"
+
+"fluvio-auth":
+  - "crates/fluvio-auth/**"
+
+"CLI:fbm":
+  - "crates/fluvio-benchmark/**"
+
+"CLI:fluvio-channel":
+  - "crates/fluvio-channel/**"
+  - "crates/fluvio-channel-cli/**"
+
+"CLI:fluvio":
+  - "crates/fluvio-cli/**"
+
+"fluvio-cli-common":
+  - "crates/fluvio-cli-common/**"
+
+"fluvio-cluster":
+  - "crates/fluvio-cluster/**"
+
+"fluvio-compression":
+  - "crates/fluvio-compression/**"
+
+"fluvio-controlplane":
+  - "crates/fluvio-controlplane/**"
+
+"fluvio-controlplane-metadata":
+  - "crates/fluvio-controlplane-metadata/**"
+
+"fluvio-extension-common":
+  - "crates/fluvio-extension-common/**"
+
+"fluvio-hub":
+  - "crates/fluvio-hub-protocol/**"
+  - "crates/fluvio-hub-util/**"
+
+"fluvio-package-index":
+  - "crates/fluvio-package-index/**"
+
+"fluvio-protocol":
+  - "crates/fluvio-protocol/**"
+
+"fluvio-protocol-derive":
+  - "crates/fluvio-protocol-derive/**"
+
+"CLI:fluvio-run":
+  - "crates/fluvio-run/**"
+
+"fluvio-sc":
+  - "crates/fluvio-sc/**"
+  - "crates/fluvio-sc-schema/**"
+
+"fluvio-service":
+  - "crates/fluvio-service/**"
+
+"fluvio-smartengine":
+  - "crates/fluvio-smartengine/**"
+
+"fluvio-smartmodule":
+  - "crates/fluvio-smartmodule/**"
+  - "crates/fluvio-smartmodule-derive/**"
+
+"fluvio-socket":
+  - "crates/fluvio-socket/**"
+
+"fluvio-spu":
+  - "crates/fluvio-spu/**"
+  - "crates/fluvio-spu-schema/**"
+
+"fluvio-storage":
+  - "crates/fluvio-storage/**"
+
+"fluvio-stream-dispatcher":
+  - "crates/fluvio-stream-dispatcher/**"
+
+"fluvio-stream-model":
+  - "crates/fluvio-stream-model/**"
+
+"CLI:fluvio-test":
+  - "crates/fluvio-test/**"
+  - "crates/fluvio-test-case-derive/**"
+  - "crates/fluvio-test-derive/**"
+  - "crates/fluvio-test-util/**"
+
+"fluvio-types":
+  - "crates/fluvio-types/**"
+
+"CLI:smdk":
+  - "crates/smartmodule-development-kit/**"
+
+# Additional groups
+
+"Smartmodule":
+  - "smartmodule/**"
+  - "crates/fluvio-smartmodule/**"
+  - "crates/fluvio-smartmodule-derive/**"
+
+"Connectors":
+  - "connectors/**"
+
+"Installation":
+  - "install.sh"
+  - "crates/fluvio-cli-common/src/install.rs"
+  - "crates/fluvio-cli/src/install/**"
+
+"CI":
+  - ".github/**"
+  - "bors.toml"
+  - "Makefile"
+  - "makefiles/**"
+  - "deny.toml"
+  - "actions/**"
+  - "build-scripts/**"
+  - "k8-util"
+  - "tls"
+  - "tests"
+  - "action.yaml"
+
+"Release":
+  - "VERSION"
+  - "CHANGELOG.md"
+  - "release-tools/**"
+  - "./github/workflows/publish.yml"
+  - "./github/workflows/release.yml"
+  - "cliff.toml"
+
+"Dev-docs:":
+  - "DEVELOPER.md"
+  - "README.md"
+  - "RELEASE.md"
+  - "examples/**"
+  - "dev-tools/**"
+
+"Repo-related":
+  - "LICENSE"
+  - "CODE-OF-CONDUCT.md"
+  - "CONTRIBUTING.md"
+  - "rustfmt.toml"
+  - ".cargo/**"
+  - ".github/ISSUE_TEMPLATE"
+  - ".github/PULL_REQUEST_TEMPLATE"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,18 +17,19 @@
 "fluvio-auth":
   - "crates/fluvio-auth/**"
 
-"CLI:fbm":
+"fluvio-benchmark":
   - "crates/fluvio-benchmark/**"
 
-"CLI:fluvio-channel":
+"fluvio-channel":
   - "crates/fluvio-channel/**"
   - "crates/fluvio-channel-cli/**"
 
-"CLI:fluvio":
+"fluvio-cli":
   - "crates/fluvio-cli/**"
 
 "CLI:misc":
   - "crates/fluvio-cli-common/**"
+  - "crates/fluvio-extension-common/**"
 
 "fluvio-cluster":
   - "crates/fluvio-cluster/**"
@@ -41,9 +42,6 @@
 
 "fluvio-controlplane-metadata":
   - "crates/fluvio-controlplane-metadata/**"
-
-"fluvio-extension-common":
-  - "crates/fluvio-extension-common/**"
 
 "fluvio-hub":
   - "crates/fluvio-hub-protocol/**"
@@ -58,7 +56,7 @@
 "fluvio-protocol-derive":
   - "crates/fluvio-protocol-derive/**"
 
-"CLI:fluvio-run":
+"fluvio-run":
   - "crates/fluvio-run/**"
 
 "fluvio-sc":
@@ -91,7 +89,7 @@
 "fluvio-stream-model":
   - "crates/fluvio-stream-model/**"
 
-"CLI:fluvio-test":
+"fluvio-test":
   - "crates/fluvio-test/**"
   - "crates/fluvio-test-case-derive/**"
   - "crates/fluvio-test-derive/**"
@@ -100,20 +98,45 @@
 "fluvio-types":
   - "crates/fluvio-types/**"
 
-"CLI:smdk":
+"smartmodule-development-kit":
   - "crates/smartmodule-development-kit/**"
 
-"CLI:fvm":
+"fluvio-version-manager":
   - "crates/fluvio-version-manager/**"
 
 # Additional groups
 
+"CLI":
+  - "crates/fluvio/**"
+  - "crates/fluvio-cli-common/**"
+  - "crates/smartmodule-development-kit/**"
+  - "crates/fluvio-run/**"
+  - "crates/cdk"
+  - "crates/fluvio-connector-common/**"
+  - "crates/fluvio-connector-deployer/**"
+  - "crates/fluvio-connector-derive/**"
+  - "crates/fluvio-connector-package/**"
+  - "crates/fluvio-version-manager/**"
+  - "crates/fluvio-benchmark/**"
+  - "crates/fluvio-test/**"
+  - "crates/fluvio-test-case-derive/**"
+  - "crates/fluvio-test-derive/**"
+  - "crates/fluvio-test-util/**"
+  - "crates/fluvio-channel/**"
+  - "crates/fluvio-channel-cli/**"
+  - "crates/fluvio-cluster/src/cli/**"
+  - "crates/fluvio-hub-util/src/cmd/**"
+  - "crates/fluvio/src/config"
+  - "crates/fluvio-extension-common/**"
+  - "crates/fluvio-smartengine/src/transformation.rs"
+  - "crates/fluvio-controlplane-metadata/src/tableformat/spec.rs"
+  
 "Smartmodule":
   - "smartmodule/**"
   - "crates/fluvio-smartmodule/**"
   - "crates/fluvio-smartmodule-derive/**"
 
-"Connectors":
+"Connector":
   - "connectors/**"
 
 "Installation":

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,15 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
This PR adds https://github.com/marketplace/actions/labeler

We use this workflow on [fluvio-website's PRs](https://github.com/infinyon/fluvio-website/pulls), and it exposes the scope of changes to review without needing to look at the file list. Makes it easier to know who should review.

I've made an initial pass to define the labels for this repo. There is a label for each crate (with exceptions). For systems, I grouped or double labeled some crates or files. The labels are updated on PRs as commits are made, with respect to directory or specific file changes.

In another PR, we can use these labels to automatically assign reviewers when there are PRs to specific areas of the repo, for example with https://github.com/marketplace/actions/assign-reviewers-by-labels