### PR TITLE
feat(cdk): supply `arch` tag on publish if not set

### DIFF
--- a/crates/cdk/src/publish.rs
+++ b/crates/cdk/src/publish.rs
@@ -63,7 +63,7 @@ impl PublishCmd {
                     .package_meta
                     .clone()
                     .unwrap_or_else(|| hubutil::DEF_HUB_PKG_META.to_string());
-                let pkgdata = package_assemble(&pkgmetapath, &access)?;
+                let pkgdata = package_assemble(&pkgmetapath, &self.target, &access)?;
                 package_push(self, &pkgdata, &access)?;
             }
 
@@ -73,7 +73,7 @@ impl PublishCmd {
                     .package_meta
                     .clone()
                     .unwrap_or_else(|| hubutil::DEF_HUB_PKG_META.to_string());
-                package_assemble(&pkgmetapath, &access)?;
+                package_assemble(&pkgmetapath, &self.target, &access)?;
             }
 
             // --push only, needs ipkg file
@@ -90,8 +90,8 @@ impl PublishCmd {
     }
 }
 
-pub fn package_assemble(pkgmeta: &str, access: &HubAccess) -> Result<String> {
-    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None)?;
+pub fn package_assemble(pkgmeta: &str, target: &str, access: &HubAccess) -> Result<String> {
+    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None, Some(target))?;
     println!("Package {pkgname} created");
     Ok(pkgname)
 }

--- a/crates/fluvio-hub-util/src/package_meta_ext.rs
+++ b/crates/fluvio-hub-util/src/package_meta_ext.rs
@@ -242,6 +242,10 @@ fn hub_package_meta_t_read() {
         name: "example".into(),
         version: "0.0.1".into(),
         manifest: ["tests/apackage/module.wasm".into()].to_vec(),
+        tags: Some(vec![fluvio_hub_protocol::PkgTag {
+            tag: "arch".to_owned(),
+            value: "aarch64-unknown-linux-gnu".to_owned(),
+        }]),
         ..PackageMeta::default()
     };
 

--- a/crates/fluvio-hub-util/tests/apackage/package-meta.yaml
+++ b/crates/fluvio-hub-util/tests/apackage/package-meta.yaml
@@ -9,3 +9,5 @@ visibility: private
 manifest:
   - tests/apackage/module.wasm
 tags:
+  - tag: arch
+    value: aarch64-unknown-linux-gnu

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -79,7 +79,7 @@ impl PublishCmd {
 }
 
 pub fn package_assemble(pkgmeta: &str, access: &HubAccess) -> Result<String> {
-    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None)?;
+    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None, None)?;
     println!("Package {pkgname} created");
     Ok(pkgname)
 }


### PR DESCRIPTION
The presence of `arch` tag is required for multi-arch packaging. If it is not specified in `package-meta.yaml` we supply it before publishing (to be precise, before the package assembling). 