### PR TITLE
[Merged by Bors] - improvement: add helper method to get utf8 from data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes 1.4.0",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ fluvio-controlplane-metadata = { version = "0.22.0", default-features = false, p
 fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-extension-common = { path = "crates/fluvio-extension-common", default-features = false }
 fluvio-package-index = { version = "0.7.0", path = "crates/fluvio-package-index", default-features = false }
-fluvio-protocol = { version = "0.9.0", path = "crates/fluvio-protocol" }
+fluvio-protocol = { version = "0.9.3", path = "crates/fluvio-protocol" }
 fluvio-spu-schema = { version = "0.14.0", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-sc-schema = { version = "0.19.0", path = "crates/fluvio-sc-schema", default-features = false }
 fluvio-service = { path = "crates/fluvio-service" }

--- a/connector/cargo_template/src/main.rs
+++ b/connector/cargo_template/src/main.rs
@@ -27,8 +27,7 @@ use fluvio_connector_common::{connector, consumer::ConsumerStream, Result};
 async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<()> {
     println!("Starting {{project-name}} sink connector with {config:?}");
     while let Some(Ok(record)) = stream.next().await {
-        let string = String::from_utf8_lossy(record.value());
-        println!("{string}");
+        println!("{}",record.value().as_ut8_lossy_string());
     }
     Ok(())
 }

--- a/crates/fluvio-benchmark/src/consumer_worker.rs
+++ b/crates/fluvio-benchmark/src/consumer_worker.rs
@@ -78,7 +78,7 @@ impl ConsumerWorker {
 
     pub async fn send_results(&mut self) -> Result<()> {
         for (record, recv_time) in self.received.iter() {
-            let data = String::from_utf8_lossy(record.value());
+            let data = record.get_value().as_utf8_lossy_string();
             self.tx_to_stats_collector
                 .send(StatsCollectorMessage::MessageHash {
                     hash: hash_record(&data),

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -564,17 +564,18 @@ mod cmd {
             pb: &ProgressRenderer,
         ) {
             let formatted_key = record
-                .key()
-                .map(|key| String::from_utf8_lossy(key).to_string())
-                .unwrap_or_else(|| "null".to_string());
+                .get_key()
+                .map(|key| key.as_utf8_lossy_string())
+                .unwrap_or_else(|| "null".into());
 
             let formatted_value = match (&self.output, templates) {
                 (Some(ConsumeOutputType::json), None) => {
                     format_json(record.value(), self.suppress_unknown)
                 }
-                (Some(ConsumeOutputType::text), None) => {
-                    Some(format_text_record(record.value(), self.suppress_unknown))
-                }
+                (Some(ConsumeOutputType::text), None) => Some(format_text_record(
+                    record.get_value(),
+                    self.suppress_unknown,
+                )),
                 (Some(ConsumeOutputType::binary), None) => {
                     Some(format_binary_record(record.value()))
                 }
@@ -600,7 +601,7 @@ mod cmd {
                     }
                 }
                 (_, Some(templates)) => {
-                    let value = String::from_utf8_lossy(record.value()).to_string();
+                    let value = record.get_value().as_utf8_lossy_string();
                     let timestamp_rfc3339 = if record.timestamp() == NO_TIMESTAMP {
                         "NA".to_string()
                     } else {

--- a/crates/fluvio-cli/src/client/consume/record_format.rs
+++ b/crates/fluvio-cli/src/client/consume/record_format.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Result};
 
 use fluvio::{metadata::tableformat::TableFormatColumnConfig};
 use fluvio_extension_common::{bytes_to_hex_dump, hex_dump_separator};
+use fluvio_smartmodule::RecordData;
 
 use super::TableModel;
 
@@ -34,11 +35,11 @@ pub fn format_json(value: &[u8], suppress: bool) -> Option<String> {
 // -----------------------------------
 
 /// Print a single record in text format
-pub fn format_text_record(record: &[u8], suppress: bool) -> String {
-    if is_binary(record) && !suppress {
-        format!("binary: ({} bytes)", record.len())
+pub fn format_text_record(data: &RecordData, suppress: bool) -> String {
+    if data.is_binary() && !suppress {
+        format!("binary: ({} bytes)", data.len())
     } else {
-        format!("{}", String::from_utf8_lossy(record))
+        format!("{}", data.as_utf8_lossy_string())
     }
 }
 

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/record/data.rs
+++ b/crates/fluvio-protocol/src/record/data.rs
@@ -1,8 +1,10 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::io::Error;
 use std::io::ErrorKind;
+use std::ops::Deref;
 use std::str::Utf8Error;
 
 use bytes::Bytes;
@@ -98,11 +100,15 @@ impl<K: Into<Vec<u8>>> From<K> for RecordKey {
 #[derive(Clone, Default, Eq, PartialEq, Hash)]
 pub struct RecordData(Bytes);
 
-impl RecordData {
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
+impl Deref for RecordData {
+    type Target = Bytes;
 
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl RecordData {
     /// Check if value is binary content
     pub fn is_binary(&self) -> bool {
         matches!(inspect(&self.0), ContentType::BINARY)
@@ -120,6 +126,11 @@ impl RecordData {
     // as string slice
     pub fn as_str(&self) -> Result<&str, Utf8Error> {
         std::str::from_utf8(self.as_ref())
+    }
+
+    // as lossy utf8
+    pub fn as_utf8_lossy_string(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(self.as_ref())
     }
 }
 
@@ -545,21 +556,19 @@ where
     }
 }
 
-use Record as DefaultRecord;
-
 /// Record that can be used by Consumer which needs access to metadata
-pub struct ConsumerRecord<B = DefaultRecord> {
+pub struct ConsumerRecord {
     /// The offset of this Record into its partition
     pub offset: i64,
     /// The partition where this Record is stored
     pub partition: PartitionId,
     /// The Record contents
-    pub record: B,
+    pub record: Record<RecordData>,
     /// Timestamp base of batch in which the records is present
     pub(crate) timestamp_base: Timestamp,
 }
 
-impl<B> ConsumerRecord<B> {
+impl ConsumerRecord {
     /// The offset from the initial offset for a given stream.
     pub fn offset(&self) -> i64 {
         self.offset
@@ -571,26 +580,36 @@ impl<B> ConsumerRecord<B> {
     }
 
     /// Returns the inner representation of the Record
-    pub fn into_inner(self) -> B {
+    pub fn into_inner(self) -> Record<RecordData> {
         self.record
     }
 
     /// Returns a ref to the inner representation of the Record
-    pub fn inner(&self) -> &B {
+    #[inline(always)]
+    pub fn inner(&self) -> &Record {
         &self.record
     }
-}
 
-impl ConsumerRecord<DefaultRecord> {
-    /// Returns the contents of this Record's key, if it exists
+    /// Returns record key
+    pub fn get_key(&self) -> Option<&RecordData> {
+        self.inner().key()
+    }
+
+    /// Returns record value
+    pub fn get_value(&self) -> &RecordData {
+        self.inner().value()
+    }
+
+    /// Returns the contents of this Record's key as a byte slice
     pub fn key(&self) -> Option<&[u8]> {
-        self.record.key().map(|it| it.as_ref())
+        self.inner().key().map(|it| it.as_ref())
     }
 
-    /// Returns the contents of this Record's value
+    /// Returns the contents of this Record's value as a byte slice
     pub fn value(&self) -> &[u8] {
-        self.record.value().as_ref()
+        self.inner().value().as_ref()
     }
+
     /// Return the timestamp of the Record
     pub fn timestamp(&self) -> Timestamp {
         if self.timestamp_base <= 0 {
@@ -601,7 +620,7 @@ impl ConsumerRecord<DefaultRecord> {
     }
 }
 
-impl AsRef<[u8]> for ConsumerRecord<DefaultRecord> {
+impl AsRef<[u8]> for ConsumerRecord {
     fn as_ref(&self) -> &[u8] {
         self.value()
     }
@@ -742,7 +761,7 @@ mod test {
 
     #[test]
     fn test_consumer_record_no_timestamp() {
-        let record = ConsumerRecord::<Record<RecordData>> {
+        let record = ConsumerRecord {
             timestamp_base: NO_TIMESTAMP,
             offset: 0,
             partition: 0,
@@ -750,7 +769,7 @@ mod test {
         };
 
         assert_eq!(record.timestamp(), NO_TIMESTAMP);
-        let record = ConsumerRecord::<Record<RecordData>> {
+        let record = ConsumerRecord {
             timestamp_base: 0,
             offset: 0,
             partition: 0,
@@ -761,7 +780,7 @@ mod test {
 
     #[test]
     fn test_consumer_record_timestamp() {
-        let record = ConsumerRecord::<Record<RecordData>> {
+        let record = ConsumerRecord {
             timestamp_base: 1_000_000_000,
             offset: 0,
             partition: 0,
@@ -771,7 +790,7 @@ mod test {
         assert_eq!(record.timestamp(), 1_000_000_000);
         let mut memory_record = Record::<RecordData>::default();
         memory_record.preamble.timestamp_delta = 800;
-        let record = ConsumerRecord::<Record<RecordData>> {
+        let record = ConsumerRecord {
             timestamp_base: 1_000_000_000,
             record: memory_record,
             offset: 0,

--- a/crates/fluvio-test/src/tests/data_generator/mod.rs
+++ b/crates/fluvio-test/src/tests/data_generator/mod.rs
@@ -126,9 +126,9 @@ pub fn data_generator(test_driver: FluvioTestDriver, test_case: TestCase) {
             let mut is_ready = false;
             while let Some(Ok(record)) = sync_stream.next().await {
                 let _key = record
-                    .key()
-                    .map(|key| String::from_utf8_lossy(key).to_string());
-                let value = String::from_utf8_lossy(record.value()).to_string();
+                    .get_key()
+                    .map(|key| key.as_utf8_lossy_string());
+                let value = record.get_value().as_utf8_lossy_string();
 
                 if !is_ready {
                     if value.contains("ready") {

--- a/crates/fluvio-test/src/tests/data_generator/producer.rs
+++ b/crates/fluvio-test/src/tests/data_generator/producer.rs
@@ -108,12 +108,8 @@ pub async fn producer(
 
     println!("{producer_id}: waiting for start");
     while let Some(Ok(record)) = sync_stream.next().await {
-        //let _key = record
-        //    .key()
-        //    .map(|key| String::from_utf8_lossy(key).to_string());
-        let value = String::from_utf8_lossy(record.value()).to_string();
-
-        if value.eq("start") {
+        let value_str = record.get_value().as_utf8_lossy_string();
+        if value_str.eq("start") {
             println!("Starting producer");
             break;
         }

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -87,6 +87,8 @@ where
     /// stream using an [`Offset`] and periodically receive events, either individually
     /// or in batches.
     ///
+    /// Note this uses ConsumerRecord instead of batches
+    ///
     /// If you want more fine-grained control over how records are streamed,
     /// check out the [`stream_with_config`] method.
     ///
@@ -102,9 +104,9 @@ where
     /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
-    ///     let key = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-    ///     let value = String::from_utf8_lossy(record.value()).to_string();
-    ///     println!("Got event: key={:?}, value={}", key, value);
+    ///     let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+    ///     let value_str = record.get_value().as_utf8_lossy_string();
+    ///     println!("Got event: key={:?}, value={value_str}", key_str);
     /// }
     /// # Ok(())
     /// # }
@@ -152,9 +154,9 @@ where
     ///     .build()?;
     /// let mut stream = consumer.stream_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Some(Ok(record)) = stream.next().await {
-    ///     let key: Option<String> = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-    ///     let value = String::from_utf8_lossy(record.value());
-    ///     println!("Got record: key={:?}, value={}", key, value);
+    ///     let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+    ///     let value_str = record.get_value().as_utf8_lossy_string();
+    ///     println!("Got record: key={:?}, value={}", key_str, value_str);
     /// }
     /// # Ok(())
     /// # }
@@ -209,9 +211,9 @@ where
     /// let mut stream = consumer.stream_batches_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Some(Ok(batch)) = stream.next().await {
     ///     for record in batch.records() {
-    ///         let key = record.key.as_ref().map(|key| String::from_utf8_lossy(key.as_ref()).to_string());
-    ///         let value = String::from_utf8_lossy(record.value.as_ref()).to_string();
-    ///         println!("Got record: key={:?}, value={}", key, value);
+    ///         let key_str = record.key().map(|key| key.as_utf8_lossy_string());
+    ///         let value_str = record.value().as_utf8_lossy_string();
+    ///         println!("Got record: key={:?}, value={}", key_str, value_str);
     ///     }
     /// }
     /// # Ok(())
@@ -654,9 +656,9 @@ impl MultiplePartitionConsumer {
     /// use futures::StreamExt;
     /// let mut stream = consumer.stream(Offset::beginning()).await?;
     /// while let Some(Ok(record)) = stream.next().await {
-    ///     let key = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-    ///     let value = String::from_utf8_lossy(record.value()).to_string();
-    ///     println!("Got event: key={:?}, value={}", key, value);
+    ///     let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+    ///     let value_str = record.get_value().as_utf8_lossy_string();
+    ///     println!("Got event: key={:?}, value={}", key_str, value_str);
     /// }
     /// # Ok(())
     /// # }
@@ -704,9 +706,9 @@ impl MultiplePartitionConsumer {
     ///     .build()?;
     /// let mut stream = consumer.stream_with_config(Offset::beginning(), fetch_config).await?;
     /// while let Some(Ok(record)) = stream.next().await {
-    ///     let key: Option<String> = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-    ///     let value = String::from_utf8_lossy(record.value());
-    ///     println!("Got record: key={:?}, value={}", key, value);
+    ///     let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+    ///     let value_str = record.get_value().as_utf8_lossy_string();
+    ///     println!("Got record: key={:?}, value={}", key_str, value_str);
     /// }
     /// # Ok(())
     /// # }

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -70,9 +70,9 @@
 //!     let mut stream = consumer.stream(Offset::beginning()).await?;
 //!
 //!     while let Some(Ok(record)) = stream.next().await {
-//!         let key = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-//!         let value = String::from_utf8_lossy(record.value()).to_string();
-//!         println!("Got record: key={:?}, value={}", key, value);
+//!         let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+//!         let value_str = record.get_value().as_utf8_lossy_string();
+//!         println!("Got record: key={:?}, value={}", key_str, value_str);
 //!     }
 //!     Ok(())
 //! }
@@ -210,9 +210,9 @@ pub async fn producer<S: Into<String>>(topic: S) -> anyhow::Result<TopicProducer
 /// let consumer = fluvio::consumer("my-topic", 0).await?;
 /// let mut stream = consumer.stream(Offset::beginning()).await?;
 /// while let Some(Ok(record)) = stream.next().await {
-///     let key = record.key().map(|key| String::from_utf8_lossy(key).to_string());
-///     let value = String::from_utf8_lossy(record.value()).to_string();
-///     println!("Got record: key={:?}, value={}", key, value);
+///     let key_str = record.get_key().map(|key| key.as_utf8_lossy_string());
+///     let value_str = record.get_value().as_utf8_lossy_string();
+///     println!("Got record: key={:?}, value={}", key_str, value_str);
 /// }
 /// # Ok(())
 /// # }

--- a/examples/02-consume/src/main.rs
+++ b/examples/02-consume/src/main.rs
@@ -47,8 +47,7 @@ async fn consume() -> anyhow::Result<()> {
     let mut stream = consumer.stream(fluvio::Offset::beginning()).await?;
 
     while let Some(Ok(record)) = stream.next().await {
-        let string = String::from_utf8_lossy(record.value());
-        println!("{string}");
+        println!("{}", record.get_value().as_utf8_lossy_string());
     }
     Ok(())
 }

--- a/examples/03-echo/src/main.rs
+++ b/examples/03-echo/src/main.rs
@@ -158,10 +158,8 @@ async fn consume() -> anyhow::Result<()> {
     let mut stream = consumer.stream(Offset::beginning()).await?;
 
     while let Some(Ok(record)) = stream.next().await {
-        let key = record
-            .key()
-            .map(|key| String::from_utf8_lossy(key).to_string());
-        let value = String::from_utf8_lossy(record.value()).to_string();
+        let key = record.get_key().map(|key| key.as_utf8_lossy_string());
+        let value = record.get_value().as_utf8_lossy_string();
         println!("Got record: key={key:?}, value={value}");
         if value == "Done!" {
             return Ok(());

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytes",
  "content_inspector",
@@ -234,7 +234,7 @@ name = "fluvio-smartmodule"
 version = "0.5.1"
 dependencies = [
  "eyre",
- "fluvio-protocol 0.9.2",
+ "fluvio-protocol 0.9.3",
  "fluvio-smartmodule-derive 0.4.0",
  "thiserror",
  "tracing",


### PR DESCRIPTION
Make it easier to get the utf8 string from record data, especially for consumers.   This helps unnecessary conversion to owned unless it is necessary.   Replaced existing examples with improved patterns to reduce unnecessary allocations and establish best practices for string conversion.  

Also, add  `get_key()` and `get_value()` to ConsumerRecord, which should be used rather than the existing `value()`, which returns `&[u8]`.   Minor clean-up to remove unnecessary abstractions 


Before:
```
while let Some(Ok(record)) = stream.next().await {
        let string = String::from_utf8_lossy(record.value());
        println!("{string}");
 }
```

After:
```
while let Some(Ok(record)) = stream.next().await {
      println!("{}", record.get_value().as_utf8_lossy_string());
}
```

