### PR TITLE
[Merged by Bors] - fix(workflow): put bash argument inside quotes in smartmodule publish

### DIFF
--- a/.github/workflows/smartmodule-publish.yml
+++ b/.github/workflows/smartmodule-publish.yml
@@ -38,8 +38,8 @@ jobs:
         run: fluvio install smdk
       - name: Fluvio Login
         run: |
-          fluvio cloud login --email ${{ secrets.ORG_HUB_SA_NAME }} \
-          --password ${{ !inputs.target_prod && secrets.ORG_HUB_SA_PASSWD_DEV || secrets.ORG_HUB_SA_PASSWD_PROD }} \
+          fluvio cloud login --email "${{ secrets.ORG_HUB_SA_NAME }}" \
+          --password "${{ !inputs.target_prod && secrets.ORG_HUB_SA_PASSWD_DEV || secrets.ORG_HUB_SA_PASSWD_PROD }}" \
           ${{ !inputs.target_prod && '--remote' || '' }} ${{ !inputs.target_prod && secrets.ORG_CLOUD_URL_DEV || '' }}
       - uses: actions/download-artifact@v3
         id: download-file


### PR DESCRIPTION
I suspect this causes workflow to fail if password contains the `)` character or similar characters.

Failing workflow run: https://github.com/infinyon/fluvio-jolt/actions/runs/5560132807/jobs/10156903714.

Similar example of using quotes: https://github.com/infinyon/fluvio/blob/master/.github/workflows/ci.yml#L1229.

This isn't a breaking change