### PR TITLE
feat: use `async-std`@`1.12.0` and `async-channel`@`1.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-io = "1.3.1"
 async-lock = "2.4.0"
 async-net = { version = "1.7.0", default-features = false  }
 async-rwlock = "1.3.0"
-async-std = { version = "1.8.0", default-features = false }
+async-std = { version = "1.12.0", default-features = false }
 async-trait = { version = "0.1.41", default-features = false }
 base64 = "0.21.0"
 bytes = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ resolver = "2"
 [workspace.dependencies]
 adaptive_backoff = "0.2.1"
 anyhow = "1.0.38"
-async-channel = { version = "1.9.0", default-features = false }
+async-channel = { version = "1.5", default-features = false }
 async-io = "1.3.1"
 async-lock = "2.4.0"
 async-net = { version = "1.7.0", default-features = false  }


### PR DESCRIPTION
Updates `async-std` to use [latest version available](https://crates.io/crates/async-std), in order to
tackle compile-time issues due to dependency conflicts.

`async-std`@`1.12.0` only supports `async-channel`@`1.5`, so we could use latest `async-std`
by downgrading `async-channel` to `1.5`.

(_Let's hope this doesn't ends in Yak Shaving 😅_)

## Related

- [ ] https://github.com/infinyon/sql-connector/pull/76