### PR TITLE
[Merged by Bors] - chore: Replace tempdir with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,8 +809,7 @@ dependencies = [
 [[package]]
 name = "cargo-generate"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfaa524771775edda726081cd21163c61270e1fa711ab20c8be1cba04e1cfce"
+source = "git+https://github.com/cargo-generate/cargo-generate.git#c467a9313ba4a3a95f744a6ceb3cd6393eb47b46"
 dependencies = [
  "anyhow",
  "clap 4.1.8",
@@ -831,7 +830,7 @@ dependencies = [
  "paste",
  "path-absolutize",
  "regex",
- "remove_dir_all 0.8.1",
+ "remove_dir_all",
  "rhai",
  "sanitize-filename",
  "semver 1.0.16",
@@ -2417,7 +2416,6 @@ dependencies = [
  "sha2 0.10.6",
  "static_assertions",
  "sysinfo",
- "tempdir",
  "thiserror",
  "tokio",
  "tracing",
@@ -2443,7 +2441,6 @@ dependencies = [
  "isahc",
  "semver 1.0.16",
  "sha2 0.10.6",
- "tempdir",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2493,7 +2490,6 @@ dependencies = [
  "serde_yaml 0.9.19",
  "sysinfo",
  "tar",
- "tempdir",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3337,12 +3333,6 @@ dependencies = [
  "smart-default",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -5613,19 +5603,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5667,21 +5644,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5749,15 +5711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5814,15 +5767,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -6799,27 +6743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all 0.5.3",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all 0.5.3",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cargo-generate"
 version = "0.18.1"
-source = "git+https://github.com/cargo-generate/cargo-generate.git#c467a9313ba4a3a95f744a6ceb3cd6393eb47b46"
+source = "git+https://github.com/cargo-generate/cargo-generate.git?rev=241a598f1031f2df52f96e03fd3a96a5229883cc#241a598f1031f2df52f96e03fd3a96a5229883cc"
 dependencies = [
  "anyhow",
  "clap 4.1.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,6 @@ codegen-units = 256
 [profile.release-lto]
 inherits = "release"
 lto = true
+
+[patch.crates-io]
+cargo-generate = { git = 'https://github.com/cargo-generate/cargo-generate.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ cargo_toml = "0.15"
 base64 = "0.21.0"
 toml = "0.7.0"
 wasmparser = { version = "0.101.0" }
+tempfile = "3.4.0"
 
 # Used to make eyre faster on debug builds
 # See https://github.com/yaahc/color-eyre#improving-perf-on-debug-builds
@@ -100,4 +101,4 @@ inherits = "release"
 lto = true
 
 [patch.crates-io]
-cargo-generate = { git = 'https://github.com/cargo-generate/cargo-generate.git' }
+cargo-generate = { git = "https://github.com/cargo-generate/cargo-generate.git", rev = "241a598f1031f2df52f96e03fd3a96a5229883cc"}

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -29,7 +29,7 @@ comfy-table = { version = "6.1" }
 sysinfo = { workspace = true, default-features = false }
 cargo-generate = "0.18.0"
 include_dir = "0.7.2"
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 current_platform = { version = "0.2" }
 
 fluvio = { path = "../fluvio"}

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -22,7 +22,7 @@ semver = "1.0.0"
 home = "0.5.3"
 sha2 = "0.10.0"
 hex = "0.4.2"
-tempdir = "0.3.7"
+tempfile = "3.4.0"
 thiserror = "1.0.20"
 http = { version = "0.2", default-features = false}
 isahc = { version = "1.7", default-features = false, features = ["static-curl"] }
@@ -37,4 +37,3 @@ fluvio-protocol = { path = "../fluvio-protocol", optional = true }
 
 [dev-dependencies]
 fluvio-future = { version = "0.4.0", features = ["fs", "io", "subscriber", "native2_tls", "fixture"] }
-tempfile = "3.3.0"

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -22,7 +22,7 @@ semver = "1.0.0"
 home = "0.5.3"
 sha2 = "0.10.0"
 hex = "0.4.2"
-tempfile = "3.4.0"
+tempfile = { workspace = true }
 thiserror = "1.0.20"
 http = { version = "0.2", default-features = false}
 isahc = { version = "1.7", default-features = false, features = ["static-curl"] }

--- a/crates/fluvio-cli-common/src/install.rs
+++ b/crates/fluvio-cli-common/src/install.rs
@@ -177,7 +177,9 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     std::fs::create_dir_all(parent)?;
 
     // Create a temporary dir to write file to
-    let tmp_dir = tempfile::Builder::new().prefix("fluvio-tmp").tempdir_in(parent)?;
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("fluvio-tmp")
+        .tempdir_in(parent)?;
 
     // Write bin to temporary file
     let tmp_path = tmp_dir.path().join("fluvio-exe-tmp");

--- a/crates/fluvio-cli-common/src/install.rs
+++ b/crates/fluvio-cli-common/src/install.rs
@@ -177,7 +177,7 @@ pub fn install_bin<P: AsRef<Path>, B: AsRef<[u8]>>(bin_path: P, bytes: B) -> Res
     std::fs::create_dir_all(parent)?;
 
     // Create a temporary dir to write file to
-    let tmp_dir = tempdir::TempDir::new_in(parent, "fluvio-tmp")?;
+    let tmp_dir = tempfile::Builder::new().prefix("fluvio-tmp").tempdir_in(parent)?;
 
     // Write bin to temporary file
     let tmp_path = tmp_dir.path().join("fluvio-exe-tmp");

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -55,7 +55,6 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 comfy-table = "6.0.0"
 static_assertions = "1.1.0"
-tempdir = "0.3.7"
 sysinfo = { workspace = true }
 atty = { version = "0.2.14", optional = true }
 ctrlc = { version = "3.1.3", optional = true }

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -42,7 +42,7 @@ once_cell = "1.5"
 
 which = "4.1.0"
 directories = "4.0.0"
-tempfile = "3.4.0"
+tempfile = { workspace = true }
 include_dir = "0.7.2"
 anyhow = { workspace = true }
 async-channel = "1.6.1"

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -42,9 +42,8 @@ once_cell = "1.5"
 
 which = "4.1.0"
 directories = "4.0.0"
-tempfile = "3.2"
+tempfile = "3.4.0"
 include_dir = "0.7.2"
-tempdir = "0.3.7"
 anyhow = { workspace = true }
 async-channel = "1.6.1"
 bytesize = { version = "1.1.0", features = ['serde'] }

--- a/crates/fluvio-cluster/src/charts/location.rs
+++ b/crates/fluvio-cluster/src/charts/location.rs
@@ -108,8 +108,8 @@ mod inline {
     use std::io::Write;
 
     use tracing::{debug, trace};
-    use tempdir::TempDir;
     use include_dir::{Dir};
+    use tempfile::TempDir;
 
     /// Inline chart contains only a single chart
     pub struct InlineChart {
@@ -120,7 +120,7 @@ mod inline {
     impl InlineChart {
         /// create new inline chart
         pub fn new(inline: &Dir<'static>) -> Result<Self, IoError> {
-            let temp_dir = TempDir::new("chart")?;
+            let temp_dir = tempfile::Builder::new().prefix("chart").tempdir()?;
             let chart = Self::unpack(inline, temp_dir.path())?;
             Ok(Self {
                 _dir: temp_dir,

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -43,7 +43,9 @@ impl DiagnosticsOpt {
     pub async fn process(self) -> Result<()> {
         let profile_ty = self.get_profile_ty()?;
         println!("Using profile type: {profile_ty:#?}");
-        let temp_dir = tempfile::Builder::new().prefix("fluvio-diagnostics").tempdir()?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix("fluvio-diagnostics")
+            .tempdir()?;
         let temp_path = temp_dir.path();
 
         let spu_specs = match self.copy_fluvio_specs(temp_path).await {

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -43,7 +43,7 @@ impl DiagnosticsOpt {
     pub async fn process(self) -> Result<()> {
         let profile_ty = self.get_profile_ty()?;
         println!("Using profile type: {profile_ty:#?}");
-        let temp_dir = tempdir::TempDir::new("fluvio-diagnostics")?;
+        let temp_dir = tempfile::Builder::new().prefix("fluvio-diagnostics").tempdir()?;
         let temp_path = temp_dir.path();
 
         let spu_specs = match self.copy_fluvio_specs(temp_path).await {

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -31,5 +31,5 @@ openapiv3 = { git = "https://github.com/galibey/openapiv3", rev = "bdd22f046d2bc
 once_cell = { version = "1.17" }
 
 [dev-dependencies]
-tempfile = "3.3"
+tempfile = { workspace = true }
 pretty_assertions = "1.3.0"

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 ssh-key = { version="0.4.3", features=[ "ed25519" ] }
 tar = "0.4"
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -23,7 +23,7 @@ dirs = "4.0.0"
 toml = { workspace = true }
 cargo-generate = "0.18.0"
 include_dir = "0.7.2"
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 enum-display = "0.1.3"
 lib-cargo-crate = "0.1.6"
 


### PR DESCRIPTION
Remove dependency on remove_dir_all 0.5.3, see https://rustsec.org/advisories/RUSTSEC-2023-0018.