### PR TITLE
[Merged by Bors] - Update generate to use new version

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -20,6 +20,7 @@ For more detail, refer to [`RELEASE.md`](https://github.com/infinyon/fluvio/blob
 - [ ] Create a PR for release
   - [ ] Update `VERSION` and `CHANGELOG.md` files (do not place a \n in the VERSION file, it breaks the CI)
   - [ ] Update [`CHANGELOG`](https://github.com/infinyon/fluvio/blob/master/CHANGELOG.md) with replacement of the `UNRELEASED` date
+  - [ ] Update dependency in connector [template](https://github.com/infinyon/fluvio/blob/master/connector/cargo_template/Cargo.toml)
   - [ ] Merge the PR
 - [ ] Run the [`Release` workflow in Github Actions](https://github.com/infinyon/fluvio/actions/workflows/release.yml) (Retry at least once if failure)  
 

--- a/connector/cargo_template/Cargo.toml
+++ b/connector/cargo_template/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["{{authors}}"]
 edition = "2021"
 
 [dependencies]
-fluvio = { git = "https://github.com/infinyon/fluvio", rev = "fece619111485a7e3ed91be429bb7ab6864a79a6"}
-fluvio-connector-common = { git = "https://github.com/infinyon/fluvio", rev = "fece619111485a7e3ed91be429bb7ab6864a79a6", features = ["derive"]}
+fluvio = { git = "https://github.com/infinyon/fluvio", tag = "v0.10.8" }
+fluvio-connector-common = { git = "https://github.com/infinyon/fluvio", tag = "v0.10.8", features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}


### PR DESCRIPTION
http-sink initial commit has this very old version. Updating this and adding to checklist so we keep using new versions