### PR TITLE
[Merged by Bors] - feat: introduce utilily to check k8s resource names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-future",

--- a/crates/fluvio-cli/src/client/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/create.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 use tracing::debug;
 use async_trait::async_trait;
 use clap::Parser;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use fluvio::Fluvio;
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasm, SmartModuleSpec};
 use fluvio_extension_common::Terminal;
+use fluvio_sc_schema::shared::{MAX_RESOURCE_NAME_LEN, is_valid_resource_name};
 
 use crate::client::cmd::ClientCmd;
 
@@ -68,6 +69,11 @@ impl ClientCmd for CreateSmartModuleOpt {
             (None, BTreeMap::new())
         };
         */
+
+        if !is_valid_resource_name(&self.name) {
+            debug!(name = self.name, "Invalid name provided for SmartModule");
+            return Err(anyhow!("Invalid name for SmartModule {}. Names must have a maximum of {} characters, and don't include any special characters nor spaces.", self.name, MAX_RESOURCE_NAME_LEN));
+        }
 
         let raw = std::fs::read(self.wasm_file)?;
 

--- a/crates/fluvio-cli/src/client/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/create.rs
@@ -70,7 +70,7 @@ impl ClientCmd for CreateSmartModuleOpt {
         };
         */
 
-        if !is_valid_resource_name(&self.name) {
+        if is_valid_resource_name(&self.name).is_err() {
             debug!(name = self.name, "Invalid name provided for SmartModule");
             return Err(anyhow!("Invalid name for SmartModule {}. Names must have a maximum of {} characters, and don't include any special characters nor spaces.", self.name, MAX_RESOURCE_NAME_LEN));
         }

--- a/crates/fluvio-cli/src/client/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/create.rs
@@ -72,11 +72,7 @@ impl ClientCmd for CreateSmartModuleOpt {
 
         if let Err(err) = validate_resource_name(&self.name) {
             debug!(name = self.name, "Invalid name provided for SmartModule");
-            return Err(anyhow!(
-                "Invalid name for SmartModule {}. {}",
-                self.name,
-                err.to_string()
-            ));
+            return Err(anyhow!("Invalid name for SmartModule {}, {err}", self.name));
         }
 
         let raw = std::fs::read(self.wasm_file)?;

--- a/crates/fluvio-cli/src/client/smartmodule/create.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/create.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 use fluvio::Fluvio;
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasm, SmartModuleSpec};
 use fluvio_extension_common::Terminal;
-use fluvio_sc_schema::shared::{MAX_RESOURCE_NAME_LEN, is_valid_resource_name};
+use fluvio_sc_schema::shared::validate_resource_name;
 
 use crate::client::cmd::ClientCmd;
 
@@ -70,9 +70,13 @@ impl ClientCmd for CreateSmartModuleOpt {
         };
         */
 
-        if is_valid_resource_name(&self.name).is_err() {
+        if let Err(err) = validate_resource_name(&self.name) {
             debug!(name = self.name, "Invalid name provided for SmartModule");
-            return Err(anyhow!("Invalid name for SmartModule {}. Names must have a maximum of {} characters, and don't include any special characters nor spaces.", self.name, MAX_RESOURCE_NAME_LEN));
+            return Err(anyhow!(
+                "Invalid name for SmartModule {}. {}",
+                self.name,
+                err.to_string()
+            ));
         }
 
         let raw = std::fs::read(self.wasm_file)?;

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -133,12 +133,9 @@ impl CreateTopicOpt {
         };
 
         if let Err(err) = validate_resource_name(&self.topic) {
-            return Err(CliError::InvalidArg(format!(
-                "Invalid Topic name {}. {}",
-                self.topic,
-                err.to_string()
-            ))
-            .into());
+            return Err(
+                CliError::InvalidArg(format!("Invalid Topic name {}. {err}", self.topic,)).into(),
+            );
         }
 
         let mut topic_spec: TopicSpec = replica_spec.into();

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -22,7 +22,7 @@ use fluvio::metadata::topic::SegmentBasedPolicy;
 use fluvio::metadata::topic::TopicStorageConfig;
 use fluvio::metadata::topic::CompressionAlgorithm;
 
-use fluvio_sc_schema::topic::validate::valid_topic_name;
+use fluvio_sc_schema::shared::is_valid_resource_name;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
@@ -132,7 +132,7 @@ impl CreateTopicOpt {
             })
         };
 
