### PR TITLE
[Merged by Bors] - fix: unblock cd_dev.yaml

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -61,7 +61,7 @@ jobs:
           kind create cluster --config k8-util/cluster/kind.yaml
       - name: Install Fluvio CLI
         run: |
-          curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest bash
+          curl -fsS https://packages.fluvio.io/v1/install.sh | VERSION=latest FLV_VERSION=latest bash
           echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
       - name: Install Local Fluvio cluster
         timeout-minutes: 3
@@ -180,7 +180,9 @@ jobs:
 
       - name: Curl Install - latest 
         if: matrix.version == 'latest'
-        run: echo "VERSION=latest" | tee -a $GITHUB_ENV
+        run: |
+          echo "VERSION=latest" | tee -a $GITHUB_ENV
+          echo "FLV_VERSION=latest" | tee -a $GITHUB_ENV
 
         # Utilizes the env var set in the previous step 
       - name: Curl Install


### PR DESCRIPTION
narrow workaound, use FLV_VERSION because last dev version install.sh is being used in CD_Dev in order to release next install.sh