### PR TITLE
[Merged by Bors] - feat: measure metrics on `look_back` calls

### DIFF
--- a/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
+++ b/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
@@ -87,6 +87,7 @@ impl SmartModuleInstance {
     }
 
     pub(crate) fn lookback(&self) -> Option<Lookback> {
+        self.look_back.as_ref()?; // return None if there is no function
         self.ctx.lookback
     }
 }


### PR DESCRIPTION
We will measure `bytes_in` and `invocations` for `look_back` in the same way as for `transform`.