### PR TITLE
[Merged by Bors] - fix: remove `lib-cargo-crate` from `cdk` crate

### DIFF
--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -30,8 +30,6 @@ sysinfo = { workspace = true, default-features = false }
 cargo-generate = "0.18.0"
 include_dir = "0.7.2"
 tempfile = "3.3.0"
-lib-cargo-crate = "0.1.6"
-
 
 fluvio = { path = "../fluvio"}
 fluvio-connector-deployer = { path = "../fluvio-connector-deployer"}


### PR DESCRIPTION
Reported on https://github.com/infinyon/fluvio/actions/runs/4357510921/jobs/7616904513#step:6:1723
while checking on [latest commit CI results](https://github.com/infinyon/fluvio/commit/7d46304c5cd1daf19601b971622e7305e30df342).