### PR TITLE
[Merged by Bors] - feat: added topic-level deduplication mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "bytes 1.4.0",
  "content_inspector",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/fixture.rs
+++ b/crates/fluvio-protocol/src/fixture.rs
@@ -67,6 +67,16 @@ pub fn create_recordset(num_records: u16) -> RecordSet {
     records.add(create_batch_with_producer(12, num_records))
 }
 
+#[cfg(feature = "compress")]
+pub fn create_raw_recordset(num_records: u16) -> RecordSet<crate::record::RawRecords> {
+    let records = RecordSet::default();
+    records.add(
+        create_batch_with_producer(12, num_records)
+            .try_into()
+            .expect("converted from memory records to raw"),
+    )
+}
+
 pub const TEST_RECORD: &[u8] = &[10, 20];
 
 /// create batches with produce and records count

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -13,7 +13,7 @@ use flv_util::fixture::ensure_clean_dir;
 use fluvio_types::SpuId;
 use fluvio_controlplane_metadata::partition::{Replica};
 use fluvio_controlplane_metadata::spu::{IngressAddr, IngressPort, SpuSpec};
-use fluvio_protocol::fixture::{create_recordset};
+use fluvio_protocol::fixture::{create_raw_recordset};
 
 use crate::core::{DefaultSharedGlobalContext, GlobalContext};
 use crate::config::SpuConfig;
