### PR TITLE
[Merged by Bors] - ci: parse input as boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
 
   publish_crates:
     name: Publish Crates
-    if: ${{ !github.event.inputs.pre_release }}
+    if: ${{ !inputs.pre_release }}
     uses: ./.github/workflows/publish_crates.yml
     with:
       commit: ${{ github.event.inputs.commit }}
@@ -254,7 +254,7 @@ jobs:
     needs: [setup_job, release_github, release_docker, release_fluvio]
     #permissions: write-all
     runs-on: ubuntu-latest
-    if: ${{ !github.event.inputs.pre_release }}
+    if: ${{ !inputs.pre_release }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
>> Note: The workflow will also receive the inputs in the github.event.inputs context. The information in the inputs context and github.event.inputs context is identical except that the inputs context preserves Boolean values as Booleans instead of converting them to strings.

https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

This should fix https://github.com/infinyon/fluvio/issues/3045 