### PR TITLE
[Merged by Bors] - feat(spu): added smart engine memory limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "event-listener",
  "fluvio-future",

--- a/crates/fluvio-protocol/src/link/error_code.rs
+++ b/crates/fluvio-protocol/src/link/error_code.rs
@@ -153,6 +153,11 @@ pub enum ErrorCode {
     #[fluvio(tag = 6007)]
     #[error("SmartModule look_back error: {0}")]
     SmartModuleLookBackError(String),
+    #[fluvio(tag = 6008)]
+    #[error(
+        "SmartModule memory limit exceeded: requested {requested} bytes, max allowed {max} bytes"
+    )]
+    SmartModuleMemoryLimitExceeded { requested: u64, max: u64 },
 
     // TableFormat Errors
     #[fluvio(tag = 7000)]

--- a/crates/fluvio-smartengine/src/engine/error.rs
+++ b/crates/fluvio-smartengine/src/engine/error.rs
@@ -4,4 +4,10 @@ pub enum EngineError {
     UnknownSmartModule,
     #[error("Failed to instantiate: {0}")]
     Instantiate(anyhow::Error),
+    #[error("Requested memory {requested}b exceeded max allowed {max}b")]
+    StoreMemoryExceeded {
+        current: usize,
+        requested: usize,
+        max: usize,
+    },
 }

--- a/crates/fluvio-smartengine/src/engine/mod.rs
+++ b/crates/fluvio-smartengine/src/engine/mod.rs
@@ -6,6 +6,7 @@ pub use config::{
     SmartModuleInitialData, Lookback,
 };
 mod error;
+pub use error::EngineError;
 
 #[cfg(test)]
 mod fixture;

--- a/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
+++ b/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
@@ -135,7 +135,10 @@ impl SmartModuleInstanceContext {
         debug!("instantiating WASMtime");
         let instance = state
             .instantiate(&module, copy_records_fn)
-            .map_err(EngineError::Instantiate)?;
+            .map_err(|e| match e.downcast::<EngineError>() {
+                Ok(e) => e,
+                Err(e) => EngineError::Instantiate(e),
+            })?;
         Ok(Self {
             instance,
             records_cb,

--- a/crates/fluvio-smartengine/src/engine/wasmtime/limiter.rs
+++ b/crates/fluvio-smartengine/src/engine/wasmtime/limiter.rs
@@ -1,0 +1,48 @@
+use wasmtime::ResourceLimiter;
+
+use crate::engine::error::EngineError;
+
+#[derive(Debug, Default)]
+pub(crate) struct StoreResourceLimiter {
+    pub memory_size: Option<usize>,
+}
+
+impl StoreResourceLimiter {
+    pub(crate) fn set_memory_size(&mut self, memory_size: usize) -> &mut Self {
+        self.memory_size = Some(memory_size);
+        self
+    }
+}
+
+impl ResourceLimiter for StoreResourceLimiter {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        let allow = match self.memory_size {
+            Some(limit) if desired > limit => false,
+            _ => !matches!(maximum, Some(max) if desired > max),
+        };
+        if !allow {
+            Err(EngineError::StoreMemoryExceeded {
+                current,
+                requested: desired,
+                max: self.memory_size.or(maximum).unwrap_or_default(),
+            }
+            .into())
+        } else {
+            Ok(allow)
+        }
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}

--- a/crates/fluvio-smartengine/src/engine/wasmtime/mod.rs
+++ b/crates/fluvio-smartengine/src/engine/wasmtime/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod state;
 pub(crate) mod engine;
 pub(crate) mod instance;
 pub(crate) mod look_back;
+pub(crate) mod limiter;
 pub use engine::{SmartEngine, SmartModuleChainBuilder, SmartModuleChainInstance};
 
 use super::*;

--- a/crates/fluvio-spu/src/config/cli.rs
+++ b/crates/fluvio-spu/src/config/cli.rs
@@ -59,6 +59,13 @@ pub struct SpuOpt {
     )]
     pub peer_max_bytes: u32,
 
+    #[arg(
+        long,
+        value_name = "integer",
+        env = "FLV_SMART_ENGINE_MAX_MEMORY_BYTES"
+    )]
+    pub smart_engine_max_memory: Option<usize>,
+
     #[clap(flatten)]
     tls: TlsConfig,
 }
