### PR TITLE
[Merged by Bors] - feat: explicit set of errors to retry

### DIFF
--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.15.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/multiplexing.rs
+++ b/crates/fluvio-socket/src/multiplexing.rs
@@ -136,7 +136,7 @@ impl MultiplexerSocket {
             use std::env;
 
             let var_value = env::var("FLV_SOCKET_WAIT").unwrap_or_default();
-            let wait_time: u64 = var_value.parse().unwrap_or(300); // match TCP socket timeout
+            let wait_time: u64 = var_value.parse().unwrap_or(60);
             wait_time
         });
 


### PR DESCRIPTION
The current default time to wait for Fluvio Socket is 5 minutes, and until that time, if there is a network connectivity issue, it does not report an error. It seems too coarse, it doesn't align well with retries. For the producer, for example, we set a whole timeout for all retries is 5 minutes.

This PR is a proposal to decrease this value and explicitly define the set of socket errors that we want to retry.

Related #3124 