### PR TITLE
[Merged by Bors] - chore: point ci badge to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,13 @@ jobs:
           override: true
       - name: Install Zig
         run: ./actions/zig-install.sh ${{ matrix.os }}
+
+      # based upon https://github.com/orgs/community/discussions/25678
+      # check test regularly runs out of disk space
+      - name: Save Space
+        if: matrix.check == 'test'
+        run: rm -rf /opt/hostedtoolcache
+
       - uses: Swatinem/rust-cache@v2
         timeout-minutes: 10
         with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br>
   <br>
 
-  [![CI Status](https://github.com/infinyon/fluvio/workflows/CI/badge.svg?branch=master)](https://github.com/infinyon/fluvio/actions/workflows/ci.yml)
+  [![CI Status](https://github.com/infinyon/fluvio/workflows/CI/badge.svg?branch=staging)](https://github.com/infinyon/fluvio/actions/workflows/ci.yml)
   [![CD Status](https://github.com/infinyon/fluvio/workflows/CD_Dev/badge.svg)](https://github.com/infinyon/fluvio/actions/workflows/cd_dev.yaml)
   [![fluvio Crates.io version](https://img.shields.io/crates/v/fluvio?style=flat)](https://crates.io/crates/fluvio)
   [![Fluvio Rust documentation](https://docs.rs/fluvio/badge.svg)](https://docs.rs/fluvio)


### PR DESCRIPTION
because of the merge bot, staging is the more stable CI status, master does not have CI action status...