### PR TITLE
feat: skip spu group creation if `--spu 0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,6 +708,74 @@ jobs:
           path: diagnostics*.gz
           retention-days: 1
 
+  cluster_management_test:
+    name: Cluster ${{ matrix.test }} Tests (${{ matrix.os }})-${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build_primary_binaries
+      - config
+    env:
+      UNINSTALL: noclean
+      FLUVIO_BIN: ~/bin/fluvio
+      SERVER_LOG: fluvio=info
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust-target: [x86_64-unknown-linux-musl]
+        test: [cluster-base-test]
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v3
+
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v3
+        with:
+          name: fluvio-${{ matrix.rust-target }}
+          path: ~/bin
+
+      - name: Set up Fluvio Binaries
+        run: |
+          chmod +x ~/bin/fluvio
+          echo "~/bin" >> $GITHUB_PATH
+          FLUVIO_BIN=~/bin/fluvio
+          echo "FLUVIO_BIN=${FLUVIO_BIN}" >> $GITHUB_ENV
+
+      - name: Print version
+        run: fluvio version
+
+      - name: Set up cluster
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
+          ./k8-util/cluster/reset-k3d.sh
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: ${{ env.BATS_VERSION }}
+
+      - name: Sleep for 15s
+        run: sleep 15
+
+      - name: Run cluster-base-test
+        if: matrix.test == 'cluster-base-test'
+        timeout-minutes: 15
+        run: |
+          make cluster-base-test
+
+      - name: Run diagnostics
+        if: ${{ !success() }}
+        timeout-minutes: 5
+        run: fluvio cluster diagnostics --local
+
+      - name: Upload diagnostics
+        uses: actions/upload-artifact@v3
+        timeout-minutes: 5
+        if: ${{ !success() }}
+        with:
+          name: local-${{ matrix.run }}-${{ matrix.test }}-diag
+          path: diagnostics*.gz
+          retention-days: 1
+
   build_image:
     name: Build Fluvio Docker image
     needs: build_primary_binaries

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -1305,6 +1305,11 @@ impl ClusterInstaller {
     /// Provisions a SPU group for the given cluster according to internal config
     #[instrument(skip(self, fluvio))]
     async fn create_managed_spu_group(&self, fluvio: &Fluvio) -> Result<()> {
+        if self.config.spu_replicas == 0 {
+            println!("🤖 Skipping SPU Group creation");
+            return Ok(());
+        }
+
         let pb = self.pb_factory.create()?;
         let spg_name = self.config.group_name.clone();
         pb.set_message(format!("📝 Checking for existing SPU Group: {spg_name}"));

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -209,6 +209,9 @@ cli-smdk-smoke:
 cli-cdk-smoke:
 	bats $(shell ls -1 ./tests/cli/cdk_smoke_tests/*.bats | sort -R)
 
+cluster-base-test:
+	bats ./tests/cli/cluster_smoke_tests/basic.bats
+
 cli-basic-test:
 	bats ./tests/cli/fluvio_smoke_tests/e2e-basic.bats
 

--- a/tests/cli/cluster_smoke_tests/basic.bats
+++ b/tests/cli/cluster_smoke_tests/basic.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+
+setup_file() {
+    "$FLUVIO_BIN" cluster delete
+    sleep 15
+}
+
+@test "Creates Cluster with \"--spu 0\"" {
+    if [[ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]]; then
+        skip "don't use --spu 0 on stable version"
+    fi
+
+    run timeout 15s "$FLUVIO_BIN" cluster delete || true
+    assert_success
+
+    make -C k8-util/helm clean
+    sleep 15
+
+    run timeout 15s "$FLUVIO_BIN" cluster start
+    assert_success
+
+    sleep 20s
+}
+
+@test "Creates Local Cluster with \"--spu 0\"" {
+    if [[ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]]; then
+        skip "don't use --spu 0 on stable version"
+    fi
+
+    run timeout 15s "$FLUVIO_BIN" cluster delete || true
+    assert_success
+
+    make -C k8-util/helm clean
+    sleep 15
+
+    run timeout 15s "$FLUVIO_BIN" cluster start
+    assert_success
+
+    sleep 20s
+}


### PR DESCRIPTION
Skips SPU Group creation when the `--spu` argument is provided with value `0`.

```
flvd cluster start --spu 0
📝 Running pre-flight checks
    ✅ Kubectl active cluster rancher-desktop at: https://127.0.0.1:6443 found
    ✅ Supported helm version 3.12.1+gf32a527 is installed
    ✅ Supported Kubernetes server 1.26.4+k3s1 found
    ✅ Fixed: Fluvio Sys chart 0.10.15-dev-1 is installed
    ✅ Previous fluvio installation not found
🎉 All checks passed!
✅ Installed Fluvio app chart: 0.10.15-dev-1
✅ Connected to SC: localhost:30003
👤 Profile set
🤖 Skipping SPU Group creation
🎯 Successfully installed Fluvio!
```

## Open Questions

- Perhaps in the future we could have `--no-spu`?
- Should we also allow specifying `0` as the SPU group? As of today its not allowed to provide `0` as the SPU Group value because the K8 client complains about invalid value.