@@ -137,6 +144,14 @@ impl SpuOpt {
         }
 
         config.peer_max_bytes = self.peer_max_bytes;
+
+        if let Some(smart_engine_max_memory) = self.smart_engine_max_memory {
+            info!(
+                "overriding smart engine max memory: {}",
+                smart_engine_max_memory
+            );
+            config.smart_engine.store_max_memory = smart_engine_max_memory;
+        }
 
         Ok((config, tls_port))
     }

--- a/crates/fluvio-spu/src/config/spu_config.rs
+++ b/crates/fluvio-spu/src/config/spu_config.rs
@@ -21,6 +21,7 @@ use fluvio_types::defaults::SPU_LOG_INDEX_MAX_BYTES;
 use fluvio_types::defaults::SPU_LOG_INDEX_MAX_INTERVAL_BYTES;
 use fluvio_types::defaults::SPU_LOG_SEGMENT_MAX_BYTES;
 use fluvio_types::defaults::SPU_RETRY_SC_TIMEOUT_MS;
+use fluvio_types::defaults::SPU_SMARTENGINE_STORE_MAX_BYTES;
 
 // environment variables
 
@@ -75,6 +76,19 @@ impl Default for Log {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct SmartEngineConfig {
+    pub store_max_memory: usize,
+}
+
+impl Default for SmartEngineConfig {
+    fn default() -> Self {
+        Self {
+            store_max_memory: SPU_SMARTENGINE_STORE_MAX_BYTES,
+        }
+    }
+}
+
 /// streaming processing unit configuration file
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SpuConfig {
@@ -95,6 +109,8 @@ pub struct SpuConfig {
     pub log: Log,
 
     pub peer_max_bytes: u32,
+
+    pub smart_engine: SmartEngineConfig,
 }
 
 impl Default for SpuConfig {
@@ -109,6 +125,7 @@ impl Default for SpuConfig {
             sc_retry_ms: SPU_RETRY_SC_TIMEOUT_MS,
             log: Log::default(),
             peer_max_bytes: fluvio_storage::FileReplica::PREFER_MAX_LEN,
+            smart_engine: SmartEngineConfig::default(),
         }
     }
 }

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -285,11 +285,11 @@ impl ScDispatcher<FileReplica> {
                 ReplicaChange::Remove(remove) => {
                     let message = RequestMessage::new_request(remove);
                     if let Err(err) = sc_sink.send_request(&message).await {
-                        error!("error sending back to sc {}", err);
+                        error!("error sending back to sc {err:#?}");
                     }
                 }
                 ReplicaChange::StorageError(err) => {
-                    error!("error storage {}", err);
+                    error!("error storage {err:#?}");
                 }
             }
         }

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -2636,7 +2636,7 @@ async fn stream_fetch_filter_lookback(
         assert_eq!(partition.records.batches.len(), 0);
         assert_eq!(
             partition.error_code,
-            ErrorCode::SmartModuleLookBackError("error in look_back chain: invalid digit found in string\n\nSmartModule Lookback Error: \n    Offset: 0\n    Key: NULL\n    Value: wrong record".to_string())
+            ErrorCode::SmartModuleLookBackError("invalid digit found in string\n\nSmartModule Lookback Error: \n    Offset: 0\n    Key: NULL\n    Value: wrong record".to_string())
         );
     }
 

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -51,6 +51,8 @@ pub const STORAGE_FLUSH_WRITE_COUNT: u32 = 1;
 pub const STORAGE_FLUSH_IDLE_MSEC: u32 = 0;
 pub const STORAGE_MAX_BATCH_SIZE: u32 = 33_554_432;
 
+pub const SPU_SMARTENGINE_STORE_MAX_BYTES: usize = 1_073_741_824; //1Gb
+
 // CLI config
 pub const CLI_PROFILES_DIR: &str = "profiles";
 pub const CLI_DEFAULT_PROFILE: &str = "default";


### PR DESCRIPTION
Added a memory limit for smartmodules and an ability to specify it on SPU config.

Default value is set to 1 Gb. Can be overridden by passing SPU cli argument:
 `fluvio-run spu ... --smart-engine-max-memory N` 

Fixes #3406 