### PR TITLE
[Merged by Bors] - feat(cdk): provide error for package publish

### DIFF
--- a/crates/fluvio-hub-protocol/src/errors.rs
+++ b/crates/fluvio-hub-protocol/src/errors.rs
@@ -56,6 +56,9 @@ pub enum HubError {
     #[error("Package verification: {0}")]
     PackageVerify(String),
 
+    #[error("Package already published: {0}")]
+    PackageAlreadyPublished(String),
+
     #[error("Unable to package: {0}")]
     UnableToAssemblePackage(String),
 

--- a/crates/fluvio-hub-util/src/utils.rs
+++ b/crates/fluvio-hub-util/src/utils.rs
@@ -198,6 +198,9 @@ async fn push_package_api(put_url: &str, pkgpath: &str, access: &HubAccess) -> R
         surf::http::StatusCode::Unauthorized => {
             Err(HubError::HubAccess("Unauthorized, please log in".into()))
         }
+        surf::http::StatusCode::Conflict => Err(HubError::PackageAlreadyPublished(
+            "Make sure version is up to date and name doesn't conflicts with other package.".into(),
+        )),
         _ => {
             debug!("push result: {} \n{res:?}", res.status());
             let bodymsg = res


### PR DESCRIPTION
Provides better error reporting on CLI for packages with versions
that already exists.

```
Using hub https://hub-dev.infinyon.cloud
Creating package ee/myproj@0.1.0
.. fill out info in /myproj/.hub/package-meta.yaml
Package /myproj/.hub/myproj-0.1.0.ipkg created
Package already published: Make sure version is up to date and name doesn't conflicts with other package.
```