### PR TITLE
[Merged by Bors] - fix: relax `cdk` secrets validation

### DIFF
--- a/connector/sink-test-connector/Connector.toml
+++ b/connector/sink-test-connector/Connector.toml
@@ -14,3 +14,5 @@ dest = true
 [deployment]
 binary = "sink-test-connector"
 
+[secret.TEST_API_KEY]
+type = "env"

--- a/crates/fluvio-connector-package/src/metadata.rs
+++ b/crates/fluvio-connector-package/src/metadata.rs
@@ -315,14 +315,6 @@ fn validate_deployment(deployment: &Deployment, config: &ConnectorConfig) -> any
 
 fn validate_secrets(secrets: &Secrets, config: &serde_yaml::Value) -> anyhow::Result<()> {
     let cfg_secrets = detect_secrets(config);
-    for meta_secret in secrets.keys() {
-        if !cfg_secrets.contains(meta_secret.as_str()) {
-            return Err(anyhow!(
-                "missing required secret '{}' in config",
-                meta_secret
-            ));
-        }
-    }
     for cfg_secret in cfg_secrets {
         if !secrets.contains_key(cfg_secret) {
             return Err(anyhow!(
@@ -582,10 +574,8 @@ mod tests {
         let res = validate_secrets(&meta_secrets, &config);
 
         //then
-        assert_eq!(
-            res.unwrap_err().to_string(),
-            "missing required secret 'secret_name' in config"
-        );
+        assert!(res.is_ok()); // config file is not obligated to use all secrets defined in
+                              // Connector.toml
     }
 
     #[test]


### PR DESCRIPTION
Currently, in `cdk deploy`, we validate strict correspondence between metadata of secrets defined in `Connector.toml` and secrets presented in the config file. This is incorrect because, in the config file, secrets might not be used or used as a raw string(`SecretString` supports using secrets by its name or raw string value).

Fixed by removing this part of validation. 

Fixes #3087