### PR TITLE
[Merged by Bors] - fix: enable connector crates tests in CI

### DIFF
--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -36,6 +36,6 @@ fluvio-smartengine = { workspace = true , features = [ "transformation"] }
 
 
 [dev-dependencies]
-trybuild = { workspace = true }
+trybuild = { version = "1.0" } # default workspace dep is forked and fails for this crate 
 serde = { workspace = true, features = ["derive"]}
 fluvio = { workspace = true }

--- a/makefiles/check.mk
+++ b/makefiles/check.mk
@@ -39,6 +39,8 @@ run-all-unit-test: install_rustup_target
 	cargo test -p fluvio-storage $(BUILD_FLAGS)
 	cargo test -p fluvio-channel-cli $(BUILD_FLAGS)
 	cargo test -p fluvio-connector-derive $(BUILD_FLAGS)
+	cargo test -p fluvio-connector-common --all-features $(BUILD_FLAGS) 
+	cargo test -p fluvio-connector-package $(BUILD_FLAGS) 
 	cargo test -p fluvio-controlplane-metadata --features=smartmodule $(BUILD_FLAGS)
 	make test-all -C crates/fluvio-protocol
 


### PR DESCRIPTION
Added running integration tests for `fluvio-connector-common` and `fluvio-connector-package` crates in CI and fixed one of those tests.
