### PR TITLE
[Merged by Bors] - build: fix toolchain reference

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69"
+channel = "1.69.0"


### PR DESCRIPTION
Without this change it fails at this way:

```
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the '1.69-aarch64-apple-darwin' toolchain
```