### PR TITLE
[Merged by Bors] - Remove lazy_static in favor of once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ name = "fluvio-package-index"
 version = "0.7.4"
 dependencies = [
  "http",
- "lazy_static",
+ "once_cell",
  "semver 1.0.18",
  "serde",
  "serde_json",

--- a/crates/fluvio-package-index/Cargo.toml
+++ b/crates/fluvio-package-index/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/lib.rs"
 http_agent = ["http"]
 
 [dependencies]
-lazy_static = "1.4.0"
 http = { version = "0.2", default-features = false, optional = true}
+once_cell = { workspace = true }
+semver = { workspace = true,  features = ["serde"] }
 serde = { workspace = true,  features = ["derive"] }
 serde_json = { workspace = true }
-semver = { workspace = true,  features = ["serde"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }

--- a/crates/fluvio-package-index/Cargo.toml
+++ b/crates/fluvio-package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-package-index/src/package_id.rs
+++ b/crates/fluvio-package-index/src/package_id.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use once_cell::sync::Lazy;
 use serde::{Serialize, Deserialize, Deserializer, Serializer};
 use url::Url;
 use crate::Error;
@@ -24,15 +25,12 @@ impl Registry {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref DEFAULT_REGISTRY: Registry = {
-        let url = url::Url::parse("https://packages.fluvio.io/v1/").unwrap();
-        Registry::from(url)
-    };
-    static ref DEFAULT_GROUP: GroupName = {
-        "fluvio".parse().unwrap()
-    };
-}
+static DEFAULT_REGISTRY: Lazy<Registry> = Lazy::new(|| {
+    let url = url::Url::parse("https://packages.fluvio.io/v1/").unwrap();
+    Registry::from(url)
+});
+
+static DEFAULT_GROUP: Lazy<GroupName> = Lazy::new(|| GroupName("fluvio".to_owned()));
 
 impl fmt::Display for Registry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
`fluvio-package-index` was the only package using `lazy_static` - this small change favors `once_cell` instead.

This way we have one less dependency and it will be easier to update once [`std::sync::LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) is stabilized.