### PR TITLE
[Merged by Bors] - chore: disable default `fluvio` features for sdk

### DIFF
--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive", "rc"], default-features = false }
 serde_json = { version = "1" }
 serde_yaml = { version = "0.8" }
 
-fluvio = { path = "../fluvio/", features = ["smartengine"]}
+fluvio = { path = "../fluvio/", features = ["smartengine"], default-features = false }
 fluvio-connector-package = { path = "../fluvio-connector-package/" }
 fluvio-connector-derive = { path = "../fluvio-connector-derive/", optional = true}
 fluvio-sc-schema = { path = "../fluvio-sc-schema/"}


### PR DESCRIPTION
`fluvio-connector-common` activates `openssl` feature for `fluvio` crate without the actual need for that, and this prevents users from choosing if they want this feature for `fluvio`.