### PR TITLE
[Merged by Bors] - fix(smdk): fix smdk publish with --push flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,6 @@ version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
- "crossterm 0.26.1",
  "strum",
  "strum_macros",
  "unicode-width",

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -73,10 +73,9 @@ impl PublishCmd {
 
             // --push only, needs ipkg file
             (false, true) => {
-                let pkgfile = &self
-                    .package_meta
-                    .clone()
-                    .ok_or_else(|| anyhow::anyhow!("package file required for push"))?;
+                let pkgfile = package_meta_path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("invalid package metadata path"))?;
                 package_push(self, pkgfile, &access)?;
             }
         }


### PR DESCRIPTION
With current code, it is impossible to run `smdk publish --push`