### PR TITLE
[Merged by Bors] - fix: use explicit `Result` type from std on generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"

--- a/crates/fluvio-protocol-derive/src/de.rs
+++ b/crates/fluvio-protocol-derive/src/de.rs
@@ -27,7 +27,7 @@ pub(crate) fn generate_decode_trait_impls(input: &DeriveItem) -> TokenStream {
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
                 impl #impl_generics fluvio_protocol::Decoder for #ident #ty_generics #where_clause {
-                    fn decode<T>(&mut self, src: &mut T,version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::Buf {
+                    fn decode<T>(&mut self, src: &mut T,version: fluvio_protocol::Version) -> ::std::result::Result<(),std::io::Error> where T: fluvio_protocol::bytes::Buf {
                       //  tracing::trace!("decoding struct: {}",stringify!(#ident));
                         #field_tokens
                         Ok(())

--- a/crates/fluvio-protocol-derive/src/ser.rs
+++ b/crates/fluvio-protocol-derive/src/ser.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_encode_trait_impls(input: &DeriveItem) -> TokenStream {
 
             quote! {
                 impl #impl_generics fluvio_protocol::Encoder for #ident #ty_generics #where_clause {
-                    fn encode<T>(&self, dest: &mut T, version: fluvio_protocol::Version) -> Result<(),std::io::Error> where T: fluvio_protocol::bytes::BufMut {
+                    fn encode<T>(&self, dest: &mut T, version: fluvio_protocol::Version) ->  ::std::result::Result<(),std::io::Error> where T: fluvio_protocol::bytes::BufMut {
                         #trace_encode
                         #encoded_field_tokens
                         Ok(())

--- a/crates/fluvio-protocol/ui-tests/pass_derive_decode_encode_with_custom_results.rs
+++ b/crates/fluvio-protocol/ui-tests/pass_derive_decode_encode_with_custom_results.rs
@@ -1,0 +1,8 @@
+use fluvio_protocol::{Encoder, Decoder};
+
+pub type Result = std::result::Result<(), ()>;
+
+fn main() {}
+
+#[derive(Default, Decoder, Encoder)]
+struct PassTupleStruct(String);


### PR DESCRIPTION
this is done in order to avoid issues that could happen if a different Result type is on scope