### PR TITLE
[Merged by Bors] - feat(connector): added topic config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/connector/json-test-connector/sample-config-v2.yaml
+++ b/connector/json-test-connector/sample-config-v2.yaml
@@ -1,0 +1,24 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-json-test-connector
+  type: json-test-source
+  topic:
+    version: 0.1.0
+    meta:
+      name: test-full-topic
+    partition:
+      count: 1
+      max-size: 4.0 KB
+      replication: 1
+      ignore-rack-assignment: true
+    retention:
+      time: 2m
+      segment-size: 2.0 KB
+    compression:
+      type: Lz4
+json:
+  interval: 5  
+  timeout: 15
+  template: '{"template":"test"}'  
+

--- a/connector/sink-test-connector/sample-config-v2.yaml
+++ b/connector/sink-test-connector/sample-config-v2.yaml
@@ -1,0 +1,35 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-sink-test-connector
+  type: test-sink
+  topic: 
+    version: 0.1.0
+    meta:
+      name: test-full-topic
+    partition:
+      count: 1
+      max-size: 4.0 KB
+      replication: 1
+      ignore-rack-assignment: true
+    retention:
+      time: 2m
+      segment-size: 2.0 KB
+    compression:
+      type: Lz4
+  secrets:
+    - name: TEST_API_KEY
+    - name: TEST_API_CLIENT_ID
+custom:
+  api_key:
+    secret:
+      name: TEST_API_KEY
+  client_id: ${{ secrets.TEST_API_CLIENT_ID }}
+transforms:
+  - uses: infinyon/jolt@0.1.0
+    with:
+      spec:
+        - operation: default
+          spec:
+            data:
+              source: "sink-test-connector"

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -261,7 +261,7 @@ fn connector_name_from_config(package_cmd: PackageCmd, config: PathBuf) -> Resul
 
     let config = metadata.validate_config(config_file)?;
 
-    Ok(config.meta().name.to_owned())
+    Ok(config.meta().name().to_owned())
 }
 
 pub(crate) fn from_cargo_package(

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -30,7 +30,7 @@ pub fn get_value(value: Value, root: Option<&str>) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
-    use fluvio_connector_package::config::MetaConfig;
+    use fluvio_connector_package::config::MetaConfigV1;
 
     #[test]
     fn test_from_value() {
@@ -49,7 +49,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        let config: MetaConfig = from_value(value, Some("meta")).unwrap();
+        let config: MetaConfigV1 = from_value(value, Some("meta")).unwrap();
         assert_eq!(config.name, "test");
         assert_eq!(config.topic, "test");
         assert_eq!(

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -20,17 +20,16 @@ pub async fn consumer_stream_from_config(
     config: &ConnectorConfig,
 ) -> Result<(Fluvio, impl ConsumerStream)> {
     let mut cluster_config = FluvioConfig::load()?;
-    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name));
+    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name()));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;
     ensure_topic_exists(config).await?;
     let consumer = fluvio
         .partition_consumer(
-            &config.meta().topic,
+            config.meta().topic(),
             config
                 .meta()
-                .consumer
-                .as_ref()
+                .consumer()
                 .and_then(|c| c.partition)
                 .unwrap_or_default(),
         )
