### PR TITLE
[Merged by Bors] - feat: use kebab case for group names on hub packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "cargo-generate",
  "clap 4.2.7",
  "comfy-table",
+ "convert_case",
  "current_platform",
  "fluvio",
  "fluvio-connector-deployer",
@@ -3002,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/connector/cargo_template/Connector.toml
+++ b/connector/cargo_template/Connector.toml
@@ -1,6 +1,6 @@
 [package]
 name = "{{project-name}}"
-group = "{{project-group}}"
+group = "{{project-group | kebab_case}}"
 version = "0.1.0"
 apiVersion = "0.1.0"
 fluvio = "0.10.0"

--- a/smartmodule/cargo_template/SmartModule.toml
+++ b/smartmodule/cargo_template/SmartModule.toml
@@ -1,6 +1,6 @@
 [package]
 name = "{{project-name}}"
-group = "{{project-group}}"
+group = "{{project-group | kebab_case}}"
 version = "0.1.0"
 apiVersion = "0.1.0"
 description = "{{project-description}}"


### PR DESCRIPTION
When generating new packages, either with SMDK or CDK we are now
making sure the `group` name is using the correct casing.

Refer: https://cargo-generate.github.io/cargo-generate/templates/index.html#placeholders
