### PR TITLE
[Merged by Bors] - Update connector-publish.yml

### DIFF
--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -74,7 +74,7 @@ jobs:
             ${{ inputs.public && '--public-yes' || '' }} \
             --target ${{ matrix.rust-target }} \
             -p ${{ inputs.package-name }} \
-            ${{ (inputs.readme && format('--readme {}', inputs.readme))  || '' }}
+            ${{ (inputs.readme && format('--readme {0}', inputs.readme))  || '' }}
 
   macos:
     name: macos
@@ -110,4 +110,4 @@ jobs:
           cdk publish ${{ inputs.public && '--public-yes' || '' }} \
             --target ${{ matrix.rust-target }} \
             -p ${{ inputs.package-name }} \
-            ${{ (inputs.readme && format('--readme {}', inputs.readme)) || '' }}
+            ${{ (inputs.readme && format('--readme {0}', inputs.readme)) || '' }}


### PR DESCRIPTION
Fix issue:

```
Error: infinyon/fluvio/.github/workflows/connector-publish.yml@master (Line: 72, Col: 14):
Error: The template is not valid. infinyon/fluvio/.github/workflows/connector-publish.yml@master (Line: 72, Col: 14): The following format string is invalid: --readme {}
```

See reference: https://docs.github.com/en/actions/learn-github-actions/expressions#format