### PR TITLE
[Merged by Bors] - refactor(smartengine): reuse code for transforms except agg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/src/transforms/array_map.rs
+++ b/crates/fluvio-smartengine/src/transforms/array_map.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod test {
 
-    const ARRAY_MAP_FN_NAME: &str = "array_map";
-
     use std::{convert::TryFrom};
 
     use fluvio_smartmodule::{
@@ -12,6 +10,7 @@ mod test {
 
     use crate::{
         SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, metrics::SmartModuleChainMetrics,
+        transforms::simple_transform::ARRAY_MAP_FN_NAME,
     };
 
     const SM_ARRAY_MAP: &str = "fluvio_smartmodule_array_map_array";

--- a/crates/fluvio-smartengine/src/transforms/array_map.rs
+++ b/crates/fluvio-smartengine/src/transforms/array_map.rs
@@ -1,73 +1,7 @@
-use std::convert::TryFrom;
-use std::fmt::Debug;
-
-use anyhow::Result;
-use fluvio_smartmodule::dataplane::smartmodule::{
-    SmartModuleInput, SmartModuleOutput, SmartModuleTransformErrorStatus,
-};
-use wasmtime::{AsContextMut, TypedFunc};
-
-use crate::{
-    instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    state::WasmState,
-};
-
-const ARRAY_MAP_FN_NAME: &str = "array_map";
-type WasmArrayMapFn = TypedFunc<(i32, i32, u32), i32>;
-
-pub(crate) struct SmartModuleArrayMap(WasmArrayMapFn);
-
-impl Debug for SmartModuleArrayMap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ArrayMapFnWithParam")
-    }
-}
-
-impl SmartModuleArrayMap {
-    pub fn try_instantiate(
-        ctx: &SmartModuleInstanceContext,
-        store: &mut impl AsContextMut,
-    ) -> Result<Option<Self>> {
-        match ctx.get_wasm_func(&mut *store, ARRAY_MAP_FN_NAME) {
-            Some(func) => {
-                // check type signature
-
-                func.typed(&mut *store)
-                    .or_else(|_| func.typed(store))
-                    .map(|array_map_fn| Some(Self(array_map_fn)))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-impl SmartModuleTransform for SmartModuleArrayMap {
-    fn process(
-        &mut self,
-        input: SmartModuleInput,
-        ctx: &mut SmartModuleInstanceContext,
-        store: &mut WasmState,
-    ) -> Result<SmartModuleOutput> {
-        let slice = ctx.write_input(&input, &mut *store)?;
-        let map_output = self.0.call(&mut *store, slice)?;
-
-        if map_output < 0 {
-            let internal_error = SmartModuleTransformErrorStatus::try_from(map_output)
-                .unwrap_or(SmartModuleTransformErrorStatus::UnknownError);
-            return Err(internal_error.into());
-        }
-
-        let output: SmartModuleOutput = ctx.read_output(store)?;
-        Ok(output)
-    }
-
-    fn name(&self) -> &str {
-        ARRAY_MAP_FN_NAME
-    }
-}
-
 #[cfg(test)]
 mod test {
+
+    const ARRAY_MAP_FN_NAME: &str = "array_map";
 
     use std::{convert::TryFrom};
 
@@ -101,7 +35,7 @@ mod test {
 
         assert_eq!(
             chain.instances().first().expect("first").transform().name(),
-            super::ARRAY_MAP_FN_NAME
+            ARRAY_MAP_FN_NAME
         );
 
         let metrics = SmartModuleChainMetrics::default();

--- a/crates/fluvio-smartengine/src/transforms/filter.rs
+++ b/crates/fluvio-smartengine/src/transforms/filter.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test {
-    const FILTER_FN_NAME: &str = "filter";
 
     use std::{convert::TryFrom};
 
@@ -11,6 +10,7 @@ mod test {
 
     use crate::{
         SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, metrics::SmartModuleChainMetrics,
+        transforms::simple_transform::FILTER_FN_NAME,
     };
 
     const SM_FILTER: &str = "fluvio_smartmodule_filter";

--- a/crates/fluvio-smartengine/src/transforms/filter.rs
+++ b/crates/fluvio-smartengine/src/transforms/filter.rs
@@ -1,74 +1,6 @@
-use std::convert::TryFrom;
-use std::fmt::Debug;
-
-use anyhow::Result;
-use wasmtime::{AsContextMut, TypedFunc};
-
-use fluvio_smartmodule::dataplane::smartmodule::{
-    SmartModuleInput, SmartModuleOutput, SmartModuleTransformErrorStatus,
-};
-
-use crate::{
-    instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    state::WasmState,
-};
-
-const FILTER_FN_NAME: &str = "filter";
-
-type WasmFilterFn = TypedFunc<(i32, i32, u32), i32>;
-
-pub(crate) struct SmartModuleFilter(WasmFilterFn);
-
-impl Debug for SmartModuleFilter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FilterFn")
-    }
-}
-
-impl SmartModuleFilter {
-    /// Try to create filter by matching function, if function is not found, then return empty
-    pub fn try_instantiate(
-        ctx: &SmartModuleInstanceContext,
-        store: &mut impl AsContextMut,
-    ) -> Result<Option<Self>> {
-        match ctx.get_wasm_func(store, FILTER_FN_NAME) {
-            // check type signature
-            Some(func) => func
-                .typed(&mut *store)
-                .or_else(|_| func.typed(store))
-                .map(|filter_fn| Some(Self(filter_fn))),
-            None => Ok(None),
-        }
-    }
-}
-
-impl SmartModuleTransform for SmartModuleFilter {
-    fn process(
-        &mut self,
-        input: SmartModuleInput,
-        ctx: &mut SmartModuleInstanceContext,
-        store: &mut WasmState,
-    ) -> Result<SmartModuleOutput> {
-        let slice = ctx.write_input(&input, &mut *store)?;
-        let filter_output = self.0.call(&mut *store, slice)?;
-
-        if filter_output < 0 {
-            let internal_error = SmartModuleTransformErrorStatus::try_from(filter_output)
-                .unwrap_or(SmartModuleTransformErrorStatus::UnknownError);
-            return Err(internal_error.into());
-        }
-
-        let output: SmartModuleOutput = ctx.read_output(store)?;
-        Ok(output)
-    }
-
-    fn name(&self) -> &str {
-        FILTER_FN_NAME
-    }
-}
-
 #[cfg(test)]
 mod test {
+    const FILTER_FN_NAME: &str = "filter";
 
     use std::{convert::TryFrom};
 
@@ -103,7 +35,7 @@ mod test {
 
         assert_eq!(
             chain.instances().first().expect("first").transform().name(),
-            super::FILTER_FN_NAME
+            FILTER_FN_NAME
         );
 
         let metrics = SmartModuleChainMetrics::default();
@@ -161,10 +93,7 @@ mod test {
 
         let instance = chain.instances().first().expect("first");
 
-        assert_eq!(
-            instance.transform().name(),
-            crate::transforms::filter::FILTER_FN_NAME
-        );
+        assert_eq!(instance.transform().name(), FILTER_FN_NAME);
 
         assert!(instance.get_init().is_some());
 

--- a/crates/fluvio-smartengine/src/transforms/filter_map.rs
+++ b/crates/fluvio-smartengine/src/transforms/filter_map.rs
@@ -1,75 +1,7 @@
-use std::convert::TryFrom;
-use std::fmt::Debug;
-
-use anyhow::Result;
-use fluvio_smartmodule::dataplane::smartmodule::{
-    SmartModuleInput, SmartModuleOutput, SmartModuleTransformErrorStatus,
-};
-use wasmtime::{AsContextMut, TypedFunc};
-
-use crate::{
-    instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    state::WasmState,
-};
-
-const FILTER_MAP_FN_NAME: &str = "filter_map";
-
-type WasmFilterMapFn = TypedFunc<(i32, i32, u32), i32>;
-
-pub(crate) struct SmartModuleFilterMap(WasmFilterMapFn);
-
-impl Debug for SmartModuleFilterMap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FilterMapFnWithParam")
-    }
-}
-
-impl SmartModuleFilterMap {
-    pub fn try_instantiate(
-        ctx: &SmartModuleInstanceContext,
-        store: &mut impl AsContextMut,
-    ) -> Result<Option<Self>> {
-        match ctx.get_wasm_func(&mut *store, FILTER_MAP_FN_NAME) {
-            Some(func) => {
-                // check type signature
-
-                func.typed(&mut *store)
-                    .or_else(|_| func.typed(store))
-                    .map(|filter_map_fn| Some(Self(filter_map_fn)))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-impl SmartModuleTransform for SmartModuleFilterMap {
-    fn process(
-        &mut self,
-        input: SmartModuleInput,
-        ctx: &mut SmartModuleInstanceContext,
-        store: &mut WasmState,
-    ) -> Result<SmartModuleOutput> {
-        let slice = ctx.write_input(&input, &mut *store)?;
-        let map_output = self.0.call(&mut *store, slice)?;
-
-        if map_output < 0 {
-            let internal_error = SmartModuleTransformErrorStatus::try_from(map_output)
-                .unwrap_or(SmartModuleTransformErrorStatus::UnknownError);
-            return Err(internal_error.into());
-        }
-
-        let output: SmartModuleOutput = ctx.read_output(store)?;
-        Ok(output)
-    }
-
-    fn name(&self) -> &str {
-        FILTER_MAP_FN_NAME
-    }
-}
-
 #[cfg(test)]
 mod test {
 
+    const FILTER_MAP_FN_NAME: &str = "filter_map";
     use std::{convert::TryFrom};
 
     use fluvio_smartmodule::{
@@ -102,7 +34,7 @@ mod test {
 
         assert_eq!(
             chain.instances().first().expect("first").transform().name(),
-            super::FILTER_MAP_FN_NAME
+            FILTER_MAP_FN_NAME
         );
 
         let metrics = SmartModuleChainMetrics::default();

--- a/crates/fluvio-smartengine/src/transforms/filter_map.rs
+++ b/crates/fluvio-smartengine/src/transforms/filter_map.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod test {
 
-    const FILTER_MAP_FN_NAME: &str = "filter_map";
     use std::{convert::TryFrom};
 
     use fluvio_smartmodule::{
@@ -11,6 +10,7 @@ mod test {
 
     use crate::{
         SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, metrics::SmartModuleChainMetrics,
+        transforms::simple_transform::FILTER_MAP_FN_NAME,
     };
 
     const SM_FILTER_MAP: &str = "fluvio_smartmodule_filter_map";

--- a/crates/fluvio-smartengine/src/transforms/map.rs
+++ b/crates/fluvio-smartengine/src/transforms/map.rs
@@ -1,74 +1,6 @@
-use std::convert::TryFrom;
-use std::fmt::Debug;
-
-use anyhow::Result;
-use wasmtime::{AsContextMut, TypedFunc};
-
-use fluvio_smartmodule::dataplane::smartmodule::{
-    SmartModuleInput, SmartModuleOutput, SmartModuleTransformErrorStatus,
-};
-use crate::{
-    instance::{SmartModuleInstanceContext, SmartModuleTransform},
-    state::WasmState,
-};
-
-const MAP_FN_NAME: &str = "map";
-
-type WasmMapFn = TypedFunc<(i32, i32, u32), i32>;
-
-pub struct SmartModuleMap(WasmMapFn);
-
-impl Debug for SmartModuleMap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MapFnWithParam")
-    }
-}
-
-impl SmartModuleMap {
-    #[tracing::instrument(skip(ctx, store))]
-    pub(crate) fn try_instantiate(
-        ctx: &SmartModuleInstanceContext,
-        store: &mut impl AsContextMut,
-    ) -> Result<Option<Self>> {
-        match ctx.get_wasm_func(store, MAP_FN_NAME) {
-            Some(func) => {
-                // check type signature
-                func.typed(&mut *store)
-                    .or_else(|_| func.typed(&mut *store))
-                    .map(|map_fn| Some(Self(map_fn)))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-impl SmartModuleTransform for SmartModuleMap {
-    fn process(
-        &mut self,
-        input: SmartModuleInput,
-        ctx: &mut SmartModuleInstanceContext,
-        store: &mut WasmState,
-    ) -> Result<SmartModuleOutput> {
-        let slice = ctx.write_input(&input, &mut *store)?;
-        let map_output = self.0.call(&mut *store, slice)?;
-
-        if map_output < 0 {
-            let internal_error = SmartModuleTransformErrorStatus::try_from(map_output)
-                .unwrap_or(SmartModuleTransformErrorStatus::UnknownError);
-            return Err(internal_error.into());
-        }
-
-        let output: SmartModuleOutput = ctx.read_output(store)?;
-        Ok(output)
-    }
-
-    fn name(&self) -> &str {
-        MAP_FN_NAME
-    }
-}
-
 #[cfg(test)]
 mod test {
+    const MAP_FN_NAME: &str = "map";
 
     use std::{convert::TryFrom};
 
@@ -101,7 +33,7 @@ mod test {
 
         assert_eq!(
             chain.instances().first().expect("first").transform().name(),
-            super::MAP_FN_NAME
+            MAP_FN_NAME
         );
 
         let metrics = SmartModuleChainMetrics::default();

--- a/crates/fluvio-smartengine/src/transforms/map.rs
+++ b/crates/fluvio-smartengine/src/transforms/map.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test {
-    const MAP_FN_NAME: &str = "map";
 
     use std::{convert::TryFrom};
 
@@ -11,6 +10,7 @@ mod test {
 
     use crate::{
         SmartEngine, SmartModuleChainBuilder, SmartModuleConfig, metrics::SmartModuleChainMetrics,
+        transforms::simple_transform::MAP_FN_NAME,
     };
     use crate::fixture::read_wasm_module;
 

--- a/crates/fluvio-smartengine/src/transforms/mod.rs
+++ b/crates/fluvio-smartengine/src/transforms/mod.rs
@@ -18,8 +18,10 @@ mod instance {
     };
 
     use super::{
-        simple_transform::SimpleTansform, aggregate::SmartModuleAggregate,
-        simple_transform::SimpleTansformKind,
+        simple_transform::{
+            SimpleTansform, FILTER_FN_NAME, MAP_FN_NAME, FILTER_MAP_FN_NAME, ARRAY_MAP_FN_NAME,
+        },
+        aggregate::SmartModuleAggregate,
     };
 
     pub(crate) fn create_transform(
@@ -27,23 +29,20 @@ mod instance {
         initial_data: SmartModuleInitialData,
         store: &mut impl AsContextMut,
     ) -> Result<Box<dyn DowncastableTransform>> {
-        if let Some(tr) = SimpleTansform::try_instantiate(SimpleTansformKind::Filter, ctx, store)?
+        if let Some(tr) = SimpleTansform::try_instantiate(FILTER_FN_NAME, ctx, store)?
             .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) =
-            SimpleTansform::try_instantiate(SimpleTansformKind::Map, ctx, store)?
-                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) = SimpleTansform::try_instantiate(MAP_FN_NAME, ctx, store)?
+            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) =
-            SimpleTansform::try_instantiate(SimpleTansformKind::FilterMap, ctx, store)?
-                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) = SimpleTansform::try_instantiate(FILTER_MAP_FN_NAME, ctx, store)?
+            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) =
-            SimpleTansform::try_instantiate(SimpleTansformKind::ArrayMap, ctx, store)?
-                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) = SimpleTansform::try_instantiate(ARRAY_MAP_FN_NAME, ctx, store)?
+            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
         } else if let Some(tr) = SmartModuleAggregate::try_instantiate(ctx, initial_data, store)?

--- a/crates/fluvio-smartengine/src/transforms/mod.rs
+++ b/crates/fluvio-smartengine/src/transforms/mod.rs
@@ -3,8 +3,8 @@ pub(crate) mod map;
 pub(crate) mod array_map;
 pub(crate) mod filter_map;
 pub(crate) mod aggregate;
-
 pub(crate) use instance::create_transform;
+mod simple_transform;
 
 mod instance {
 
@@ -18,8 +18,8 @@ mod instance {
     };
 
     use super::{
-        filter::SmartModuleFilter, map::SmartModuleMap, filter_map::SmartModuleFilterMap,
-        array_map::SmartModuleArrayMap, aggregate::SmartModuleAggregate,
+        simple_transform::SimpleTansform, aggregate::SmartModuleAggregate,
+        simple_transform::SimpleTansformKind,
     };
 
     pub(crate) fn create_transform(
@@ -27,20 +27,23 @@ mod instance {
         initial_data: SmartModuleInitialData,
         store: &mut impl AsContextMut,
     ) -> Result<Box<dyn DowncastableTransform>> {
-        if let Some(tr) = SmartModuleFilter::try_instantiate(ctx, store)?
+        if let Some(tr) = SimpleTansform::try_instantiate(SimpleTansformKind::Filter, ctx, store)?
             .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) = SmartModuleMap::try_instantiate(ctx, store)?
-            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) =
+            SimpleTansform::try_instantiate(SimpleTansformKind::Map, ctx, store)?
+                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) = SmartModuleFilterMap::try_instantiate(ctx, store)?
-            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) =
+            SimpleTansform::try_instantiate(SimpleTansformKind::FilterMap, ctx, store)?
+                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
-        } else if let Some(tr) = SmartModuleArrayMap::try_instantiate(ctx, store)?
-            .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
+        } else if let Some(tr) =
+            SimpleTansform::try_instantiate(SimpleTansformKind::ArrayMap, ctx, store)?
+                .map(|transform| Box::new(transform) as Box<dyn DowncastableTransform>)
         {
             Ok(tr)
         } else if let Some(tr) = SmartModuleAggregate::try_instantiate(ctx, initial_data, store)?

--- a/crates/fluvio-smartengine/src/transforms/simple_transform.rs
+++ b/crates/fluvio-smartengine/src/transforms/simple_transform.rs
@@ -1,0 +1,91 @@
+use fluvio_smartmodule::dataplane::smartmodule::{
+    SmartModuleInput, SmartModuleOutput, SmartModuleTransformErrorStatus,
+};
+use wasmtime::{TypedFunc, AsContextMut};
+use anyhow::Result;
+
+use crate::{
+    instance::{SmartModuleInstanceContext, SmartModuleTransform},
+    state::WasmState,
+};
+
+type WasmFn = TypedFunc<(i32, i32, u32), i32>;
+
+#[derive(Debug)]
+pub enum SimpleTansformKind {
+    Filter,
+    Map,
+    FilterMap,
+    ArrayMap,
+}
+
+impl SimpleTansformKind {
+    fn name(&self) -> &str {
+        match self {
+            Self::Filter => "filter",
+            Self::Map => "map",
+            Self::FilterMap => "filter_map",
+            Self::ArrayMap => "array_map",
+        }
+    }
+}
+
+pub struct SimpleTansform {
+    f: WasmFn,
+    kind: SimpleTansformKind,
+}
+
+impl std::fmt::Debug for SimpleTansform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            SimpleTansformKind::Filter => write!(f, "FilterFn"),
+            SimpleTansformKind::Map => write!(f, "MapFnWithParam"),
+            SimpleTansformKind::FilterMap => write!(f, "FilterMapFnWithParam"),
+            SimpleTansformKind::ArrayMap => write!(f, "ArrayMapFnWithParam"),
+        }
+    }
+}
+
+impl SimpleTansform {
+    #[tracing::instrument(skip(ctx, store))]
+    pub(crate) fn try_instantiate(
+        kind: SimpleTansformKind,
+        ctx: &SmartModuleInstanceContext,
+        store: &mut impl AsContextMut,
+    ) -> Result<Option<Self>> {
+        match ctx.get_wasm_func(store, kind.name()) {
+            Some(func) => {
+                // check type signature
+                func.typed(&mut *store)
+                    .or_else(|_| func.typed(&mut *store))
+                    .map(|f| Some(Self { f, kind }))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl SmartModuleTransform for SimpleTansform {
+    fn process(
+        &mut self,
+        input: SmartModuleInput,
+        ctx: &mut SmartModuleInstanceContext,
+        store: &mut WasmState,
+    ) -> Result<SmartModuleOutput> {
+        let slice = ctx.write_input(&input, &mut *store)?;
+        let map_output = self.f.call(&mut *store, slice)?;
+
+        if map_output < 0 {
+            let internal_error = SmartModuleTransformErrorStatus::try_from(map_output)
+                .unwrap_or(SmartModuleTransformErrorStatus::UnknownError);
+            return Err(internal_error.into());
+        }
+
+        let output: SmartModuleOutput = ctx.read_output(store)?;
+        Ok(output)
+    }
+
+    fn name(&self) -> &str {
+        self.kind.name()
+    }
+}

--- a/crates/fluvio-smartengine/src/transforms/simple_transform.rs
+++ b/crates/fluvio-smartengine/src/transforms/simple_transform.rs
@@ -23,13 +23,7 @@ pub(crate) struct SimpleTansform {
 
 impl std::fmt::Debug for SimpleTansform {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.name.as_str() {
-            FILTER_FN_NAME => write!(f, "FilterFn"),
-            MAP_FN_NAME => write!(f, "MapFnWithParam"),
-            FILTER_MAP_FN_NAME => write!(f, "FilterMapFnWithParam"),
-            ARRAY_MAP_FN_NAME => write!(f, "ArrayMapFnWithParam"),
-            _ => unreachable!("unknown transform function"),
-        }
+        write!(f, "{}", self.name)
     }
 }
 

--- a/crates/fluvio-smartengine/src/transforms/simple_transform.rs
+++ b/crates/fluvio-smartengine/src/transforms/simple_transform.rs
@@ -11,12 +11,12 @@ use crate::{
 
 type WasmFn = TypedFunc<(i32, i32, u32), i32>;
 
-pub const FILTER_FN_NAME: &str = "filter";
-pub const MAP_FN_NAME: &str = "map";
-pub const FILTER_MAP_FN_NAME: &str = "filter_map";
-pub const ARRAY_MAP_FN_NAME: &str = "array_map";
+pub(crate) const FILTER_FN_NAME: &str = "filter";
+pub(crate) const MAP_FN_NAME: &str = "map";
+pub(crate) const FILTER_MAP_FN_NAME: &str = "filter_map";
+pub(crate) const ARRAY_MAP_FN_NAME: &str = "array_map";
 
-pub struct SimpleTansform {
+pub(crate) struct SimpleTansform {
     f: WasmFn,
     name: String,
 }


### PR DESCRIPTION
All transforms except agg shares the same code, so this PR unifies them into one shared implementation. By the way, in `smartmodule-derive`, all these transforms except agg shares the same implementation via `generate_transform`, so I think it also makes sense to reuse code in smartengine.