### PR TITLE
[Merged by Bors] - feat: use `.hub` and `.DS_Store` for gitignore

### DIFF
--- a/connector/cargo_template/.gitignore
+++ b/connector/cargo_template/.gitignore
@@ -1,0 +1,3 @@
+/target
+/.hub
+.DS_Store

--- a/smartmodule/cargo_template/.gitignore
+++ b/smartmodule/cargo_template/.gitignore
@@ -1,2 +1,3 @@
 /target
-
+/.hub
+.DS_Store


### PR DESCRIPTION
Provides `.hub` directory and `.DS_Store` to the gitignore.