### PR TITLE
[Merged by Bors] - chore: update `fluvio-connector-derive` to syn@2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,7 +2672,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/crates/fluvio-connector-derive/Cargo.toml
+++ b/crates/fluvio-connector-derive/Cargo.toml
@@ -11,6 +11,6 @@ description = "Fluvio SmartConnector procedural macro"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", default-features = false, features = ["full", "parsing", "proc-macro", "derive", "printing"] }
+syn = { workspace = true, features = ["full"] }
 quote =  { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/fluvio-connector-derive/src/lib.rs
+++ b/crates/fluvio-connector-derive/src/lib.rs
@@ -4,11 +4,14 @@ mod generator;
 use ast::{ConnectorDirection, ConnectorFn, ConnectorConfigStruct};
 use generator::{generate_connector, generate_connector_config};
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, AttributeArgs, ItemFn, Item, ItemStruct, Error, spanned::Spanned};
+use syn::{
+    parse_macro_input, ItemFn, Item, ItemStruct, Error, spanned::Spanned, punctuated::Punctuated,
+    Token, Meta,
+};
 
 #[proc_macro_attribute]
 pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(args as AttributeArgs);
+    let args = parse_macro_input!(args with Punctuated::<Meta, Token![,]>::parse_terminated);
     let input = parse_macro_input!(input as Item);
 
     match input {
@@ -20,7 +23,7 @@ pub fn connector(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-fn connector_func(args: AttributeArgs, func: ItemFn) -> TokenStream {
+fn connector_func(args: Punctuated<Meta, Token![,]>, func: ItemFn) -> TokenStream {
     let direction = match ConnectorDirection::from_ast(&args) {
         Ok(dir) => dir,
         Err(e) => return e.into_compile_error().into(),
@@ -36,7 +39,7 @@ fn connector_func(args: AttributeArgs, func: ItemFn) -> TokenStream {
     output.into()
 }
 
-fn connector_config(args: AttributeArgs, item: ItemStruct) -> TokenStream {
+fn connector_config(args: Punctuated<Meta, Token![,]>, item: ItemStruct) -> TokenStream {
     let item = match ConnectorConfigStruct::from_ast(&args, &item) {
         Ok(it) => it,
         Err(e) => return e.into_compile_error().into(),


### PR DESCRIPTION
`fluvio-connector-derive` was the last crate using `syn = "1"`.

Now the entire project is using `syn = "2.0"` and in sync with the workspace.

related to #3240