### PR TITLE
[Merged by Bors] - feat(cdk): add `-p package_name` in `cdk publish`

### DIFF
--- a/crates/cargo-builder/src/package.rs
+++ b/crates/cargo-builder/src/package.rs
@@ -91,9 +91,7 @@ impl PackageInfo {
     }
 
     pub fn package_relative_path<P: AsRef<Path>>(&self, child: P) -> PathBuf {
-        let mut package_path = self.package_path().to_path_buf();
-        package_path.push(child);
-        package_path
+        self.package_path().join(child)
     }
 
     /// path to package's bin target

--- a/crates/cdk/src/publish.rs
+++ b/crates/cdk/src/publish.rs
@@ -1,26 +1,32 @@
 //!
 //! Command for hub publishing
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
+use anyhow::Context;
 use anyhow::Result;
+use cargo_builder::package::PackageInfo;
 use clap::Parser;
 
 use fluvio_connector_package::metadata::ConnectorMetadata;
 use fluvio_connector_package::metadata::ConnectorVisibility;
 use fluvio_future::task::run_block_on;
 use fluvio_hub_util as hubutil;
-use hubutil::{
-    DEF_HUB_INIT_DIR, DEF_HUB_PKG_META, HubAccess, PackageMeta, PkgVisibility, PackageMetaExt,
-};
+use hubutil::{DEF_HUB_INIT_DIR, HubAccess, PackageMeta, PkgVisibility, PackageMetaExt};
 use hubutil::packagename_validate;
 use tracing::{debug, info};
+
+use crate::cmd::PackageCmd;
 
 pub const CONNECTOR_TOML: &str = "Connector.toml";
 
 /// Publish Connector package to the Hub
 #[derive(Debug, Parser)]
 pub struct PublishCmd {
+    #[clap(flatten)]
+    package: PackageCmd,
+
     pub package_meta: Option<String>,
 
     /// don't ask for confirmation of public package publish
@@ -50,20 +56,30 @@ impl PublishCmd {
     pub(crate) fn process(&self) -> Result<()> {
         let access = HubAccess::default_load(&self.remote)?;
 
-        let hubdir = Path::new(DEF_HUB_INIT_DIR);
+        let opt = self.package.as_opt();
+        let package_info = PackageInfo::from_options(&opt)?;
+
+        info!(
+            "publishing package {} from {}",
+            package_info.package_name(),
+            package_info.package_path().to_string_lossy()
+        );
+
+        let hubdir = package_info.package_relative_path(DEF_HUB_INIT_DIR);
         if !hubdir.exists() {
-            init_package_template()?;
+            init_package_template(&package_info)?;
         } else if !self.public_yes {
-            check_package_meta_visiblity()?;
+            check_package_meta_visiblity(&package_info)?;
         }
 
         match (self.pack, self.push) {
             (false, false) | (true, true) => {
                 let pkgmetapath = self
                     .package_meta
-                    .clone()
-                    .unwrap_or_else(|| hubutil::DEF_HUB_PKG_META.to_string());
-                let pkgdata = package_assemble(&pkgmetapath, &self.target, &access)?;
+                    .as_ref()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| hubdir.join(hubutil::HUB_PACKAGE_META));
+                let pkgdata = package_assemble(pkgmetapath, &self.target, &access)?;
                 package_push(self, &pkgdata, &access)?;
             }
 
@@ -71,9 +87,10 @@ impl PublishCmd {
             (true, false) => {
                 let pkgmetapath = self
                     .package_meta
-                    .clone()
-                    .unwrap_or_else(|| hubutil::DEF_HUB_PKG_META.to_string());
-                package_assemble(&pkgmetapath, &self.target, &access)?;
+                    .as_ref()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| hubdir.join(hubutil::HUB_PACKAGE_META));
+                package_assemble(pkgmetapath, &self.target, &access)?;
             }
 
             // --push only, needs ipkg file
@@ -90,8 +107,20 @@ impl PublishCmd {
     }
 }
 
-pub fn package_assemble(pkgmeta: &str, target: &str, access: &HubAccess) -> Result<String> {
-    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None, Some(target))?;
+pub fn package_assemble<P: AsRef<Path>>(
+    pkgmeta: P,
+    target: &str,
+    access: &HubAccess,
+) -> Result<String> {
+    let pkgname = hubutil::package_assemble_and_sign(
+        &pkgmeta,
+        access,
+        pkgmeta
+            .as_ref()
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("invalid package meta path"))?,
+        Some(target),
+    )?;
     println!("Package {pkgname} created");
     Ok(pkgname)
 }
@@ -111,9 +140,8 @@ pub fn package_push(opts: &PublishCmd, pkgpath: &str, access: &HubAccess) -> Res
 }
 
 // todo: review for Connectors
