### PR TITLE
[Merged by Bors] - chore: move spu smartmodule to controlplane only

### DIFF
--- a/crates/fluvio-controlplane-metadata/src/smartmodule/mod.rs
+++ b/crates/fluvio-controlplane-metadata/src/smartmodule/mod.rs
@@ -8,41 +8,10 @@ pub use self::spec::*;
 pub use self::status::*;
 pub use self::package::*;
 
-use std::fmt;
-
-use fluvio_stream_model::core::MetadataItem;
-use fluvio_stream_model::store::MetadataStoreObject;
-use fluvio_types::SmartModuleName;
-use fluvio_protocol::{Encoder, Decoder};
-
 #[cfg(feature = "k8")]
 mod k8;
 #[cfg(feature = "k8")]
 pub use k8::*;
-
-/// SmartModule object that can be used to transport from SC to SPU
-#[derive(Debug, Default, Clone, Eq, PartialEq, Encoder, Decoder)]
-pub struct SmartModule {
-    pub name: SmartModuleName,
-    pub spec: SmartModuleSpec,
-}
-
-impl fmt::Display for SmartModule {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SmartModule({})", self.name)
-    }
-}
-
-impl<C> From<MetadataStoreObject<SmartModuleSpec, C>> for SmartModule
-where
-    C: MetadataItem,
-{
-    fn from(mso: MetadataStoreObject<SmartModuleSpec, C>) -> Self {
-        let name = mso.key_owned();
-        let spec = mso.spec;
-        Self { name, spec }
-    }
-}
 
 mod metadata {
 

--- a/crates/fluvio-controlplane/src/message/mod.rs
+++ b/crates/fluvio-controlplane/src/message/mod.rs
@@ -13,10 +13,9 @@ mod spu_msg {
 }
 
 mod smartmodule_msg {
-    use fluvio_controlplane_metadata::{
-        smartmodule::SmartModule,
-        message::{Message, Messages},
-    };
+    use fluvio_controlplane_metadata::message::{Message, Messages};
+
+    use crate::spu_api::update_smartmodule::SmartModule;
 
     pub type SmartModuleMsg = Message<SmartModule>;
     pub type SmartModuleMsgs = Messages<SmartModule>;

--- a/crates/fluvio-controlplane/src/message/replica_msg.rs
+++ b/crates/fluvio-controlplane/src/message/replica_msg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 //!
 //! # Replica Messages
 //!

--- a/crates/fluvio-controlplane/src/sc_api/register_spu.rs
+++ b/crates/fluvio-controlplane/src/sc_api/register_spu.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 //!
 //! # Register SPU
 //!

--- a/crates/fluvio-controlplane/src/sc_api/remove.rs
+++ b/crates/fluvio-controlplane/src/sc_api/remove.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 use std::fmt;
 
 use fluvio_protocol::api::Request;

--- a/crates/fluvio-controlplane/src/sc_api/update_lrs.rs
+++ b/crates/fluvio-controlplane/src/sc_api/update_lrs.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 use std::fmt;
 use std::hash::{Hash, Hasher};
 

--- a/crates/fluvio-controlplane/src/spu_api/update_replica.rs
+++ b/crates/fluvio-controlplane/src/spu_api/update_replica.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 use fluvio_protocol::api::Request;
 use fluvio_protocol::Decoder;
 use fluvio_protocol::Encoder;

--- a/crates/fluvio-controlplane/src/spu_api/update_smartmodule.rs
+++ b/crates/fluvio-controlplane/src/spu_api/update_smartmodule.rs
@@ -1,9 +1,12 @@
-#![allow(clippy::assign_op_pattern)]
+use std::fmt;
 
+use fluvio_controlplane_metadata::core::MetadataItem;
+use fluvio_controlplane_metadata::smartmodule::SmartModuleSpec;
+use fluvio_controlplane_metadata::store::MetadataStoreObject;
 use fluvio_protocol::Decoder;
 use fluvio_protocol::Encoder;
 use fluvio_protocol::api::Request;
-use fluvio_controlplane_metadata::smartmodule::SmartModule;
+use fluvio_types::SmartModuleName;
 
 use crate::requests::ControlPlaneRequest;
 
@@ -19,3 +22,27 @@ impl Request for UpdateSmartModuleRequest {
 
 #[derive(Decoder, Encoder, Default, Debug)]
 pub struct UpdateSmartModuleResponse {}
+
+/// SmartModule object that can be used to transport from SC to SPU
+#[derive(Debug, Default, Clone, Eq, PartialEq, Encoder, Decoder)]
+pub struct SmartModule {
+    pub name: SmartModuleName,
+    pub spec: SmartModuleSpec,
+}
+
+impl fmt::Display for SmartModule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SmartModule({})", self.name)
+    }
+}
+
+impl<C> From<MetadataStoreObject<SmartModuleSpec, C>> for SmartModule
+where
+    C: MetadataItem,
+{
+    fn from(mso: MetadataStoreObject<SmartModuleSpec, C>) -> Self {
+        let name = mso.key_owned();
+        let spec = mso.spec;
+        Self { name, spec }
+    }
+}

--- a/crates/fluvio-controlplane/src/spu_api/update_spu.rs
+++ b/crates/fluvio-controlplane/src/spu_api/update_spu.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::assign_op_pattern)]
-
 use fluvio_protocol::api::Request;
 use fluvio_protocol::Decoder;
 use fluvio_protocol::Encoder;

