### PR TITLE
feat: add a fluvio-cluster local no-k8 logic

### DIFF
--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -44,6 +44,8 @@ pub async fn process_local(
     let installer = LocalInstaller::from_config(config);
     if opt.setup {
         setup_local(&installer).await?;
+    } else if opt.no_k8 {
+        installer.install_no_k8().await?;
     } else {
         install_local(&installer).await?;
     }

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -149,6 +149,10 @@ pub struct StartOpt {
     #[arg(long)]
     local: bool,
 
+    /// install local spu/sc(custom) (temporary)
+    #[arg(long)]
+    no_k8: bool,
+
     #[clap(flatten)]
     pub tls: TlsOpt,
 

--- a/crates/fluvio-cluster/src/runtime/local/sc.rs
+++ b/crates/fluvio-cluster/src/runtime/local/sc.rs
@@ -6,7 +6,7 @@ use std::{
 
 use fluvio::config::TlsPolicy;
 use fluvio_command::CommandExt;
-use tracing::{info};
+use tracing::{debug, info};
 
 use super::{FluvioLocalProcess, LocalRuntimeError};
 
@@ -27,10 +27,12 @@ impl ScProcess {
         let launcher = self.launcher.clone();
         let mut binary = {
             let base = launcher.ok_or(LocalRuntimeError::MissingFluvioRunner)?;
+            debug!(launcher=?base);
             let mut cmd = Command::new(base);
             cmd.arg("run").arg("sc").arg("--local");
             cmd
         };
+
         if let TlsPolicy::Verified(tls) = &self.tls_policy {
             self.set_server_tls(&mut binary, tls, 9005)?;
         }

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -620,7 +620,6 @@ impl LocalInstaller {
         let runtime = self.config.as_spu_cluster_manager();
         for i in 0..count {
             pb.set_message(InstallProgressMessage::StartSPU(i + 1, count).msg());
-            // register spu_local!
             self.launch_spu_local(i, client, &runtime).await?;
         }
         debug!(
@@ -631,6 +630,7 @@ impl LocalInstaller {
         Ok(())
     }
 
+    /// Register and launch spu
     #[instrument(skip(self, client, cluster_manager))]
     async fn launch_spu_local(
         &self,
@@ -656,6 +656,10 @@ impl LocalInstaller {
         let name = format!("local-spu-{}", spec.id);
         let admin = client.admin().await;
         let spec = CustomSpuSpec::from(spec.clone());
+        debug!(spec=?spec, "creating custom spu");
+        // gets stuck here due to k8 in sc - for testing a fluvio-cluster --local was required
+        // to setup crds that the sc (even w/ k8 feat disabled) still uses..
+        // so some integration w/ edge mirror sc config is nseeded
         admin.create(name, false, spec).await?;
         Ok(())
     }


### PR DESCRIPTION
- fix: install.sh, fluvio install/update, add arch/target overrides (#3463)
- Update `fluvio hub` subcommands (#3409)
- Add stdin input support for `smdk test` (#3464)
- feat: fluvio cluster no-k8
- feat: register local spu w/ local sc