@@ -230,7 +230,10 @@ async fn test_just_leader() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -259,7 +262,10 @@ async fn test_replication2_existing() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -344,7 +350,10 @@ async fn test_replication2_new_records() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -393,7 +402,10 @@ async fn test_replication3_existing() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -482,7 +494,10 @@ async fn test_replication3_new_records() {
 
     // write records
     leader_replica
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -606,7 +621,10 @@ async fn test_replication_dispatch_in_sequence() {
     assert_eq!(leader.hw(), 0);
 
     leader
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 
@@ -697,7 +715,10 @@ async fn test_replication_dispatch_out_of_sequence() {
     assert_eq!(leader.hw(), 0);
 
     leader
-        .write_record_set(&mut create_recordset(2), leader_gctx.follower_notifier())
+        .write_record_set(
+            &mut create_raw_recordset(2),
+            leader_gctx.follower_notifier(),
+        )
         .await
         .expect("write");
 

--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -150,14 +150,14 @@ async fn handle_produce_topic(
 }
 
 #[instrument(
-    skip(ctx, replica_id, partition_request),
+    skip(ctx, replica_id, partition_request, leader_state),
     fields(%replica_id),
 )]
-async fn handle_produce_partition<R: BatchRecords>(
+async fn handle_produce_partition(
     ctx: &DefaultSharedGlobalContext,
     replica_id: ReplicaKey,
     leader_state: SharedFileLeaderState,
-    partition_request: PartitionProduceData<RecordSet<R>>,
+    partition_request: PartitionProduceData<RecordSet<RawRecords>>,
     is_connector: bool,
 ) -> PartitionWriteResult {
     trace!("Handling produce request for partition:");

--- a/crates/fluvio-spu/src/smartengine/mod.rs
+++ b/crates/fluvio-spu/src/smartengine/mod.rs
@@ -1,5 +1,74 @@
+use std::collections::BTreeMap;
+
+use fluvio::{
+    SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind, SmartModuleExtraParams,
+};
+use fluvio_controlplane_metadata::topic::Deduplication;
+use fluvio_smartmodule::dataplane::smartmodule::Lookback;
+
 pub(crate) mod batch;
 pub(crate) mod file_batch;
 pub(crate) mod produce_batch;
 pub(crate) mod context;
 mod chain;
+
+pub(crate) fn dedup_to_invocation(dedup: &Deduplication) -> SmartModuleInvocation {
+    let lookback = Lookback {
+        last: dedup.bounds.count,
+        age: dedup.bounds.age,
+    };
+    let mut params = BTreeMap::new();
+    params.insert("count".to_owned(), dedup.bounds.count.to_string());
+    if let Some(age) = dedup.bounds.age {
+        params.insert("age".to_string(), age.as_millis().to_string());
+    };
+    for (k, v) in dedup.filter.transform.with.iter() {
+        params.insert(k.clone(), v.clone());
+    }
+    SmartModuleInvocation {
+        wasm: SmartModuleInvocationWasm::Predefined(dedup.filter.transform.uses.clone()),
+        kind: SmartModuleKind::Filter,
+        params: SmartModuleExtraParams::new(params, Some(lookback)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use fluvio_controlplane_metadata::topic::{Bounds, Filter, Transform};
+
+    use super::*;
+
+    #[test]
+    fn test_dedup_to_inv() {
+        //when
+        let dedup = Deduplication {
+            bounds: Bounds {
+                count: 1,
+                age: Some(Duration::from_secs(1)),
+            },
+            filter: Filter {
+                transform: Transform {
+                    uses: "filter@0.1.0".to_string(),
+                    with: BTreeMap::from([("param_name".to_string(), "param_value".to_string())]),
+                },
+            },
+        };
+        //when
+        let inv = dedup_to_invocation(&dedup);
+
+        //then
+        assert!(matches!(
+            inv.wasm,
+            SmartModuleInvocationWasm::Predefined(str) if str.eq("filter@0.1.0")
+        ));
+        assert!(matches!(inv.kind, SmartModuleKind::Filter));
+        assert_eq!(inv.params.get("count"), Some(&"1".to_string()));
+        assert_eq!(inv.params.get("age"), Some(&"1000".to_string()));
+        assert_eq!(
+            inv.params.get("param_name"),
+            Some(&"param_value".to_string())
+        );
+    }
+}

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -287,6 +287,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-smartmodule-filter-hashset"
+version = "0.0.0"
+dependencies = [
+ "fluvio-smartmodule 0.7.1",
+]
+
+[[package]]
 name = "fluvio-smartmodule-filter-init"
 version = "0.0.0"
 dependencies = [

--- a/smartmodule/examples/Cargo.toml
+++ b/smartmodule/examples/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "filter_json",
     "filter_regex",
     "filter_with_param_v1",
+    "filter_hashset",
     "map",
     "map_double",
     "map_json",

--- a/smartmodule/examples/filter_hashset/Cargo.toml
+++ b/smartmodule/examples/filter_hashset/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fluvio-smartmodule-filter-hashset"
+version = "0.0.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ['cdylib', 'rlib']
+
+[dependencies]
+fluvio-smartmodule = { workspace = true }

--- a/smartmodule/examples/filter_hashset/README.md
+++ b/smartmodule/examples/filter_hashset/README.md
@@ -1,0 +1,23 @@
+Filter-kind SmartModule that mimics bounded HashSet.
+
+In order to build and use this SmartModule in your cluster, follow these steps:
+
+1. Install `smdk` tool:
+```bash
+fluvio install smdk
+```
+2. Build:
+```bash
+smdk build
+```
+
+3. Load built SmartModule into the cluster:
+```bash
+smdk load
+```
+
+After that, you can consume from your topic and apply the aggregation as trasnformation:
+```bash
+fluvio consume test-filter-hashset --transforms-file transforms.yaml
+```
+

--- a/smartmodule/examples/filter_hashset/SmartModule.toml
+++ b/smartmodule/examples/filter_hashset/SmartModule.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fluvio-smartmodule-filter-hashset"
+group = "infinyon"
+version = "0.1.0"
+apiVersion = "0.1.0"
+description = ""
+license = "Apache-2.0"
+visibility = "private"
+
+[[params]]
+name = "param"

--- a/smartmodule/examples/filter_hashset/src/lib.rs
+++ b/smartmodule/examples/filter_hashset/src/lib.rs
@@ -1,0 +1,109 @@
+use std::{
+    sync::OnceLock,
+    collections::{
+        BTreeMap,
+        btree_map::Entry::{Vacant, Occupied},
+    },
+};
+
+use fluvio_smartmodule::{
+    smartmodule, Record, Result, dataplane::smartmodule::SmartModuleExtraParams, eyre,
+};
+
+static SET: OnceLock<BoundedHashSet<String>> = OnceLock::new();
+
+#[smartmodule(filter)]
+pub fn filter(record: &Record) -> Result<bool> {
+    let string = std::str::from_utf8(record.value.as_ref())?;
+    Ok(get_mut_set()?.insert(string.to_owned()))
+}
+
+#[smartmodule(look_back)]
+pub fn look_back(record: &Record) -> Result<()> {
+    let string = std::str::from_utf8(record.value.as_ref())?;
+    get_mut_set()?.insert(string.to_owned());
+    Ok(())
+}
+
+#[smartmodule(init)]
+fn init(params: SmartModuleExtraParams) -> Result<()> {
+    let count: usize = if let Some(count) = params.get("count") {
+        count.parse()?
+    } else {
+        usize::MAX - 1
+    };
+    let _ = SET.set(BoundedHashSet::new(count));
+    Ok(())
+}
+
+fn get_mut_set() -> Result<&'static mut BoundedHashSet<String>> {
+    let ptr: *const BoundedHashSet<String> = SET
+        .get()
+        .ok_or_else(|| eyre!("hashset must be set before"))?;
+    Ok(unsafe { &mut *(ptr as *mut BoundedHashSet<String>) })
+}
+
+struct BoundedHashSet<K: Ord> {
+    inner: BTreeMap<K, usize>,
+    limit: usize,
+    seq: usize,
+}
+
+impl<K: Ord + Clone + std::fmt::Debug> BoundedHashSet<K> {
+    fn new(limit: usize) -> Self {
+        Self {
+            inner: Default::default(),
+            limit,
+            seq: Default::default(),
+        }
+    }
+
+    fn insert(&mut self, value: K) -> bool {
+        self.seq = self.seq.saturating_add(1);
+        let res = match self.inner.entry(value) {
+            Vacant(entry) => {
+                entry.insert(self.seq);
+                true
+            }
+            Occupied(_) => false,
+        };
+        if self.inner.len() > self.limit {
+            self.remove_first();
+        }
+        res
+    }
+
+    fn remove_first(&mut self) {
+        let min: Option<(&K, &usize)> = self.inner.iter().min_by(|x, y| x.1.cmp(y.1));
+        if let Some((key, _)) = min {
+            let key = key.clone();
+            self.inner.remove(&key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set() {
+        //given
+        let mut set = BoundedHashSet::new(3);
+
+        //when
+        assert!(set.insert("1"));
+        assert!(set.insert("3"));
+        assert!(set.insert("2"));
+        assert!(!set.insert("3"));
+        assert!(!set.insert("1"));
+        assert!(set.insert("5"));
+        assert!(set.insert("1"));
+
+        //then
+        assert_eq!(
+            set.inner.keys().cloned().collect::<Vec<&str>>(),
+            &["1", "2", "5"]
+        );
+    }
+}

--- a/smartmodule/examples/filter_hashset/transforms.yaml
+++ b/smartmodule/examples/filter_hashset/transforms.yaml
@@ -1,0 +1,5 @@
+transforms:
+  - uses: infinyon/fluvio-smartmodule-filter-hashset@0.1.0
+    lookback:
+      last: 10
+


### PR DESCRIPTION
Upd.: Split into two parts: [first](https://github.com/infinyon/fluvio/pull/3392)

Added topic-level deduplication mechanism. 
Key impacted components:
 - Topic Config
 - Fluvio CLI (topic creation, topic list, topic describe)
 - SPU (replica and producer handler)
 - SC
 - K8s CRDs (topic and partition)

The feature requires for Dedup SmartModule filter to be provided. It is coming, but the one from the examples can be used to try it out:
```bash
cd smartmodule/examples/filter_hashset
smdk build
smdk load
```
then create a file `topic.yaml`:
```yaml
version: 0.1.0
meta:
  name: dedup-topic
deduplication:
  bounds:
    count: 10
  filter:
    transform:
      uses: infinyon/fluvio-smartmodule-filter-hashset@0.1.0
```
and 
```bash
fluvio topic create -c topic.yaml
```
with such configuration the window will be last 10 records.

Closes infinyon/roadmap#114