### PR TITLE
[Merged by Bors] - feat(smdk): support `lookback` in test

### DIFF
--- a/crates/fluvio-smartengine/src/engine/config.rs
+++ b/crates/fluvio-smartengine/src/engine/config.rs
@@ -61,6 +61,10 @@ impl SmartModuleConfig {
     pub(crate) fn version(&self) -> i16 {
         self.version.unwrap_or(DEFAULT_SMARTENGINE_VERSION)
     }
+
+    pub fn set_lookback(&mut self, lookback: Option<Lookback>) {
+        self.lookback = lookback;
+    }
 }
 
 #[cfg(feature = "transformation")]

--- a/crates/smartmodule-development-kit/src/main.rs
+++ b/crates/smartmodule-development-kit/src/main.rs
@@ -7,7 +7,7 @@ mod publish;
 mod hub;
 mod set_public;
 
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 use anyhow::Result;

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -867,3 +867,22 @@ setup_file() {
     assert_output --partial "Creating SmartModule: $SM_PACKAGE_NAME"
     assert_success
 }
+
+@test "Test Lookback" {
+  # Test with smartmodule example with Lookback
+  cd "$(pwd)/smartmodule/examples/filter_look_back/"
+
+  # Build
+  run $SMDK_BIN build
+  refute_output --partial "could not compile"
+
+  # Test
+  run $SMDK_BIN test --text '111' --lookback-last '1' --record '222' --record '333'
+  refute_output --partial "111"
+  assert_success
+
+  run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333'
+  assert_output --partial "444"
+  assert_success
+
+}


### PR DESCRIPTION
Added an ability to specify the lookback parameter and provide existing records to simulate data in the topic.

For example, here we run `test` and pass input record "1" and provide other records "2" and "3" as they would exist in the topic before:
```bash
smdk test --text "1" --lookback-last 1 --record "2" --record "3" 
```
the `look_back` function will receive record "3".

Closes #3315 