### PR TITLE
feat: print causes for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,6 @@ version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
- "crossterm 0.26.1",
  "strum",
  "strum_macros",
  "unicode-width",

--- a/crates/fluvio-auth/src/error.rs
+++ b/crates/fluvio-auth/src/error.rs
@@ -4,14 +4,14 @@ use thiserror::Error;
 /// Possible errors from Auth
 #[derive(Error, Debug)]
 pub enum AuthError {
-    #[error("IoError")]
+    #[error("fluvio-auth error: {0}")]
     IoError(#[from] IoError),
 }
 
 impl From<AuthError> for IoError {
     fn from(e: AuthError) -> Self {
-        match e {
-            AuthError::IoError(source) => source,
+        match &e {
+            AuthError::IoError(source) => IoError::new(source.kind(), e),
         }
     }
 }

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -16,33 +16,33 @@ use crate::common::target::TargetError;
 pub enum CliError {
     #[error(transparent)]
     OutputError(#[from] OutputError),
-    #[error("Failed to parse format string")]
+    #[error("Failed to parse format string: {0}")]
     TemplateError(#[from] TemplateError),
 
     #[cfg(feature = "k8s")]
-    #[error("Fluvio cluster error")]
+    #[error("Fluvio cluster error: {0}")]
     ClusterCliError(#[from] ClusterCliError),
 
-    #[error("Target Error")]
+    #[error("Target Error: {0}")]
     TargetError(#[from] TargetError),
-    #[error("Fluvio client error")]
+    #[error("Fluvio client error: {0}")]
     ClientError(#[from] FluvioError),
 
     #[cfg(feature = "k8s")]
-    #[error("Kubernetes config error")]
+    #[error("Kubernetes config error: {0}")]
     K8ConfigError(#[from] k8_config::ConfigError),
 
     #[cfg(feature = "k8s")]
-    #[error("Kubernetes client error")]
+    #[error("Kubernetes client error: {0}")]
     K8ClientError(#[from] k8_client::ClientError),
 
     /// An error occurred while processing the connector yaml
-    #[error("Fluvio connector config")]
+    #[error("Fluvio connector config: {0}")]
     ConnectorConfig(#[from] serde_yaml::Error),
 
-    #[error("Package index error")]
+    #[error("Package index error: {0}")]
     IndexError(#[from] fluvio_index::Error),
-    #[error("Error finding executable")]
+    #[error("Error finding executable: {0}")]
     WhichError(#[from] which::Error),
     #[error("Http Error: {0}")]
     HttpError(#[from] fluvio_cli_common::error::HttpError),
@@ -71,7 +71,7 @@ pub enum CliError {
     ProfileNotFoundInConfig(String),
     #[error("Cluster not found in config: {0}")]
     ClusterNotFoundInConfig(String),
-    #[error("Progress Error")]
+    #[error("Progress Error: {0}")]
     ProgressError(#[from] ProgressTemplateError),
     #[cfg(feature = "smartengine")]
     #[error("SmartModuleEngine config: {0}")]

--- a/crates/fluvio-cluster/src/error.rs
+++ b/crates/fluvio-cluster/src/error.rs
@@ -18,18 +18,18 @@ use crate::runtime::local::LocalRuntimeError;
 #[derive(thiserror::Error, Debug)]
 pub enum ClusterError {
     /// An error occurred while trying to install Fluvio on Kubernetes
-    #[error("Failed to install Fluvio on Kubernetes")]
+    #[error("Failed to install Fluvio on Kubernetes: {0}")]
     InstallK8(#[from] K8InstallError),
     /// An error occurred while trying to install Fluvio locally
-    #[error("Failed to install Fluvio locally")]
+    #[error("Failed to install Fluvio locally: {0}")]
     InstallLocal(#[from] LocalInstallError),
     /// An error occurred while trying to install Fluvio system charts
-    #[error("Failed to install Fluvio system charts")]
+    #[error("Failed to install Fluvio system charts: {0}")]
     InstallSys(#[from] ChartInstallError),
     /// An error occurred while trying to uninstall Fluvio
-    #[error("Failed to uninstall Fluvio")]
+    #[error("Failed to uninstall Fluvio: {0}")]
     Uninstall(#[from] UninstallError),
-    #[error("Progress Error")]
+    #[error("Progress Error: {0}")]
     ProgressError(#[from] TemplateError),
 }
 
@@ -37,25 +37,25 @@ pub enum ClusterError {
 #[derive(thiserror::Error, Debug)]
 pub enum K8InstallError {
     /// An error occurred with the Kubernetes config.
-    #[error("Kubernetes config error")]
+    #[error("Kubernetes config error: {0}")]
     K8ConfigError(#[from] K8ConfigError),
     /// An error occurred with the Kubernetes client.
-    #[error("Kubernetes client error")]
+    #[error("Kubernetes client error: {0}")]
     K8ClientError(#[from] K8ClientError),
     /// An error occurred while running helm.
-    #[error("Helm client error")]
+    #[error("Helm client error: {0}")]
     HelmError(#[from] HelmError),
     /// An error occurred while running helm.
-    #[error("Helm Chart error")]
+    #[error("Helm Chart error: {0}")]
     ChartError(#[from] ChartInstallError),
     /// Failed to execute a command
     #[error(transparent)]
     CommandError(#[from] CommandError),
     /// One or more pre-checks (successfully) failed when trying to start the cluster
-    #[error("Pre-checks failed during cluster startup")]
+    #[error("Pre-checks failed during cluster startup: {0:#?}")]
     FailedPrecheck(CheckStatuses),
     /// Encountered an error while performing one or more pre-checks
-    #[error("Failed to perform one or more pre-checks")]
+    #[error("Failed to perform one or more pre-checks: {0:#?}")]
     PrecheckErrored(CheckResults),
     /// Failed to update Fluvio cluster
     #[error("Expected to find cluster with platform version {0}")]
@@ -88,12 +88,12 @@ pub enum K8InstallError {
     #[error("Missing required config option {0}")]
     MissingRequiredConfig(String),
     /// Kubectl not found
-    #[error("kubectl not found")]
+    #[error("kubectl not found: {0}")]
     KubectlNotFoundError(IoError),
     /// Kubectl not found
     #[error("Port forwarding process exited with code: {0}")]
     PortForwardingFailed(ExitStatus),
-    #[error("Progress Error")]
+    #[error("Progress Error: {0}")]
     ProgressError(#[from] TemplateError),
 }
 
@@ -101,7 +101,7 @@ pub enum K8InstallError {
 #[derive(thiserror::Error, Debug)]
 pub enum LocalInstallError {
     /// An IO error occured during log dir creation
-    #[error("An error occurred creating the cluster log directory {path:?}")]
+    #[error("An error occurred creating the cluster log directory {path:?}: {source}")]
     LogDirectoryError {
         path: std::path::PathBuf,
         source: IoError,
@@ -110,25 +110,25 @@ pub enum LocalInstallError {
     #[error(transparent)]
     IoError(#[from] IoError),
     /// An error occurred with the Fluvio client.
-    #[error("Fluvio client error")]
+    #[error("Fluvio client error: {0}")]
     FluvioError(#[from] FluvioError),
     /// An error occurred with the Kubernetes config.
-    #[error("Kubernetes config error")]
+    #[error("Kubernetes config error: {0}")]
     K8ConfigError(#[from] K8ConfigError),
     /// An error occurred with the Kubernetes client.
-    #[error("Kubernetes client error")]
+    #[error("Kubernetes client error: {0}")]
     K8ClientError(#[from] K8ClientError),
     /// An error occurred while running helm.
-    #[error("Helm client error")]
+    #[error("Helm client error: {0}")]
     HelmError(#[from] HelmError),
     /// Failed to execute a command
     #[error(transparent)]
     CommandError(#[from] CommandError),
     /// One or more pre-checks (successfully) failed when trying to start the cluster
-    #[error("Pre-checks failed during cluster startup")]
+    #[error("Pre-checks failed during cluster startup: {0:#?}")]
     FailedPrecheck(CheckStatuses),
     /// Encountered an error while performing one or more pre-checks
-    #[error("Failed to perform one or more pre-checks")]
+    #[error("Failed to perform one or more pre-checks: {0:#?}")]
     PrecheckErrored(CheckResults),
     /// Timed out when waiting for SC service.
     #[error("Timed out when waiting for SC service")]
@@ -160,7 +160,7 @@ pub enum LocalInstallError {
     Other(String),
     #[error(transparent)]
     ClusterCheckError(#[from] ClusterCheckError),
-    #[error("Progress Error")]
+    #[error("Progress Error: {0}")]
     ProgressError(#[from] TemplateError),
 }
 
@@ -171,19 +171,19 @@ pub enum UninstallError {
     #[error(transparent)]
     IoError(#[from] IoError),
     /// An error occurred with the Fluvio client.
-    #[error("Fluvio client error")]
+    #[error("Fluvio client error: {0}")]
     FluvioError(#[from] FluvioError),
     /// Failed to execute a command
     #[error(transparent)]
     CommandError(#[from] CommandError),
     /// An error occurred with the Kubernetes config.
-    #[error("Kubernetes config error")]
+    #[error("Kubernetes config error: {0}")]
     K8ConfigError(#[from] K8ConfigError),
     /// An error occurred with the Kubernetes client.
-    #[error("Kubernetes client error")]
+    #[error("Kubernetes client error: {0}")]
     K8ClientError(#[from] K8ClientError),
     /// An error occurred while running helm.
-    #[error("Helm client error")]
+    #[error("Helm client error: {0}")]
     HelmError(#[from] HelmError),
     /// Timed out when waiting for SC service.
     #[error("Timed out when waiting for SC service")]


### PR DESCRIPTION
closes https://github.com/infinyon/fluvio/issues/3353

This is WIP, but requesting reviews to get feedback on the approach.

I'm just doing this pattern:
```
#[error("Failed to parse format string: {0}")]
TemplateError(#[from] TemplateError),
```
