### PR TITLE
Improve error message for client cluster version mismatch

### DIFF
--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -135,8 +135,8 @@ impl FluvioAdmin {
             })
         } else {
             let cluster_version = versions.platform_version().clone();
-            let client_version = Version::parse(crate::PLATFORM_VERSION)
-                .expect("PLATFORM_VERSION must be semver");
+            let client_version =
+                Version::parse(crate::PLATFORM_VERSION).expect("PLATFORM_VERSION must be semver");
             if client_version > cluster_version {
                 Err(FluvioError::MaximumPlatformVersion {
                     cluster_version,

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -135,13 +135,23 @@ impl FluvioAdmin {
             })
         } else {
             let cluster_version = versions.platform_version().clone();
-            let client_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
-                .expect("MINIMUM_PLATFORM_VERSION must be semver");
-            Err(FluvioError::MinimumPlatformVersion {
-                cluster_version,
-                client_minimum_version: client_version,
+            let client_version = Version::parse(crate::PLATFORM_VERSION)
+                .expect("PLATFORM_VERSION must be semver");
+            if client_version > cluster_version {
+                Err(FluvioError::MaximumPlatformVersion {
+                    cluster_version,
+                    client_maximum_version: client_version,
+                }
+                .into())
+            } else {
+                let client_minimum_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
+                    .expect("MINIMUM_PLATFORM_VERSION must be semver");
+                Err(FluvioError::MinimumPlatformVersion {
+                    cluster_version,
+                    client_minimum_version,
+                }
+                .into())
             }
-            .into())
         }
     }
 

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -116,13 +116,23 @@ impl Fluvio {
             })
         } else {
             let cluster_version = versions.platform_version().clone();
-            let client_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
-                .expect("MINIMUM_PLATFORM_VERSION must be semver");
-            Err(FluvioError::MinimumPlatformVersion {
-                cluster_version,
-                client_minimum_version: client_version,
+            let client_version = Version::parse(crate::PLATFORM_VERSION)
+                .expect("PLATFORM_VERSION must be semver");
+            if client_version > cluster_version {
+                Err(FluvioError::MaximumPlatformVersion {
+                    cluster_version,
+                    client_maximum_version: client_version,
+                }
+                .into())
+            } else {
+                let client_minimum_version = Version::parse(crate::MINIMUM_PLATFORM_VERSION)
+                    .expect("MINIMUM_PLATFORM_VERSION must be semver");
+                Err(FluvioError::MinimumPlatformVersion {
+                    cluster_version,
+                    client_minimum_version,
+                }
+                .into())
             }
-            .into())
         }
     }
 

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -116,8 +116,8 @@ impl Fluvio {
             })
         } else {
             let cluster_version = versions.platform_version().clone();
-            let client_version = Version::parse(crate::PLATFORM_VERSION)
-                .expect("PLATFORM_VERSION must be semver");
+            let client_version =
+                Version::parse(crate::PLATFORM_VERSION).expect("PLATFORM_VERSION must be semver");
             if client_version > cluster_version {
                 Err(FluvioError::MaximumPlatformVersion {
                     cluster_version,

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -46,6 +46,8 @@ use tracing::instrument;
 
 /// The minimum VERSION of the Fluvio Platform that this client is compatible with.
 const MINIMUM_PLATFORM_VERSION: &str = "0.9.0";
+/// The current version of the Fluvio Platform.
+const PLATFORM_VERSION: &str = include_str!("../../../VERSION");
 
 /// Creates a producer that sends records to the named topic
 ///


### PR DESCRIPTION
I'm not sure if maybe return the `MaximumPlatformVersion` variant for cases where the client is too new, see https://github.com/infinyon/fluvio/blob/b7a2765b8aa2263838a46fd2ce55921bfdf64736/crates/fluvio/src/error.rs#L39-L54 for the error message. That would mean we have to define a `MAXIMUM_PLATFORM_VERSION`, similar to [`MINIMUM_PLATFORM_VERSION`](https://github.com/infinyon/fluvio/blob/b7a2765b8aa2263838a46fd2ce55921bfdf64736/crates/fluvio/src/lib.rs#L48).

Fixes https://github.com/infinyon/fluvio/issues/3441