### PR TITLE
[Merged by Bors] - feat: cleanup after publishing packages

### DIFF
--- a/crates/cdk/src/publish.rs
+++ b/crates/cdk/src/publish.rs
@@ -84,6 +84,7 @@ impl PublishCmd {
                     .unwrap_or_else(|| hubdir.join(hubutil::HUB_PACKAGE_META));
                 let pkgdata = package_assemble(pkgmetapath, &opt.target, &access)?;
                 package_push(self, &pkgdata, &access)?;
+                remove_dir_all(&hubdir)?;
             }
 
             // --pack only
@@ -103,6 +104,7 @@ impl PublishCmd {
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("package file required for push"))?;
                 package_push(self, pkgfile, &access)?;
+                remove_dir_all(&hubdir)?;
             }
         }
 

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -68,6 +68,7 @@ impl PublishCmd {
             (false, false) | (true, true) => {
                 let pkgdata = package_assemble(&package_meta_path, &access)?;
                 package_push(self, &pkgdata, &access)?;
+                remove_dir_all(&hubdir)?;
             }
 
             // --pack only
@@ -82,6 +83,7 @@ impl PublishCmd {
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("package file required for push"))?;
                 package_push(self, pkgfile, &access)?;
+                remove_dir_all(&hubdir)?;
             }
         }
 

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -49,11 +49,7 @@ impl PublishCmd {
         let package_info = PackageInfo::from_options(&opt)?;
         let hubdir = package_info.package_relative_path(DEF_HUB_INIT_DIR);
 
-        if hubdir.exists() {
-            // Delete the `.hub` directory if already exists
-            tracing::warn!("Removing directory at {:?}", hubdir);
-            remove_dir_all(&hubdir)?;
-        }
+        self.cleanup(&package_info)?;
 
         init_package_template(&package_info)?;
         check_package_meta_visiblity(&package_info)?;
@@ -68,7 +64,6 @@ impl PublishCmd {
             (false, false) | (true, true) => {
                 let pkgdata = package_assemble(&package_meta_path, &access)?;
                 package_push(self, &pkgdata, &access)?;
-                remove_dir_all(&hubdir)?;
             }
 
             // --pack only
@@ -83,8 +78,23 @@ impl PublishCmd {
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("package file required for push"))?;
                 package_push(self, pkgfile, &access)?;
-                remove_dir_all(&hubdir)?;
             }
+        }
+
+        if !self.pack {
+            self.cleanup(&package_info)?;
+        }
+
+        Ok(())
+    }
+
+    fn cleanup(&self, package_info: &PackageInfo) -> Result<()> {
+        let hubdir = package_info.package_relative_path(DEF_HUB_INIT_DIR);
+
+        if hubdir.exists() {
+            // Delete the `.hub` directory if already exists
+            tracing::warn!("Removing directory at {:?}", hubdir);
+            remove_dir_all(&hubdir)?;
         }
 
         Ok(())


### PR DESCRIPTION
Removes `.hub` directory after publishing packages
to the Hub when using both **cdk** or **smdk**.