--- a/crates/fluvio-socket/src/sink.rs
+++ b/crates/fluvio-socket/src/sink.rs
@@ -3,11 +3,11 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use tracing::{trace, instrument};
-use futures_util::{SinkExt};
+use futures_util::SinkExt;
 use async_lock::Mutex;
 use async_lock::MutexGuard;
 use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
-use tokio_util::codec::{FramedWrite};
+use tokio_util::codec::FramedWrite;
 
 use fluvio_protocol::api::{RequestMessage, ResponseMessage};
 use fluvio_protocol::codec::FluvioCodec;

--- a/crates/fluvio-spu/src/core/smartmodule/metadata.rs
+++ b/crates/fluvio-spu/src/core/smartmodule/metadata.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use fluvio_controlplane_metadata::smartmodule::SmartModule;
+use fluvio_controlplane::spu_api::update_smartmodule::SmartModule;
 use fluvio_controlplane_metadata::smartmodule::SmartModulePackageKey;
 use fluvio_types::SmartModuleName;
 

--- a/crates/fluvio-spu/src/lib.rs
+++ b/crates/fluvio-spu/src/lib.rs
@@ -15,7 +15,6 @@ cfg_if::cfg_if! {
     }
 }
 
-use self::error::InternalServerError;
 pub use config::SpuOpt;
 
 const VERSION: &str = include_str!("../../../VERSION");

--- a/crates/fluvio-spu/src/services/public/tests/mod.rs
+++ b/crates/fluvio-spu/src/services/public/tests/mod.rs
@@ -5,8 +5,9 @@ use std::{
 
 use chrono::Utc;
 use flate2::{bufread::GzEncoder, Compression};
+use fluvio_controlplane::spu_api::update_smartmodule::SmartModule;
 use fluvio_controlplane_metadata::smartmodule::{
-    SmartModuleSpec, SmartModule, SmartModuleWasm, SmartModuleWasmFormat,
+    SmartModuleSpec, SmartModuleWasm, SmartModuleWasmFormat,
 };
 use fluvio_protocol::{
     fixture::BatchProducer,

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 
 use chrono::{Utc, Days};
 use fluvio_controlplane::replica::Replica;
+use fluvio_controlplane::spu_api::update_smartmodule::SmartModule;
 use fluvio_smartmodule::dataplane::smartmodule::Lookback;
 use tracing::{debug, info};
 
 use fluvio_controlplane_metadata::smartmodule::{
-    SmartModule, SmartModuleWasm, SmartModuleWasmFormat, SmartModuleSpec,
+    SmartModuleWasm, SmartModuleWasmFormat, SmartModuleSpec,
 };
 use fluvio_storage::FileReplica;
 use flv_util::fixture::ensure_clean_dir;


### PR DESCRIPTION
`SmartModule` wrapper is only needed for controlplane.  moving out of `controlplane-metadata`