### PR TITLE
[Merged by Bors] - feat(cdk): prebuild artifacts for publish and deploy

### DIFF
--- a/crates/cdk/src/build.rs
+++ b/crates/cdk/src/build.rs
@@ -3,9 +3,10 @@ use std::fmt::Debug;
 use anyhow::Result;
 use clap::Parser;
 
-use cargo_builder::{package::PackageInfo, cargo::Cargo};
+use cargo_builder::package::PackageInfo;
 
 use crate::cmd::PackageCmd;
+use crate::utils::build::{BuildOpts, build_connector};
 
 /// Build the Connector in the current working directory
 #[derive(Debug, Parser)]
@@ -22,14 +23,13 @@ impl BuildCmd {
     pub(crate) fn process(self) -> Result<()> {
         let opt = self.package.as_opt();
         let p = PackageInfo::from_options(&opt)?;
-        let cargo = Cargo::build()
-            .profile(opt.release)
-            .lib(false)
-            .package(p.package_name())
-            .target(p.arch_target())
-            .extra_arguments(self.extra_arguments)
-            .build()?;
 
-        cargo.run()
+        build_connector(
+            &p,
+            BuildOpts {
+                release: opt.release,
+                extra_arguments: self.extra_arguments,
+            },
+        )
     }
 }

