### PR TITLE
[Merged by Bors] - feat: multi partition consumer in sink connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.25",
  "tracing",
- "trybuild 1.0.82",
+ "trybuild 1.0.42",
 ]
 
 [[package]]
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "http",
  "once_cell",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "bytes 1.4.0",
  "content_inspector",

--- a/crates/fluvio-connector-common/src/config.rs
+++ b/crates/fluvio-connector-common/src/config.rs
@@ -30,7 +30,7 @@ pub fn get_value(value: Value, root: Option<&str>) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
-    use fluvio_connector_package::config::MetaConfigV1;
+    use fluvio_connector_package::config::{MetaConfigV1, ConsumerPartitionConfig};
 
     #[test]
     fn test_from_value() {
@@ -57,7 +57,7 @@ mod tests {
                 .consumer
                 .expect("expected some consume config")
                 .partition,
-            Some(0)
+            ConsumerPartitionConfig::One(0)
         );
     }
 }

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -1,5 +1,6 @@
-use fluvio::{FluvioConfig, Fluvio};
+use fluvio::{FluvioConfig, Fluvio, PartitionSelectionStrategy};
 use fluvio::dataplane::record::ConsumerRecord;
+use fluvio_connector_package::config::ConsumerPartitionConfig;
 use fluvio_sc_schema::errors::ErrorCode;
 use futures::StreamExt;
 use crate::{config::ConnectorConfig, Result};
@@ -24,28 +25,50 @@ pub async fn consumer_stream_from_config(
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;
     ensure_topic_exists(config).await?;
-    let consumer = fluvio
-        .partition_consumer(
-            config.meta().topic(),
-            config
-                .meta()
-                .consumer()
-                .and_then(|c| c.partition)
-                .unwrap_or_default(),
-        )
-        .await?;
 
     let mut builder = fluvio::ConsumerConfig::builder();
-
     if let Some(max_bytes) = config.meta().consumer().and_then(|c| c.max_bytes) {
         builder.max_bytes(max_bytes.as_u64() as i32);
     }
-
     if let Some(smartmodules) = smartmodule_vec_from_config(config) {
         builder.smartmodule(smartmodules);
     }
-    let config = builder.build()?;
+    let consumer_config = builder.build()?;
+    let consumer_partition = config
+        .meta()
+        .consumer()
+        .map(|c| c.partition.clone())
+        .unwrap_or_default();
     let offset = fluvio::Offset::end();
-    let stream = consumer.stream_with_config(offset, config).await?;
+    let topic = config.meta().topic().to_string();
+    let stream = match consumer_partition {
+        ConsumerPartitionConfig::One(partition) => {
+            let consumer = fluvio.partition_consumer(topic, partition).await?;
+            consumer
+                .stream_with_config(offset, consumer_config)
+                .await?
+                .boxed()
+        }
+        ConsumerPartitionConfig::All => {
+            let consumer = fluvio
+                .consumer(PartitionSelectionStrategy::All(topic))
+                .await?;
+            consumer
+                .stream_with_config(offset, consumer_config)
+                .await?
+                .boxed()
+        }
+        ConsumerPartitionConfig::Many(partitions) => {
+            let partitions = partitions.into_iter().map(|p| (topic.clone(), p)).collect();
+            let consumer = fluvio
+                .consumer(PartitionSelectionStrategy::Multiple(partitions))
+                .await?;
+            consumer
+                .stream_with_config(offset, consumer_config)
+                .await?
+                .boxed()
+        }
+    };
+
     Ok((fluvio, stream))
 }

--- a/crates/fluvio-connector-package/test-data/connectors/all-partitions.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/all-partitions.yaml
@@ -1,0 +1,12 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: 
+    version: 0.1.0
+    meta:
+      name: test-topic
+  consumer:
+    partition: all
+    max_bytes: "1 MB"

--- a/crates/fluvio-connector-package/test-data/connectors/many-partitions.yaml
+++ b/crates/fluvio-connector-package/test-data/connectors/many-partitions.yaml
@@ -1,0 +1,14 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-test-mqtt
+  type: mqtt
+  topic: 
+    version: 0.1.0
+    meta:
+      name: test-topic
+  consumer:
+    partition: 
+      - 0
+      - 1
+    max_bytes: "1 MB"

