### PR TITLE
[Merged by Bors] - refactor!: replaced `$VERSION` with `$FLV_VERSION` to make it unambigous on install.sh

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -513,6 +513,6 @@ Instead of building Fluvio, you may want to prefer just to download it and get t
 
 ```
 $ curl -fsS https://packages.fluvio.io/v1/install.sh | bash                 # Install latest release
-$ curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash  # Install latest pre-release
-$ curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=x.y.z bash   # Install specific version
+$ curl -fsS https://packages.fluvio.io/v1/install.sh | FLV_VERSION=latest bash  # Install latest pre-release
+$ curl -fsS https://packages.fluvio.io/v1/install.sh | FLV_VERSION=x.y.z bash   # Install specific version
 ```

--- a/install.sh
+++ b/install.sh
@@ -88,10 +88,10 @@ download_fluvio_to_temp() {
     downloader "${_url}" "${_temp_file}"
     _status=$?
     if [ $_status -ne 0 ]; then
-        if [ -n "${VERSION:-""}" ]; then
-            # If a VERSION was set, warn that it may be invalid
-            err "❌ Failed to download Fluvio, could not find custom VERSION=${VERSION}"
-            err "    Make sure this is a valid version, or unset VERSION to download latest"
+        if [ -n "${FLV_VERSION:-""}" ]; then
+            # If a FLV_VERSION was set, warn that it may be invalid
+            err "❌ Failed to download Fluvio, could not find custom FLV_VERSION=${FLV_VERSION}"
+            err "    Make sure this is a valid version, or unset FLV_VERSION to download stable"
         else
             # If downloading the latest version, warn a general download error
             err "❌ Failed to download Fluvio!"
@@ -492,24 +492,24 @@ main() {
     _target=$(normalize_target ${_arch})
 
 
-    VERSION="${VERSION:-stable}"
+    FLV_VERSION="${FLV_VERSION:-stable}"
 
 
     set +e
-    _version=$(fetch_tag_version "${VERSION}")
+    _version=$(fetch_tag_version "${FLV_VERSION}")
     _status=$?
     set -e
 
-    # If we did not find a version via a tag, use VERSION as the version itself
+    # If we did not find a version via a tag, use FLV_VERSION as the version itself
     if [ $_status -ne 0 ]; then
-        _version="${VERSION}"
+        _version="${FLV_VERSION}"
     fi
 
     # If we are using "stable" or "latest"
     # Be sure to use those tags in the installed artifacts
     # Otherwise, use the value from ${_version}
 
-    if [[ "${VERSION}" == "stable" ]] || [[ "${VERSION}" == "latest" ]] ; then
+    if [[ "${FLV_VERSION}" == "stable" ]] || [[ "${FLV_VERSION}" == "latest" ]] ; then
         #say "DEBUG: Using stable or latest"
         _use_tag_file_name="true"
     else
@@ -539,16 +539,16 @@ main() {
     if [[ "${_use_tag_file_name}" == "true" ]] ; then
 
         # Stable extensions go in main dir
-        if [[ "${VERSION}" == "stable" ]] ; then
+        if [[ "${FLV_VERSION}" == "stable" ]] ; then
             ensure mkdir -p "${FLUVIO_EXTENSIONS}"
         fi
 
         # Latest extensions go in latest dir
-        if [[ "${VERSION}" == "latest" ]] ; then
-            ensure mkdir -p "${FLUVIO_EXTENSIONS}-${VERSION}"
+        if [[ "${FLV_VERSION}" == "latest" ]] ; then
+            ensure mkdir -p "${FLUVIO_EXTENSIONS}-${FLV_VERSION}"
         fi
 
-        local _install_file="${FLUVIO_BIN}/fluvio-${VERSION}"
+        local _install_file="${FLUVIO_BIN}/fluvio-${FLV_VERSION}"
     else 
         # If we installed a specific version, place extension in that dir
         # Ex. fluvio-0.x.y
@@ -564,13 +564,13 @@ main() {
     # Download Fluvio-channel to a temporary file
 
     set +e
-    _version=$(fetch_tag_version "${VERSION}" "${FLUVIO_FRONTEND_PACKAGE}")
+    _version=$(fetch_tag_version "${FLV_VERSION}" "${FLUVIO_FRONTEND_PACKAGE}")
     _status=$?
     set -e
 
-    # If we did not find a version via a tag, use VERSION as the version itself
+    # If we did not find a version via a tag, use FLV_VERSION as the version itself
     if [ $_status -ne 0 ]; then
-        _version="${VERSION}"
+        _version="${FLV_VERSION}"
     fi
 
     local _url="${FLUVIO_PREFIX}/packages/${FLUVIO_FRONTEND_PACKAGE}/${_version}/${_target}/fluvio-channel"
@@ -589,9 +589,9 @@ main() {
     say "✅ Successfully installed ${_install_file}"
 
 
-    # If a VERSION env variable is set, use it for fluvio-run:
-    if [ -n "${VERSION:-""}" ]; then
-        local _fluvio_run="fluvio-run:${VERSION}"
+    # If a FLV_VERSION env variable is set, use it for fluvio-run:
+    if [ -n "${FLV_VERSION:-""}" ]; then
+        local _fluvio_run="fluvio-run:${FLV_VERSION}"
     else
         local _fluvio_run="fluvio-run"
     fi
@@ -599,10 +599,10 @@ main() {
     # Let fluvio know it is invoked from installer
     # Also let fluvio know what channel is being installed
     say "☁️ Installing Fluvio Cloud..."
-    FLUVIO_BOOTSTRAP=true CHANNEL_BOOTSTRAP=${VERSION} "${FLUVIO_BIN}/fluvio" install fluvio-cloud
+    FLUVIO_BOOTSTRAP=true CHANNEL_BOOTSTRAP=${FLV_VERSION} "${FLUVIO_BIN}/fluvio" install fluvio-cloud
 
     say "☁️ Installing Fluvio Runner..."
-    FLUVIO_BOOTSTRAP=true CHANNEL_BOOTSTRAP=${VERSION} "${FLUVIO_BIN}/fluvio" install "${_fluvio_run}"
+    FLUVIO_BOOTSTRAP=true CHANNEL_BOOTSTRAP=${FLV_VERSION} "${FLUVIO_BIN}/fluvio" install "${_fluvio_run}"
 
     say "🎉 Install complete!"
     remind_path


### PR DESCRIPTION
Closes #3020

After refactoring, I also explored and executed `./install.sh` using these `FLV_VERSION` values `inexistent`,`latest`, and not set. I've also confirmed that if a `VERSION=inexistent` is set it doesn't interfere as expected.


```
❯ FLV_VERSION=inexistent ./install.sh
fluvio: ⏳ Downloading Fluvio inexistent for x86_64-unknown-linux-musl...
curl: (22) The requested URL returned error: 404
fluvio: ❌ Failed to download Fluvio, could not find custom FLV_VERSION=inexistent
fluvio:     Make sure this is a valid version, or unset FLV_VERSION to download stable
fluvio: 
fluvio: If you believe this is a bug (or just need help),
fluvio: please feel free to file an issue on Github ❤️
fluvio:     https://github.com/infinyon/fluvio/issues/new
```


```
❯ FLV_VERSION=latest ./install.sh
fluvio: ⏳ Downloading Fluvio 0.10.7-dev-1+18c80fbd0ec5a9162aae5024d327097fb593fd46 for x86_64-unknown-linux-musl...
fluvio: ⬇️  Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio-latest
fluvio: ⏳ Downloading Fluvio channel frontend 0.10.7-dev-1+18c80fbd0ec5a9162aae5024d327097fb593fd46 for x86_64-unknown-linux-musl...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio
fluvio: ☁️ Installing Fluvio Cloud...
Current channel: stable
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.2.8...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: ☁️ Installing Fluvio Runner...
Current channel: stable
fluvio: ⏳ Downloading package with provided version: fluvio/fluvio-run:latest...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: 🎉 Install complete!
fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
fluvio:     You can run the following to set your PATH on shell startup:
fluvio:       echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
```

```
❯ ./install.sh        
fluvio: ⏳ Downloading Fluvio 0.10.5 for x86_64-unknown-linux-musl...
fluvio: ⬇️  Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio-stable
fluvio: ⏳ Downloading Fluvio channel frontend 0.10.5 for x86_64-unknown-linux-musl...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio
fluvio: ☁️ Installing Fluvio Cloud...
Current channel: stable
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.2.8...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: ☁️ Installing Fluvio Runner...
Current channel: stable
fluvio: ⏳ Downloading package with provided version: fluvio/fluvio-run:stable...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: 🎉 Install complete!
fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
fluvio:     You can run the following to set your PATH on shell startup:
fluvio:       echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
```


```
❯ VERSION=inexistent ./install.sh
fluvio: ⏳ Downloading Fluvio 0.10.5 for x86_64-unknown-linux-musl...
fluvio: ⬇️  Downloaded Fluvio, installing...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio-stable
fluvio: ⏳ Downloading Fluvio channel frontend 0.10.5 for x86_64-unknown-linux-musl...
fluvio: ✅ Successfully installed /home/viniarck/.fluvio/bin/fluvio
fluvio: ☁️ Installing Fluvio Cloud...
Current channel: stable
fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.2.8...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: ☁️ Installing Fluvio Runner...
Current channel: stable
fluvio: ⏳ Downloading package with provided version: fluvio/fluvio-run:stable...
fluvio: 🔑 Downloaded and verified package file

💡 An update to Fluvio is available!
💡     Run 'fluvio update' to install v0.10.6 of Fluvio
fluvio: 🎉 Install complete!
fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
fluvio:     You can run the following to set your PATH on shell startup:
fluvio:       echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
```