--- a/crates/cdk/src/build.rs
+++ b/crates/cdk/src/build.rs
@@ -22,10 +22,10 @@ pub struct BuildCmd {
 impl BuildCmd {
     pub(crate) fn process(self) -> Result<()> {
         let opt = self.package.as_opt();
-        let p = PackageInfo::from_options(&opt)?;
+        let package_info = PackageInfo::from_options(&opt)?;
 
         build_connector(
-            &p,
+            &package_info,
             BuildOpts {
                 release: opt.release,
                 extra_arguments: self.extra_arguments,

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -153,12 +153,6 @@ impl DeployLogCmd {
     }
 }
 
-fn make_package_info(package_cmd: &PackageCmd) -> Result<PackageInfo> {
-    let opt = package_cmd.as_opt();
-
-    PackageInfo::from_options(&opt)
-}
-
 fn deploy_local(
     package_cmd: PackageCmd,
     config: PathBuf,
@@ -166,7 +160,7 @@ fn deploy_local(
     ipkg_file: Option<PathBuf>,
 ) -> Result<()> {
     let opt = package_cmd.as_opt();
-    let package_info = make_package_info(&package_cmd)?;
+    let package_info = PackageInfo::from_options(&opt)?;
 
     build_connector(&package_info, BuildOpts::with_release(opt.release.as_str()))?;
 

--- a/crates/cdk/src/main.rs
+++ b/crates/cdk/src/main.rs
@@ -6,6 +6,8 @@ mod deploy;
 mod publish;
 mod set_public;
 
+pub(crate) mod utils;
+
 fn main() -> anyhow::Result<()> {
     use clap::Parser;
 

--- a/crates/cdk/src/publish.rs
+++ b/crates/cdk/src/publish.rs
@@ -21,6 +21,7 @@ use hubutil::packagename_validate;
 use tracing::{debug, info};
 
 use crate::cmd::PackageCmd;
+use crate::utils::build::{BuildOpts, build_connector};
 
 pub const CONNECTOR_TOML: &str = "Connector.toml";
 
@@ -70,6 +71,7 @@ impl PublishCmd {
             remove_dir_all(&hubdir)?;
         }
 
+        build_connector(&package_info, BuildOpts::with_release(opt.release.as_str()))?;
         init_package_template(&package_info, &self.readme)?;
         check_package_meta_visiblity(&package_info)?;
 

--- a/crates/cdk/src/test.rs
+++ b/crates/cdk/src/test.rs
@@ -3,10 +3,12 @@ use std::{fmt::Debug, path::PathBuf};
 use anyhow::{Result, Context};
 use clap::Parser;
 
-use cargo_builder::{package::PackageInfo, cargo::Cargo};
+use cargo_builder::package::PackageInfo;
 use fluvio_connector_deployer::{Deployment, DeploymentType};
 
-use crate::{cmd::PackageCmd, deploy::from_cargo_package};
+use crate::cmd::PackageCmd;
+use crate::deploy::from_cargo_package;
+use crate::utils::build::{build_connector, BuildOpts};
 
 /// Build and run the Connector in the current working directory
 #[derive(Debug, Parser)]
@@ -31,16 +33,12 @@ impl TestCmd {
     pub(crate) fn process(self) -> Result<()> {
         let opt = self.package.as_opt();
         let package_info = PackageInfo::from_options(&opt)?;
+        let build_options = BuildOpts {
+            release: opt.release,
+            extra_arguments: self.extra_arguments,
+        };
 
-        let cargo = Cargo::build()
-            .profile(opt.release)
-            .target(opt.target)
-            .lib(false)
-            .package(package_info.package_name())
-            .extra_arguments(self.extra_arguments)
-            .build()?;
-
-        cargo.run()?;
+        build_connector(&package_info, build_options)?;
 
         let (executable, connector_metadata) = from_cargo_package(&package_info)
             .context("Failed to deploy from within cargo package directory")?;

--- a/crates/cdk/src/test.rs
+++ b/crates/cdk/src/test.rs
@@ -30,19 +30,19 @@ pub struct TestCmd {
 impl TestCmd {
     pub(crate) fn process(self) -> Result<()> {
         let opt = self.package.as_opt();
-        let p = PackageInfo::from_options(&opt)?;
+        let package_info = PackageInfo::from_options(&opt)?;
 
         let cargo = Cargo::build()
             .profile(opt.release)
             .target(opt.target)
             .lib(false)
-            .package(p.package_name())
+            .package(package_info.package_name())
             .extra_arguments(self.extra_arguments)
             .build()?;
 
         cargo.run()?;
 
-        let (executable, connector_metadata) = from_cargo_package(self.package)
+        let (executable, connector_metadata) = from_cargo_package(&package_info)
             .context("Failed to deploy from within cargo package directory")?;
 
         let mut builder = Deployment::builder();

--- a/crates/cdk/src/utils.rs
+++ b/crates/cdk/src/utils.rs
@@ -9,6 +9,15 @@ pub mod build {
         pub(crate) extra_arguments: Vec<String>,
     }
 
+    impl BuildOpts {
+        pub fn with_release(release: &str) -> Self {
+            Self {
+                release: release.to_string(),
+                extra_arguments: Vec::default(),
+            }
+        }
+    }
+
     /// Builds a Connector given it's package info and Cargo Build options
     pub fn build_connector(package_info: &PackageInfo, opts: BuildOpts) -> Result<()> {
         let cargo = Cargo::build()

--- a/crates/cdk/src/utils.rs
+++ b/crates/cdk/src/utils.rs
@@ -1,0 +1,24 @@
+pub mod build {
+    use anyhow::Result;
+
+    use cargo_builder::package::PackageInfo;
+    use cargo_builder::cargo::Cargo;
+
+    pub struct BuildOpts {
+        pub(crate) release: String,
+        pub(crate) extra_arguments: Vec<String>,
+    }
+
+    /// Builds a Connector given it's package info and Cargo Build options
+    pub fn build_connector(package_info: &PackageInfo, opts: BuildOpts) -> Result<()> {
+        let cargo = Cargo::build()
+            .profile(opts.release)
+            .lib(false)
+            .package(package_info.package_name())
+            .target(package_info.arch_target())
+            .extra_arguments(opts.extra_arguments)
+            .build()?;
+
+        cargo.run()
+    }
+}


### PR DESCRIPTION
Abstracts the build command used for `build`, `test`, `deploy` and `publish` and then
makes sure commands relying on binaries from build process output (Artifacts) are present
by spawning the `build` process before proceeding.