### PR TITLE
[Merged by Bors] - chore: migrate to OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,7 +2659,6 @@ dependencies = [
  "fluvio-types",
  "humantime-serde",
  "minijinja",
- "once_cell",
  "openapiv3",
  "pretty_assertions",
  "serde",

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -16,7 +16,6 @@ bytesize = { workspace = true}
 humantime-serde = "1.1.1"
 minijinja = { version = "1.0.0", default-features = false, features = ["custom_syntax", "fuel"] }
 openapiv3 = { git = "https://github.com/galibey/openapiv3", rev = "bdd22f046d2bc19ede257504645d31f835545222", default-features = false }
-once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"], default-features = false }
 serde_yaml = { workspace = true }
 toml = { workspace = true , optional = true, features = ["display", "parse", "preserve_order"] }

--- a/crates/fluvio-connector-package/src/secret.rs
+++ b/crates/fluvio-connector-package/src/secret.rs
@@ -3,12 +3,12 @@ use std::{
     path::{PathBuf, Path},
     fs::File,
 };
+use std::sync::OnceLock;
 
-use once_cell::sync::OnceCell;
 use serde::{Serialize, Deserialize, de::Visitor, Deserializer};
 use anyhow::{Result, anyhow};
 
-static SECRET_STORE: OnceCell<Box<dyn SecretStore>> = OnceCell::new();
+static SECRET_STORE: OnceLock<Box<dyn SecretStore>> = OnceLock::new();
 
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct SecretString {

--- a/smartmodule/cargo_template/src/lib.rs
+++ b/smartmodule/cargo_template/src/lib.rs
@@ -1,7 +1,7 @@
 {% if smartmodule-params %}
 use fluvio_smartmodule::dataplane::smartmodule::{SmartModuleExtraParams{% if smartmodule-type == "filter" %}, SmartModuleInitError{% endif %}};
 {% if smartmodule-type == "filter" %}
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use fluvio_smartmodule::eyre;
 {% endif %}
 {% endif %}
@@ -85,7 +85,7 @@ pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData
 
 {% if smartmodule-params %}
 {% if smartmodule-type == "filter" %}
-static CRITERIA: OnceCell<String> = OnceCell::new();
+static CRITERIA: OnceLock<String> = OnceLock::new();
 
 #[smartmodule(init)]
 fn init(params: SmartModuleExtraParams) -> Result<()> {

--- a/smartmodule/examples/aggregate-init/Cargo.toml
+++ b/smartmodule/examples/aggregate-init/Cargo.toml
@@ -10,5 +10,4 @@ crate-type = ['cdylib']
 
 [dependencies]
 fluvio-smartmodule = { workspace = true }
-once_cell = { version = "1.17" }
 

--- a/smartmodule/examples/aggregate-init/src/lib.rs
+++ b/smartmodule/examples/aggregate-init/src/lib.rs
@@ -1,12 +1,13 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
 use fluvio_smartmodule::{
     dataplane::smartmodule::SmartModuleExtraParams, smartmodule, Record, RecordData, Result,
 };
 
-use once_cell::sync::OnceCell;
 
-static INITIAL_VALUE: OnceCell<UseOnce<RecordData>> = OnceCell::new();
+
+static INITIAL_VALUE: OnceLock<UseOnce<RecordData>> = OnceLock::new();
 
 const PARAM_NAME: &str = "initial_value";
 

--- a/smartmodule/examples/filter_init/Cargo.toml
+++ b/smartmodule/examples/filter_init/Cargo.toml
@@ -10,5 +10,4 @@ description = "SmartModule filter with mandatory param"
 crate-type = ['cdylib']
 
 [dependencies]
-once_cell = "1.13.0"
 fluvio-smartmodule = { workspace = true }

--- a/smartmodule/examples/filter_init/src/lib.rs
+++ b/smartmodule/examples/filter_init/src/lib.rs
@@ -1,11 +1,11 @@
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use fluvio_smartmodule::{
     smartmodule, Record, Result, eyre,
     dataplane::smartmodule::{SmartModuleExtraParams, SmartModuleInitError},
 };
 
-static CRITERIA: OnceCell<String> = OnceCell::new();
+static CRITERIA: OnceLock<String> = OnceLock::new();
 
 #[smartmodule(init)]
 fn init(params: SmartModuleExtraParams) -> Result<()> {

--- a/smartmodule/examples/filter_with_param/Cargo.toml
+++ b/smartmodule/examples/filter_with_param/Cargo.toml
@@ -10,5 +10,4 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-once_cell = "1.13.0"
 fluvio-smartmodule = { workspace = true }

--- a/smartmodule/examples/filter_with_param/src/lib.rs
+++ b/smartmodule/examples/filter_with_param/src/lib.rs
@@ -1,11 +1,11 @@
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use fluvio_smartmodule::{
     smartmodule, Record, Result, eyre,
     dataplane::smartmodule::{SmartModuleExtraParams},
 };
 
-static CRITERIA: OnceCell<String> = OnceCell::new();
+static CRITERIA: OnceLock<String> = OnceLock::new();
 
 #[smartmodule(init)]
 fn init(params: SmartModuleExtraParams) -> Result<()> {

--- a/smartmodule/regex-filter/Cargo.toml
+++ b/smartmodule/regex-filter/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ['cdylib']
 
 [dependencies]
 regex = "1.5"
-once_cell = "1.13.0"
 fluvio-smartmodule = { path = "../../crates/fluvio-smartmodule" }
 
 

--- a/smartmodule/regex-filter/src/lib.rs
+++ b/smartmodule/regex-filter/src/lib.rs
@@ -1,12 +1,14 @@
+use std::sync::OnceLock;
+
 use regex::Regex;
-use once_cell::sync::OnceCell;
+
 
 use fluvio_smartmodule::{
     smartmodule, Record, Result, eyre,
     dataplane::smartmodule::{SmartModuleExtraParams, SmartModuleInitError},
 };
 
-static REGEX: OnceCell<Regex> = OnceCell::new();
+static REGEX: OnceLock<Regex> = OnceLock::new();
 
 #[smartmodule(init)]
 fn init(params: SmartModuleExtraParams) -> Result<()> {


### PR DESCRIPTION
migrate `once_cell::sync::OnceCell` to std rust `OnceLock`.    This will reduce external dep