### PR TITLE
[Merged by Bors] - refactor: use common version for all SPU api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "bytes 1.4.0",
  "educe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ name = "fluvio-spu-schema"
 version = "0.13.3"
 dependencies = [
  "bytes 1.4.0",
+ "derive_builder",
  "educe",
  "flate2",
  "fluvio-future",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "bytes 1.4.0",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-extension-common = { path = "crates/fluvio-extension-common", default-features = false }
 fluvio-package-index = { version = "0.7.0", path = "crates/fluvio-package-index", default-features = false }
 fluvio-protocol = { version = "0.9.0", path = "crates/fluvio-protocol" }
-fluvio-spu-schema = { version = "0.13.0", path = "crates/fluvio-spu-schema", default-features  = false }
+fluvio-spu-schema = { version = "0.14.0", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-sc-schema = { version = "0.19.0", path = "crates/fluvio-sc-schema", default-features = false }
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-socket = { version = "0.14.2", path = "crates/fluvio-socket", default-features = false }

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -15,13 +15,13 @@ path = "src/lib.rs"
 file = ["fluvio-future","fluvio-protocol/store"]
 
 [dependencies]
-
-tracing = { workspace = true }
 bytes = { workspace = true }
-serde = { workspace = true, features = ['derive'] }
-static_assertions = { workspace = true }
+derive_builder = { workspace = true }
 educe = { version = "0.4.19", features = ["Debug"] }
 flate2 = { workspace = true  }
+serde = { workspace = true, features = ['derive'] }
+static_assertions = { workspace = true }
+tracing = { workspace = true }
 
 fluvio-types = { workspace = true }
 fluvio-future = { workspace = true, optional = true }

--- a/crates/fluvio-spu-schema/src/client/offset.rs
+++ b/crates/fluvio-spu-schema/src/client/offset.rs
@@ -3,6 +3,8 @@ use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::record::ReplicaKey;
 use fluvio_protocol::record::Offset;
 
+use crate::COMMON_VERSION;
+
 use super::SpuClientApiKey;
 
 // -----------------------------------
@@ -29,7 +31,7 @@ pub struct ReplicaOffsetUpdate {
 
 impl Request for ReplicaOffsetUpdateRequest {
     const API_KEY: u16 = SpuClientApiKey::ReplicaOffsetUpdate as u16;
-    const DEFAULT_API_VERSION: i16 = 0;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = ReplicaOffsetUpdateResponse;
 }
 

--- a/crates/fluvio-spu-schema/src/fetch/request.rs
+++ b/crates/fluvio-spu-schema/src/fetch/request.rs
@@ -7,6 +7,7 @@ use fluvio_protocol::derive::FluvioDefault;
 use fluvio_protocol::record::RecordSet;
 use fluvio_types::PartitionId;
 
+use crate::COMMON_VERSION;
 use crate::isolation::Isolation;
 
 use super::FetchResponse;
@@ -51,8 +52,7 @@ where
     const API_KEY: u16 = 1;
 
     const MIN_API_VERSION: i16 = 0;
-    const MAX_API_VERSION: i16 = 10;
-    const DEFAULT_API_VERSION: i16 = 10;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
 
     type Response = FetchResponse<R>;
 }

--- a/crates/fluvio-spu-schema/src/lib.rs
+++ b/crates/fluvio-spu-schema/src/lib.rs
@@ -15,3 +15,6 @@ pub mod errors {
 
 pub use fluvio_protocol::link::versions::{ApiVersions, ApiVersionsRequest, ApiVersionsResponse};
 pub use isolation::*;
+
+/// Default API version for all API
+pub(crate) const COMMON_VERSION: i16 = 19;

--- a/crates/fluvio-spu-schema/src/produce/request.rs
+++ b/crates/fluvio-spu-schema/src/produce/request.rs
@@ -53,7 +53,6 @@ where
     const API_KEY: u16 = 0;
 
     const MIN_API_VERSION: i16 = 0;
-    const MAX_API_VERSION: i16 = PRODUCER_TRANSFORMATION_API_VERSION;
     const DEFAULT_API_VERSION: i16 = PRODUCER_TRANSFORMATION_API_VERSION;
 
     type Response = ProduceResponse;

--- a/crates/fluvio-spu-schema/src/server/fetch_offset.rs
+++ b/crates/fluvio-spu-schema/src/server/fetch_offset.rs
@@ -11,6 +11,7 @@ use fluvio_protocol::record::ReplicaKey;
 
 use fluvio_types::PartitionId;
 
+use crate::COMMON_VERSION;
 use crate::errors::ErrorCode;
 use super::SpuServerApiKey;
 
@@ -27,7 +28,7 @@ pub struct FetchOffsetsRequest {
 
 impl Request for FetchOffsetsRequest {
     const API_KEY: u16 = SpuServerApiKey::FetchOffsets as u16;
-    const DEFAULT_API_VERSION: i16 = 0;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = FetchOffsetsResponse;
 }
 

--- a/crates/fluvio-spu-schema/src/server/smartmodule.rs
+++ b/crates/fluvio-spu-schema/src/server/smartmodule.rs
@@ -21,7 +21,7 @@ use fluvio_smartmodule::dataplane::smartmodule::SmartModuleExtraParams;
     since = "0.10.0",
     note = "will be removed in the next version. Use SmartModuleInvocation instead "
 )]
-pub struct LegacySmartModulePayload {
+pub(crate) struct LegacySmartModulePayload {
     pub wasm: SmartModuleWasmCompressed,
     pub kind: SmartModuleKind,
     pub params: SmartModuleExtraParams,

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -58,20 +58,23 @@ pub struct StreamFetchRequest<R> {
     pub fetch_offset: i64,
     pub max_bytes: i32,
     pub isolation: Isolation,
-    /// no longer used, but keep to avoid breaking compatibility, this will not be honored
-    // TODO: remove in 0.10
+    // these private fields will be removed
     #[educe(Debug(ignore))]
+    #[builder(setter(skip))]
     #[fluvio(min_version = 11, max_version = 18)]
     wasm_module: Vec<u8>,
-    // TODO: remove in 0.10
+    #[builder(setter(skip))]
     #[fluvio(min_version = 12, max_version = 18)]
     wasm_payload: Option<LegacySmartModulePayload>,
+    #[builder(setter(skip))]
     #[fluvio(min_version = 16, max_version = 18)]
     smartmodule: Option<SmartModuleInvocation>,
+    #[builder(setter(skip))]
     #[fluvio(min_version = 16, max_version = 18)]
     derivedstream: Option<DerivedStreamInvocation>,
     #[fluvio(min_version = 18)]
     pub smartmodules: Vec<SmartModuleInvocation>,
+    #[builder(setter(skip))]
     data: PhantomData<R>,
 }
 
@@ -95,7 +98,7 @@ where
 
 ///
 #[derive(Debug, Default, Clone, Encoder, Decoder)]
-pub struct DerivedStreamInvocation {
+pub(crate) struct DerivedStreamInvocation {
     pub stream: String,
     pub params: SmartModuleExtraParams,
 }

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -14,7 +14,7 @@ use fluvio_protocol::{Encoder, Decoder};
 use fluvio_protocol::api::Request;
 use fluvio_protocol::record::RecordSet;
 use fluvio_smartmodule::dataplane::smartmodule::SmartModuleExtraParams;
-use fluvio_types::PartitionId;
+use fluvio_types::{PartitionId, defaults::FLUVIO_CLIENT_MAX_FETCH_BYTES};
 
 use crate::COMMON_VERSION;
 use crate::fetch::FetchablePartitionResponse;
@@ -54,9 +54,13 @@ pub const CHAIN_SMARTMODULE_API: i16 = 18;
 #[educe(Debug)]
 pub struct StreamFetchRequest<R> {
     pub topic: String,
+    #[builder(default = "0")]
     pub partition: PartitionId,
+    #[builder(default = "0")]
     pub fetch_offset: i64,
+    #[builder(default = "FLUVIO_CLIENT_MAX_FETCH_BYTES")]
     pub max_bytes: i32,
+    #[builder(default = "Isolation::ReadUncommitted")]
     pub isolation: Isolation,
     // these private fields will be removed
     #[educe(Debug(ignore))]

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -16,6 +16,7 @@ use fluvio_protocol::record::RecordSet;
 use fluvio_smartmodule::dataplane::smartmodule::SmartModuleExtraParams;
 use fluvio_types::PartitionId;
 
+use crate::COMMON_VERSION;
 use crate::fetch::FetchablePartitionResponse;
 use crate::isolation::Isolation;
 
@@ -78,7 +79,7 @@ where
     R: Debug + Decoder + Encoder,
 {
     const API_KEY: u16 = SpuServerApiKey::StreamFetch as u16;
-    const DEFAULT_API_VERSION: i16 = CHAIN_SMARTMODULE_API;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
     type Response = StreamFetchResponse<R>;
 }
 

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -76,6 +76,7 @@ pub struct StreamFetchRequest<R> {
     #[builder(setter(skip))]
     #[fluvio(min_version = 16, max_version = 18)]
     derivedstream: Option<DerivedStreamInvocation>,
+    #[builder(default)]
     #[fluvio(min_version = 18)]
     pub smartmodules: Vec<SmartModuleInvocation>,
     #[builder(setter(skip))]

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -19,7 +19,6 @@ use futures_util::{Future, StreamExt};
 use fluvio_future::timer::sleep;
 use fluvio_socket::{FluvioSocket, MultiplexerSocket};
 use fluvio_spu_schema::{
-    Isolation,
     server::smartmodule::{
         SmartModuleKind, SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleContextData,
     },
@@ -119,14 +118,11 @@ async fn test_stream_fetch_basic() {
             .expect("replica");
         ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-        let stream_request = DefaultStreamFetchRequest {
-            topic: topic.clone(),
-            partition: 0,
-            fetch_offset: 0,
-            isolation: Isolation::ReadUncommitted,
-            max_bytes: 1000,
-            ..Default::default()
-        };
+        let stream_request = DefaultStreamFetchRequest::builder()
+            .topic(topic.clone())
+            .max_bytes(1000)
+            .build()
+            .expect("request");
 
         let mut stream = client_socket
             .create_stream(RequestMessage::new_request(stream_request), version)
@@ -455,15 +451,12 @@ async fn test_stream_fetch_filter(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("build");
 
     // 1 out of 2 are filtered
     let mut records = create_filter_records(2);
@@ -641,15 +634,12 @@ async fn test_stream_fetch_filter_individual(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("builder");
 
     // First, open the consumer stream
     let mut stream = client_socket
@@ -764,15 +754,12 @@ async fn test_stream_filter_error_fetch(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("builder");
 
     fn generate_record(record_index: usize, _producer: &BatchProducer) -> Record {
         let value = if record_index < 10 {
@@ -912,15 +899,12 @@ async fn test_stream_filter_max(
         .expect("write"); // 3000 bytes total
                           // now total of 300 filter records bytes (min), but last filter record is greater than max
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 250,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(250)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1040,15 +1024,12 @@ async fn test_stream_fetch_map(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 300,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(300)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1192,12 +1173,12 @@ async fn test_stream_fetch_map_chain(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        max_bytes: 300,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(300)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1346,15 +1327,12 @@ async fn test_stream_fetch_map_error(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1479,15 +1457,12 @@ async fn test_stream_aggregate_fetch_single_batch(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     // Aggregate 5 records
     // These records look like:
@@ -1657,15 +1632,12 @@ async fn test_stream_aggregate_fetch_multiple_batch(
         .await
         .expect("write");
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1754,15 +1726,12 @@ async fn test_stream_fetch_and_new_request(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let _stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1858,15 +1827,12 @@ async fn test_stream_fetch_array_map(
         .await
         .expect("write");
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -1980,15 +1946,12 @@ async fn test_stream_fetch_filter_map(
         .await
         .expect("write");
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -2087,7 +2050,7 @@ async fn test_stream_fetch_filter_with_params(
     let mut params = BTreeMap::new();
     params.insert("key".to_string(), "b".to_string());
 
-    let smartmodule_with_params = smartmodules
+    let smartmodule_with_params: Vec<SmartModuleInvocation> = smartmodules
         .clone()
         .into_iter()
         .map(|mut w| {
@@ -2096,15 +2059,12 @@ async fn test_stream_fetch_filter_with_params(
         })
         .collect();
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules: smartmodule_with_params,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodule_with_params)
+        .build()
+        .expect("stream request");
 
     // 1 out of 2 are filtered
     let mut records = create_filter_records(2);
@@ -2153,15 +2113,12 @@ async fn test_stream_fetch_filter_with_params(
         assert_eq!(partition.records.batches.len(), 1);
     }
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -2277,15 +2234,12 @@ async fn test_stream_fetch_invalid_smartmodule(
         .expect("replica");
     ctx.leaders_state().insert(test_id, replica.clone()).await;
 
-    let stream_request = DefaultStreamFetchRequest {
-        topic: topic.to_owned(),
-        partition: 0,
-        fetch_offset: 0,
-        isolation: Isolation::ReadUncommitted,
-        max_bytes: 10000,
-        smartmodules,
-        ..Default::default()
-    };
+    let stream_request = DefaultStreamFetchRequest::builder()
+        .topic(topic.to_owned())
+        .max_bytes(10000)
+        .smartmodules(smartmodules)
+        .build()
+        .expect("stream request");
 
     let mut stream = client_socket
         .create_stream(RequestMessage::new_request(stream_request), 11)
@@ -2357,11 +2311,13 @@ async fn test_stream_metrics() {
     {
         let mut stream = client_socket
             .create_stream(
-                RequestMessage::new_request(DefaultStreamFetchRequest {
-                    topic: topic.to_string(),
-                    max_bytes: 1000,
-                    ..Default::default()
-                }),
+                RequestMessage::new_request(
+                    DefaultStreamFetchRequest::builder()
+                        .topic(topic.to_string())
+                        .max_bytes(1000)
+                        .build()
+                        .expect("stream request"),
+                ),
                 10,
             )
             .await
@@ -2383,11 +2339,13 @@ async fn test_stream_metrics() {
         assert_eq!(ctx.metrics().chain_metrics().invocation_count(), 0);
     }
     {
-        let mut request = RequestMessage::new_request(DefaultStreamFetchRequest {
-            topic: topic.to_string(),
-            max_bytes: 1000,
-            ..Default::default()
-        });
+        let mut request = RequestMessage::new_request(
+            DefaultStreamFetchRequest::builder()
+                .topic(topic.to_string())
+                .max_bytes(1000)
+                .build()
+                .expect("stream request"),
+        );
         request.header.set_client_id("fluvio_connector");
         let mut stream = client_socket
             .create_stream(request, 10)
@@ -2416,12 +2374,15 @@ async fn test_stream_metrics() {
             kind: SmartModuleKind::Filter,
             ..Default::default()
         };
-        let mut request = RequestMessage::new_request(DefaultStreamFetchRequest {
-            topic: topic.to_string(),
-            max_bytes: 1000,
-            smartmodules: vec![smartmodule],
-            ..Default::default()
-        });
+        let mut request = RequestMessage::new_request(
+            DefaultStreamFetchRequest::builder()
+                .topic(topic.to_string())
+                .max_bytes(1000)
+                .smartmodules(vec![smartmodule])
+                .build()
+                .expect("request"),
+        );
+
         request.header.set_client_id("fluvio_connector2");
         let mut stream = client_socket
             .create_stream(request, 10)

--- a/crates/fluvio-storage/tests/replica_test.rs
+++ b/crates/fluvio-storage/tests/replica_test.rs
@@ -3,11 +3,11 @@
 use std::{env::temp_dir, sync::Arc};
 use std::time::Duration;
 
-use fluvio_spu_schema::Isolation;
 use tracing::debug;
 use futures_lite::StreamExt;
 use futures_lite::future::zip;
 
+use fluvio_spu_schema::Isolation;
 use fluvio_future::timer::sleep;
 use fluvio_future::net::TcpListener;
 use fluvio_spu_schema::{
@@ -16,7 +16,7 @@ use fluvio_spu_schema::{
         FilePartitionResponse, FileTopicResponse,
     },
 };
-use fluvio_protocol::api::RequestMessage;
+use fluvio_protocol::api::{Request, RequestMessage};
 use fluvio_protocol::record::{Record, RecordSet};
 use fluvio_protocol::record::Offset;
 use fluvio_protocol::fixture::BatchProducer;
@@ -124,7 +124,7 @@ async fn handle_response(socket: &mut FluvioSocket, replica: &FileReplica) {
     let response = RequestMessage::<FileFetchRequest>::response_with_header(&header, response);
     socket
         .get_mut_sink()
-        .encode_file_slices(&response, 10)
+        .encode_file_slices(&response, FileFetchRequest::DEFAULT_API_VERSION)
         .await
         .expect("encoding");
     debug!("server: finish sending out");

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use fluvio_types::PartitionId;
+use anyhow::Result;
 use tracing::{debug, error, trace, instrument, info, warn};
 use futures_util::stream::{Stream, select_all};
 use once_cell::sync::Lazy;
@@ -8,6 +8,7 @@ use futures_util::future::{Either, err, join_all};
 use futures_util::stream::{StreamExt, once, iter};
 use futures_util::FutureExt;
 
+use fluvio_types::PartitionId;
 use fluvio_types::defaults::{FLUVIO_CLIENT_MAX_FETCH_BYTES, FLUVIO_MAX_SIZE_TOPIC_NAME};
 use fluvio_types::event::offsets::OffsetPublisher;
 use fluvio_spu_schema::server::stream_fetch::{
@@ -116,7 +117,7 @@ where
     pub async fn stream(
         &self,
         offset: Offset,
-    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>> {
         let config = ConsumerConfig::builder().build()?;
         let stream = self.stream_with_config(offset, config).await?;
 
@@ -166,7 +167,7 @@ where
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>> {
         let (stream, start_offset) = self
             .inner_stream_batches_with_config(offset, config)
             .await?;
@@ -221,7 +222,7 @@ where
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item = Result<Batch, ErrorCode>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Batch, ErrorCode>>> {
         let (stream, _start_offset) = self
             .inner_stream_batches_with_config(offset, config)
             .await?;
@@ -235,13 +236,10 @@ where
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<
-        (
-            impl Stream<Item = Result<Batch, ErrorCode>>,
-            fluvio_protocol::record::Offset,
-        ),
-        FluvioError,
-    > {
+    ) -> Result<(
+        impl Stream<Item = Result<Batch, ErrorCode>>,
+        fluvio_protocol::record::Offset,
+    )> {
         let (stream, start_offset) = self.request_stream(offset, config).await?;
         let metrics = self.metrics.clone();
         let flattened =
@@ -301,13 +299,10 @@ where
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<
-        (
-            impl Stream<Item = Result<DefaultStreamFetchResponse, ErrorCode>>,
-            fluvio_protocol::record::Offset,
-        ),
-        FluvioError,
-    > {
+    ) -> Result<(
+        impl Stream<Item = Result<DefaultStreamFetchResponse, ErrorCode>>,
+        fluvio_protocol::record::Offset,
+    )> {
         use fluvio_future::task::spawn;
         use futures_util::stream::empty;
 
@@ -321,15 +316,14 @@ where
 
         debug!(start_absolute_offset, end_absolute_offset, record_count);
 
-        let stream_request = DefaultStreamFetchRequest {
-            topic: self.topic.to_owned(),
-            partition: self.partition,
-            fetch_offset: start_absolute_offset,
-            isolation: config.isolation,
-            max_bytes: config.max_bytes,
-            smartmodules: config.smartmodule,
-            ..Default::default()
-        };
+        let stream_request = DefaultStreamFetchRequest::builder()
+            .topic(self.topic.to_owned())
+            .partition(self.partition)
+            .fetch_offset(start_absolute_offset)
+            .isolation(config.isolation)
+            .max_bytes(config.max_bytes)
+            .smartmodules(config.smartmodule)
+            .build()?;
 
         let stream_fetch_version = serial_socket
             .versions()
@@ -678,7 +672,7 @@ impl MultiplePartitionConsumer {
     pub async fn stream(
         &self,
         offset: Offset,
-    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>> {
         let config = ConsumerConfig::builder().build()?;
         let stream = self.stream_with_config(offset, config).await?;
 
@@ -728,7 +722,7 @@ impl MultiplePartitionConsumer {
         &self,
         offset: Offset,
         config: ConsumerConfig,
-    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>, FluvioError> {
+    ) -> Result<impl Stream<Item = Result<Record, ErrorCode>>> {
         let consumers = self
             .strategy
             .selection(self.pool.clone())

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -321,7 +321,7 @@ where
 
         debug!(start_absolute_offset, end_absolute_offset, record_count);
 
-        let mut stream_request = DefaultStreamFetchRequest {
+        let stream_request = DefaultStreamFetchRequest {
             topic: self.topic.to_owned(),
             partition: self.partition,
             fetch_offset: start_absolute_offset,
@@ -339,8 +339,6 @@ where
         if stream_fetch_version < CHAIN_SMARTMODULE_API {
             warn!("SPU does not support SmartModule chaining. SmartModules will not be applied to the stream");
         }
-
-        stream_request.derivedstream = config.derivedstream;
 
         let mut stream = self
             .pool
@@ -575,9 +573,6 @@ pub struct ConsumerConfig {
     pub(crate) isolation: Isolation,
     #[builder(default)]
     pub(crate) smartmodule: Vec<SmartModuleInvocation>,
-    #[builder(default)]
-    pub(crate) derivedstream:
-        Option<fluvio_spu_schema::server::stream_fetch::DerivedStreamInvocation>,
 }
 
 impl ConsumerConfig {

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -93,12 +93,12 @@ where
     /// # Example
     ///
     /// ```
-    /// # use fluvio::{PartitionConsumer, FluvioError};
+    /// # use fluvio::{PartitionConsumer};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # mod futures {
     /// #     pub use futures_util::stream::StreamExt;
     /// # }
-    /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
+    /// # async fn example(consumer: &PartitionConsumer) -> anyhow::Result<()> {
     /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
@@ -139,12 +139,12 @@ where
     /// # Example
     ///
     /// ```
-    /// # use fluvio::{PartitionConsumer, FluvioError};
+    /// # use fluvio::{PartitionConsumer};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # mod futures {
     /// #     pub use futures_util::stream::StreamExt;
     /// # }
-    /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
+    /// # async fn example(consumer: &PartitionConsumer) -> anyhow::Result<()> {
     /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::builder()
@@ -195,12 +195,12 @@ where
     /// Continuously streams batches of messages, starting an offset in the consumer's partition
     ///
     /// ```
-    /// # use fluvio::{PartitionConsumer, FluvioError};
+    /// # use fluvio::{PartitionConsumer};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # mod futures {
     /// #     pub use futures_util::stream::StreamExt;
     /// # }
-    /// # async fn example(consumer: &PartitionConsumer) -> Result<(), FluvioError> {
+    /// # async fn example(consumer: &PartitionConsumer) -> anyhow::Result<()> {
     /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::builder()
@@ -576,7 +576,7 @@ impl ConsumerConfig {
 }
 
 impl ConsumerConfigBuilder {
-    pub fn build(&self) -> Result<ConsumerConfig, FluvioError> {
+    pub fn build(&self) -> Result<ConsumerConfig> {
         let config = self.build_impl().map_err(|e| {
             FluvioError::ConsumerConfig(format!("Missing required config option: {e}"))
         })?;
@@ -593,10 +593,7 @@ pub enum PartitionSelectionStrategy {
 }
 
 impl PartitionSelectionStrategy {
-    async fn selection(
-        &self,
-        spu_pool: Arc<SpuPool>,
-    ) -> Result<Vec<(String, PartitionId)>, FluvioError> {
+    async fn selection(&self, spu_pool: Arc<SpuPool>) -> Result<Vec<(String, PartitionId)>> {
         let pairs = match self {
             PartitionSelectionStrategy::All(topic) => {
                 let topics = spu_pool.metadata.topics();
@@ -648,12 +645,12 @@ impl MultiplePartitionConsumer {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::{MultiplePartitionConsumer, FluvioError};
+    /// # use fluvio::{MultiplePartitionConsumer};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # mod futures {
     /// #     pub use futures_util::stream::StreamExt;
     /// # }
-    /// # async fn example(consumer: &MultiplePartitionConsumer) -> Result<(), FluvioError> {
+    /// # async fn example(consumer: &MultiplePartitionConsumer) -> anyhow::Result<()> {
     /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
@@ -694,12 +691,12 @@ impl MultiplePartitionConsumer {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::{MultiplePartitionConsumer, FluvioError};
+    /// # use fluvio::{MultiplePartitionConsumer};
     /// # use fluvio::{Offset, ConsumerConfig};
     /// # mod futures {
     /// #     pub use futures_util::stream::StreamExt;
     /// # }
-    /// # async fn example(consumer: &MultiplePartitionConsumer) -> Result<(), FluvioError> {
+    /// # async fn example(consumer: &MultiplePartitionConsumer) -> anyhow::Result<()> {
     /// use futures::StreamExt;
     /// // Use a custom max_bytes value in the config
     /// let fetch_config = ConsumerConfig::builder()

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -108,6 +108,8 @@ dependencies = [
 [[package]]
 name = "fluvio-compression"
 version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ba05160af33e9086cb390efc5e3d27ac0215a98c9c8540c73cee5a4ea22965"
 dependencies = [
  "bytes",
  "flate2",
@@ -119,9 +121,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ba05160af33e9086cb390efc5e3d27ac0215a98c9c8540c73cee5a4ea22965"
+version = "0.2.5"
 dependencies = [
  "bytes",
  "flate2",
@@ -142,7 +142,7 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "eyre",
- "fluvio-compression 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluvio-compression 0.2.4",
  "fluvio-future",
  "fluvio-protocol 0.7.9",
  "fluvio-types 0.3.9",
@@ -186,7 +186,7 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "eyre",
- "fluvio-compression 0.2.4",
+ "fluvio-compression 0.2.5",
  "fluvio-protocol-derive 0.5.0",
  "fluvio-types 0.4.2",
  "flv-util",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "eyre",
  "fluvio-protocol 0.9.2",
@@ -244,14 +244,14 @@ dependencies = [
 name = "fluvio-smartmodule-aggregate"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
 name = "fluvio-smartmodule-array-map-array"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde_json",
 ]
 
@@ -259,7 +259,7 @@ dependencies = [
 name = "fluvio-smartmodule-array-map-object"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde_json",
 ]
 
@@ -287,14 +287,14 @@ dependencies = [
 name = "fluvio-smartmodule-filter"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
 name = "fluvio-smartmodule-filter-init"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "once_cell",
 ]
 
@@ -302,14 +302,14 @@ dependencies = [
 name = "fluvio-smartmodule-filter-map"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
 name = "fluvio-smartmodule-filter-param"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "once_cell",
 ]
 
@@ -317,7 +317,7 @@ dependencies = [
 name = "fluvio-smartmodule-map"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ dependencies = [
 name = "fluvio-wasm-aggregate-average"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde",
  "serde_json",
 ]
@@ -351,7 +351,7 @@ dependencies = [
 name = "fluvio-wasm-aggregate-json"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde",
  "serde_json",
 ]
@@ -360,14 +360,14 @@ dependencies = [
 name = "fluvio-wasm-aggregate-sum"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
 name = "fluvio-wasm-array-map-reddit"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde",
  "serde_json",
 ]
@@ -376,7 +376,7 @@ dependencies = [
 name = "fluvio-wasm-filter-json"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde",
  "serde_json",
 ]
@@ -385,7 +385,7 @@ dependencies = [
 name = "fluvio-wasm-filter-odd"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "thiserror",
 ]
 
@@ -393,7 +393,7 @@ dependencies = [
 name = "fluvio-wasm-filter-regex"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "regex",
 ]
 
@@ -408,14 +408,14 @@ dependencies = [
 name = "fluvio-wasm-map-double"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
 ]
 
 [[package]]
 name = "fluvio-wasm-map-json"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -425,7 +425,7 @@ dependencies = [
 name = "fluvio-wasm-map-regex"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "once_cell",
  "regex",
 ]
@@ -829,7 +829,7 @@ dependencies = [
 name = "sm-integer-sum-aggegrate"
 version = "0.0.0"
 dependencies = [
- "fluvio-smartmodule 0.5.0",
+ "fluvio-smartmodule 0.5.1",
  "once_cell",
 ]
 


### PR DESCRIPTION
In the SPU Schema, the same version is used for all APIs similar to SC.   In the PR, the SPU schema version is bumped up to 19 so that deprecated fields can be in the next release.   Deprecated fields are hidden in the StreamFetchRequest and converted to the builder pattern.