### PR TITLE
Issue-3479: Refactor: Fetch Platform Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-sc",
  "fluvio-spu",
+ "fluvio-types",
  "semver 1.0.19",
  "serde_json",
  "thiserror",
@@ -3415,6 +3416,8 @@ version = "0.4.4"
 dependencies = [
  "event-listener 3.0.0",
  "fluvio-future",
+ "once_cell",
+ "semver 1.0.19",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -101,6 +101,5 @@ fluvio-future = { workspace = true, features = ["fs", "io", "subscriber", "nativ
 fluvio-sc-schema = { workspace = true,  features = ["use_serde"], optional = true }
 fluvio-spu-schema = { workspace = true, optional = true }
 
-
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture"] }

--- a/crates/fluvio-cli/src/install/update.rs
+++ b/crates/fluvio-cli/src/install/update.rs
@@ -277,12 +277,11 @@ pub async fn check_update_available(
     let package = agent.package_from_response(&body).await?;
 
     let release = package.latest_release_for_target(&target, prerelease)?;
-    let latest_version = release.version.clone();
-    let current_version =
-        Version::parse(crate::VERSION).expect("Fluvio CLI 'VERSION' should be a valid semver");
+    let latest_version = &release.version;
+    let current_version = &*crate::FLUVIO_PLATFORM_VERSION;
 
     if current_version < latest_version {
-        Ok(Some(latest_version))
+        Ok(Some(latest_version.clone()))
     } else {
         Ok(None)
     }

--- a/crates/fluvio-cli/src/lib.rs
+++ b/crates/fluvio-cli/src/lib.rs
@@ -13,9 +13,8 @@ pub(crate) mod monitoring;
 
 pub(crate) use error::CliError;
 use fluvio_extension_common as common;
-pub(crate) const VERSION: &str = include_str!("../../../VERSION");
-
 use fluvio_index::HttpAgent;
+use fluvio_types::FLUVIO_PLATFORM_VERSION;
 use install::update::{
     should_always_print_available_update, check_update_available, prompt_available_update,
 };
@@ -197,7 +196,7 @@ mod root {
                         println!("Current channel: {}", &channel_name);
                     };
 
-                    let version = semver::Version::parse(crate::VERSION).unwrap();
+                    let version = crate::FLUVIO_PLATFORM_VERSION.clone();
                     cluster.process(out, version, root.target).await?;
                 }
                 Self::Install(mut install) => {

--- a/crates/fluvio-cli/src/version.rs
+++ b/crates/fluvio-cli/src/version.rs
@@ -20,7 +20,7 @@ impl VersionOpt {
             self.print("Release Channel", &channel_name);
         };
 
-        self.print("Fluvio CLI", crate::VERSION.trim());
+        self.print("Fluvio CLI", &crate::FLUVIO_PLATFORM_VERSION.to_string());
         self.print("Fluvio CLI Arch", CURRENT_PLATFORM);
 
         if let Some(sha) = self.format_cli_sha() {

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -34,8 +34,7 @@ use fluvio_extension_common as common;
 use common::target::ClusterTarget;
 use common::output::Terminal;
 use fluvio_channel::{ImageTagStrategy, FLUVIO_IMAGE_TAG_STRATEGY};
-
-pub(crate) const VERSION: &str = include_str!("../../../../VERSION");
+use fluvio_types::FLUVIO_PLATFORM_VERSION;
 
 /// Manage and view Fluvio clusters
 #[derive(Debug, Parser)]
@@ -104,10 +103,11 @@ impl ClusterCmd {
                         .unwrap_or(ImageTagStrategy::Version);
                     match tag_strategy {
                         ImageTagStrategy::Version => {
-                            debug!("Using image version: {}", VERSION);
+                            debug!("Using image version: {}", *FLUVIO_PLATFORM_VERSION);
                         }
                         ImageTagStrategy::VersionGit => {
-                            let image_version = format!("{}-{}", VERSION, env!("GIT_HASH"));
+                            let image_version =
+                                format!("{}-{}", *FLUVIO_PLATFORM_VERSION, env!("GIT_HASH"));
                             debug!("Using image version: {:?}", &image_version);
                             start.k8_config.image_version = Some(image_version);
                         }
@@ -127,7 +127,8 @@ impl ClusterCmd {
                     match tag_strategy {
                         ImageTagStrategy::Version => {}
                         ImageTagStrategy::VersionGit => {
-                            let image_version = format!("{}-{}", VERSION, env!("GIT_HASH"));
+                            let image_version =
+                                format!("{}-{}", *FLUVIO_PLATFORM_VERSION, env!("GIT_HASH"));
                             upgrade.start.k8_config.image_version = Some(image_version);
                         }
                         ImageTagStrategy::Git => upgrade.start.develop = true,

--- a/crates/fluvio-run/Cargo.toml
+++ b/crates/fluvio-run/Cargo.toml
@@ -23,7 +23,7 @@ spu_smartengine = ["fluvio-spu/smartengine"]
 rustls = ["fluvio-future/rust_tls"]
 
 [dependencies]
-clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context"]}
+clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "string"] }
 semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -35,3 +35,4 @@ fluvio-future = { workspace = true, features = ["subscriber"] }
 fluvio-extension-common = { workspace = true }
 fluvio-sc = { path = "../fluvio-sc", default-features = false }
 fluvio-spu = { path = "../fluvio-spu", default-features = false  }
+fluvio-types = { workspace = true }

--- a/crates/fluvio-run/src/lib.rs
+++ b/crates/fluvio-run/src/lib.rs
@@ -7,11 +7,10 @@ use error::Result;
 use fluvio_spu::SpuOpt;
 use fluvio_sc::cli::ScOpt;
 use fluvio_extension_common::FluvioExtensionMetadata;
-
-const VERSION: &str = include_str!("../../../VERSION");
+use fluvio_types::FLUVIO_PLATFORM_VERSION;
 
 #[derive(Debug, Parser)]
-#[command(version = crate::VERSION)]
+#[command(version = FLUVIO_PLATFORM_VERSION.to_string())]
 pub enum RunCmd {
     /// Run a new Streaming Processing Unit (SPU)
     #[command(name = "spu")]
@@ -74,7 +73,7 @@ pub struct VersionOpt {}
 impl VersionOpt {
     pub fn process(self) -> Result<()> {
         println!("Git Commit: {}", env!("GIT_HASH"));
-        println!("Platform Version: {VERSION}");
+        println!("Platform Version: {}", *FLUVIO_PLATFORM_VERSION);
 
         Ok(())
     }

--- a/crates/fluvio-sc/src/lib.rs
+++ b/crates/fluvio-sc/src/lib.rs
@@ -11,7 +11,7 @@ mod error;
 mod services;
 mod controllers;
 
-const VERSION: &str = include_str!("../../../VERSION");
+use fluvio_types::FLUVIO_PLATFORM_VERSION;
 
 pub mod dispatcher {
     pub use fluvio_stream_dispatcher::*;

--- a/crates/fluvio-sc/src/services/public_api/api_version.rs
+++ b/crates/fluvio-sc/src/services/public_api/api_version.rs
@@ -1,6 +1,5 @@
 use tracing::{trace, instrument, debug};
 use semver::Version;
-use once_cell::sync::Lazy;
 use anyhow::Result;
 
 use fluvio_protocol::api::{RequestMessage, ResponseMessage, Request};
@@ -14,14 +13,12 @@ use fluvio_sc_schema::AdminPublicApiKey;
 
 // Fluvi Client version 0.14.0 corresponds to Platform version 10.0.0
 
-static PLATFORM_VER: Lazy<Version> = Lazy::new(|| Version::parse(crate::VERSION).unwrap());
-
 #[instrument(skip(request))]
 pub async fn handle_api_versions_request(
     request: RequestMessage<ApiVersionsRequest>,
 ) -> Result<ResponseMessage<ApiVersionsResponse>> {
     let mut response = ApiVersionsResponse {
-        platform_version: PlatformVersion::new(&PLATFORM_VER),
+        platform_version: PlatformVersion::new(&crate::FLUVIO_PLATFORM_VERSION),
         ..Default::default()
     };
 

--- a/crates/fluvio-sc/src/start.rs
+++ b/crates/fluvio-sc/src/start.rs
@@ -18,7 +18,7 @@ pub fn main_loop(opt: ScOpt) {
     let is_local = opt.is_local();
 
     inspect_system();
-    println!("Starting SC, platform: {}", crate::VERSION);
+    println!("Starting SC, platform: {}", *crate::FLUVIO_PLATFORM_VERSION);
 
     if let Some(read_only_path) = opt.read_only().clone() {
         info!("Running in read only mode");
@@ -48,7 +48,8 @@ fn inspect_system() {
 
     let mut sys = System::new_all();
     sys.refresh_all();
-    info!(version = crate::VERSION, "Platform");
+    let platform_version = crate::FLUVIO_PLATFORM_VERSION.to_string();
+    info!(version = platform_version, "Platform");
     info!(commit = env!("GIT_HASH"), "Git");
     info!(name = ?sys.name(),"System");
     info!(kernel = ?sys.kernel_version(),"System");

--- a/crates/fluvio-spu/src/lib.rs
+++ b/crates/fluvio-spu/src/lib.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
 
 pub use config::SpuOpt;
 
-const VERSION: &str = include_str!("../../../VERSION");
+use fluvio_types::FLUVIO_PLATFORM_VERSION;
 
 pub(crate) mod traffic {
     use fluvio_protocol::api::RequestHeader;

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -30,7 +30,8 @@ pub fn main_loop(opt: SpuOpt) {
 
     let mut sys = System::new_all();
     sys.refresh_all();
-    info!(version = crate::VERSION, "Platform");
+    let platform_version = crate::FLUVIO_PLATFORM_VERSION.to_string();
+    info!(version = platform_version, "Platform");
     info!(commit = env!("GIT_HASH"), "Git");
     info!(name = ?sys.name(),"System");
     info!(kernel = ?sys.kernel_version(),"System");

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -38,5 +38,8 @@ fluvio-cluster = { path = "../fluvio-cluster" }
 fluvio-command = { workspace = true  }
 fluvio-controlplane-metadata = { workspace = true, features = ["k8"] }
 
+[build-dependencies]
+semver = { workspace = true }
+
 [lib]
 path = "lib.rs"

--- a/crates/fluvio-test-util/build.rs
+++ b/crates/fluvio-test-util/build.rs
@@ -1,0 +1,25 @@
+use semver::Version;
+
+fn main() {
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Parse the Fluvio Platform Version
+    let version = include_str!("../../VERSION").trim();
+    let version = Version::parse(version)
+        .unwrap_or_else(|_| panic!("Fluvio Platform VERSION '{version}' is not a valid semver"));
+
+    // Append an optional version suffix
+    let test_fluvio_platform_version =
+        match option_env!("FLUVIO_VERSION_SUFFIX").filter(|s| !s.is_empty()) {
+            Some(suffix) => Version::parse(&format!("{version}-{suffix}"))
+                .expect("Invalid value in 'FLUVIO_VERSION_SUFFIX' ENV variable."),
+            None => version,
+        };
+    println!("cargo:rustc-env=FLUVIO_PLATFORM_TEST_VERSION={test_fluvio_platform_version}");
+}

--- a/crates/fluvio-test-util/lib.rs
+++ b/crates/fluvio-test-util/lib.rs
@@ -4,11 +4,10 @@ pub mod tls;
 
 pub mod test_meta;
 use once_cell::sync::Lazy;
+use semver::Version;
 
-static VERSION: Lazy<String> = Lazy::new(|| {
-    let version = include_str!("../../VERSION");
-    match option_env!("FLUVIO_VERSION_SUFFIX") {
-        Some(suffix) => format!("{version}-{suffix}"),
-        None => version.to_string(),
-    }
+static FLUVIO_PLATFORM_TEST_VERSION: Lazy<Version> = Lazy::new(|| {
+    let version = env!("FLUVIO_PLATFORM_TEST_VERSION").trim();
+    Version::parse(version)
+        .expect("Env variable 'FLUVIO_PLATFORM_TEST_VERSION' should contain a valid semver.")
 });

--- a/crates/fluvio-test-util/setup/environment/k8.rs
+++ b/crates/fluvio-test-util/setup/environment/k8.rs
@@ -30,7 +30,7 @@ impl EnvironmentDriver for K8EnvironmentDriver {
     }
 
     async fn start_cluster(&self) -> StartStatus {
-        let version = semver::Version::parse(&crate::VERSION).unwrap();
+        let version = crate::FLUVIO_PLATFORM_TEST_VERSION.clone();
         let mut builder = ClusterConfig::builder(version);
         if self.option.develop_mode() {
             builder.development().expect("should test in develop mode");

--- a/crates/fluvio-test-util/setup/environment/local.rs
+++ b/crates/fluvio-test-util/setup/environment/local.rs
@@ -20,7 +20,7 @@ impl LocalEnvDriver {
     }
 
     fn load_config(option: &EnvironmentSetup) -> LocalConfig {
-        let version = semver::Version::parse(&crate::VERSION).unwrap();
+        let version = crate::FLUVIO_PLATFORM_TEST_VERSION.clone();
         let mut builder = LocalConfig::builder(version);
         builder.spu_replicas(option.spu()).hide_spinner(false);
 

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -12,10 +12,14 @@ events = ["event-listener"]
 
 [dependencies]
 event-listener = { workspace = true,  optional = true }
+once_cell = { workspace = true }
+semver = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture", "subscriber"] }
 tokio = { workspace = true,  features = ["macros"] }
+
+[build-dependencies]
+semver = { workspace = true }

--- a/crates/fluvio-types/build.rs
+++ b/crates/fluvio-types/build.rs
@@ -1,0 +1,17 @@
+use semver::Version;
+
+fn main() {
+    if let Ok(verpath) = std::fs::canonicalize("../../VERSION") {
+        if verpath.exists() {
+            println!("cargo:rerun-if-changed=../../VERSION");
+        }
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Parse the Fluvio Platform Version
+    let version = include_str!("../../VERSION").trim();
+    let version = Version::parse(version)
+        .unwrap_or_else(|_| panic!("Fluvio Platform VERSION '{version}' is not a valid semver"));
+    println!("cargo:rustc-env=FLUVIO_PLATFORM_VERSION={version}");
+}

--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -1,7 +1,15 @@
+use once_cell::sync::Lazy;
+use semver::Version;
+
 pub const PRODUCT_NAME: &str = "fluvio";
 
 // Fluvio
 pub const FLUVIO_MAX_SIZE_TOPIC_NAME: u8 = 255;
+pub static FLUVIO_PLATFORM_VERSION: Lazy<Version> = Lazy::new(|| {
+    let version = env!("FLUVIO_PLATFORM_VERSION").trim();
+    Version::parse(version)
+        .expect("Env variable 'FLUVIO_PLATFORM_VERSION' should contain a valid semver.")
+});
 
 // Client
 pub const FLUVIO_CLIENT_MAX_FETCH_BYTES: i32 = 1_048_588;

--- a/crates/fluvio-types/src/lib.rs
+++ b/crates/fluvio-types/src/lib.rs
@@ -8,7 +8,7 @@ pub mod partition;
 pub mod event;
 
 pub use partition::PartitionError;
-
+pub use defaults::FLUVIO_PLATFORM_VERSION;
 //
 // Types
 //


### PR DESCRIPTION
Hey @tjtelan,

I added a common library (`fluvio-common`) to parse the `VERSION` file and made all relevant crates refer to it. I saw that there was `fluvio-cli-common`, but It seemed more specific to `fluvio-cli` versus being a light dependency that can be used by all. 

Please let me know if there's another place that you recommend that the change be made.

Thanks

---
Resolves #3479