@@ -38,7 +37,7 @@ pub async fn consumer_stream_from_config(
 
     let mut builder = fluvio::ConsumerConfig::builder();
 
-    if let Some(max_bytes) = config.meta().consumer.as_ref().and_then(|c| c.max_bytes) {
+    if let Some(max_bytes) = config.meta().consumer().and_then(|c| c.max_bytes) {
         builder.max_bytes(max_bytes.as_u64() as i32);
     }
 

--- a/crates/fluvio-connector-common/src/lib.rs
+++ b/crates/fluvio-connector-common/src/lib.rs
@@ -13,6 +13,7 @@ pub use fluvio_connector_derive::connector;
 use fluvio::{Offset, metadata::topic::TopicSpec};
 use futures::stream::LocalBoxStream;
 use async_trait::async_trait;
+use ::tracing::{info, error};
 
 pub type Error = anyhow::Error;
 pub type Result<T> = std::result::Result<T, Error>;
@@ -40,19 +41,30 @@ pub trait Sink<I> {
 }
 
 pub async fn ensure_topic_exists(config: &config::ConnectorConfig) -> Result<()> {
+    let topic = config.meta().topic().to_string();
     let admin = fluvio::FluvioAdmin::connect().await?;
-    let topics = admin
-        .list::<TopicSpec, String>(vec![config.meta().topic.clone()])
-        .await?;
-    let topic_exists = topics.iter().any(|t| t.name.eq(&config.meta().topic));
+    let topics = admin.list::<TopicSpec, String>(vec![topic.clone()]).await?;
+    let topic_exists = topics.iter().any(|t| t.name.eq(&topic));
     if !topic_exists {
-        let _ = admin
+        match admin
             .create(
-                config.meta().topic.clone(),
+                topic.to_owned(),
                 false,
-                TopicSpec::new_computed(1, 1, Some(false)),
+                config
+                    .meta()
+                    .topic_config()
+                    .cloned()
+                    .map(TopicSpec::from)
+                    .unwrap_or(TopicSpec::new_computed(1, 1, Some(false))),
             )
-            .await;
+            .await
+        {
+            Ok(_) => info!(topic, "succesfully created"),
+            Err(err) => {
+                error!("unable to create topic {topic}: {err}");
+                return Err(err);
+            }
+        }
     }
     Ok(())
 }

--- a/crates/fluvio-connector-common/src/producer.rs
+++ b/crates/fluvio-connector-common/src/producer.rs
@@ -5,13 +5,13 @@ use crate::{ensure_topic_exists, smartmodule::smartmodule_chain_from_config};
 
 pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, TopicProducer)> {
     let mut cluster_config = FluvioConfig::load()?;
-    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name));
+    cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name()));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;
     ensure_topic_exists(config).await?;
     let mut config_builder = TopicProducerConfigBuilder::default();
 
