### PR TITLE
[Merged by Bors] - fix: properly handle produce operation failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -280,11 +280,6 @@ impl PartitionProducer {
                 let mut futures = Vec::with_capacity(partition_count);
                 for topic in produce_response.responses.into_iter() {
                     for partition in topic.partitions {
-                        if partition.error_code.is_error() {
-                            return Err(FluvioError::from(ProducerError::from(
-                                partition.error_code,
-                            )));
-                        }
                         futures.push(ProducePartitionResponseFuture::ready(
                             partition.base_offset,
                             partition.error_code,


### PR DESCRIPTION
The failure of produce operation was mistakenly treated as a failure of the transportation layer, which is not. That led to non-helpful error reporting to the user:
```bash
Producer error: failed to get record metadata
```
Fixed by not handling return error code too early.