### PR TITLE
[Merged by Bors] - feat: consume all partitions by default

### DIFF
--- a/crates/fluvio-cli-common/src/user_input.rs
+++ b/crates/fluvio-cli-common/src/user_input.rs
@@ -148,7 +148,7 @@ mod file_tests {
     #[test]
     fn file_lines() -> Result<(), ()> {
         let mut file = NamedTempFile::new().unwrap();
-        let data = vec!["123", "abc", "📼🍅🐊"];
+        let data = ["123", "abc", "📼🍅🐊"];
 
         writeln!(file, "{}", data[0]).unwrap();
         writeln!(file, "{}", data[1]).unwrap();
@@ -173,7 +173,7 @@ mod file_tests {
     fn file_whole() -> Result<(), ()> {
         let mut file = NamedTempFile::new().unwrap();
 
-        let data = vec!["123", "abc", "📼🍅🐊"];
+        let data = ["123", "abc", "📼🍅🐊"];
 
         writeln!(file, "{}", data[0]).unwrap();
         writeln!(file, "{}", data[1]).unwrap();

--- a/crates/fluvio-cli/src/bin/main.rs
+++ b/crates/fluvio-cli/src/bin/main.rs
@@ -26,7 +26,7 @@ fn print_help_hack() -> Result<()> {
         std::process::exit(0);
     } else if let Some(first_arg) = args.nth(1) {
         // We pick help up here as a courtesy
-        if vec!["-h", "--help", "help"].contains(&first_arg.as_str()) {
+        if ["-h", "--help", "help"].contains(&first_arg.as_str()) {
             HelpOpt {}.process()?;
             std::process::exit(0);
         }

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -274,7 +274,7 @@ impl MetaConfig<'_> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ConsumerParameters {
-    #[serde(default, skip_serializing_if = "ConsumerPartitionConfig::is_default")]
+    #[serde(default)]
     pub partition: ConsumerPartitionConfig,
     #[serde(
         with = "bytesize_serde",
@@ -397,13 +397,7 @@ pub enum ConsumerPartitionConfig {
 
 impl Default for ConsumerPartitionConfig {
     fn default() -> Self {
-        Self::One(0)
-    }
-}
-
-impl ConsumerPartitionConfig {
-    pub fn is_default(&self) -> bool {
-        matches!(self, ConsumerPartitionConfig::One(partition) if partition.eq(&PartitionId::default()))
+        Self::All
     }
 }
 

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -131,7 +131,7 @@ mod v1 {
 
     impl MetaConfigV1 {
         pub fn secrets(&self) -> HashSet<SecretConfig> {
-            HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+            HashSet::from_iter(self.secrets.clone().unwrap_or_default())
         }
 
         pub fn direction(&self) -> Direction {
@@ -184,7 +184,7 @@ mod v2 {
 
     impl MetaConfigV2 {
         pub fn secrets(&self) -> HashSet<SecretConfig> {
-            HashSet::from_iter(self.secrets.clone().unwrap_or_default().into_iter())
+            HashSet::from_iter(self.secrets.clone().unwrap_or_default())
         }
 
         pub fn direction(&self) -> Direction {

--- a/crates/fluvio-hub-protocol/src/package_meta.rs
+++ b/crates/fluvio-hub-protocol/src/package_meta.rs
@@ -266,7 +266,7 @@ impl From<&SmartModuleVisibility> for PkgVisibility {
 
 #[test]
 fn builds_obj_key_from_package_name() {
-    let pkg_names = vec![
+    let pkg_names = [
         "infinyon/example@0.0.1",
         "infinyon/example-sm@0.1.0",
         "infinyon/json-sql@0.0.2",
@@ -275,7 +275,7 @@ fn builds_obj_key_from_package_name() {
         "infinyon/test-cli@0.1.0",
         "infinyon/regex@0.0.1",
     ];
-    let obj_paths = vec![
+    let obj_paths = [
         "infinyon/example-0.0.1.ipkg",
         "infinyon/example-sm-0.1.0.ipkg",
         "infinyon/json-sql-0.0.2.ipkg",

--- a/crates/fluvio-hub-util/src/package_meta_ext.rs
+++ b/crates/fluvio-hub-util/src/package_meta_ext.rs
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn builds_obj_key_from_package_name() {
-        let pkg_names = vec![
+        let pkg_names = [
             "infinyon/example@0.0.1",
             "infinyon/example-sm@0.1.0",
             "infinyon/json-sql@0.0.2",
@@ -196,7 +196,7 @@ mod tests {
             "infinyon/test-cli@0.1.0",
             "infinyon/regex@0.0.1",
         ];
-        let obj_paths = vec![
+        let obj_paths = [
             "infinyon/example-0.0.1.ipkg",
             "infinyon/example-sm-0.1.0.ipkg",
             "infinyon/json-sql-0.0.2.ipkg",
@@ -414,7 +414,7 @@ mod tests {
         /// the current code should be able to load all old versions
         #[test]
         fn backward_compat() {
-            let flist = vec![
+            let flist = [
                 "tests/apackage/package-meta.yaml",
                 "tests/apackage/package-meta-v0.1.yaml",
                 "tests/apackage/package-meta-v0.2-owner.yaml",
@@ -435,7 +435,7 @@ mod tests {
             const TAGGED_PM: &str = "tests/apackage/package-meta-v0.3-targets.yaml";
             let msg = format!("couldn't read {TAGGED_PM}");
             let pm = read_pkgmeta(TAGGED_PM).expect(&msg);
-            let tags = vec![
+            let tags = [
                 ("arch", "aarch64-apple-darwin"),
                 ("arch", "aarch64-unknown-linux-musl"),
             ]

--- a/crates/fluvio-protocol/src/core/bytebuf.rs
+++ b/crates/fluvio-protocol/src/core/bytebuf.rs
@@ -22,7 +22,7 @@ impl From<Bytes> for ByteBuf {
 impl From<Vec<u8>> for ByteBuf {
     fn from(bytes: Vec<u8>) -> Self {
         ByteBuf {
-            inner: Bytes::from_iter(bytes.into_iter()),
+            inner: Bytes::from_iter(bytes),
         }
     }
 }

--- a/crates/fluvio-spu/src/smartengine/context.rs
+++ b/crates/fluvio-spu/src/smartengine/context.rs
@@ -159,7 +159,7 @@ async fn lookback_last_iterator<R: ReplicaStorage>(
 
     let Some(file_slice) = slice.file_slice else {
         trace!(?slice);
-        return Ok(Box::new(std::iter::empty()))
+        return Ok(Box::new(std::iter::empty()));
     };
 
     let batch_iter = FileBatchIterator::from_raw_slice(file_slice);
@@ -218,7 +218,9 @@ async fn read_batches_by_age<R: ReplicaStorage>(
             break;
         };
         let mut batch_iter = FileBatchIterator::from_raw_slice(file_slice);
-        let Some(batch) = batch_iter.next() else { break };
+        let Some(batch) = batch_iter.next() else {
+            break;
+        };
         let batch = batch?;
         trace!(?batch.batch, "next file batch");
 

--- a/crates/fluvio-test/src/tests/producer_fail/mod.rs
+++ b/crates/fluvio-test/src/tests/producer_fail/mod.rs
@@ -49,7 +49,7 @@ pub async fn produce_batch(
     println!("Got cluster manager");
 
     let value = "a".repeat(5000);
-    let result: Result<_> = (|| async move {
+    let result: Result<_> = async move {
         let mut results = Vec::new();
         for _ in 0..1000 {
             let result = producer.send(RecordKey::NULL, value.clone()).await?;
@@ -86,7 +86,7 @@ pub async fn produce_batch(
         producer.flush().await?;
 
         Ok(())
-    })()
+    }
     .await;
 
     // Ensure that one of the calls returned a failure


### PR DESCRIPTION
Consume all partitions by default in Fluvio CLI and connectors.

Fluvio CLI can also read a sub-set of partitions: `fluvio consume topic -p 1 -p 2`

Fixes #3486 