### PR TITLE
[Merged by Bors] - chore: ci, fix fluvio-run aarch-unknown-linux-musl release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,6 +1201,8 @@ jobs:
         include:
           - rust-target: x86_64-unknown-linux-musl
             artifact: fluvio-run
+          - rust-target: aarch64-unknown-linux-musl
+            artifact: fluvio-run
           - rust-target: x86_64-apple-darwin
             artifact: fluvio-run
           - rust-target: aarch64-apple-darwin


### PR DESCRIPTION
Fixes #3361   artifact was not uploaded to release list