### PR TITLE
[Merged by Bors] - fix: don't require Cargo project to start connector from ipkg

### DIFF
--- a/connector/json-test-connector/Connector.toml
+++ b/connector/json-test-connector/Connector.toml
@@ -12,8 +12,7 @@ license = "Apache-2.0"
 source = true
 
 [deployment]
-image = "infinyon/fluvio-connect-json-test-source:0.1.0"
-
+binary = "json-test-connector"
 
 [custom]
 name = "json"

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -186,14 +186,15 @@ fn deploy_local(
     log_level: LogLevel,
 ) -> Result<()> {
     let opt = package_cmd.as_opt();
-    let package_info = PackageInfo::from_options(&opt)?;
-
-    build_connector(&package_info, BuildOpts::with_release(opt.release.as_str()))?;
 
     let (executable, connector_metadata) = match ipkg_file {
         Some(ipkg_file) => from_ipkg_file(ipkg_file).context("Failed to deploy from ipkg file")?,
-        None => from_cargo_package(&package_info)
-            .context("Failed to deploy from within cargo package directory")?,
+        None => {
+            let package_info = PackageInfo::from_options(&opt)?;
+            build_connector(&package_info, BuildOpts::with_release(opt.release.as_str()))?;
+            from_cargo_package(&package_info)
+                .context("Failed to deploy from within cargo package directory")?
+        }
     };
 
     let mut log_path = std::env::current_dir()?;

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -83,3 +83,20 @@ setup_file() {
     cat ./.hub/package-meta.yaml | grep '../../testing/README.md'
     assert_success
 }
+
+@test "Run connector with --ipkg" {
+    # create package meta doesn't exist
+    cd $CONNECTOR_DIR
+    run $CDK_BIN publish --pack --target x86_64-unknown-linux-gnu
+    assert_success
+
+    mkdir $TEST_DIR/ipkg
+    cp .hub/json-test-connector-0.1.0.ipkg $TEST_DIR/ipkg
+    cp sample-config.yaml $TEST_DIR/ipkg 
+
+    cd $TEST_DIR/ipkg
+
+    run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config.yaml
+    assert_success
+    assert_output --partial "Connector runs with process id"
+}


### PR DESCRIPTION
Fixes #3339 