### PR TITLE
[Merged by Bors] - Unify common dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "criterion",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ color-eyre = { version = "0.6.0", default-features = false }
 colored = "2.0.0"
 crc32c = { version = "0.6"}
 comfy-table = { version = "7.0.1", default-features = false }
-convert_case = "0.6.0"
 derive_builder = "0.12.0"
 directories = "5.0.0"
 dirs = "5.0.0"
@@ -92,13 +91,18 @@ futures = { version = "0.3.1" }
 futures-util = { version = "0.3.6", default-features = false }
 futures-channel = "0.3"
 futures-lite = "1.11"
+hdrhistogram = "7.0"
+humantime = "2.0"
 humantime-serde = { version = "1.1.1", default-features = false}
 include_dir = "0.7.2"
 indicatif = "0.17.0"
+inventory = "0.3"
 nix = "0.26.0"
 once_cell = "1.7.2"
 pin-project = "1.1.0"
 portpicker = "0.1.1"
+proc-macro2 = "1.0"
+quote = "1.0"
 rand = "0.8.5"
 regex = "1.7"
 semver = "1.0.13"
@@ -118,6 +122,7 @@ toml = { version = "0.7.0", default-features = false }
 tracing = "0.1.19"
 tracing-subscriber = { version = "0.3", default-features = false }
 url = "2.1.1"
+uuid = { version = "1.1", features = ["serde", "v4"] }
 wasm-bindgen-test = "0.3.24"
 wasmparser = "0.110.0"
 which = "4.1.0"

--- a/connector/json-test-connector/Cargo.toml
+++ b/connector/json-test-connector/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 
 
 [dependencies]
-async-trait = { version = "0.1", default-features = false}
+async-trait = { workspace = true }
 futures = { version = "0.3", default-features = false }
-anyhow = { workspace = true}
-async-std = { version = "1.12",  default-features = false, features = ["attributes", "tokio1"]}
-tokio = { version = "1.23", default-features = false, features = ["time"]}
-serde = { version = "1.0", default-features = false, features = ["derive"]}
+anyhow = { workspace = true }
+async-std = { features = ["attributes", "tokio1"], workspace = true }
+tokio = { default-features = false, features = ["time"], workspace = true }
+serde = { default-features = false, features = ["derive"], workspace = true }
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }

--- a/connector/sink-test-connector/Cargo.toml
+++ b/connector/sink-test-connector/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 
 
 [dependencies]
-async-trait = { version = "0.1", default-features = false}
-futures = { version = "0.3", default-features = false }
-anyhow = { workspace = true}
-async-std = { version = "1.12",  default-features = false, features = ["attributes"]}
-serde = { version = "1.0", default-features = false, features = ["derive"]}
+async-trait = { workspace = true }
+futures = { workspace = true }
+anyhow = { workspace = true }
+async-std = { features = ["attributes"], workspace = true }
+serde = { default-features = false, features = ["derive"], workspace = true }
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -27,7 +27,7 @@ toml = { workspace=true, features = ["parse", "display", "preserve_order"] }
 comfy-table = { workspace = true  }
 sysinfo = { workspace = true, default-features = false }
 cargo-generate = { workspace = true }
-include_dir = "0.7.2"
+include_dir = { workspace = true }
 tempfile = { workspace = true }
 current_platform = { version = "0.2" }
 

--- a/crates/fluvio-benchmark/Cargo.toml
+++ b/crates/fluvio-benchmark/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { workspace = true, features = ['serde']}
 clap = { workspace = true, features = ["std","derive"] }
 derive_builder = { workspace = true}
 futures-util = { workspace = true }
-hdrhistogram = "7.5.2"
+hdrhistogram = { workspace = true }
 madato = "0.5.3"
 rand = { workspace = true }
 serde = { workspace = true , features = ['derive'] }

--- a/crates/fluvio-channel-cli/Cargo.toml
+++ b/crates/fluvio-channel-cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 default = ["fluvio-future", "fluvio-types"]
 
 [dependencies]
-colored = "2"
+colored = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context"], default-features = false }
 tracing = { workspace = true }
 cfg-if = { workspace = true }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -46,8 +46,8 @@ bytesize = { workspace = true, features = ['serde'] }
 clap = { workspace = true, features = ["std", "derive", "string", "help", "usage", "env", "error-context"] }
 clap_complete = "4.0.2"
 dirs = { workspace = true}
-indicatif = "0.17.0"
-eyre = "0.6.1"
+indicatif = { workspace = true }
+eyre = { workspace = true}
 sha2 = "0.10.0"
 hex = "0.4.2"
 home = "0.5.3"
@@ -55,7 +55,7 @@ current_platform = "0.2"
 comfy-table = { workspace = true }
 atty = { version = "0.2.14", optional = true }
 ctrlc = { version = "3.1.3", optional = true }
-colored = "2"
+colored = { workspace = true }
 handlebars = "4"
 content_inspector = { version = "0.2.4", optional = true }
 flate2 = { workspace = true }
@@ -63,7 +63,7 @@ crossterm = { version = "0.26.0", features = ['event-stream']}
 tui = { version = "0.19.0", default-features = false, features = ['crossterm'] }
 futures = { workspace = true}
 futures-util = { workspace = true, features = ["sink"] }
-humantime = "2.1.0"
+humantime = { workspace = true }
 static_assertions = { workspace = true }
 sysinfo = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/fluvio-connector-derive/Cargo.toml
