### PR TITLE
[Merged by Bors] - feat: report error if lookback is used on producer

### DIFF
--- a/crates/fluvio-connector-common/src/producer.rs
+++ b/crates/fluvio-connector-common/src/producer.rs
@@ -34,7 +34,7 @@ pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, T
         .await?;
 
     if let Some(chain) = smartmodule_chain_from_config(config).await? {
-        Ok((fluvio, producer.with_chain(chain)?))
+        Ok((fluvio, producer.with_chain(chain).await?))
     } else {
         Ok((fluvio, producer))
     }


### PR DESCRIPTION
`lookback` is not supported if running on SmartEngine on Producer side. The error will be reported in that case.

Closes #3302 