### PR TITLE
[Merged by Bors] - feat: add support to string interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bce8d450891e3b36f85a2230cec441fddd60e0c455b61b15bb3ffba955ca85"
+
+[[package]]
 name = "aligned"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2654,7 @@ dependencies = [
  "fluvio-smartengine",
  "fluvio-types",
  "humantime-serde",
+ "minijinja",
  "once_cell",
  "openapiv3",
  "pretty_assertions",
@@ -3812,7 +3819,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -4869,6 +4876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "0.32.1"
+source = "git+https://github.com/mitsuhiko/minijinja?rev=c4b48dc5be9de0143e06bef97618c7ed029fb155#c4b48dc5be9de0143e06bef97618c7ed029fb155"
+dependencies = [
+ "aho-corasick 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5886,7 +5902,7 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "memchr",
  "regex-syntax",
 ]

--- a/connector/sink-test-connector/Connector.toml
+++ b/connector/sink-test-connector/Connector.toml
@@ -7,12 +7,8 @@ fluvio = "0.10.0"
 description = "Test Sink Connector"
 license = "Apache-2.0"
 
-
 [direction]
 dest = true
 
 [deployment]
 binary = "sink-test-connector"
-
-[secret.TEST_API_KEY]
-type = "env"

--- a/connector/sink-test-connector/config-example.yaml
+++ b/connector/sink-test-connector/config-example.yaml
@@ -5,10 +5,12 @@ meta:
   topic: test-topic
   secrets:
     - name: TEST_API_KEY
+    - name: TEST_API_CLIENT_ID
 custom:
   api_key:
     secret:
       name: TEST_API_KEY
+  client_id: ${{ secrets.TEST_API_CLIENT_ID }}
 transforms:
   - uses: infinyon/jolt@0.1.0
     with:

--- a/connector/sink-test-connector/secrets.txt
+++ b/connector/sink-test-connector/secrets.txt
@@ -1,1 +1,2 @@
 TEST_API_KEY=test value
+TEST_API_CLIENT_ID=client1

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -18,4 +18,5 @@ async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<
 #[connector(config)]
 struct CustomConfig {
     api_key: SecretString,
+    client_id: String,
 }

--- a/connector/sink-test-connector/src/sink.rs
+++ b/connector/sink-test-connector/src/sink.rs
@@ -14,7 +14,9 @@ impl TestSink {
     pub(crate) fn new(config: &CustomConfig) -> Result<Self> {
         debug!(?config.api_key);
         let resolved = config.api_key.resolve()?;
+        let resolved_2 = config.client_id.clone();
         debug!(resolved);
+        debug!(resolved_2);
         Ok(Self {})
     }
 }

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -1,15 +1,14 @@
-pub use fluvio_connector_package::config::ConnectorConfig;
+use std::io::Read;
+
+use anyhow::{Result, Context};
+use serde::de::DeserializeOwned;
+use serde_yaml::Value;
 use tracing::trace;
 
-use std::{path::PathBuf, fs::File};
+pub use fluvio_connector_package::config::ConnectorConfig;
 
-use serde::de::DeserializeOwned;
-use anyhow::{Result, Context};
-use serde_yaml::Value;
-
-pub fn value_from_file<P: Into<PathBuf>>(path: P) -> Result<Value> {
-    let file = File::open(path.into())?;
-    serde_yaml::from_reader(file).context("unable to parse config file into YAML")
+pub fn value_from_reader<R: Read>(reader: R) -> Result<Value> {
+    serde_yaml::from_reader(reader).context("unable to parse config file into YAML")
 }
 
 pub fn from_value<T: DeserializeOwned>(value: Value, root: Option<&str>) -> Result<T> {

--- a/crates/fluvio-connector-common/src/lib.rs
+++ b/crates/fluvio-connector-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod monitoring;
 pub mod consumer;
 pub mod config;
 
+pub use fluvio_connector_package::render_config_str;
 pub use fluvio_connector_package::secret;
 
 #[cfg(feature = "derive")]

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -14,6 +14,7 @@ default = ["toml"]
 anyhow = { workspace = true }
 bytesize = { workspace = true}
 humantime-serde = "1.1.1"
+minijinja = { git = "https://github.com/mitsuhiko/minijinja" , rev = "c4b48dc5be9de0143e06bef97618c7ed029fb155", default-features = false, features = ["custom_syntax", "fuel"] }
 openapiv3 = { git = "https://github.com/galibey/openapiv3", rev = "bdd22f046d2bc19ede257504645d31f835545222", default-features = false }
 once_cell = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/fluvio-connector-package/src/config.rs
+++ b/crates/fluvio-connector-package/src/config.rs
@@ -47,6 +47,12 @@ pub struct MetaConfig {
     pub secrets: Option<Vec<SecretConfig>>,
 }
 
+impl MetaConfig {
+    fn secrets(&self) -> HashSet<SecretConfig> {
+        HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ConsumerParameters {
@@ -173,7 +179,7 @@ impl ConnectorConfig {
     }
 
     pub fn secrets(&self) -> HashSet<SecretConfig> {
-        HashSet::from_iter(self.meta.secrets.clone().unwrap_or_default().into_iter())
+        self.meta.secrets()
     }
 
     pub fn from_value(value: serde_yaml::Value) -> Result<Self> {

--- a/crates/fluvio-connector-package/src/lib.rs
+++ b/crates/fluvio-connector-package/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod metadata;
 pub mod config;
 pub mod secret;
+mod render;
+
+pub use render::render_config_str;

--- a/crates/fluvio-connector-package/src/render/context.rs
+++ b/crates/fluvio-connector-package/src/render/context.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+use minijinja::value::Value;
+
+use crate::{secret::SecretStore, config::ConnectorConfig};
+
+/// Context for the template engine
+/// This is the data that is available to the template engine
+/// when it is rendering the template.
+#[derive(Serialize, Default)]
+pub(crate) struct Context(pub(crate) HashMap<&'static str, Value>);
+
+/// Template engine does not allow lazy loading of context values.
+/// This trait allows us to load context values on demand.
+pub(crate) trait ContextStore {
+    /// values to add to the context
+    fn extract_context_values(&self, input: &str) -> anyhow::Result<Value>;
+    /// key name for the context
+    fn context_name(&self) -> &'static str;
+}
+impl dyn ContextStore {
+    pub(crate) fn add_to_context(&self, context: &mut Context, input: &str) -> anyhow::Result<()> {
+        let value = self.extract_context_values(input)?;
+
+        context.0.insert(self.context_name(), value);
+        Ok(())
+    }
+}
+impl ContextStore for &dyn SecretStore {
+    fn extract_context_values(&self, input: &str) -> anyhow::Result<Value> {
+        let connector_config: ConnectorConfig = serde_yaml::from_reader(input.as_bytes())?;
+        let mut values = HashMap::default();
+
+        for secret in connector_config.secrets().iter() {
+            let secret_value = self.read(secret.name())?;
+            values.insert(secret.name().to_owned(), secret_value);
+        }
+        Ok(values.into())
+    }
+
+    fn context_name(&self) -> &'static str {
+        "secrets"
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use minijinja::value::Value;
+
+    use super::ContextStore;
+
+    pub struct TestStore;
+
+    impl ContextStore for TestStore {
+        fn extract_context_values(&self, _input: &str) -> anyhow::Result<Value> {
+            Ok([("test", "value")].into_iter().collect())
+        }
+
+        fn context_name(&self) -> &'static str {
+            "test"
+        }
+    }
+
+    #[test]
+    fn test_context_store() {
+        let store = &TestStore as &dyn ContextStore;
+        let mut context = super::Context::default();
+        store.add_to_context(&mut context, "").unwrap();
+        assert_eq!(
+            context
+                .0
+                .get("test")
+                .unwrap()
+                .get_attr("test")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "value"
+        );
+    }
+}

--- a/crates/fluvio-connector-package/src/render/mod.rs
+++ b/crates/fluvio-connector-package/src/render/mod.rs
@@ -1,0 +1,209 @@
+use minijinja::{Environment};
+
+use crate::{
+    secret::{self},
+};
+
+use self::{
+    context::{Context, ContextStore},
+    syntax::ConnectorTemplateSyntax,
+};
+
+mod context;
+mod syntax;
+
+/// Config renderer. This is the main entry point for rendering a config.
+/// It is responsible for resolving secrets and rendering the config.
+pub(crate) struct ConfigRenderer {
+    inner_renderer: Environment<'static>,
+    context_stores: Vec<Box<dyn ContextStore>>,
+}
+
+impl ConfigRenderer {
+    fn new(
+        inner_renderer: Environment<'static>,
+        context_stores: Vec<Box<dyn ContextStore>>,
+    ) -> Self {
+        Self {
+            inner_renderer,
+            context_stores,
+        }
+    }
+
+    fn new_with_context_stores(context_stores: Vec<Box<dyn ContextStore>>) -> anyhow::Result<Self> {
+        let mut inner_renderer = Environment::new();
+        inner_renderer.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+        inner_renderer.set_syntax(ConnectorTemplateSyntax::default().into())?;
+        inner_renderer.set_fuel(Some(500));
+
+        Ok(Self::new(inner_renderer, context_stores))
+    }
+
+    fn new_with_default_stores() -> anyhow::Result<Self> {
+        let context_stores = Self::default_stores()?;
+
+        Self::new_with_context_stores(context_stores)
+    }
+
+    fn render_str(&self, input: &str) -> anyhow::Result<String> {
+        let context = self.build_context(input)?;
+        match self.inner_renderer.render_str(input, context) {
+            Ok(rendered) => Ok(rendered),
+            Err(_) => Err(anyhow::anyhow!("failed to render: `{}`.", input)),
+        }
+    }
+
+    fn default_stores() -> anyhow::Result<Vec<Box<dyn ContextStore>>> {
+        Ok(vec![Box::new(secret::default_secret_store()?)])
+    }
+
+    fn build_context(&self, input: &str) -> anyhow::Result<Context> {
+        let mut context = Context::default();
+        for store in self.context_stores.iter() {
+            store.add_to_context(&mut context, input)?;
+        }
+        Ok(context)
+    }
+}
+
+/// Render a config from a string.
+/// This is the main entry point for rendering a config.
+/// It is responsible for resolving secrets and rendering the config.
+pub fn render_config_str(input: &str) -> anyhow::Result<String> {
+    let renderer = ConfigRenderer::new_with_default_stores()?;
+
+    let value = renderer.render_str(input)?;
+
+    Ok(value)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{io::Write};
+
+    use minijinja::value::Value;
+
+    use crate::{
+        secret::{FileSecretStore},
+    };
+
+    use super::{ConfigRenderer, context::ContextStore};
+
+    // mock secret store
+    pub struct SecretTestStore;
+
+    impl ContextStore for SecretTestStore {
+        fn extract_context_values(&self, _input: &str) -> anyhow::Result<Value> {
+            let values = [
+                ("foo", "bar"),
+                ("api_key", "my_api_key"),
+                ("interval", "10s"),
+            ]
+            .into_iter()
+            .collect();
+            Ok(values)
+        }
+
+        fn context_name(&self) -> &'static str {
+            "test_secrets"
+        }
+    }
+
+    #[test]
+    fn test_build_context() {
+        let store = Box::new(SecretTestStore);
+
+        let renderer = ConfigRenderer::new_with_context_stores(vec![store]).unwrap();
+        let context: super::context::Context = renderer.build_context("").unwrap();
+
+        assert_eq!(
+            context
+                .0
+                .get("test_secrets")
+                .unwrap()
+                .get_attr("foo")
+                .unwrap(),
+            "bar".into()
+        );
+        assert_eq!(context.0.get("test_secrets").unwrap().len().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_render_str() {
+        let store = Box::new(SecretTestStore);
+        let renderer = ConfigRenderer::new_with_context_stores(vec![store]).unwrap();
+        let output = renderer
+            .render_str("hello ${{ test_secrets.foo }}")
+            .unwrap();
+        assert_eq!(output, "hello bar");
+    }
+
+    #[test]
+    fn test_render_str_undefined_secret() {
+        let store = Box::new(SecretTestStore);
+
+        let renderer = ConfigRenderer::new_with_context_stores(vec![store]).unwrap();
+        let output = renderer.render_str("hello ${{ test_secrets.undefined_var }}");
+        assert!(output.is_err());
+    }
+
+    #[test]
+    fn test_invalid_syntax() {
+        let store = Box::new(SecretTestStore);
+
+        let renderer = ConfigRenderer::new_with_context_stores(vec![store]).unwrap();
+        let output = renderer.render_str("hello ${{");
+        assert!(output.is_err());
+    }
+
+    #[test]
+    fn test_undefined_context_variable() {
+        let store = Box::new(SecretTestStore);
+
+        let renderer = ConfigRenderer::new_with_context_stores(vec![store]).unwrap();
+        let output = renderer.render_str("hello ${{ some_undefined }}");
+        assert!(output.is_err());
+    }
+
+    #[test]
+    fn test_resolve_config() {
+        use super::*;
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create tmp file");
+        file.write_all(b"foo=bar\napi_key=my_api_key\ninterval=10s")
+            .expect("file to write");
+        let _ = secret::set_default_secret_store(::std::boxed::Box::new(FileSecretStore::from(
+            file.path(),
+        )));
+
+        let value_str = r#"
+            meta:
+                name: test
+                version: 0.1.0
+                topic: test
+                type: http-source
+                consumer:
+                    partition: 0
+                secrets:
+                    - name: api_key
+                    - name: interval
+            my_service:
+                api_key: ${{secrets.api_key}}
+                interval: ${{ secrets.interval }}
+            "#;
+
+        let value_str = render_config_str(value_str).unwrap();
+        let value: serde_yaml::Value = serde_yaml::from_str(&value_str).expect("should be yaml");
+        assert_eq!(
+            value["my_service"]["api_key"]
+                .as_str()
+                .expect("should be str"),
+            "my_api_key"
+        );
+        assert_eq!(
+            value["my_service"]["interval"]
+                .as_str()
+                .expect("should be str"),
+            "10s"
+        );
+    }
+}

--- a/crates/fluvio-connector-package/src/render/mod.rs
+++ b/crates/fluvio-connector-package/src/render/mod.rs
@@ -85,6 +85,7 @@ mod test {
 
     use crate::{
         secret::{FileSecretStore},
+        config::ConnectorConfig,
     };
 
     use super::{ConfigRenderer, context::ContextStore};
@@ -192,7 +193,14 @@ mod test {
             "#;
 
         let value_str = render_config_str(value_str).unwrap();
+        let connector_config: ConnectorConfig =
+            serde_yaml::from_str(&value_str).expect("should be yaml");
         let value: serde_yaml::Value = serde_yaml::from_str(&value_str).expect("should be yaml");
+
+        assert_eq!(connector_config.meta.name, "test");
+        assert_eq!(connector_config.meta.version, "0.1.0");
+        assert_eq!(connector_config.meta.topic, "test");
+        assert_eq!(connector_config.meta.type_, "http-source");
         assert_eq!(
             value["my_service"]["api_key"]
                 .as_str()

--- a/crates/fluvio-connector-package/src/render/syntax.rs
+++ b/crates/fluvio-connector-package/src/render/syntax.rs
@@ -1,0 +1,22 @@
+use minijinja::Syntax;
+
+pub struct ConnectorTemplateSyntax(Syntax);
+
+impl Default for ConnectorTemplateSyntax {
+    fn default() -> Self {
+        Self(Syntax {
+            block_start: "${%".into(),
+            block_end: "%}".into(),
+            variable_start: "${{".into(),
+            variable_end: "}}".into(),
+            comment_start: "${#".into(),
+            comment_end: "#}".into(),
+        })
+    }
+}
+
+impl From<ConnectorTemplateSyntax> for Syntax {
+    fn from(syntax: ConnectorTemplateSyntax) -> Self {
+        syntax.0
+    }
+}

--- a/crates/fluvio-connector-package/src/secret.rs
+++ b/crates/fluvio-connector-package/src/secret.rs
@@ -106,7 +106,7 @@ impl<T: AsRef<Path>> From<T> for FileSecretStore {
     }
 }
 
-fn default_secret_store() -> Result<&'static (dyn SecretStore)> {
+pub(crate) fn default_secret_store() -> Result<&'static (dyn SecretStore)> {
     SECRET_STORE
         .get()
         .map(AsRef::as_ref)


### PR DESCRIPTION
Solves #3127 

With this change we could use something like:

```
http:
  headers:
   - "Authorization: JWT ${{ secrets.JWT_TOKEN }}"
```

And that should be resolved as

   - "Authorization: JWT MYSECRET_TOKEN"
