### PR TITLE
[Merged by Bors] - Copy keys-value output behavior from `fluvio consume` to `smdk test`

### DIFF
--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -41,6 +41,10 @@ pub struct TestCmd {
     /// Key to use with the test record(s)
     key: Option<String>,
 
+    /// Print records in "[key] value" format, with "[null]" for no key
+    #[arg(short, long)]
+    key_value: bool,
+
     #[clap(flatten)]
     package: PackageCmd,
 
@@ -159,7 +163,20 @@ impl TestCmd {
             println!("{:?} records outputed", output.successes.len());
         }
         for output_record in output.successes {
-            let output_value = output_record.value.as_str()?;
+            let output_value = if self.key_value {
+                format!(
+                    "[{formatted_key}] {value}",
+                    formatted_key = if let Some(key) = output_record.key() {
+                        key.to_string()
+                    } else {
+                        "null".to_string()
+                    },
+                    value = output_record.value.as_str()?
+                )
+            } else {
+                output_record.value.as_str()?.to_string()
+            };
+
             println!("{output_value}");
         }
 

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -869,20 +869,37 @@ setup_file() {
 }
 
 @test "Test Lookback" {
-  # Test with smartmodule example with Lookback
-  cd "$(pwd)/smartmodule/examples/filter_look_back/"
+    # Test with smartmodule example with Lookback
+    cd "$(pwd)/smartmodule/examples/filter_look_back/"
 
-  # Build
-  run $SMDK_BIN build
-  refute_output --partial "could not compile"
+    # Build
+    run $SMDK_BIN build
+    refute_output --partial "could not compile"
 
-  # Test
-  run $SMDK_BIN test --text '111' --lookback-last '1' --record '222' --record '333'
-  refute_output --partial "111"
-  assert_success
+    # Test
+    run $SMDK_BIN test --text '111' --lookback-last '1' --record '222' --record '333'
+    refute_output --partial "111"
+    assert_success
 
-  run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333'
-  assert_output --partial "444"
-  assert_success
+    run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333'
+    assert_output --partial "444"
+    assert_success
+}
 
+@test "Test output with visible keys" {
+    # Test with smartmodule example with Lookback
+    cd "$(pwd)/smartmodule/examples/filter_look_back/"
+
+    # Build
+    run $SMDK_BIN build
+    refute_output --partial "could not compile"
+
+    # Test
+    run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333' --key-value
+    assert_output --partial "[null]"
+    assert_success
+
+    run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333' --key-value my-key
+    assert_output --partial "[my-key]"
+    assert_success
 }


### PR DESCRIPTION
Fixes #3375