### PR TITLE
[Merged by Bors] - feat: cdk deploy log level support

### DIFF
--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -64,7 +64,7 @@ enum DeployStartCmd {
         ipkg_file: Option<PathBuf>,
 
         /// Log level for the connector process
-        #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
+        #[arg(long, value_name = "LOG_LEVEL", default_value_t)]
         log_level: LogLevel,
     },
 }

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -64,7 +64,7 @@ enum DeployStartCmd {
         ipkg_file: Option<PathBuf>,
 
         /// Log level for the connector process
-        #[arg(long, value_name = "LOG_LEVEL")]
+        #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
         log_level: LogLevel,
     },
 }

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -8,11 +8,11 @@ use std::{
 
 use anyhow::{Result, Context, anyhow};
 use clap::{Parser, Subcommand};
+use tracing::{debug, trace};
 
 use cargo_builder::package::PackageInfo;
-use fluvio_connector_deployer::{Deployment, DeploymentType};
+use fluvio_connector_deployer::{Deployment, DeploymentType, LogLevel};
 use fluvio_connector_package::metadata::ConnectorMetadata;
-use tracing::{debug, trace};
 
 use crate::cmd::PackageCmd;
 use crate::utils::build::{BuildOpts, build_connector};
@@ -62,6 +62,10 @@ enum DeployStartCmd {
         /// Deploy from local package file
         #[arg(long = "ipkg", value_name = "PATH")]
         ipkg_file: Option<PathBuf>,
+
+        /// Log level for the connector process
+        #[arg(long, value_name = "LOG_LEVEL")]
+        log_level: LogLevel,
     },
 }
 
@@ -144,7 +148,8 @@ impl DeployStartCmd {
                 config,
                 secrets,
                 ipkg_file,
-            } => deploy_local(package, config, secrets, ipkg_file),
+                log_level,
+            } => deploy_local(package, config, secrets, ipkg_file, log_level),
         }
     }
 }
@@ -178,6 +183,7 @@ fn deploy_local(
     config: PathBuf,
     secrets: Option<PathBuf>,
     ipkg_file: Option<PathBuf>,
+    log_level: LogLevel,
 ) -> Result<()> {
     let opt = package_cmd.as_opt();
     let package_info = PackageInfo::from_options(&opt)?;
@@ -200,6 +206,7 @@ fn deploy_local(
         .config(config)
         .secrets(secrets)
         .pkg(connector_metadata)
+        .log_level(log_level)
         .deployment_type(DeploymentType::Local {
             output_file: Some(log_path),
         });

--- a/crates/fluvio-connector-deployer/src/local.rs
+++ b/crates/fluvio-connector-deployer/src/local.rs
@@ -27,6 +27,8 @@ pub(crate) fn deploy_local<P: AsRef<Path>>(
     ))?;
     debug!("running executable: {}", &executable.to_string_lossy());
     let mut cmd = Command::new(executable);
+
+    cmd.env("RUST_LOG", "debug");
     cmd.stdin(Stdio::null());
     cmd.stdout(stdout);
     cmd.stderr(stderr);


### PR DESCRIPTION
Provides `LogLevel` support for CDK deployment.

## By default uses info

```
➜  cdk deploy -p http-sink start --config development-config.yml
    Finished release [optimized] target(s) in 0.30s
Log file: Desktop/http-sink-connector/http-sink.log
Connector runs with process id: 52183
Started connector `slack-sink`

➜  cdk deploy log --name slack-sink
2023-05-25T02:09:26.347493Z  INFO http_sink: Using EnvSecretStore
2023-05-25T02:09:26.347638Z  INFO http_sink: Reading config file from: Desktop/http-sink-connector/development-config.yml
2023-05-25T02:09:26.348481Z  INFO http_sink: starting processing
2023-05-25T02:09:26.350663Z  INFO fluvio::config::tls: Using verified TLS with inline certificates domain="cool-hola-cb182885c86619eeae654583a1a165db.c.infinyon.cloud"
2023-05-25T02:09:26.353771Z  INFO fluvio::fluvio: Connecting to Fluvio cluster fluvio_crate_version="0.19.0" fluvio_git_hash="83a194b9ada7f1834df0644954375d88f246e592"
```

## You can set the desired Log Level

```
➜  cdk deploy -p http-sink start --config development-config.yml --log-level debug
    Finished release [optimized] target(s) in 0.18s
Log file: Desktop/http-sink-connector/http-sink.log
Connector runs with process id: 52372
Started connector `slack-sink`
➜  cdk deploy log --name slack-sink
2023-05-25T02:15:36.204705Z  INFO http_sink: Using EnvSecretStore
2023-05-25T02:15:36.205036Z  INFO http_sink: Reading config file from: Desktop/http-sink-connector/development-config.yml
2023-05-25T02:15:36.205122Z DEBUG http_sink: input config config_str=meta:
  version: 0.2.1
  name: slack-sink
  type: http-sink
  topic: http-sink
http:
  endpoint: "http://localhost:8080"
  http_request_timeout: 1s
  http_connect_timeout: 15s

2023-05-25T02:15:36.206610Z DEBUG fluvio_connector_package::config: Using connector config V0_0_0(
    ConnectorConfigV1 {
        meta: MetaConfig {
            name: "slack-sink",
            type_: "http-sink",
            topic: "http-sink",
            version: "0.2.1",
            producer: None,
            consumer: None,
            secrets: None,
        },
        transforms: None,
    },
)
2023-05-25T02:15:36.207073Z  INFO http_sink: starting processing
2023-05-25T02:15:36.210066Z  INFO fluvio::config::tls: Using verified TLS with inline certificates domain="cool-hola-cb182885c86619eeae654583a1a165db.c.infinyon.cloud"
2023-05-25T02:15:36.216557Z  INFO fluvio::fluvio: Connecting to Fluvio cluster fluvio_crate_version="0.19.0" fluvio_git_hash="83a194b9ada7f1834df0644954375d88f246e592"
2023-05-25T02:15:36.216679Z DEBUG connect: fluvio_socket::versioned: try connection to add=localhost:9003
2023-05-25T02:15:36.216714Z DEBUG connect:connect_with_connector{addr="localhost:9003"}: fluvio_socket::socket: connecting to addr at: localhost:9003
2023-05-25T02:15:36.216750Z DEBUG connect:connect_with_connector{addr="localhost:9003"}: fluvio_future::openssl::connector: connect to tls addr: localhost:9003
```

## The log file inherits the Log Level

```
➜  cat http-sink.log
2023-05-25T02:15:36.204705Z  INFO http_sink: Using EnvSecretStore
2023-05-25T02:15:36.205036Z  INFO http_sink: Reading config file from: Desktop/http-sink-connector/development-config.yml
2023-05-25T02:15:36.205122Z DEBUG http_sink: input config config_str=meta:
  version: 0.2.1
  name: slack-sink
  type: http-sink
  topic: http-sink
http:
  endpoint: "http://localhost:8080"
  http_request_timeout: 1s
  http_connect_timeout: 15s

2023-05-25T02:15:36.206610Z DEBUG fluvio_connector_package::config: Using connector config V0_0_0(
```