-pub fn init_package_template() -> Result<()> {
+pub fn init_package_template(package_info: &PackageInfo) -> Result<()> {
     // fill out template w/ defaults
-    let pmetapath = hubutil::DEF_HUB_PKG_META;
 
     let mut pm = PackageMeta {
         group: "no-hubid".into(),
@@ -122,35 +150,40 @@ pub fn init_package_template() -> Result<()> {
         manifest: Vec::new(),
         ..PackageMeta::default()
     };
-    let pkg_toml_file = find_connector_toml()?;
+    let pkg_toml_file = find_connector_toml(package_info)?;
     pm.update_from_connector_toml(&pkg_toml_file.to_string_lossy())?;
 
     println!("Creating package {}", pm.pkg_name());
     pm.naming_check()?;
 
     // create directoy name pkgname
-    let pkgdir = Path::new(hubutil::DEF_HUB_INIT_DIR);
+    let pkgdir = package_info.package_relative_path(hubutil::DEF_HUB_INIT_DIR);
     if pkgdir.exists() {
         return Err(anyhow::anyhow!("package hub directory exists already"));
     }
-    std::fs::create_dir(pkgdir)?;
-    pm.write(pmetapath)?;
+    std::fs::create_dir(&pkgdir)?;
+    let pmetapath = pkgdir.join(hubutil::HUB_PACKAGE_META);
+    pm.write(&pmetapath)?;
 
-    println!(".. fill out info in {pmetapath}");
+    println!(".. fill out info in {}", pmetapath.to_string_lossy());
     Ok(())
 }
 
-fn check_package_meta_visiblity() -> Result<()> {
-    let cmeta_toml_file = find_connector_toml()?;
+fn check_package_meta_visiblity(package_info: &PackageInfo) -> Result<()> {
+    let cmeta_toml_file = find_connector_toml(package_info)?;
     let mpkg = ConnectorMetadata::from_toml_file(cmeta_toml_file)?;
     let mpkg_vis = from_connectorvis(&mpkg.package.visibility);
-    let mut pm = PackageMeta::read_from_file(DEF_HUB_PKG_META)?;
+    let package_meta_path = package_info.package_relative_path(hubutil::DEF_HUB_PKG_META);
+    let mut pm = PackageMeta::read_from_file(&package_meta_path).context(format!(
+        "unable to read package meta file from {}",
+        package_meta_path.to_string_lossy()
+    ))?;
     if mpkg_vis == PkgVisibility::Public && mpkg_vis != pm.visibility {
         println!("Package visibility changing from private to public!");
         verify_public_or_exit()?;
         // writeout package metadata visibility change
         pm.visibility = PkgVisibility::Public;
-        pm.write(DEF_HUB_PKG_META)?;
+        pm.write(package_meta_path)?;
     }
     Ok(())
 }
@@ -162,11 +195,11 @@ fn from_connectorvis(cv: &ConnectorVisibility) -> PkgVisibility {
     }
 }
 
-pub(crate) fn find_connector_toml() -> Result<PathBuf> {
-    let smartmodule_toml = Path::new(CONNECTOR_TOML);
+pub(crate) fn find_connector_toml(package_info: &PackageInfo) -> Result<PathBuf> {
+    let smartmodule_toml = package_info.package_relative_path(CONNECTOR_TOML);
 
     if smartmodule_toml.exists() {
-        return Ok(smartmodule_toml.to_path_buf());
+        return Ok(smartmodule_toml);
     }
 
     Err(anyhow::anyhow!("No \"{}\" file found", CONNECTOR_TOML))

--- a/crates/cdk/src/set_public.rs
+++ b/crates/cdk/src/set_public.rs
@@ -1,19 +1,27 @@
 use anyhow::Result;
+use cargo_builder::package::PackageInfo;
 use clap::Parser;
 
 use fluvio_connector_package::metadata as mpkg;
 use mpkg::ConnectorVisibility;
 
+use crate::cmd::PackageCmd;
 use crate::publish::find_connector_toml;
 use crate::publish::CONNECTOR_TOML;
 
 /// Set connector visibility to public
 #[derive(Debug, Parser)]
-pub struct SetPublicCmd {}
+pub struct SetPublicCmd {
+    #[clap(flatten)]
+    package: PackageCmd,
+}
 
 impl SetPublicCmd {
     pub(crate) fn process(&self) -> Result<()> {
-        let smm_path = find_connector_toml()?;
+        let opt = self.package.as_opt();
+        let package_info = PackageInfo::from_options(&opt)?;
+
+        let smm_path = find_connector_toml(&package_info)?;
         let mut cm = mpkg::ConnectorMetadata::from_toml_file(smm_path)?;
         if cm.package.visibility == ConnectorVisibility::Private {
             println!("warning: publishing a public package is irreversible");

--- a/crates/fluvio-hub-util/src/package_meta_ext.rs
+++ b/crates/fluvio-hub-util/src/package_meta_ext.rs
@@ -241,7 +241,7 @@ fn hub_package_meta_t_read() {
         group: "infinyon".into(),
         name: "example".into(),
         version: "0.0.1".into(),
-        manifest: ["tests/apackage/module.wasm".into()].to_vec(),
+        manifest: ["module.wasm".into()].to_vec(),
         tags: Some(vec![fluvio_hub_protocol::PkgTag {
             tag: "arch".to_owned(),
             value: "aarch64-unknown-linux-gnu".to_owned(),

--- a/crates/fluvio-hub-util/tests/apackage/package-meta.yaml
+++ b/crates/fluvio-hub-util/tests/apackage/package-meta.yaml
@@ -7,7 +7,7 @@ description: Describe the module here
 license: e.g. Apache2
 visibility: private
 manifest:
-  - tests/apackage/module.wasm
+  - module.wasm
 tags:
   - tag: arch
     value: aarch64-unknown-linux-gnu

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -79,7 +79,15 @@ impl PublishCmd {
 }
 
 pub fn package_assemble(pkgmeta: &str, access: &HubAccess) -> Result<String> {
-    let pkgname = hubutil::package_assemble_and_sign(pkgmeta, access, None, None)?;
+    let pkgmeta = Path::new(pkgmeta);
+    let pkgname = hubutil::package_assemble_and_sign(
+        pkgmeta,
+        access,
+        pkgmeta
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("invalid package meta path"))?,
+        None,
+    )?;
     println!("Package {pkgname} created");
     Ok(pkgname)
 }


### PR DESCRIPTION
Currently, `cdk publish` command does not have the option to specify the package; hence must be executed from the crate's directory. It is inconvenient in CI/CD pipelines. 
This PR adds the support `-p` parameter so the command can be executed from any workspace directory.

 This includes how files listed `package-meta.yaml` are searched: now they are looked up relative to the file `package-meta.yaml` itself instead of the current directory where `cdk` runs.