### PR TITLE
[Merged by Bors] - feat: `HUB_API_BPKG_AUTH` as part of the `fluvio-hub-util`

### DIFF
--- a/crates/fluvio-cli/src/install/plugins.rs
+++ b/crates/fluvio-cli/src/install/plugins.rs
@@ -12,8 +12,8 @@ use fluvio_cli_common::install::{
 use fluvio_index::{PackageId, HttpAgent, MaybeVersion};
 use fluvio_channel::{LATEST_CHANNEL_NAME, FLUVIO_RELEASE_CHANNEL};
 use fluvio_hub_util as hubutil;
-use hubutil::{http, HubAccess, INFINYON_HUB_REMOTE, FLUVIO_HUB_PROFILE_ENV};
-use hubutil::http::StatusCode;
+use hubutil::{HubAccess, HUB_API_BPKG_AUTH, INFINYON_HUB_REMOTE, FLUVIO_HUB_PROFILE_ENV};
+use hubutil::http::{self, StatusCode};
 
 use crate::error::CliError;
 use crate::install::update::{
@@ -21,7 +21,6 @@ use crate::install::update::{
 };
 
 use super::update::should_always_print_available_update;
-pub const HUB_API_BPKG_AUTH: &str = "hub/v0/bpkg-auth"; // copied from hub-tool
 
 #[derive(Parser, Debug)]
 pub struct InstallOpt {

--- a/crates/fluvio-hub-util/src/lib.rs
+++ b/crates/fluvio-hub-util/src/lib.rs
@@ -22,3 +22,4 @@ pub const HUB_API_SM: &str = concatcp!(HUB_API_V, "/pkg/pub");
 pub const HUB_API_ACT: &str = concatcp!(HUB_API_V, "/action");
 pub const HUB_API_HUBID: &str = concatcp!(HUB_API_V, "/hubid");
 pub const HUB_API_LIST: &str = concatcp!(HUB_API_V, "/list");
+pub const HUB_API_BPKG_AUTH: &str = concatcp!(HUB_API_V, "/bpkg-auth");


### PR DESCRIPTION
Defines `HUB_API_BPKG_AUTH` as part of the Hub Util crate.