### PR TITLE
[Merged by Bors] - chore: add generic signature to topic controller to make it easier to test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-rwlock",
  "async-std",

--- a/crates/fluvio-controlplane-metadata/src/topic/store.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/store.rs
@@ -2,7 +2,7 @@ use tracing::debug;
 use async_trait::async_trait;
 
 use crate::store::{MetadataStoreObject, LocalStore};
-use crate::core::{MetadataItem};
+use crate::core::MetadataItem;
 use crate::partition::store::{PartitionLocalStore, PartitionMetadata};
 use crate::partition::*;
 use super::*;

--- a/crates/fluvio-sc/src/controllers/partitions/controller.rs
+++ b/crates/fluvio-sc/src/controllers/partitions/controller.rs
@@ -12,7 +12,7 @@ use fluvio_future::task::spawn;
 use fluvio_controlplane_metadata::core::MetadataItem;
 use fluvio_controlplane_metadata::store::k8::K8MetaItem;
 
-use crate::stores::{StoreContext};
+use crate::stores::StoreContext;
 use crate::stores::partition::PartitionSpec;
 use crate::stores::spu::SpuSpec;
 

--- a/crates/fluvio-sc/src/controllers/topics/actions.rs
+++ b/crates/fluvio-sc/src/controllers/topics/actions.rs
@@ -5,14 +5,18 @@
 //!
 use std::fmt;
 
-use crate::controllers::partitions::PartitionWSAction;
+use fluvio_controlplane_metadata::{topic::TopicSpec, partition::PartitionSpec};
+use fluvio_stream_model::{store::k8::K8MetaItem, core::MetadataItem};
 
-use super::*;
+use crate::stores::actions::WSAction;
 
 #[derive(Debug, Default)]
-pub struct TopicActions {
-    pub topics: Vec<TopicWSAction>,
-    pub partitions: Vec<PartitionWSAction>,
+pub struct TopicActions<C = K8MetaItem>
+where
+    C: MetadataItem + Send + Sync,
+{
+    pub topics: Vec<WSAction<TopicSpec, C>>,
+    pub partitions: Vec<WSAction<PartitionSpec, C>>,
 }
 
 impl fmt::Display for TopicActions {

--- a/crates/fluvio-sc/src/controllers/topics/mod.rs
+++ b/crates/fluvio-sc/src/controllers/topics/mod.rs
@@ -6,12 +6,3 @@ mod policy;
 pub use self::actions::*;
 pub use self::controller::*;
 pub use self::policy::*;
-pub use common::*;
-
-mod common {
-
-    use ::fluvio_controlplane_metadata::topic::TopicSpec;
-    use crate::stores::actions::WSAction;
-
-    pub type TopicWSAction = WSAction<TopicSpec>;
-}

--- a/crates/fluvio-sc/src/k8/controllers/spu_service.rs
+++ b/crates/fluvio-sc/src/k8/controllers/spu_service.rs
@@ -7,9 +7,9 @@ use fluvio_future::timer::sleep;
 use fluvio_controlplane_metadata::store::MetadataStoreObject;
 use fluvio_controlplane_metadata::store::k8::K8MetaItem;
 use fluvio_stream_dispatcher::actions::WSAction;
-use k8_client::{ClientError};
+use k8_client::ClientError;
 
-use crate::stores::spg::{SpuGroupSpec};
+use crate::stores::spg::SpuGroupSpec;
 use crate::stores::{StoreContext, K8ChangeListener};
 use crate::k8::objects::spu_k8_config::ScK8Config;
 use crate::k8::objects::spg_group::SpuGroupObj;
@@ -187,7 +187,7 @@ impl SpuServiceController {
         spu_name: &str,
         spu_k8_config: &ScK8Config,
     ) -> Result<(), ClientError> {
-        use k8_types::core::service::{ServiceSpec as K8ServiceSpec};
+        use k8_types::core::service::ServiceSpec as K8ServiceSpec;
 
         let mut selector = HashMap::new();
         let pod_name = format!("fluvio-spg-{spu_name}");

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2021"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-stream-model/src/store/k8.rs
+++ b/crates/fluvio-stream-model/src/store/k8.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use tracing::error;
 
 use crate::k8_types::{Spec as K8Spec, Status as K8Status, ObjectMeta, K8Obj};
-use crate::store::{MetadataStoreObject};
+use crate::store::MetadataStoreObject;
 use crate::core::{Spec, MetadataItem, MetadataContext};
 
 pub type K8MetadataContext = MetadataContext<K8MetaItem>;


### PR DESCRIPTION
Remove tech debt.  TopicController default to only work in K8 metadata.  This changes add generic signature similar to other controllers which will make it easier to unit test