### PR TITLE
[Merged by Bors] - feat: provides deprecation docs for warning

### DIFF
--- a/crates/fluvio-smartmodule/src/input.rs
+++ b/crates/fluvio-smartmodule/src/input.rs
@@ -136,7 +136,7 @@ impl SmartModuleInput {
     /// Creates an instance of [`Record`] from the raw bytes and ignoring the
     /// base offset and timestamp. This method is used to keep backwards
     /// compatibility with SmartModule engines previous to Version `21`.
-    #[deprecated = "use SmartModuleRecord instead"]
+    #[deprecated = "use SmartModuleRecord instead. Read more here: https://www.fluvio.io/smartmodules/smdk/smartmodulerecord/."]
     pub fn try_into_records(mut self, version: Version) -> Result<Vec<Record>, std::io::Error> {
         Decoder::decode_from(&mut Cursor::new(&mut self.raw_bytes), version)
     }


### PR DESCRIPTION
When attempting to build a SmartModule using `Record` instead of `SmartModuleRecord` the
current warning will also include link to documentation.

```
warning: use of deprecated method `fluvio_smartmodule::dataplane::smartmodule::SmartModuleInput::try_into_records`: use SmartModuleRecord instead. Read more here: https://www.fluvio.io/smartmodules/smdk/smartmodulerecord/.
 --> filter_map/src/lib.rs:5:1
  |
5 | #[smartmodule(filter_map)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
  = note: this warning originates in the attribute macro `smartmodule` (in Nightly builds, run with -Z macro-backtrace for more info)

```