--- a/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+
+SKIP_CLUSTER_START=true
+export SKIP_CLUSTER_START
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup_file() {
+    PROJECT_NAME_PREFIX="$(random_string)"
+    export PROJECT_NAME_PREFIX
+    TEST_DIR="$(mktemp -d -t cdk-consumer-test.XXXXX)"
+    export TEST_DIR
+
+    CONNECTOR_DIR="$(pwd)/connector/sink-test-connector"
+    export CONNECTOR_DIR
+    LOG_PATH="$CONNECTOR_DIR/sink-test-connector.log"
+    export LOG_PATH
+
+}
+
+setup() {
+    rm $LOG_PATH | true
+}
+
+@test "Topic with 2 partitions. Consumer reads one partition" {
+    # Prepare config
+    TOPIC_NAME=$(random_string)
+    debug_msg "Topic name: $TOPIC_NAME"
+    CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
+    cat <<EOF >$CONFIG_PATH
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: $TOPIC_NAME
+  type: test-sink
+  topic: 
+    meta:
+      name: $TOPIC_NAME
+    partition:
+      count: 2
+  consumer:
+    partition: 1
+custom:
+  api_key: api_key
+  client_id: client_id
+EOF
+    # Test
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info
+    assert_success
+    assert_output --partial "Connector runs with process id"
+    
+    wait_for_line_in_file "succesfully created" $LOG_PATH 30
+    wait_for_line_in_file "monitoring started" $LOG_PATH 30
+
+    echo 1:1 | fluvio produce $TOPIC_NAME --key-separator ":"
+    echo 4:4 | fluvio produce $TOPIC_NAME --key-separator ":"
+
+    wait_for_line_in_file "Received record: 4" $LOG_PATH 30
+
+    run cat $LOG_PATH
+
+    refute_output --partial 'Received record: 1'
+
+    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    assert_success
+}
+
+@test "Topic with 2 partitions. Consumer reads all partitions" {
+    # Prepare config
+    TOPIC_NAME=$(random_string)
+    debug_msg "Topic name: $TOPIC_NAME"
+    CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
+    cat <<EOF >$CONFIG_PATH
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: $TOPIC_NAME
+  type: test-sink
+  topic: 
+    meta:
+      name: $TOPIC_NAME
+    partition:
+      count: 2
+  consumer:
+    partition: all
+custom:
+  api_key: api_key
+  client_id: client_id
+EOF
+    # Test
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
+    assert_success
+    assert_output --partial "Connector runs with process id"
+    
+    wait_for_line_in_file "succesfully created" $LOG_PATH 30
+    wait_for_line_in_file "monitoring started" $LOG_PATH 30
+
+    echo 1:1 | fluvio produce $TOPIC_NAME --key-separator ":"
+    echo 4:4 | fluvio produce $TOPIC_NAME --key-separator ":"
+
+    wait_for_line_in_file "Received record: 4" $LOG_PATH 30
+    wait_for_line_in_file "Received record: 1" $LOG_PATH 2
+
+    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    assert_success
+}
+
+@test "Topic with 3 partitions. Consumer reads 2 partitions" {
+    # Prepare config
+    TOPIC_NAME=$(random_string)
+    debug_msg "Topic name: $TOPIC_NAME"
+    CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
+    cat <<EOF >$CONFIG_PATH
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: $TOPIC_NAME
+  type: test-sink
+  topic: 
+    meta:
+      name: $TOPIC_NAME
+    partition:
+      count: 3
+  consumer:
+    partition: 
+      - 1
+      - 2
+custom:
+  api_key: api_key
+  client_id: client_id
+EOF
+    # Test
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
+    assert_success
+    assert_output --partial "Connector runs with process id"
+    
+    wait_for_line_in_file "succesfully created" $LOG_PATH 30
+    wait_for_line_in_file "monitoring started" $LOG_PATH 30
+
+    echo 3:3 | fluvio produce $TOPIC_NAME --key-separator ":"
+    echo 1:1 | fluvio produce $TOPIC_NAME --key-separator ":"
+    echo 2:2 | fluvio produce $TOPIC_NAME --key-separator ":"
+
+    wait_for_line_in_file "Received record: 2" $LOG_PATH 30
+    wait_for_line_in_file "Received record: 1" $LOG_PATH 2
+
+    run cat $LOG_PATH
+    refute_output --partial 'Received record: 3'
+
+    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    assert_success
+}
+

--- a/tests/cli/test_helper/tools_check.bash
+++ b/tests/cli/test_helper/tools_check.bash
@@ -87,4 +87,27 @@ function check_timeout_bin() {
     fi
 }
 
+function wait_for_line_in_file() {
+    LINE="$1"
+    FILE="$2"
+    MAX_SECONDS="${3:-30}" # 30 seconds default value
+
+    echo "Waiting for file $FILE containing $LINE"
+  
+    ELAPSED=0;
+    until grep -q "$LINE" "$FILE"
+    do
+      sleep 1
+      let ELAPSED=$ELAPSED+1
+      if [[ $ELAPSED -ge MAX_SECONDS ]]
+      then
+        echo "timeout $MAX_SECONDS seconds elapsed"
+        exit 1
+      fi  
+    done
+    echo "Done waiting for file $FILE containing $LINE"
+}
+
+
+
 main;


### PR DESCRIPTION
Added an ability to configure which partitions the connector should read.
Supported options:
1. String value `all` for consuming all partitions: 
```yaml
consumer:
  partition: all
```
2. List of partitions:
```yaml
consumer:
  partition: 
    - 2
    - 3
```
3. One partition (supported previously):
```yaml
consumer:
  partition: 1
```

Closes #3467