### PR TITLE
[Merged by Bors] - build: updates for rust 1.69

### DIFF
--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_fluvio.stderr
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
  --> tests/ui/config_use_reserved_name_fluvio.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `TopicProducer`
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `TopicProducer`
 4 | async fn start_fn(config: CustomConfig, producer: ()) {}
   |          -------- arguments to this function are incorrect
   |

--- a/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/config_use_reserved_name_transforms.stderr
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
  --> tests/ui/config_use_reserved_name_transforms.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `TopicProducer`
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `TopicProducer`
 4 | async fn start_fn(config: CustomConfig, producer: ()) {}
   |          -------- arguments to this function are incorrect
   |

--- a/crates/fluvio-connector-derive/tests/ui/struct_without_config.stderr
+++ b/crates/fluvio-connector-derive/tests/ui/struct_without_config.stderr
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
  --> tests/ui/struct_without_config.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `TopicProducer`
+  | ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `TopicProducer`
 4 | async fn start_fn(config: CustomConfig, producer: ()) {}
   |          -------- arguments to this function are incorrect
   |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.68.2"
+channel = "1.69"


### PR DESCRIPTION
compiler errors are differents for this new release, therefore we need to update our ui tests snapshots