-    if let Some(producer_params) = &config.meta().producer {
+    if let Some(producer_params) = &config.meta().producer() {
         // Linger
         if let Some(linger) = producer_params.linger {
             config_builder = config_builder.linger(linger)
@@ -30,7 +30,7 @@ pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, T
 
     let producer_config = config_builder.build()?;
     let producer = fluvio
-        .topic_producer_with_config(&config.meta().topic, producer_config)
+        .topic_producer_with_config(config.meta().topic(), producer_config)
         .await?;
 
     if let Some(chain) = smartmodule_chain_from_config(config).await? {

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -65,7 +65,7 @@ impl DeploymentBuilder {
 
         match &deployment.deployment_type {
             DeploymentType::Local { output_file } => {
-                let name = config.meta().name.to_owned();
+                let name = config.meta().name().to_owned();
                 let process_id = local::deploy_local(&deployment, output_file.as_ref(), &name)?;
                 let log_file = output_file.clone();
 

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -227,6 +227,13 @@ impl MetaConfig<'_> {
         }
     }
 
+    pub fn type_(&self) -> &str {
+        match self {
+            MetaConfig::V0_1_0(inner) => &inner.type_,
+            MetaConfig::V0_2_0(inner) => &inner.type_,
+        }
+    }
+
     pub fn topic(&self) -> &str {
         match self {
             MetaConfig::V0_1_0(inner) => &inner.topic,
@@ -449,15 +456,15 @@ impl ConnectorConfig {
     }
 
     pub fn name(&self) -> String {
-        self.meta().name.clone()
+        self.meta().name().to_string()
     }
 
     pub fn version(&self) -> String {
-        self.meta().version.clone()
+        self.meta().version().to_string()
     }
 
     pub fn r#type(&self) -> String {
-        self.meta().type_.clone()
+        self.meta().type_().to_string()
     }
 }
 
@@ -958,7 +965,7 @@ mod tests {
     #[test]
     fn retrieves_name_and_version() {
         let have = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "my-test-mqtt".to_string(),
                 type_: "mqtt-source".to_string(),
                 topic: "my-mqtt".to_string(),

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -6,6 +6,7 @@ use std::path::{PathBuf, Path};
 use std::str::FromStr;
 use std::time::Duration;
 
+use fluvio_controlplane_metadata::topic::config::TopicConfig;
 use fluvio_types::PartitionId;
 use tracing::debug;
 use anyhow::Result;
@@ -15,6 +16,11 @@ use bytesize::ByteSize;
 use fluvio_smartengine::transformation::TransformationConfig;
 use fluvio_compression::Compression;
 use crate::metadata::Direction;
+
+pub use self::v1::ConnectorConfigV1;
+pub use self::v1::MetaConfigV1;
+pub use self::v2::ConnectorConfigV2;
+pub use self::v2::MetaConfigV2;
 
 mod bytesize_serde;
 
@@ -32,6 +38,8 @@ pub enum ConnectorConfig {
     V0_0_0(ConnectorConfigV1),
     #[serde(rename = "0.1.0")]
     V0_1_0(ConnectorConfigV1),
+    #[serde(rename = "0.2.0")]
+    V0_2_0(ConnectorConfigV2),
 }
 
 impl Default for ConnectorConfig {
@@ -41,9 +49,9 @@ impl Default for ConnectorConfig {
 }
 
 mod serde_impl {
-    use serde::{Deserialize};
+    use serde::Deserialize;
 
-    use crate::config::ConnectorConfigV1;
+    use crate::config::{ConnectorConfigV1, ConnectorConfigV2};
 
     use super::ConnectorConfig;
 
@@ -58,6 +66,8 @@ mod serde_impl {
                 V0,
                 #[serde(rename = "0.1.0")]
                 V1,
+                #[serde(rename = "0.2.0")]
+                V2,
             }
             #[derive(Deserialize)]
             #[serde(rename_all = "camelCase")]
@@ -76,55 +86,180 @@ mod serde_impl {
                 Version::V1 => ConnectorConfigV1::deserialize(versioned_config.config)
                     .map(ConnectorConfig::V0_1_0)
                     .map_err(serde::de::Error::custom),
+
+                Version::V2 => ConnectorConfigV2::deserialize(versioned_config.config)
+                    .map(ConnectorConfig::V0_2_0)
+                    .map_err(serde::de::Error::custom),
             }
         }
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-pub struct ConnectorConfigV1 {
-    pub meta: MetaConfig,
+mod v1 {
+    use super::*;
 
-    #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
-    pub transforms: Option<TransformationConfig>,
-}
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+    pub struct ConnectorConfigV1 {
+        pub meta: MetaConfigV1,
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-pub struct MetaConfig {
-    pub name: String,
-
-    #[serde(rename = "type")]
-    pub type_: String,
-
-    pub topic: String,
-
-    pub version: String,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub producer: Option<ProducerParameters>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub consumer: Option<ConsumerParameters>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub secrets: Option<Vec<SecretConfig>>,
-}
-
-impl MetaConfig {
-    fn secrets(&self) -> HashSet<SecretConfig> {
-        HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+        #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
+        pub transforms: Option<TransformationConfig>,
     }
 
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+    pub struct MetaConfigV1 {
+        pub name: String,
+
+        #[serde(rename = "type")]
+        pub type_: String,
+
+        pub topic: String,
+
+        pub version: String,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub producer: Option<ProducerParameters>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub consumer: Option<ConsumerParameters>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub secrets: Option<Vec<SecretConfig>>,
+    }
+
+    impl MetaConfigV1 {
+        pub fn secrets(&self) -> HashSet<SecretConfig> {
+            HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+        }
+
+        pub fn direction(&self) -> Direction {
+            if self.type_.ends_with(SOURCE_SUFFIX) {
+                Direction::source()
+            } else {
+                Direction::dest()
+            }
+        }
+
+        pub fn image(&self) -> String {
+            format!("{}-{}:{}", IMAGE_PREFFIX, self.type_, self.version)
+        }
+    }
+}
+
+mod v2 {
+    use fluvio_controlplane_metadata::topic::config::TopicConfig;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+    pub struct ConnectorConfigV2 {
+        pub meta: MetaConfigV2,
+
+        #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
+        pub transforms: Option<TransformationConfig>,
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+    pub struct MetaConfigV2 {
+        pub name: String,
+
+        #[serde(rename = "type")]
+        pub type_: String,
+
+        pub topic: TopicConfig,
+
+        pub version: String,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub producer: Option<ProducerParameters>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub consumer: Option<ConsumerParameters>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub secrets: Option<Vec<SecretConfig>>,
+    }
+
+    impl MetaConfigV2 {
+        pub fn secrets(&self) -> HashSet<SecretConfig> {
+            HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+        }
+
+        pub fn direction(&self) -> Direction {
+            if self.type_.ends_with(SOURCE_SUFFIX) {
+                Direction::source()
+            } else {
+                Direction::dest()
+            }
+        }
+
+        pub fn image(&self) -> String {
+            format!("{}-{}:{}", IMAGE_PREFFIX, self.type_, self.version)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetaConfig<'a> {
+    V0_1_0(&'a MetaConfigV1),
+    V0_2_0(&'a MetaConfigV2),
+}
+
+impl MetaConfig<'_> {
     fn direction(&self) -> Direction {
-        if self.type_.ends_with(SOURCE_SUFFIX) {
-            Direction::source()
-        } else {
-            Direction::dest()
+        match self {
+            MetaConfig::V0_1_0(inner) => inner.direction(),
+            MetaConfig::V0_2_0(inner) => inner.direction(),
         }
     }
 
     pub fn image(&self) -> String {
-        format!("{}-{}:{}", IMAGE_PREFFIX, self.type_, self.version)
+        match self {
+            MetaConfig::V0_1_0(inner) => inner.image(),
+            MetaConfig::V0_2_0(inner) => inner.image(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            MetaConfig::V0_1_0(inner) => &inner.name,
+            MetaConfig::V0_2_0(inner) => &inner.name,
+        }
+    }
+
+    pub fn topic(&self) -> &str {
+        match self {
+            MetaConfig::V0_1_0(inner) => &inner.topic,
+            MetaConfig::V0_2_0(inner) => &inner.topic.meta.name,
+        }
+    }
+
+    pub fn version(&self) -> &str {
+        match self {
+            MetaConfig::V0_1_0(inner) => &inner.version,
+            MetaConfig::V0_2_0(inner) => &inner.version,
+        }
+    }
+
+    pub fn consumer(&self) -> Option<&ConsumerParameters> {
+        match self {
+            MetaConfig::V0_1_0(inner) => inner.consumer.as_ref(),
+            MetaConfig::V0_2_0(inner) => inner.consumer.as_ref(),
+        }
+    }
+
+    pub fn producer(&self) -> Option<&ProducerParameters> {
+        match self {
+            MetaConfig::V0_1_0(inner) => inner.producer.as_ref(),
+            MetaConfig::V0_2_0(inner) => inner.producer.as_ref(),
+        }
+    }
+
+    pub fn topic_config(&self) -> Option<&TopicConfig> {
+        match self {
+            MetaConfig::V0_1_0(_) => None,
+            MetaConfig::V0_2_0(inner) => Some(&inner.topic),
+        }
     }
 }
 
@@ -244,16 +379,6 @@ impl Serialize for SecretName {
     }
 }
 
-impl ConnectorConfigV1 {
-    fn meta(&self) -> &MetaConfig {
-        &self.meta
-    }
-
-    fn mut_meta(&mut self) -> &mut MetaConfig {
-        &mut self.meta
-    }
-}
-
 impl ConnectorConfig {
     pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self> {
         let mut file = File::open(path.into())?;
@@ -277,10 +402,12 @@ impl ConnectorConfig {
         }
         Ok(())
     }
-    pub fn meta(&self) -> &MetaConfig {
+
+    pub fn meta(&self) -> MetaConfig {
         match self {
-            Self::V0_1_0(config) => config.meta(),
-            Self::V0_0_0(config) => config.meta(),
+            Self::V0_0_0(inner) => MetaConfig::V0_1_0(&inner.meta),
+            Self::V0_1_0(inner) => MetaConfig::V0_1_0(&inner.meta),
+            Self::V0_2_0(inner) => MetaConfig::V0_2_0(&inner.meta),
         }
     }
 
@@ -296,24 +423,20 @@ impl ConnectorConfig {
         std::fs::write(path, serde_yaml::to_string(self)?)?;
         Ok(())
     }
-    pub fn mut_meta(&mut self) -> &mut MetaConfig {
-        match self {
-            Self::V0_1_0(config) => config.mut_meta(),
-            Self::V0_0_0(config) => config.mut_meta(),
-        }
-    }
 
     pub fn secrets(&self) -> HashSet<SecretConfig> {
         match self {
-            Self::V0_1_0(config) => config.meta.secrets(),
             Self::V0_0_0(_) => Default::default(),
+            Self::V0_1_0(config) => config.meta.secrets(),
+            Self::V0_2_0(config) => config.meta.secrets(),
         }
     }
 
     pub fn transforms(&self) -> Option<&TransformationConfig> {
         match self {
-            Self::V0_1_0(config) => config.transforms.as_ref(),
             Self::V0_0_0(config) => config.transforms.as_ref(),
+            Self::V0_1_0(config) => config.transforms.as_ref(),
+            Self::V0_2_0(config) => config.transforms.as_ref(),
         }
     }
 
@@ -343,6 +466,13 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
+    use fluvio_controlplane_metadata::topic::{
+        config::{
+            TopicConfigBuilder, MetaConfigBuilder, MetaConfig, PartitionConfig, RetentionConfig,
+            CompressionConfig,
+        },
+        CompressionAlgorithm,
+    };
     use fluvio_smartengine::transformation::{TransformationStep, Lookback};
     use pretty_assertions::assert_eq;
 
@@ -350,7 +480,7 @@ mod tests {
     fn full_yaml_test() {
         //given
         let expected = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "my-test-mqtt".to_string(),
                 type_: "mqtt".to_string(),
                 topic: "my-mqtt".to_string(),
@@ -390,13 +520,79 @@ mod tests {
 
         //then
         assert_eq!(connector_cfg, expected);
+        assert!(connector_cfg.meta().topic_config().is_none());
+    }
+
+    #[test]
+    fn deserialize_full_config_v2() {
+        //given
+        let expected = ConnectorConfig::V0_2_0(ConnectorConfigV2 {
+            meta: MetaConfigV2 {
+                name: "my-test-mqtt".to_string(),
+                type_: "mqtt".to_string(),
+                topic: TopicConfig {
+                    version: "0.1.0".to_string(),
+                    meta: MetaConfig {
+                        name: "test-topic".to_string(),
+                    },
+                    partition: PartitionConfig {
+                        count: Some(3),
+                        max_size: Some(bytesize::ByteSize(1000)),
+                        replication: Some(2),
+                        ignore_rack_assignment: Some(true),
+                        maps: None,
+                    },
+                    retention: RetentionConfig {
+                        time: Some(Duration::from_secs(120)),
+                        segment_size: Some(bytesize::ByteSize(2000)),
+                    },
+                    compression: CompressionConfig {
+                        type_: CompressionAlgorithm::Lz4,
+                    },
+                },
+                version: "0.1.0".to_string(),
+                producer: Some(ProducerParameters {
+                    linger: Some(Duration::from_millis(1)),
+                    compression: Some(Compression::Gzip),
+                    batch_size: Some(ByteSize::mb(44)),
+                }),
+                consumer: Some(ConsumerParameters {
+                    partition: Some(10),
+                    max_bytes: Some(ByteSize::mb(1)),
+                }),
+                secrets: Some(vec![SecretConfig {
+                    name: "secret1".parse().unwrap(),
+                }]),
+            },
+            transforms: Some(
+                TransformationStep {
+                    uses: "infinyon/json-sql".to_string(),
+                    lookback: None,
+                    with: BTreeMap::from([
+                        (
+                            "mapping".to_string(),
+                            "{\"table\":\"topic_message\"}".into(),
+                        ),
+                        ("param".to_string(), "param_value".into()),
+                    ]),
+                }
+                .into(),
+            ),
+        });
+
+        //when
+        let connector_cfg = ConnectorConfig::from_file("test-data/connectors/full-config-v2.yaml")
+            .expect("Failed to load test config");
+
+        //then
+        assert_eq!(connector_cfg, expected);
     }
 
     #[test]
     fn simple_yaml_test() {
         //given
         let expected = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "my-test-mqtt".to_string(),
                 type_: "mqtt".to_string(),
                 topic: "my-mqtt".to_string(),
@@ -469,7 +665,7 @@ mod tests {
                 .expect_err("This yaml should error");
         #[cfg(unix)]
         assert_eq!(
-            "apiVersion: unknown variant `v1`, expected `0.0.0` or `0.1.0` at line 1 column 13",
+            "apiVersion: unknown variant `v1`, expected one of `0.0.0`, `0.1.0`, `0.2.0` at line 1 column 13",
             format!("{connector_cfg:?}")
         );
     }
@@ -487,7 +683,7 @@ mod tests {
             "#;
 
         let expected = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "kafka-out".to_string(),
                 type_: "kafka-sink".to_string(),
                 topic: "poc1".to_string(),
@@ -519,7 +715,7 @@ mod tests {
             "#;
 
         let expected = ConnectorConfig::V0_0_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "kafka-out".to_string(),
                 type_: "kafka-sink".to_string(),
                 topic: "poc1".to_string(),
@@ -556,7 +752,7 @@ mod tests {
         "#;
 
         let expected = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 name: "my-test-mqtt".to_string(),
                 type_: "mqtt-source".to_string(),
                 topic: "my-mqtt".to_string(),
@@ -581,6 +777,57 @@ mod tests {
 
         //then
         assert_eq!(connector_spec, expected);
+    }
+
+    #[test]
+    fn deserialize_with_topic_config() {
+        //given
+        let yaml = r#"
+        apiVersion: 0.2.0
+        meta:
+          version: 0.1.0
+          name: my-test-mqtt
+          type: mqtt-source
+          topic: 
+            meta:
+              name: my-mqtt
+        "#;
+
+        let expected = ConnectorConfig::V0_2_0(ConnectorConfigV2 {
+            meta: MetaConfigV2 {
+                name: "my-test-mqtt".to_string(),
+                type_: "mqtt-source".to_string(),
+                topic: TopicConfigBuilder::default()
+                    .meta(
+                        MetaConfigBuilder::default()
+                            .name("my-mqtt".to_string())
+                            .build()
+                            .unwrap(),
+                    )
+                    .build()
+                    .unwrap(),
+                version: "0.1.0".to_string(),
+                producer: None,
+                consumer: None,
+                secrets: None,
+            },
+            transforms: None,
+        });
+
+        //when
+        let connector_spec: ConnectorConfig =
+            serde_yaml::from_str(yaml).expect("Failed to deserialize");
+
+        //then
+        assert_eq!(connector_spec, expected);
+        assert_eq!(connector_spec.meta().topic(), "my-mqtt");
+        assert_eq!(
+            connector_spec
+                .meta()
+                .topic_config()
+                .map(|c| c.meta.name.as_str()),
+            Some("my-mqtt")
+        );
     }
 
     #[test]

--- a/crates/fluvio-connector-package/src/metadata.rs
+++ b/crates/fluvio-connector-package/src/metadata.rs
@@ -411,7 +411,7 @@ mod tests {
 
     use openapiv3::ObjectType;
 
-    use crate::config::{MetaConfig, ConnectorConfigV1};
+    use crate::config::{ConnectorConfigV1, MetaConfigV1};
 
     use super::*;
 
@@ -421,14 +421,14 @@ mod tests {
         let source = Direction::source();
         let dest = Direction::dest();
         let source_config = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 type_: "http-source".into(),
                 ..Default::default()
             },
             ..Default::default()
         });
         let sink_config = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 type_: "http-sink".into(),
                 ..Default::default()
             },
@@ -456,7 +456,7 @@ mod tests {
     fn test_validate_deployment() {
         //given
         let config = ConnectorConfig::V0_1_0(ConnectorConfigV1 {
-            meta: MetaConfig {
+            meta: MetaConfigV1 {
                 type_: "http_source".into(),
                 version: "latest".into(),
                 ..Default::default()

--- a/crates/fluvio-connector-package/src/render/mod.rs
+++ b/crates/fluvio-connector-package/src/render/mod.rs
@@ -92,14 +92,11 @@ pub fn render_config_str(input: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod test {
-    use std::{io::Write};
+    use std::io::Write;
 
     use minijinja::value::Value;
 
-    use crate::{
-        secret::{FileSecretStore},
-        config::{ConnectorConfig},
-    };
+    use crate::{secret::FileSecretStore, config::ConnectorConfig};
 
     use super::{ConfigRenderer, context::ContextStore};
 
@@ -214,11 +211,16 @@ mod test {
         let connector_config: ConnectorConfig =
             serde_yaml::from_str(&value_str).expect("should be yaml");
         let value: serde_yaml::Value = serde_yaml::from_str(&value_str).expect("should be yaml");
+        let connector_config = match connector_config {
+            ConnectorConfig::V0_0_0(inner) => inner,
+            ConnectorConfig::V0_1_0(inner) => inner,
+            _ => unreachable!("version must be 0.1.0"),
+        };
 
-        assert_eq!(connector_config.meta().name, "test");
-        assert_eq!(connector_config.meta().version, "0.1.0");
-        assert_eq!(connector_config.meta().topic, "test");
-        assert_eq!(connector_config.meta().type_, "http-source");
+        assert_eq!(connector_config.meta.name, "test");
+        assert_eq!(connector_config.meta.version, "0.1.0");
+        assert_eq!(connector_config.meta.topic, "test");
+        assert_eq!(connector_config.meta.type_, "http-source");
         assert_eq!(
             value["my_service"]["api_key"]
                 .as_str()

--- a/crates/fluvio-connector-package/test-data/connectors/full-config-v2.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/full-config-v2.yaml
@@ -1,0 +1,35 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: 
+    version: 0.1.0
+    meta:
+      name: test-topic
+    partition:
+      count: 3
+      max-size: 1.0 KB
+      replication: 2
+      ignore-rack-assignment: true
+    retention:
+      time: 2m
+      segment-size: 2.0 KB
+    compression:
+      type: Lz4
+  producer:
+    linger: 1ms
+    batch-size: "44.0 MB"
+    compression: gzip
+  consumer:
+    partition: 10
+    max_bytes: "1 MB"
+  secrets:
+    - name: secret1
+transforms:
+  - uses: infinyon/json-sql
+    with:
+      mapping:
+        table: "topic_message"
+      param: param_value
+

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.22.3"
+version = "0.22.4"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Metadata definition for Fluvio control plane"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/topic/config.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/config.rs
@@ -27,12 +27,15 @@ pub struct TopicConfig {
 
     pub meta: MetaConfig,
 
+    #[builder(default)]
     #[cfg_attr(feature = "use_serde", serde(default))]
     pub partition: PartitionConfig,
 
+    #[builder(default)]
     #[cfg_attr(feature = "use_serde", serde(default))]
     pub retention: RetentionConfig,
 
+    #[builder(default)]
     #[cfg_attr(feature = "use_serde", serde(default))]
     pub compression: CompressionConfig,
 }

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -125,11 +125,13 @@ setup_file() {
     run $CDK_BIN publish --pack --target x86_64-unknown-linux-gnu
     assert_success
 
-    mkdir $TEST_DIR/ipkg
-    cp .hub/json-test-connector-0.1.0.ipkg $TEST_DIR/ipkg
-    cp sample-config.yaml $TEST_DIR/ipkg 
+    IPKG_DIR=$TEST_DIR/ipkg
 
-    cd $TEST_DIR/ipkg
+    mkdir $IPKG_DIR
+    cp .hub/json-test-connector-0.1.0.ipkg $IPKG_DIR
+    cp sample-config.yaml $IPKG_DIR 
+
+    cd $IPKG_DIR
 
     run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config.yaml
     assert_success
@@ -142,11 +144,13 @@ setup_file() {
     run $CDK_BIN publish --pack --target x86_64-unknown-linux-gnu
     assert_success
 
-    mkdir $TEST_DIR/ipkg
-    cp .hub/json-test-connector-0.1.0.ipkg $TEST_DIR/ipkg
-    cp sample-config-v2.yaml $TEST_DIR/ipkg 
+    IPKG_DIR=$TEST_DIR/ipkg_v2
 
-    cd $TEST_DIR/ipkg
+    mkdir $IPKG_DIR
+    cp .hub/json-test-connector-0.1.0.ipkg $IPKG_DIR
+    cp sample-config-v2.yaml $IPKG_DIR 
+
+    cd $IPKG_DIR
 
     run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config-v2.yaml
     assert_success

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -22,6 +22,8 @@ setup_file() {
 
     CONFIG_FILE_FLAG="--config sample-config.yaml"
     export CONFIG_FILE_FLAG
+    CONFIG_FILE_FLAG_V2="--config sample-config-v2.yaml"
+    export CONFIG_FILE_FLAG_V2
 }
 
 @test "Build and test connector" {
@@ -29,6 +31,18 @@ setup_file() {
     cd $CONNECTOR_DIR
     run $CDK_BIN test --target x86_64-unknown-linux-gnu \
         $CONFIG_FILE_FLAG 
+    assert_success
+
+    assert_output --partial "Connector runs with process id"
+    assert_output --partial "producing a value"
+    assert_success
+}
+
+@test "Build and test connector V2" {
+    # Test
+    cd $CONNECTOR_DIR
+    run $CDK_BIN test --target x86_64-unknown-linux-gnu \
+        $CONFIG_FILE_FLAG_V2 
     assert_success
 
     assert_output --partial "Connector runs with process id"
@@ -46,6 +60,27 @@ setup_file() {
     cd $CONNECTOR_DIR
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
         $CONFIG_FILE_FLAG 
+    assert_success
+
+    assert_output --partial "Connector runs with process id"
+
+    sleep 10
+
+    run cat json-test-connector.log
+    assert_output --partial "producing a value"
+    assert_success
+}
+
+@test "Build and deploy connector V2" {
+    # Build
+    cd $CONNECTOR_DIR
+    run $CDK_BIN build --target x86_64-unknown-linux-gnu
+    assert_success
+
+    # Deploy
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
+        $CONFIG_FILE_FLAG_V2 
     assert_success
 
     assert_output --partial "Connector runs with process id"
@@ -100,3 +135,21 @@ setup_file() {
     assert_success
     assert_output --partial "Connector runs with process id"
 }
+
+@test "Run connector with --ipkg V2" {
+    # create package meta doesn't exist
+    cd $CONNECTOR_DIR
+    run $CDK_BIN publish --pack --target x86_64-unknown-linux-gnu
+    assert_success
+
+    mkdir $TEST_DIR/ipkg
+    cp .hub/json-test-connector-0.1.0.ipkg $TEST_DIR/ipkg
+    cp sample-config-v2.yaml $TEST_DIR/ipkg 
+
+    cd $TEST_DIR/ipkg
+
+    run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config-v2.yaml
+    assert_success
+    assert_output --partial "Connector runs with process id"
+}
+

--- a/tests/cli/fluvio_smoke_tests/topic-basic.bats
+++ b/tests/cli/fluvio_smoke_tests/topic-basic.bats
@@ -119,9 +119,6 @@ EOF
 
 # Create topic with empty name - Negative test
 @test "Attempt to create topic with empty name" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
     run timeout 15s "$FLUVIO_BIN" topic create " " --dry-run
     debug_msg "status: $status"
     debug_msg "output: ${lines[0]}"
@@ -132,9 +129,6 @@ EOF
 
 # Create topic with name and config file - Negative test
 @test "Attempt to create topic with name and config file" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
     run timeout 15s "$FLUVIO_BIN" topic create "$(random_string)" --config /tmp/config.yaml --dry-run
     debug_msg "status: $status"
     debug_msg "output: ${lines[0]}"
@@ -144,9 +138,6 @@ EOF
 
 # Create topic with partition size and config file - Negative test
 @test "Attempt to create topic with partition size and config file" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
     run timeout 15s "$FLUVIO_BIN" topic create --max-partition-size "2 Ki"  --config /tmp/config.yaml --dry-run
     debug_msg "status: $status"
     debug_msg "output: ${lines[0]}"
@@ -156,9 +147,6 @@ EOF
 
 # Create topic from config file
 @test "Create a topic from config file" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
     debug_msg "Topic config file: $TOPIC_CONFIG_PATH"
     run timeout 15s "$FLUVIO_BIN" topic create --config "$TOPIC_CONFIG_PATH" 
     debug_msg "status: $status"


### PR DESCRIPTION
Added new version "0.2.0" for connectors config. It supports full topic configuration. 
Minimal example:
```yaml
apiVersion: 0.2.0
meta:
  version: 0.1.0
  name: my-json-test-connector
  type: json-test-source
  topic:
    meta:
      name: test-full-topic2
json:
  interval: 5  
  timeout: 15
  template: '{"template":"test"}'  
```

Closes #3349 