+++ b/crates/fluvio-connector-derive/Cargo.toml
@@ -12,5 +12,5 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0", default-features = false, features = ["full", "parsing", "proc-macro", "derive", "printing"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+quote =  { workspace = true }
+proc-macro2 = { workspace = true }

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"
@@ -13,9 +13,9 @@ proc-macro = true
 doctest = false
 
 [dependencies]
-proc-macro2 = "1.0.0"
-quote = "1.0.0"
-tracing = "0.1"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+tracing = { workspace = true }
 
 [dependencies.syn]
 version = "1.0.0"

--- a/crates/fluvio-smartmodule-derive/Cargo.toml
+++ b/crates/fluvio-smartmodule-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule-derive"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -14,5 +14,5 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -25,9 +25,8 @@ smartmodule = []
 [dependencies]
 tracing = { workspace = true }
 thiserror = { workspace = true }
-eyre = { version = ">=0.6.8", default-features = false, features = [
-    "auto-install",
-] }
+
+eyre = { default-features = false, features = ["auto-install"], workspace = true }
 fluvio-smartmodule-derive = { version = "0.6.1", path = "../fluvio-smartmodule-derive" }
 fluvio-protocol = { workspace = true, features = ["link", "types"] }
 

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
@@ -20,12 +20,12 @@ tracing = { workspace = true }
 cfg-if = { workspace = true }
 bytes = { workspace = true }
 once_cell = { workspace = true }
-futures-util = { version = "0.3.5", features = ["sink", "io"] }
+futures-util = { features = ["sink", "io"], workspace = true }
 async-lock = { workspace = true }
 event-listener = { workspace = true }
 async-channel = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-tokio-util = { version = "0.7.0", features = ["codec", "compat"] }
+tokio-util = { features = ["codec", "compat"], workspace = true }
 async-trait = { workspace = true }
 pin-project = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { workspace = true }
 regex = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 async-channel = { workspace = true }
-async-rwlock = "1.1.0"
+async-rwlock = { workspace = true }
 async-lock = { workspace = true }
 event-listener = { workspace = true }
 async-io = { workspace = true }

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -27,6 +27,6 @@ tracing = { workspace = true }
 k8-types = { workspace = true, optional = true }
 
 [dev-dependencies]
-async-std = { workspace = true,  features = [ "attributes",] }
-tokio = { workspace = true,  features = ["macros"] }
+async-std = { workspace = true, features = ["attributes"] }
+tokio = { workspace = true, features = ["macros"] }
 fluvio-future = { workspace = true, features = ["fixture"] }

--- a/crates/fluvio-test-case-derive/Cargo.toml
+++ b/crates/fluvio-test-case-derive/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.0.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full"]}
 
 [dev-dependencies]

--- a/crates/fluvio-test-derive/Cargo.toml
+++ b/crates/fluvio-test-derive/Cargo.toml
@@ -14,8 +14,8 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full"]}
-quote = "1.0"
-proc-macro2 = "1.0"
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 serde_json = { workspace = true }
 inflections = "1.1"
 fluvio-test-util = { path = "../fluvio-test-util" }
@@ -28,6 +28,6 @@ fluvio = { workspace = true  }
 tokio = { workspace = true,  features = ["macros"] }
 fluvio-future = { workspace = true, features = ["task", "timer", "subscriber", "fixture"] }
 clap = { workspace = true,  features = ["std", "derive", "help", "usage", "error-context"] }
-inventory = "0.3"
+inventory = { workspace = true }
 tracing = { workspace = true }
 crossbeam-channel = "0.5"

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -19,16 +19,16 @@ tokio = { workspace = true, features = ["macros"] }
 syn = { workspace = true }
 serde = { workspace = true}
 serde_json = { workspace = true}
-humantime = "2.1"
-quote = "1.0"
-proc-macro2 = "1.0"
-inventory = "0.3"
+humantime = { workspace = true}
+quote =  { workspace = true }
+proc-macro2 = { workspace = true }
+inventory = { workspace = true }
 comfy-table = { workspace = true }
 once_cell = { workspace = true }
 dyn-clone = "1.0"
 semver = { workspace = true }
-hdrhistogram = "7.3.0"
-uuid = { version = "1.1", features = ["serde", "v4"] }
+hdrhistogram = { workspace = true }
+uuid = { workspace = true }
 anyhow = { workspace = true }
 
 fluvio = { workspace = true  }

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -26,18 +26,18 @@ nix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true}
 serde_yaml = { workspace = true }
-inventory = "0.3"
-tokio = { workspace = true,  features = ["macros"] }
+inventory = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 comfy-table = { workspace = true }
-hdrhistogram = "7.3.0"
+hdrhistogram = { workspace = true }
 crc = "3.0"
 fork = "0.1"
 crossbeam-channel = "0.5"
 sysinfo = { workspace = true }
 signal-hook = "0.3.13"
-indicatif = "0.17.0"
-async-std = { workspace = true,  features = ["attributes",] }
-uuid = { version = "1.1", features = ["serde", "v4"] }
+indicatif = { workspace = true }
+async-std = { workspace = true,  features = ["attributes"] }
+uuid = { workspace = true }
 
 tracing = { workspace = true }
 

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -23,7 +23,7 @@ clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-
 dirs = { workspace = true}
 toml = { workspace = true }
 cargo-generate = { workspace = true }
-include_dir = "0.7.2"
+include_dir = { workspace = true }
 tempfile = { workspace = true }
 enum-display = "0.1.3"
 lib-cargo-crate = "0.2.1"


### PR DESCRIPTION
There is a considerable amount of dependencies and I think it is possible to cut some transient slack in order to reduce compilation time.

Starting with the unification of common dependencies that aren't part of workspace declarations. `cargo test --all-features` didn't fail so everything should probably be OK.
