### PR TITLE
[Merged by Bors] - feat: Secrets in connector meta

### DIFF
--- a/connector/sink-test-connector/config-example.yaml
+++ b/connector/sink-test-connector/config-example.yaml
@@ -3,6 +3,8 @@ meta:
   name: my-sink-test-connector
   type: test-sink
   topic: test-topic
+  secrets:
+    - name: TEST_API_KEY
 custom:
   api_key:
     secret:

--- a/connector/sink-test-connector/config-example.yaml
+++ b/connector/sink-test-connector/config-example.yaml
@@ -3,8 +3,8 @@ meta:
   name: my-sink-test-connector
   type: test-sink
   topic: test-topic
-custom: 
-  api_key: 
+custom:
+  api_key:
     secret:
       name: TEST_API_KEY
 transforms:

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -13,6 +13,11 @@ pub fn value_from_file<P: Into<PathBuf>>(path: P) -> Result<Value> {
 }
 
 pub fn from_value<T: DeserializeOwned>(value: Value, root: Option<&str>) -> Result<T> {
+    let value = get_value(value, root)?;
+    serde_yaml::from_value(value).context("unable to parse custom config type from YAML")
+}
+
+pub fn get_value(value: Value, root: Option<&str>) -> Result<Value> {
     let value = match root {
         Some(root) => value
             .get(root)
@@ -21,5 +26,39 @@ pub fn from_value<T: DeserializeOwned>(value: Value, root: Option<&str>) -> Resu
         None => value,
     };
     trace!("{:#?}", value);
-    serde_yaml::from_value(value).context("unable to parse custom config type from YAML")
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use fluvio_connector_package::config::MetaConfig;
+
+    #[test]
+    fn test_from_value() {
+        use super::*;
+        let value = serde_yaml::from_str(
+            r#"
+        meta:
+            name: test
+            version: 0.1.0
+            topic: test
+            type: http-source
+            consumer:
+                partition: 0
+        http:
+            port: 8080
+        "#,
+        )
+        .unwrap();
+        let config: MetaConfig = from_value(value, Some("meta")).unwrap();
+        assert_eq!(config.name, "test");
+        assert_eq!(config.topic, "test");
+        assert_eq!(
+            config
+                .consumer
+                .expect("expected some consume config")
+                .partition,
+            Some(0)
+        );
+    }
 }

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -18,7 +18,7 @@ openapiv3 = { git = "https://github.com/galibey/openapiv3", rev = "bdd22f046d2bc
 once_cell = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 serde_yaml = { workspace = true }
-toml = { workspace = true , optional = true, features = ["preserve_order"] }
+toml = { workspace = true , optional = true, features = ["display", "parse", "preserve_order"] }
 tracing = { workspace = true }
 
 # fluvio dependencies

--- a/crates/fluvio-connector-package/src/config.rs
+++ b/crates/fluvio-connector-package/src/config.rs
@@ -131,9 +131,7 @@ impl<'a> Deserialize<'a> for SecretName {
     {
         let inner = String::deserialize(deserializer)?;
         let secret = Self { inner };
-        secret
-            .validate()
-            .map_err(|err| serde::de::Error::custom(err))?;
+        secret.validate().map_err(serde::de::Error::custom)?;
         Ok(secret)
     }
 }

--- a/crates/fluvio-connector-package/src/config.rs
+++ b/crates/fluvio-connector-package/src/config.rs
@@ -85,7 +85,7 @@ impl SecretConfig {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SecretName {
     inner: String,
 }
@@ -144,6 +144,15 @@ impl<'a> Deserialize<'a> for SecretName {
             ));
         }
         Ok(Self { inner })
+    }
+}
+
+impl Serialize for SecretName {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.inner)
     }
 }
 

--- a/crates/fluvio-connector-package/src/config.rs
+++ b/crates/fluvio-connector-package/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
 use std::path::{PathBuf, Path};
@@ -72,13 +73,19 @@ pub struct ProducerParameters {
     #[serde(skip)]
     pub batch_size: Option<ByteSize>,
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct SecretConfig {
     /// The name of the secret. It can only contain alphanumeric ASCII characters and underscores. It cannot start with a number.
     name: SecretName,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize)]
+impl SecretConfig {
+    pub fn name(&self) -> &str {
+        &self.name.inner
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Hash)]
 pub struct SecretName {
     inner: String,
 }
@@ -165,6 +172,10 @@ impl ConnectorConfig {
             }
         }
         Ok(())
+    }
+
+    pub fn secrets(&self) -> HashSet<SecretConfig> {
+        HashSet::from_iter(self.meta.secrets.clone().unwrap_or_default().into_iter())
     }
 
     pub fn from_value(value: serde_yaml::Value) -> Result<Self> {

--- a/crates/fluvio-connector-package/test-data/connectors/error-secret-starts-with-number.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-secret-starts-with-number.yaml
@@ -1,0 +1,8 @@
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  secrets:
+    - name: 1secret

--- a/crates/fluvio-connector-package/test-data/connectors/error-secret-with-spaces.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/error-secret-with-spaces.yaml
@@ -1,0 +1,8 @@
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: my-mqtt
+  create_topic: false
+  secrets:
+    - name: secret name

--- a/crates/fluvio-connector-package/test-data/connectors/full-config.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/full-config.yaml
@@ -6,10 +6,12 @@ meta:
   create_topic: false
   producer:
     linger: 1ms
-    batch-size: '44.0 MB'
+    batch-size: "44.0 MB"
     compression: gzip
   consumer:
     partition: 10
+  secrets:
+    - name: secret1
 transforms:
   - uses: infinyon/json-sql
     with:

--- a/crates/fluvio-connector-package/tests/mod.rs
+++ b/crates/fluvio-connector-package/tests/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use fluvio_controlplane_metadata::smartmodule::FluvioSemVersion;
 use fluvio_connector_package::metadata::*;
 use openapiv3::SchemaData;
@@ -44,22 +42,6 @@ fn test_read_from_toml_file() {
                 )],
                 ["template"]
             ),
-            secrets: Secrets::from(BTreeMap::from([
-                (
-                    "password".into(),
-                    Secret {
-                        ty: SecretType::Env,
-                        mount: None,
-                    }
-                ),
-                (
-                    "my_cert".into(),
-                    Secret {
-                        ty: SecretType::File,
-                        mount: Some("/mydata/secret1".into())
-                    }
-                )
-            ])),
         }
     )
 }
@@ -94,13 +76,6 @@ source = true
 
 [deployment]
 binary = "json-test-connector"
-
-[secret.my_cert]
-type = "file"
-mount = "/mydata/secret1"
-
-[secret.password]
-type = "env"
 
 [custom]
 required = ["template"]


### PR DESCRIPTION
Previously, we defined possible secrets used by a connector on connector package spec. This approach makes less customizable the experience for the user.

In this PR we are moving this definition to the connector meta configuration, users can define explicitly the name of the secrets that they want and use them explicitly.

This change also implies that secret names are not longer detected from parsing the connector specific configuration and instead only parsing the secrets section on the connector configuration.