### PR TITLE
[Merged by Bors] - feat: `cdk build` uses a default target

### DIFF
--- a/crates/cargo-builder/src/cargo.rs
+++ b/crates/cargo-builder/src/cargo.rs
@@ -138,4 +138,66 @@ mod test {
             &["build", "--profile", "release", "--lib", "-p", "foo"]
         );
     }
+
+    #[test]
+    fn test_builder_target() {
+        let config = Cargo::build()
+            .package("foo")
+            .target("wasm32-unknown-unknown")
+            .build()
+            .expect("should build");
+
+        assert_eq!(config.profile, "release");
+        assert_eq!(config.package, Some("foo".to_string()));
+
+        let cargo = config.make_cargo_cmd().expect("cmd");
+        let args: Vec<&OsStr> = cargo.get_args().collect();
+        assert_eq!(
+            args,
+            &[
+                "build",
+                "--profile",
+                "release",
+                "--lib",
+                "-p",
+                "foo",
+                "--target",
+                "wasm32-unknown-unknown"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_builder_extra_args() {
+        let config = Cargo::build()
+            .package("foo")
+            .target("wasm32-unknown-unknown")
+            .extra_arguments(vec![
+                "--benches".to_string(),
+                "--no-default-features".to_string(),
+            ])
+            .build()
+            .expect("should build");
+
+        assert_eq!(config.profile, "release");
+        assert_eq!(config.package, Some("foo".to_string()));
+
+        let cargo = config.make_cargo_cmd().expect("cmd");
+        let args: Vec<&OsStr> = cargo.get_args().collect();
+        assert_eq!(
+            args,
+            &[
+                "build",
+                "--profile",
+                "release",
+                "--lib",
+                "-p",
+                "foo",
+                "--target",
+                "wasm32-unknown-unknown",
+                "--benches",
+                "--no-default-features"
+            ]
+        );
+    }
 }

--- a/crates/cargo-builder/src/cargo.rs
+++ b/crates/cargo-builder/src/cargo.rs
@@ -1,4 +1,4 @@
-// Run Cargo using the `cargo` command line tool.
+//! Run Cargo using the `cargo` command line tool.
 
 use std::{
     fmt::{Debug, Display, Formatter},
@@ -7,6 +7,11 @@ use std::{
 
 use anyhow::{Error, anyhow, Result};
 use derive_builder::Builder;
+
+/// Error returned from `CargoBuild` builder when both the `target` field and
+/// an extra argument with `--target` are both present.
+const AMBIGUOUS_TARGET_ERR_MSG: &str =
+    "Cannot use `--target` as extra argument if `target` is also provided";
 
 #[derive(Default)]
 pub enum Profile {
@@ -27,6 +32,7 @@ impl Display for Profile {
 /// Builder Argument
 #[derive(Builder, Debug, Default)]
 #[builder(setter(into))]
+#[builder(build_fn(validate = "Self::validate"))]
 pub struct Cargo {
     /// Basic cargo command
     pub cmd: String,
@@ -105,9 +111,24 @@ impl Cargo {
     }
 }
 
+impl CargoBuilder {
+    fn validate(&self) -> Result<(), String> {
+        if let (Some(ref _target), Some(ref extra_arguments)) =
+            (&self.target, &self.extra_arguments)
+        {
+            // We don't want to allow setting both `target` and also
+            // `extra_arguments` containing `--target` in it
+            if extra_arguments.contains(&"--target".to_string()) {
+                return Err(AMBIGUOUS_TARGET_ERR_MSG.to_string());
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
-
     use std::ffi::OsStr;
 
     use super::*;
@@ -199,5 +220,27 @@ mod test {
                 "--no-default-features"
             ]
         );
+    }
+
+    #[test]
+    fn test_builder_complains_extra_args_target() {
+        let config = Cargo::build()
+            .package("foo")
+            .target("wasm32-unknown-unknown")
+            .extra_arguments(vec![
+                "--benches".to_string(),
+                "--no-default-features".to_string(),
+                "--target".to_string(),
+                "aarch64-apple-darwin".to_string(),
+            ])
+            .build();
+
+        assert!(config.is_err());
+
+        let Err(err) = config else {
+            panic!("Expected a `Err` for `test_builder_complains_extra_args_target`");
+        };
+
+        assert_eq!(err.to_string(), AMBIGUOUS_TARGET_ERR_MSG);
     }
 }

--- a/crates/cdk/src/build.rs
+++ b/crates/cdk/src/build.rs
@@ -16,17 +16,25 @@ pub struct BuildCmd {
     /// Extra arguments to be passed to cargo
     #[clap(raw = true)]
     extra_arguments: Vec<String>,
+
+    /// Provide target platform for the package. Optional.
+    /// By default the host's one is used.
+    #[clap(
+        long,
+        default_value_t = current_platform::CURRENT_PLATFORM.to_string()
+    )]
+    target: String,
 }
 
 impl BuildCmd {
     pub(crate) fn process(self) -> Result<()> {
         let opt = self.package.as_opt();
         let p = PackageInfo::from_options(&opt)?;
-
         let cargo = Cargo::build()
             .profile(opt.release)
             .lib(false)
             .package(p.package_name())
+            .target(&self.target)
             .extra_arguments(self.extra_arguments)
             .build()?;
 

--- a/crates/smartmodule-development-kit/src/build.rs
+++ b/crates/smartmodule-development-kit/src/build.rs
@@ -4,8 +4,10 @@ use std::str;
 use anyhow::Result;
 use clap::Parser;
 
-use cargo_builder::package::{PackageInfo, PackageOption};
+use cargo_builder::package::PackageInfo;
 use cargo_builder::cargo::Cargo;
+
+use crate::cmd::PackageCmd;
 
 pub(crate) const BUILD_TARGET: &str = "wasm32-unknown-unknown";
 
@@ -34,25 +36,5 @@ impl BuildCmd {
             .build()?;
 
         cargo.run()
-    }
-}
-
-#[derive(Debug, Parser)]
-pub struct PackageCmd {
-    /// Release profile name
-    #[clap(long, default_value = "release-lto")]
-    pub release: String,
-
-    /// Optional package/project name
-    #[clap(long, short)]
-    pub package_name: Option<String>,
-}
-
-impl PackageCmd {
-    pub(crate) fn as_opt(&self) -> PackageOption {
-        PackageOption {
-            release: self.release.clone(),
-            package_name: self.package_name.clone(),
-        }
     }
 }

--- a/crates/smartmodule-development-kit/src/build.rs
+++ b/crates/smartmodule-development-kit/src/build.rs
@@ -9,6 +9,7 @@ use cargo_builder::cargo::Cargo;
 
 use crate::cmd::PackageCmd;
 
+/// Default Build Target to use when building a Connector
 pub(crate) const BUILD_TARGET: &str = "wasm32-unknown-unknown";
 
 /// Builds the SmartModule in the current working directory into a WASM file

--- a/crates/smartmodule-development-kit/src/build.rs
+++ b/crates/smartmodule-development-kit/src/build.rs
@@ -4,12 +4,9 @@ use std::str;
 use anyhow::Result;
 use clap::Parser;
 
-use cargo_builder::package::PackageInfo;
+use cargo_builder::package::{PackageInfo, PackageOption};
 use cargo_builder::cargo::Cargo;
 
-use crate::cmd::PackageCmd;
-
-/// Default Build Target to use when building a Connector
 pub(crate) const BUILD_TARGET: &str = "wasm32-unknown-unknown";
 
 /// Builds the SmartModule in the current working directory into a WASM file
@@ -37,5 +34,25 @@ impl BuildCmd {
             .build()?;
 
         cargo.run()
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct PackageCmd {
+    /// Release profile name
+    #[clap(long, default_value = "release-lto")]
+    pub release: String,
+
+    /// Optional package/project name
+    #[clap(long, short)]
+    pub package_name: Option<String>,
+}
+
+impl PackageCmd {
+    pub(crate) fn as_opt(&self) -> PackageOption {
+        PackageOption {
+            release: self.release.clone(),
+            package_name: self.package_name.clone(),
+        }
     }
 }

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -39,7 +39,7 @@ setup_file() {
 @test "Build and deploy connector" {
     # Build
     cd $CONNECTOR_DIR
-    run $CDK_BIN build
+    run $CDK_BIN build --target x86_64-unknown-linux-gnu
     assert_success
 
     # Deploy

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -39,7 +39,7 @@ setup_file() {
 @test "Build and deploy connector" {
     # Build
     cd $CONNECTOR_DIR
-    run $CDK_BIN build -- --target x86_64-unknown-linux-gnu
+    run $CDK_BIN build
     assert_success
 
     # Deploy


### PR DESCRIPTION
In order to have a predictable path when seeking for binaries
use a `target` when building, this allow us to follow: `/target/<ARCH>/binary`
when doing `cdk publish`.

---

This PR is a step forward on fixing issues when attemtpting to publish a connector
using `cdk publish` which currently complains about no binary found on:

`../target/release/<ARCH>/binary`
