### PR TITLE
fix: add `apiVersion` to connector template

### DIFF
--- a/connector/cargo_template/sample-config.yaml
+++ b/connector/cargo_template/sample-config.yaml
@@ -1,3 +1,4 @@
+apiVersion: 0.1.0
 meta:
   version: 0.1.0
   name: my-{{project-name}}-test-connector


### PR DESCRIPTION
Provides `apiVersion` to Connector Template.