-        let is_valid = valid_topic_name(&self.topic);
+        let is_valid = is_valid_resource_name(&self.topic);
         if !is_valid {
             return Err(CliError::InvalidArg(
                 "Topic name must only contain lowercase alphanumeric characters or '-'."

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -22,7 +22,7 @@ use fluvio::metadata::topic::SegmentBasedPolicy;
 use fluvio::metadata::topic::TopicStorageConfig;
 use fluvio::metadata::topic::CompressionAlgorithm;
 
-use fluvio_sc_schema::shared::is_valid_resource_name;
+use fluvio_sc_schema::shared::validate_resource_name;
 
 use fluvio::Fluvio;
 use fluvio::metadata::topic::TopicSpec;
@@ -132,12 +132,12 @@ impl CreateTopicOpt {
             })
         };
 
-        let is_valid = is_valid_resource_name(&self.topic);
-        if is_valid.is_err() {
-            return Err(CliError::InvalidArg(
-                "Topic name must only contain lowercase alphanumeric characters or '-'."
-                    .to_string(),
-            )
+        if let Err(err) = validate_resource_name(&self.topic) {
+            return Err(CliError::InvalidArg(format!(
+                "Invalid Topic name {}. {}",
+                self.topic,
+                err.to_string()
+            ))
             .into());
         }
 

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -133,7 +133,7 @@ impl CreateTopicOpt {
         };
 
         let is_valid = is_valid_resource_name(&self.topic);
-        if !is_valid {
+        if is_valid.is_err() {
             return Err(CliError::InvalidArg(
                 "Topic name must only contain lowercase alphanumeric characters or '-'."
                     .to_string(),

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -18,9 +18,11 @@ use_serde = ["fluvio-controlplane-metadata/use_serde", "serde"]
 log = "0.4.8"
 tracing = "0.1.19"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
-thiserror = "1.0.40"
 static_assertions = "1.1.0"
 paste = "1.0"
+
+# Workspace Dependencies
+thiserror = { workspace = true }
 
 # Fluvio dependencies
 fluvio-types = { version = "0.4.0", path = "../fluvio-types" }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -18,7 +18,7 @@ use_serde = ["fluvio-controlplane-metadata/use_serde", "serde"]
 log = "0.4.8"
 tracing = "0.1.19"
 serde = { version = "1.0.0", features = ['derive'], optional = true }
-thiserror = "1.0.20"
+thiserror = "1.0.40"
 static_assertions = "1.1.0"
 paste = "1.0"
 

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -6,6 +6,7 @@ pub mod smartmodule;
 pub mod partition;
 pub mod versions;
 pub mod objects;
+pub mod shared;
 pub mod tableformat;
 
 mod apis;

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -35,10 +35,10 @@ pub fn validate_resource_name(name: &str) -> Result {
         && !name.ends_with('-')
         && !name.starts_with('-')
     {
-        return Err(ValidateResourceNameError::InvalidCharacterEncountered);
+        return Ok(());
     }
 
-    Ok(())
+    Err(ValidateResourceNameError::InvalidCharacterEncountered)
 }
 
 #[cfg(test)]

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -1,0 +1,78 @@
+const K8S_MAX_RESOURCE_NAME_LEN: usize = 63;
+
+pub fn is_valid_k8s_resource_name(name: &str) -> bool {
+    if name.len() > K8S_MAX_RESOURCE_NAME_LEN {
+        return false;
+    }
+
+    name.chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+        && !name.ends_with('-')
+        && !name.starts_with('-')
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_valid_k8s_resource_name;
+
+    #[test]
+    fn validates_name_length() {
+        let name = "this-is-a-very-long-long-long-long-long-long-name-and-its-not-valid";
+
+        assert!(!is_valid_k8s_resource_name(name));
+    }
+
+    #[test]
+    fn validates_no_spaces_allowed() {
+        let name = "Hello World";
+
+        assert!(!is_valid_k8s_resource_name(name));
+    }
+
+    #[test]
+    fn validates_no_special_chars_allowed() {
+        let name = "!@#$%^&*()👻";
+
+        assert!(!is_valid_k8s_resource_name(name));
+    }
+
+    #[test]
+    fn allows_valid_names() {
+        let names = vec![
+            "prices-list-scrapper",
+            "final-countdown-actual-countdown-timer",
+            "luke-i-am-your-father",
+            "im-not-looking-for-funny-names-in-the-internet",
+            "use-fluvio-exclamation-sign",
+            "testing-1234",
+        ];
+
+        for name in names {
+            assert!(is_valid_k8s_resource_name(name));
+        }
+    }
+
+    #[test]
+    fn reject_topics_with_spaces() {
+        assert!(!is_valid_k8s_resource_name("hello world"));
+    }
+
+    #[test]
+    fn reject_topics_with_uppercase() {
+        assert!(!is_valid_k8s_resource_name("helloWorld"));
+    }
+
+    #[test]
+    fn reject_topics_with_underscore() {
+        assert!(!is_valid_k8s_resource_name("hello_world"));
+    }
+
+    #[test]
+    fn valid_topic() {
+        assert!(is_valid_k8s_resource_name("hello-world"));
+    }
+    #[test]
+    fn reject_topics_that_start_with_hyphen() {
+        assert!(!is_valid_k8s_resource_name("-helloworld"));
+    }
+}

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -1,4 +1,12 @@
+pub type Result = std::result::Result<(), ValidateResourceNameError>;
+
 pub const MAX_RESOURCE_NAME_LEN: usize = 63;
+
+#[derive(Copy, Clone, Debug)]
+pub enum ValidateResourceNameError {
+    NameLengthExceeded,
+    InvalidCharacterEncountered,
+}
 
 /// Checks if the Resource Name is valid for internal resources.
 ///
@@ -6,15 +14,21 @@ pub const MAX_RESOURCE_NAME_LEN: usize = 63;
 /// let name = "prices-list-scrapper";
 /// assert!(is_valid_resource_name(name));
 /// ```
-pub fn is_valid_resource_name(name: &str) -> bool {
+pub fn is_valid_resource_name(name: &str) -> Result {
     if name.len() > MAX_RESOURCE_NAME_LEN {
-        return false;
+        return Err(ValidateResourceNameError::NameLengthExceeded);
     }
 
-    name.chars()
+    if name
+        .chars()
         .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
         && !name.ends_with('-')
         && !name.starts_with('-')
+    {
+        return Err(ValidateResourceNameError::InvalidCharacterEncountered);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -1,6 +1,6 @@
 const K8S_MAX_RESOURCE_NAME_LEN: usize = 63;
 
-pub fn is_valid_k8s_resource_name(name: &str) -> bool {
+pub fn is_valid_resource_name(name: &str) -> bool {
     if name.len() > K8S_MAX_RESOURCE_NAME_LEN {
         return false;
     }
@@ -13,27 +13,27 @@ pub fn is_valid_k8s_resource_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod test {
-    use super::is_valid_k8s_resource_name;
+    use super::is_valid_resource_name;
 
     #[test]
     fn validates_name_length() {
         let name = "this-is-a-very-long-long-long-long-long-long-name-and-its-not-valid";
 
-        assert!(!is_valid_k8s_resource_name(name));
+        assert!(!is_valid_resource_name(name));
     }
 
     #[test]
     fn validates_no_spaces_allowed() {
         let name = "Hello World";
 
-        assert!(!is_valid_k8s_resource_name(name));
+        assert!(!is_valid_resource_name(name));
     }
 
     #[test]
     fn validates_no_special_chars_allowed() {
         let name = "!@#$%^&*()👻";
 
-        assert!(!is_valid_k8s_resource_name(name));
+        assert!(!is_valid_resource_name(name));
     }
 
     #[test]
@@ -48,31 +48,31 @@ mod test {
         ];
 
         for name in names {
-            assert!(is_valid_k8s_resource_name(name));
+            assert!(is_valid_resource_name(name));
         }
     }
 
     #[test]
     fn reject_topics_with_spaces() {
-        assert!(!is_valid_k8s_resource_name("hello world"));
+        assert!(!is_valid_resource_name("hello world"));
     }
 
     #[test]
     fn reject_topics_with_uppercase() {
-        assert!(!is_valid_k8s_resource_name("helloWorld"));
+        assert!(!is_valid_resource_name("helloWorld"));
     }
 
     #[test]
     fn reject_topics_with_underscore() {
-        assert!(!is_valid_k8s_resource_name("hello_world"));
+        assert!(!is_valid_resource_name("hello_world"));
     }
 
     #[test]
     fn valid_topic() {
-        assert!(is_valid_k8s_resource_name("hello-world"));
+        assert!(is_valid_resource_name("hello-world"));
     }
     #[test]
     fn reject_topics_that_start_with_hyphen() {
-        assert!(!is_valid_k8s_resource_name("-helloworld"));
+        assert!(!is_valid_resource_name("-helloworld"));
     }
 }

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -43,27 +43,27 @@ pub fn validate_resource_name(name: &str) -> Result {
 
 #[cfg(test)]
 mod test {
-    use super::is_valid_resource_name;
+    use super::validate_resource_name;
 
     #[test]
     fn validates_name_length() {
         let name = "this-is-a-very-long-long-long-long-long-long-name-and-its-not-valid";
 
-        assert!(!is_valid_resource_name(name));
+        assert!(validate_resource_name(name).is_err());
     }
 
     #[test]
     fn validates_no_spaces_allowed() {
         let name = "Hello World";
 
-        assert!(!is_valid_resource_name(name));
+        assert!(validate_resource_name(name).is_err());
     }
 
     #[test]
     fn validates_no_special_chars_allowed() {
         let name = "!@#$%^&*()👻";
 
-        assert!(!is_valid_resource_name(name));
+        assert!(validate_resource_name(name).is_err());
     }
 
     #[test]
@@ -78,31 +78,31 @@ mod test {
         ];
 
         for name in names {
-            assert!(is_valid_resource_name(name));
+            assert!(validate_resource_name(name).is_ok());
         }
     }
 
     #[test]
     fn reject_topics_with_spaces() {
-        assert!(!is_valid_resource_name("hello world"));
+        assert!(validate_resource_name("hello world").is_err());
     }
 
     #[test]
     fn reject_topics_with_uppercase() {
-        assert!(!is_valid_resource_name("helloWorld"));
+        assert!(validate_resource_name("helloWorld").is_err());
     }
 
     #[test]
     fn reject_topics_with_underscore() {
-        assert!(!is_valid_resource_name("hello_world"));
+        assert!(validate_resource_name("hello_world").is_err());
     }
 
     #[test]
     fn valid_topic() {
-        assert!(is_valid_resource_name("hello-world"));
+        assert!(validate_resource_name("hello-world").is_ok());
     }
     #[test]
     fn reject_topics_that_start_with_hyphen() {
-        assert!(!is_valid_resource_name("-helloworld"));
+        assert!(validate_resource_name("-helloworld").is_err());
     }
 }

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -1,7 +1,13 @@
-const K8S_MAX_RESOURCE_NAME_LEN: usize = 63;
+pub const MAX_RESOURCE_NAME_LEN: usize = 63;
 
+/// Checks if the Resource Name is valid for internal resources.
+///
+/// ```test
+/// let name = "prices-list-scrapper";
+/// assert!(is_valid_resource_name(name));
+/// ```
 pub fn is_valid_resource_name(name: &str) -> bool {
-    if name.len() > K8S_MAX_RESOURCE_NAME_LEN {
+    if name.len() > MAX_RESOURCE_NAME_LEN {
         return false;
     }
 

--- a/crates/fluvio-sc-schema/src/shared.rs
+++ b/crates/fluvio-sc-schema/src/shared.rs
@@ -1,10 +1,14 @@
+use thiserror::Error;
+
 pub type Result = std::result::Result<(), ValidateResourceNameError>;
 
 pub const MAX_RESOURCE_NAME_LEN: usize = 63;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Error)]
 pub enum ValidateResourceNameError {
+    #[error("Name exceeds max characters allowed {MAX_RESOURCE_NAME_LEN}")]
     NameLengthExceeded,
+    #[error("Contain only lowercase alphanumeric characters or '-'")]
     InvalidCharacterEncountered,
 }
 
@@ -12,9 +16,15 @@ pub enum ValidateResourceNameError {
 ///
 /// ```test
 /// let name = "prices-list-scrapper";
-/// assert!(is_valid_resource_name(name));
+/// assert!(validate_resource_name(name).is_ok());
+///
+/// let name = "prices list scrapper";
+/// assert!(validate_resource_name(name).is_err());
+///
+/// let name = "price$-l1st-scr@pper";
+/// assert!(validate_resource_name(name).is_err());
 /// ```
-pub fn is_valid_resource_name(name: &str) -> Result {
+pub fn validate_resource_name(name: &str) -> Result {
     if name.len() > MAX_RESOURCE_NAME_LEN {
         return Err(ValidateResourceNameError::NameLengthExceeded);
     }

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -1,44 +1,19 @@
 pub use fluvio_controlplane_metadata::topic::*;
+
 pub mod validate {
+    use crate::shared::is_valid_resource_name;
+
     /// Ensure a topic can be created with a given name.
     /// Topics name can only be formed by lowercase alphanumeric elements and hyphens.
     /// They should start and finish with an alphanumeric character.
+    #[inline]
     pub fn valid_topic_name(name: &str) -> bool {
-        name.chars()
-            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
-            && !name.ends_with('-')
-            && !name.starts_with('-')
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::topic::validate::valid_topic_name;
-
-        #[test]
-        fn reject_topics_with_spaces() {
-            assert!(!valid_topic_name("hello world"));
-        }
-
-        #[test]
-        fn reject_topics_with_uppercase() {
-            assert!(!valid_topic_name("helloWorld"));
-        }
-
-        #[test]
-        fn reject_topics_with_underscore() {
-            assert!(!valid_topic_name("hello_world"));
-        }
-
-        #[test]
-        fn valid_topic() {
-            assert!(valid_topic_name("hello-world"));
-        }
-        #[test]
-        fn reject_topics_that_start_with_hyphen() {
-            assert!(!valid_topic_name("-helloworld"));
-        }
+        // TODO: This reference is used to avoid introducing breaking changes
+        // in other projects
+        is_valid_resource_name(name)
     }
 }
+
 mod convert {
 
     use crate::CreatableAdminSpec;

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -10,7 +10,7 @@ pub mod validate {
     pub fn valid_topic_name(name: &str) -> bool {
         // TODO: This reference is used to avoid introducing breaking changes
         // in other projects
-        is_valid_resource_name(name)
+        is_valid_resource_name(name).is_ok()
     }
 }
 

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -1,21 +1,6 @@
 pub use fluvio_controlplane_metadata::topic::*;
 
-pub mod validate {
-    use crate::shared::is_valid_resource_name;
-
-    /// Ensure a topic can be created with a given name.
-    /// Topics name can only be formed by lowercase alphanumeric elements and hyphens.
-    /// They should start and finish with an alphanumeric character.
-    #[inline]
-    pub fn valid_topic_name(name: &str) -> bool {
-        // TODO: This reference is used to avoid introducing breaking changes
-        // in other projects
-        is_valid_resource_name(name).is_ok()
-    }
-}
-
 mod convert {
-
     use crate::CreatableAdminSpec;
     use crate::DeletableAdminSpec;
     use crate::objects::CreateFrom;

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -1,5 +1,49 @@
 pub use fluvio_controlplane_metadata::topic::*;
 
+pub mod validate {
+    use crate::shared::validate_resource_name;
+
+    /// Ensure a topic can be created with a given name.
+    /// Topics name can only be formed by lowercase alphanumeric elements and hyphens.
+    /// They should start and finish with an alphanumeric character.
+    #[deprecated(
+        since = "0.18.1",
+        note = "Will be removed in the next version. Use `fluvio_sc_schema::shared::validate_resource_name` instead."
+    )]
+    pub fn valid_topic_name(name: &str) -> bool {
+        validate_resource_name(name).is_ok()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::topic::validate::valid_topic_name;
+
+        #[test]
+        fn reject_topics_with_spaces() {
+            assert!(!valid_topic_name("hello world"));
+        }
+
+        #[test]
+        fn reject_topics_with_uppercase() {
+            assert!(!valid_topic_name("helloWorld"));
+        }
+
+        #[test]
+        fn reject_topics_with_underscore() {
+            assert!(!valid_topic_name("hello_world"));
+        }
+
+        #[test]
+        fn valid_topic() {
+            assert!(valid_topic_name("hello-world"));
+        }
+        #[test]
+        fn reject_topics_that_start_with_hyphen() {
+            assert!(!valid_topic_name("-helloworld"));
+        }
+    }
+}
+
 mod convert {
     use crate::CreatableAdminSpec;
     use crate::DeletableAdminSpec;

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -9,35 +9,6 @@ pub mod validate {
     pub fn valid_topic_name(name: &str) -> bool {
         validate_resource_name(name).is_ok()
     }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::topic::validate::valid_topic_name;
-
-        #[test]
-        fn reject_topics_with_spaces() {
-            assert!(!valid_topic_name("hello world"));
-        }
-
-        #[test]
-        fn reject_topics_with_uppercase() {
-            assert!(!valid_topic_name("helloWorld"));
-        }
-
-        #[test]
-        fn reject_topics_with_underscore() {
-            assert!(!valid_topic_name("hello_world"));
-        }
-
-        #[test]
-        fn valid_topic() {
-            assert!(valid_topic_name("hello-world"));
-        }
-        #[test]
-        fn reject_topics_that_start_with_hyphen() {
-            assert!(!valid_topic_name("-helloworld"));
-        }
-    }
 }
 
 mod convert {

--- a/crates/fluvio-sc-schema/src/topic/mod.rs
+++ b/crates/fluvio-sc-schema/src/topic/mod.rs
@@ -6,10 +6,6 @@ pub mod validate {
     /// Ensure a topic can be created with a given name.
     /// Topics name can only be formed by lowercase alphanumeric elements and hyphens.
     /// They should start and finish with an alphanumeric character.
-    #[deprecated(
-        since = "0.18.1",
-        note = "Will be removed in the next version. Use `fluvio_sc_schema::shared::validate_resource_name` instead."
-    )]
     pub fn valid_topic_name(name: &str) -> bool {
         validate_resource_name(name).is_ok()
     }

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -13,7 +13,7 @@ use std::io::{Error as IoError, ErrorKind};
 
 use fluvio_controlplane_metadata::topic::ReplicaSpec;
 use fluvio_sc_schema::objects::CommonCreateRequest;
-use fluvio_sc_schema::shared::is_valid_resource_name;
+use fluvio_sc_schema::shared::validate_resource_name;
 use tracing::{info, debug, trace, instrument};
 
 use fluvio_protocol::link::ErrorCode;
@@ -80,12 +80,11 @@ pub async fn handle_create_topics_request<AC: AuthContext>(
 async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &Context) -> Status {
     debug!("validating topic: {}", name);
 
-    let valid_name = is_valid_resource_name(name);
-    if valid_name.is_err() {
+    if let Err(err) = validate_resource_name(name) {
         return Status::new(
             name.to_string(),
             ErrorCode::TopicInvalidName,
-            Some(format!("Invalid topic name: '{name}'. Topic name can contain only lowercase alphanumeric characters or '-'.")),
+            Some(format!("Invalid topic name: '{name}'. {}", err.to_string())),
         );
     }
 

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -84,7 +84,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
         return Status::new(
             name.to_string(),
             ErrorCode::TopicInvalidName,
-            Some(format!("Invalid topic name: '{name}'. {}", err.to_string())),
+            Some(format!("Invalid topic name: '{name}'. {err}")),
         );
     }
 

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -13,7 +13,7 @@ use std::io::{Error as IoError, ErrorKind};
 
 use fluvio_controlplane_metadata::topic::ReplicaSpec;
 use fluvio_sc_schema::objects::CommonCreateRequest;
-use fluvio_sc_schema::topic::validate::valid_topic_name;
+use fluvio_sc_schema::shared::is_valid_resource_name;
 use tracing::{info, debug, trace, instrument};
 
 use fluvio_protocol::link::ErrorCode;
@@ -80,7 +80,7 @@ pub async fn handle_create_topics_request<AC: AuthContext>(
 async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &Context) -> Status {
     debug!("validating topic: {}", name);
 
-    let valid_name = valid_topic_name(name);
+    let valid_name = is_valid_resource_name(name);
     if !valid_name {
         return Status::new(
             name.to_string(),

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -81,7 +81,7 @@ async fn validate_topic_request(name: &str, topic_spec: &TopicSpec, metadata: &C
     debug!("validating topic: {}", name);
 
     let valid_name = is_valid_resource_name(name);
-    if !valid_name {
+    if valid_name.is_err() {
         return Status::new(
             name.to_string(),
             ErrorCode::TopicInvalidName,


### PR DESCRIPTION
Provides `shared::is_valid_k8s_resource_name` which checks if the provided
string is a k8s resource name compliant value. This could be used for topics,
connectors and other resources relying on k8s. In the future is likely we want to
use a single function all around to apply the same rules on a centralized approach.