### PR TITLE
[Merged by Bors] - chore: remove unnecessary generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ k8-types = { version = "0.8.3" }
 trybuild = { branch = "check_option", git = "https://github.com/infinyon/trybuild" }
 
 # Internal fluvio dependencies
-fluvio = { version = "0.21.0", path = "crates/fluvio" }
+fluvio = { version = "0.22.0", path = "crates/fluvio" }
 fluvio-auth = { path = "crates/fluvio-auth" }
 fluvio-channel = { path = "crates/fluvio-channel" }
 fluvio-cli-common = { path = "crates/fluvio-cli-common"}
@@ -162,7 +162,7 @@ fluvio-controlplane-metadata = { version = "0.24.0", default-features = false, p
 fluvio-extension-common = { path = "crates/fluvio-extension-common", default-features = false }
 fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-package-index = { version = "0.7.0", path = "crates/fluvio-package-index", default-features = false }
-fluvio-protocol = { version = "0.10.4", path = "crates/fluvio-protocol" }
+fluvio-protocol = { version = "0.10.6", path = "crates/fluvio-protocol" }
 fluvio-sc-schema = { version = "0.21.0", path = "crates/fluvio-sc-schema", default-features = false }
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.7.0", path = "crates/fluvio-smartengine", default-features = false }

--- a/crates/fluvio-benchmark/src/benchmark_driver.rs
+++ b/crates/fluvio-benchmark/src/benchmark_driver.rs
@@ -140,7 +140,7 @@ impl BenchmarkDriver {
         let result = BenchmarkDriver::run_samples(config.clone(), all_stats.clone()).await;
         // Clean up topic
         admin
-            .delete::<TopicSpec, String>(config.topic_name.clone())
+            .delete::<TopicSpec>(config.topic_name.clone())
             .await?;
         debug!("Topic deleted successfully {}", config.topic_name);
 

--- a/crates/fluvio-benchmark/src/benchmark_driver.rs
+++ b/crates/fluvio-benchmark/src/benchmark_driver.rs
@@ -139,9 +139,7 @@ impl BenchmarkDriver {
         debug!("Topic created successfully {}", config.topic_name);
         let result = BenchmarkDriver::run_samples(config.clone(), all_stats.clone()).await;
         // Clean up topic
-        admin
-            .delete::<TopicSpec>(config.topic_name.clone())
-            .await?;
+        admin.delete::<TopicSpec>(config.topic_name.clone()).await?;
         debug!("Topic deleted successfully {}", config.topic_name);
 
         result?;

--- a/crates/fluvio-cli/src/client/smartmodule/delete.rs
+++ b/crates/fluvio-cli/src/client/smartmodule/delete.rs
@@ -36,7 +36,7 @@ impl ClientCmd for DeleteSmartModuleOpt {
         let mut err_happened = false;
         for name in self.names.iter() {
             debug!(name, "deleting smartmodule");
-            if let Err(error) = admin.delete::<SmartModuleSpec, _>(name).await {
+            if let Err(error) = admin.delete::<SmartModuleSpec>(name).await {
                 err_happened = true;
                 if self.continue_on_error {
                     println!("smart module \"{name}\" delete failed with: {error}");

--- a/crates/fluvio-cli/src/client/tableformat/delete.rs
+++ b/crates/fluvio-cli/src/client/tableformat/delete.rs
@@ -22,7 +22,7 @@ pub struct DeleteTableFormatOpt {
 impl DeleteTableFormatOpt {
     pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
-        admin.delete::<TableFormatSpec, _>(&self.name).await?;
+        admin.delete::<TableFormatSpec>(&self.name).await?;
         Ok(())
     }
 }

--- a/crates/fluvio-cli/src/client/tableformat/mod.rs
+++ b/crates/fluvio-cli/src/client/tableformat/mod.rs
@@ -83,7 +83,7 @@ mod cmd {
     }
 
     impl TableFormatConfig {
-        pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<TableFormatConfig> {
+        pub fn from_file(path: impl Into<PathBuf>) -> Result<TableFormatConfig> {
             let mut file = File::open(path.into())?;
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;

--- a/crates/fluvio-cli/src/client/topic/delete.rs
+++ b/crates/fluvio-cli/src/client/topic/delete.rs
@@ -29,7 +29,7 @@ impl DeleteTopicOpt {
         let mut err_happened = false;
         for name in self.names.iter() {
             debug!(name, "deleting topic");
-            if let Err(error) = admin.delete::<TopicSpec, _>(name).await {
+            if let Err(error) = admin.delete::<TopicSpec>(name).await {
                 err_happened = true;
                 if self.continue_on_error {
                     println!("topic \"{name}\" delete failed with: {error}");

--- a/crates/fluvio-cluster/src/charts/chart.rs
+++ b/crates/fluvio-cluster/src/charts/chart.rs
@@ -71,13 +71,13 @@ impl ChartConfigBuilder {
     }
 
     /// The local chart location to install sys charts from
-    pub fn local<P: Into<PathBuf>>(&mut self, path: P) -> &mut Self {
+    pub fn local(&mut self, path: impl Into<PathBuf>) -> &mut Self {
         self.location = Some(ChartLocation::Local(path.into()));
         self
     }
 
     /// The remote chart location to install charts from
-    pub fn remote<S: Into<String>>(&mut self, location: S) -> &mut Self {
+    pub fn remote(&mut self, location: impl Into<String>) -> &mut Self {
         self.location = Some(ChartLocation::Remote(location.into()));
         self
     }

--- a/crates/fluvio-cluster/src/check/mod.rs
+++ b/crates/fluvio-cluster/src/check/mod.rs
@@ -147,7 +147,7 @@ pub enum CheckStatus {
 
 impl CheckStatus {
     /// Creates a passing check status with a success message
-    pub(crate) fn pass<S: Into<String>>(msg: S) -> Self {
+    pub(crate) fn pass(msg: impl Into<String>) -> Self {
         Self::Pass(msg.into())
     }
 }
@@ -730,7 +730,7 @@ impl ClusterChecker {
     }
 
     /// Adds a check to this `ClusterChecker`
-    pub fn with_check<C: ClusterCheck, B: Into<Box<C>>>(mut self, check: B) -> Self {
+    pub fn with_check<C: ClusterCheck>(mut self, check: impl Into<Box<C>>) -> Self {
         self.checks.push(check.into());
         self
     }

--- a/crates/fluvio-cluster/src/cli/group/delete.rs
+++ b/crates/fluvio-cluster/src/cli/group/delete.rs
@@ -23,7 +23,7 @@ pub struct DeleteManagedSpuGroupOpt {
 impl DeleteManagedSpuGroupOpt {
     pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let admin = fluvio.admin().await;
-        admin.delete::<SpuGroupSpec, _>(&self.name).await?;
+        admin.delete::<SpuGroupSpec>(&self.name).await?;
         Ok(())
     }
 }

--- a/crates/fluvio-cluster/src/cli/spu/unregister.rs
+++ b/crates/fluvio-cluster/src/cli/spu/unregister.rs
@@ -38,7 +38,7 @@ impl UnregisterCustomSpuOpt {
     pub async fn process(self, fluvio: &Fluvio) -> Result<()> {
         let delete_key = self.validate()?;
         let admin = fluvio.admin().await;
-        admin.delete::<CustomSpuSpec, _>(delete_key).await?;
+        admin.delete::<CustomSpuSpec>(delete_key).await?;
         Ok(())
     }
 

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -407,7 +407,7 @@ impl ClusterConfigBuilder {
     /// ```
     ///
     /// [`remote_chart`]: ./struct.ClusterInstallerBuilder#method.remote_chart
-    pub fn local_chart<S: Into<PathBuf>>(&mut self, local_chart_location: S) -> &mut Self {
+    pub fn local_chart(&mut self, local_chart_location: impl Into<PathBuf>) -> &mut Self {
         let user_chart_location = UserChartLocation::Local(local_chart_location.into());
         debug!(?user_chart_location, "setting local chart");
         self.chart_location(user_chart_location);
@@ -436,7 +436,7 @@ impl ClusterConfigBuilder {
     /// ```
     ///
     /// [`local_chart`]: ./struct.ClusterInstallerBuilder#method.local_chart
-    pub fn remote_chart<S: Into<String>>(&mut self, remote_chart_location: S) -> &mut Self {
+    pub fn remote_chart(&mut self, remote_chart_location: impl Into<String>) -> &mut Self {
         self.chart_location(UserChartLocation::Remote(remote_chart_location.into()));
         self
     }
@@ -474,11 +474,7 @@ impl ClusterConfigBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn tls<C: Into<TlsPolicy>, S: Into<TlsPolicy>>(
-        &mut self,
-        client: C,
-        server: S,
-    ) -> &mut Self {
+    pub fn tls(&mut self, client: impl Into<TlsPolicy>, server: impl Into<TlsPolicy>) -> &mut Self {
         let client_policy = client.into();
         let server_policy = server.into();
 

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -260,11 +260,7 @@ impl LocalConfigBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn tls<C: Into<TlsPolicy>, S: Into<TlsPolicy>>(
-        &mut self,
-        client: C,
-        server: S,
-    ) -> &mut Self {
+    pub fn tls(&mut self, client: impl Into<TlsPolicy>, server: impl Into<TlsPolicy>) -> &mut Self {
         let client_policy = client.into();
         let server_policy = server.into();
 
@@ -314,7 +310,7 @@ impl LocalConfigBuilder {
     /// ```
     ///
     /// [`with_remote_chart`]: ./struct.ClusterInstallerBuilder#method.with_remote_chart
-    pub fn local_chart<S: Into<PathBuf>>(&mut self, local_chart_location: S) -> &mut Self {
+    pub fn local_chart(&mut self, local_chart_location: impl Into<PathBuf>) -> &mut Self {
         self.chart_location(UserChartLocation::Local(local_chart_location.into()));
         self
     }

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -479,7 +479,7 @@ impl Serialize for ConsumerPartitionConfig {
 }
 
 impl ConnectorConfig {
-    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self> {
+    pub fn from_file(path: impl Into<PathBuf>) -> Result<Self> {
         let mut file = File::open(path.into())?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;

--- a/crates/fluvio-connector-package/src/metadata.rs
+++ b/crates/fluvio-connector-package/src/metadata.rs
@@ -126,14 +126,14 @@ impl Deref for CustomConfigSchema {
 }
 
 impl Deployment {
-    pub fn from_image_name<T: Into<String>>(image: T) -> Self {
+    pub fn from_image_name(image: impl Into<String>) -> Self {
         Self {
             image: Some(image.into()),
             binary: None,
         }
     }
 
-    pub fn from_binary_name<T: Into<String>>(binary: T) -> Self {
+    pub fn from_binary_name(binary: impl Into<String>) -> Self {
         Self {
             image: None,
             binary: Some(binary.into()),

--- a/crates/fluvio-controlplane-metadata/src/topic/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/spec.rs
@@ -60,10 +60,7 @@ impl Deref for TopicSpec {
 }
 
 impl TopicSpec {
-    pub fn new_assigned<J>(partition_map: J) -> Self
-    where
-        J: Into<PartitionMaps>,
-    {
+    pub fn new_assigned(partition_map: impl Into<PartitionMaps>) -> Self {
         Self {
             replicas: ReplicaSpec::new_assigned(partition_map),
             ..Default::default()

--- a/crates/fluvio-controlplane-metadata/src/topic/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/topic/status.rs
@@ -131,10 +131,11 @@ fn create_replica_map(rows: Vec<Vec<SpuId>>) -> ReplicaMap {
 }
 
 impl TopicStatus {
-    pub fn new<S>(resolution: TopicResolution, replica_map: Vec<Vec<SpuId>>, reason: S) -> Self
-    where
-        S: Into<String>,
-    {
+    pub fn new(
+        resolution: TopicResolution,
+        replica_map: Vec<Vec<SpuId>>,
+        reason: impl Into<String>,
+    ) -> Self {
         TopicStatus {
             resolution,
             replica_map: create_replica_map(replica_map),
@@ -220,17 +221,11 @@ impl TopicStatus {
         (TopicResolution::Pending, super::PENDING_REASON.to_owned())
     }
 
-    pub fn next_resolution_invalid_config<S>(reason: S) -> (TopicResolution, String)
-    where
-        S: Into<String>,
-    {
+    pub fn next_resolution_invalid_config(reason: impl Into<String>) -> (TopicResolution, String) {
         (TopicResolution::InvalidConfig, reason.into())
     }
 
-    pub fn set_resolution_no_resource<S>(reason: S) -> (TopicResolution, String)
-    where
-        S: Into<String>,
-    {
+    pub fn set_resolution_no_resource(reason: impl Into<String>) -> (TopicResolution, String) {
         (TopicResolution::InsufficientResources, reason.into())
     }
 

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"

--- a/crates/fluvio-extension-common/src/lib.rs
+++ b/crates/fluvio-extension-common/src/lib.rs
@@ -105,7 +105,7 @@ pub mod target {
     }
 
     impl TargetError {
-        pub fn invalid_arg<M: Into<String>>(reason: M) -> Self {
+        pub fn invalid_arg(reason: impl Into<String>) -> Self {
             Self::InvalidArg(reason.into())
         }
     }

--- a/crates/fluvio-package-index/src/package.rs
+++ b/crates/fluvio-package-index/src/package.rs
@@ -30,12 +30,12 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn new_binary<S1, S2, S3, V>(id: &PackageId<V>, author: S1, desc: S2, repo: S3) -> Self
-    where
-        S1: Into<String>,
-        S2: Into<String>,
-        S3: Into<String>,
-    {
+    pub fn new_binary<V>(
+        id: &PackageId<V>,
+        author: impl Into<String>,
+        desc: impl Into<String>,
+        repo: impl Into<String>,
+    ) -> Self {
         let author = author.into();
         let description = desc.into();
         let repository = repo.into();

--- a/crates/fluvio-protocol/src/api/mod.rs
+++ b/crates/fluvio-protocol/src/api/mod.rs
@@ -113,10 +113,7 @@ mod common {
             Self::new_with_client(api_key, "dummy".to_owned())
         }
 
-        pub fn new_with_client<T>(api_key: u16, client_id: T) -> Self
-        where
-            T: Into<String>,
-        {
+        pub fn new_with_client(api_key: u16, client_id: impl Into<String>) -> Self {
             RequestHeader {
                 api_key,
                 api_version: 1,

--- a/crates/fluvio-protocol/src/api/request.rs
+++ b/crates/fluvio-protocol/src/api/request.rs
@@ -89,10 +89,10 @@ where
         Self::response_with_header(&self.header, response)
     }
 
-    pub fn response_with_header<H>(header: H, response: R::Response) -> ResponseMessage<R::Response>
-    where
-        H: Into<i32>,
-    {
+    pub fn response_with_header(
+        header: impl Into<i32>,
+        response: R::Response,
+    ) -> ResponseMessage<R::Response> {
         ResponseMessage::new(header.into(), response)
     }
 

--- a/crates/fluvio-protocol/src/record/data.rs
+++ b/crates/fluvio-protocol/src/record/data.rs
@@ -455,21 +455,14 @@ impl<B: Default> Record<B> {
 }
 
 impl Record {
-    pub fn new<V>(value: V) -> Self
-    where
-        V: Into<RecordData>,
-    {
+    pub fn new(value: impl Into<RecordData>) -> Self {
         Record {
             value: value.into(),
             ..Default::default()
         }
     }
 
-    pub fn new_key_value<K, V>(key: K, value: V) -> Self
-    where
-        K: Into<RecordKey>,
-        V: Into<RecordData>,
-    {
+    pub fn new_key_value(key: impl Into<RecordKey>, value: impl Into<RecordData>) -> Self {
         let key = key.into().into_option();
         Record {
             key,

--- a/crates/fluvio-protocol/src/record/replica.rs
+++ b/crates/fluvio-protocol/src/record/replica.rs
@@ -22,11 +22,7 @@ unsafe impl Send for ReplicaKey {}
 unsafe impl Sync for ReplicaKey {}
 
 impl ReplicaKey {
-    pub fn new<S, P>(topic: S, partition: P) -> Self
-    where
-        S: Into<String>,
-        P: Into<PartitionId>,
-    {
+    pub fn new(topic: impl Into<String>, partition: impl Into<PartitionId>) -> Self {
         ReplicaKey {
             topic: topic.into(),
             partition: partition.into(),

--- a/crates/fluvio-sc/src/controllers/partitions/controller.rs
+++ b/crates/fluvio-sc/src/controllers/partitions/controller.rs
@@ -157,48 +157,6 @@ mod test {
 
     use super::*;
 
-    mod meta {
-        use fluvio_controlplane_metadata::core::{MetadataItem, MetadataRevExtension};
-
-        /// simple memory representation of meta
-        #[derive(Debug, Default, PartialEq, Clone)]
-        pub struct MemoryMeta {
-            pub rev: u32,
-        }
-
-        impl MetadataItem for MemoryMeta {
-            type UId = u32;
-
-            fn uid(&self) -> &Self::UId {
-                &self.rev
-            }
-
-            fn is_newer(&self, another: &Self) -> bool {
-                self.rev >= another.rev
-            }
-        }
-
-        impl MetadataRevExtension for MemoryMeta {
-            fn next_rev(&self) -> Self {
-                Self { rev: self.rev + 1 }
-            }
-        }
-
-        impl MemoryMeta {
-            pub fn new(rev: u32) -> Self {
-                Self { rev }
-            }
-        }
-
-        /*
-        impl From<u32> for MetadataContext<MemoryMeta> {
-            fn from(val: u32) -> MetadataContext<MemoryMeta> {
-                MemoryMeta::new(val).into()
-            }
-        }
-        */
-    }
-
     use fluvio_controlplane_metadata::store::MetadataStoreObject;
     use meta::*;
 

--- a/crates/fluvio-sc/src/controllers/partitions/reducer.rs
+++ b/crates/fluvio-sc/src/controllers/partitions/reducer.rs
@@ -70,11 +70,10 @@ impl<C: MetadataItem> Default for PartitionReducer<C> {
 }
 
 impl<C: MetadataItem> PartitionReducer<C> {
-    pub fn new<A, B>(partition_store: A, spu_store: B) -> Self
-    where
-        A: Into<Arc<PartitionLocalStore<C>>>,
-        B: Into<Arc<SpuLocalStore<C>>>,
-    {
+    pub fn new(
+        partition_store: impl Into<Arc<PartitionLocalStore<C>>>,
+        spu_store: impl Into<Arc<SpuLocalStore<C>>>,
+    ) -> Self {
         Self {
             partition_store: partition_store.into(),
             spu_store: spu_store.into(),

--- a/crates/fluvio-sc/src/stores/partition/store.rs
+++ b/crates/fluvio-sc/src/stores/partition/store.rs
@@ -31,7 +31,7 @@ pub type DefaultPartitionStore = PartitionLocalStore<u32>;
 pub trait PartitionMd<C: MetadataItem> {
     fn with_replicas(key: ReplicaKey, replicas: Vec<SpuId>) -> Self;
 
-    fn quick<S: Into<String>>(partition: ((S, PartitionId), Vec<SpuId>)) -> Self;
+    fn quick(partition: ((impl Into<String>, PartitionId), Vec<SpuId>)) -> Self;
 }
 
 impl<C: MetadataItem> PartitionMd<C> for PartitionMetadata<C> {
@@ -42,7 +42,7 @@ impl<C: MetadataItem> PartitionMd<C> for PartitionMetadata<C> {
         Self::new(key, spec, PartitionStatus::default())
     }
 
-    fn quick<S: Into<String>>(partition: ((S, PartitionId), Vec<SpuId>)) -> Self {
+    fn quick(partition: ((impl Into<String>, PartitionId), Vec<SpuId>)) -> Self {
         let (replica_key, replicas) = partition;
         Self::with_replicas(replica_key.into(), replicas)
     }
@@ -72,7 +72,7 @@ where
 
     async fn leaders(&self) -> Vec<ReplicaLeader>;
 
-    fn bulk_load<S: Into<String>>(partitions: Vec<((S, PartitionId), Vec<SpuId>)>) -> Self;
+    fn bulk_load(partitions: Vec<((impl Into<String>, PartitionId), Vec<SpuId>)>) -> Self;
 }
 
 #[async_trait]
@@ -186,7 +186,7 @@ where
             .collect()
     }
 
-    fn bulk_load<S: Into<String>>(partitions: Vec<((S, PartitionId), Vec<SpuId>)>) -> Self {
+    fn bulk_load(partitions: Vec<((impl Into<String>, PartitionId), Vec<SpuId>)>) -> Self {
         let elements = partitions
             .into_iter()
             .map(|(replica_key, replicas)| PartitionMetadata::quick((replica_key, replicas)))

--- a/crates/fluvio-sc/src/stores/spu/store.rs
+++ b/crates/fluvio-sc/src/stores/spu/store.rs
@@ -25,16 +25,11 @@ pub type SpuMetadata<C> = MetadataStoreObject<SpuSpec, C>;
 pub type DefaultSpuMd = SpuMetadata<u32>;
 
 pub trait SpuMd<C: MetadataItem> {
-    fn quick<J>(spu: (J, SpuId, bool, Option<String>)) -> SpuMetadata<C>
-    where
-        J: Into<String>;
+    fn quick(spu: (impl Into<String>, SpuId, bool, Option<String>)) -> SpuMetadata<C>;
 }
 
 impl<C: MetadataItem> SpuMd<C> for SpuMetadata<C> {
-    fn quick<J>(spu: (J, SpuId, bool, Option<String>)) -> SpuMetadata<C>
-    where
-        J: Into<String>,
-    {
+    fn quick(spu: (impl Into<String>, SpuId, bool, Option<String>)) -> SpuMetadata<C> {
         let spec = SpuSpec {
             id: spu.1,
             rack: spu.3,

--- a/crates/fluvio-smartengine/src/transformation.rs
+++ b/crates/fluvio-smartengine/src/transformation.rs
@@ -18,7 +18,7 @@ pub struct TransformationConfig {
 }
 
 impl TransformationConfig {
-    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self, anyhow::Error> {
+    pub fn from_file(path: impl Into<PathBuf>) -> Result<Self, anyhow::Error> {
         let mut file = File::open(path.into())?;
         let mut content = Vec::new();
         file.read_to_end(&mut content)?;

--- a/crates/fluvio-socket/src/versioned.rs
+++ b/crates/fluvio-socket/src/versioned.rs
@@ -111,8 +111,8 @@ impl From<String> for ClientConfig {
 }
 
 impl ClientConfig {
-    pub fn new<S: Into<String>>(
-        addr: S,
+    pub fn new(
+        addr: impl Into<String>,
         connector: DomainConnector,
         use_spu_local_address: bool,
     ) -> Self {

--- a/crates/fluvio-stream-model/src/epoch/epoch_map.rs
+++ b/crates/fluvio-stream-model/src/epoch/epoch_map.rs
@@ -67,9 +67,7 @@ impl<T> EpochCounter<T> {
         Self { epoch: 0, inner }
     }
 
-    pub fn new_with_epoch<E>(inner: T, epoch: E) -> Self
-    where
-        E: Into<i64>,
+    pub fn new_with_epoch(inner: T, epoch: impl Into<i64>) -> Self
     {
         Self {
             epoch: epoch.into(),

--- a/crates/fluvio-stream-model/src/epoch/epoch_map.rs
+++ b/crates/fluvio-stream-model/src/epoch/epoch_map.rs
@@ -67,8 +67,7 @@ impl<T> EpochCounter<T> {
         Self { epoch: 0, inner }
     }
 
-    pub fn new_with_epoch(inner: T, epoch: impl Into<i64>) -> Self
-    {
+    pub fn new_with_epoch(inner: T, epoch: impl Into<i64>) -> Self {
         Self {
             epoch: epoch.into(),
             inner,

--- a/crates/fluvio-stream-model/src/store/actions.rs
+++ b/crates/fluvio-stream-model/src/store/actions.rs
@@ -52,8 +52,7 @@ where
     S::Status: PartialEq,
     C: MetadataItem,
 {
-    pub fn add(value: impl Into<MetadataStoreObject<S, C>>) -> Self
-    {
+    pub fn add(value: impl Into<MetadataStoreObject<S, C>>) -> Self {
         LSChange::Add(value.into())
     }
 

--- a/crates/fluvio-stream-model/src/store/actions.rs
+++ b/crates/fluvio-stream-model/src/store/actions.rs
@@ -52,9 +52,7 @@ where
     S::Status: PartialEq,
     C: MetadataItem,
 {
-    pub fn add<K>(value: K) -> Self
-    where
-        K: Into<MetadataStoreObject<S, C>>,
+    pub fn add(value: impl Into<MetadataStoreObject<S, C>>) -> Self
     {
         LSChange::Add(value.into())
     }

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -55,8 +55,7 @@ where
     C: MetadataItem,
 {
     /// initialize local stores with list of metadata objects
-    pub fn bulk_new(objects: Vec<impl Into<MetadataStoreObject<S, C>>>) -> Self
-    {
+    pub fn bulk_new(objects: Vec<impl Into<MetadataStoreObject<S, C>>>) -> Self {
         let obj: Vec<MetadataStoreObject<S, C>> = objects.into_iter().map(|s| s.into()).collect();
         let mut map = HashMap::new();
         for obj in obj {

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -55,9 +55,7 @@ where
     C: MetadataItem,
 {
     /// initialize local stores with list of metadata objects
-    pub fn bulk_new<N>(objects: Vec<N>) -> Self
-    where
-        N: Into<MetadataStoreObject<S, C>>,
+    pub fn bulk_new(objects: Vec<impl Into<MetadataStoreObject<S, C>>>) -> Self
     {
         let obj: Vec<MetadataStoreObject<S, C>> = objects.into_iter().map(|s| s.into()).collect();
         let mut map = HashMap::new();

--- a/crates/fluvio-stream-model/src/store/metadata.rs
+++ b/crates/fluvio-stream-model/src/store/metadata.rs
@@ -28,10 +28,7 @@ where
     C: MetadataItem,
     S::Status: Default,
 {
-    pub fn new<J>(key: J, spec: S, status: S::Status) -> Self
-    where
-        J: Into<S::IndexKey>,
-    {
+    pub fn new(key: impl Into<S::IndexKey>, spec: S, status: S::Status) -> Self {
         Self {
             key: key.into(),
             spec,
@@ -40,10 +37,7 @@ where
         }
     }
 
-    pub fn new_with_context<J>(key: J, spec: S, ctx: MetadataContext<C>) -> Self
-    where
-        J: Into<S::IndexKey>,
-    {
+    pub fn new_with_context(key: impl Into<S::IndexKey>, spec: S, ctx: MetadataContext<C>) -> Self {
         Self {
             key: key.into(),
             spec,
@@ -52,18 +46,14 @@ where
         }
     }
 
-    pub fn with_spec<J>(key: J, spec: S) -> Self
+    pub fn with_spec(key: impl Into<S::IndexKey>, spec: S) -> Self
     where
-        J: Into<S::IndexKey>,
         C: Default,
     {
         Self::new(key.into(), spec, S::Status::default())
     }
 
-    pub fn with_key<J>(key: J) -> Self
-    where
-        J: Into<S::IndexKey>,
-    {
+    pub fn with_key(key: impl Into<S::IndexKey>) -> Self {
         Self::with_spec(key.into(), S::default())
     }
 

--- a/crates/fluvio-test/src/tests/smoke/mod.rs
+++ b/crates/fluvio-test/src/tests/smoke/mod.rs
@@ -110,7 +110,7 @@ pub fn smoke(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
                     sleep(Duration::from_secs(5)).await;
 
                     admin
-                        .delete::<TableFormatSpec, _>(name.clone())
+                        .delete::<TableFormatSpec>(name.clone())
                         .await
                         .expect("TableFormat delete failed");
                     println!(

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -187,10 +187,9 @@ impl FluvioAdmin {
     /// Delete object by key
     /// key is depend on spec, most are string but some allow multiple types
     #[instrument(skip(self, key))]
-    pub async fn delete<S, K>(&self, key: K) -> Result<()>
+    pub async fn delete<S>(&self, key: impl Into<S::DeleteKey>) -> Result<()>
     where
-        S: DeletableAdminSpec + Sync + Send,
-        K: Into<S::DeleteKey>,
+        S: DeletableAdminSpec + Sync + Send
     {
         let delete_request: DeleteRequest<S> = DeleteRequest::new(key.into());
         debug!("sending delete request: {:#?}", delete_request);

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -189,7 +189,7 @@ impl FluvioAdmin {
     #[instrument(skip(self, key))]
     pub async fn delete<S>(&self, key: impl Into<S::DeleteKey>) -> Result<()>
     where
-        S: DeletableAdminSpec + Sync + Send
+        S: DeletableAdminSpec + Sync + Send,
     {
         let delete_request: DeleteRequest<S> = DeleteRequest::new(key.into());
         debug!("sending delete request: {:#?}", delete_request);

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -44,7 +44,7 @@ impl FluvioConfig {
     }
 
     /// Create a new cluster configuration with no TLS.
-    pub fn new<S: Into<String>>(addr: S) -> Self {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             endpoint: addr.into(),
             use_spu_local_address: false,
@@ -54,7 +54,7 @@ impl FluvioConfig {
     }
 
     /// Add TLS configuration for this cluster.
-    pub fn with_tls<T: Into<TlsPolicy>>(mut self, tls: T) -> Self {
+    pub fn with_tls(mut self, tls: impl Into<TlsPolicy>) -> Self {
         self.tls = tls.into();
         self
     }

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -148,7 +148,7 @@ impl Fluvio {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn topic_producer<S: Into<String>>(&self, topic: S) -> Result<TopicProducer> {
+    pub async fn topic_producer(&self, topic: impl Into<String>) -> Result<TopicProducer> {
         self.topic_producer_with_config(topic, Default::default())
             .await
     }
@@ -170,9 +170,9 @@ impl Fluvio {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn topic_producer_with_config<S: Into<String>>(
+    pub async fn topic_producer_with_config(
         &self,
-        topic: S,
+        topic: impl Into<String>,
         config: TopicProducerConfig,
     ) -> Result<TopicProducer> {
         let topic = topic.into();
@@ -192,9 +192,9 @@ impl Fluvio {
     /// all of the events in all of the partitions, use `consumer` instead.
     ///
     ///
-    pub async fn partition_consumer<S: Into<String>>(
+    pub async fn partition_consumer(
         &self,
-        topic: S,
+        topic: impl Into<String>,
         partition: PartitionId,
     ) -> Result<PartitionConsumer> {
         let topic = topic.into();

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -108,7 +108,7 @@ const MINIMUM_PLATFORM_VERSION: &str = "0.9.0";
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
 #[instrument(skip(topic))]
-pub async fn producer<S: Into<String>>(topic: S) -> anyhow::Result<TopicProducer> {
+pub async fn producer(topic: impl Into<String>) -> anyhow::Result<TopicProducer> {
     let fluvio = Fluvio::connect().await?;
     let producer = fluvio.topic_producer(topic).await?;
     Ok(producer)
@@ -142,8 +142,8 @@ pub async fn producer<S: Into<String>>(topic: S) -> anyhow::Result<TopicProducer
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
 #[instrument(skip(topic, partition))]
-pub async fn consumer<S: Into<String>>(
-    topic: S,
+pub async fn consumer(
+    topic: impl Into<String>,
     partition: PartitionId,
 ) -> anyhow::Result<PartitionConsumer> {
     let fluvio = Fluvio::connect().await?;

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -426,8 +426,11 @@ impl TopicProducer {
         skip(self, key, value),
         fields(topic = %self.inner.topic),
     )]
-    pub async fn send(&self, key: impl Into<RecordKey>, value: impl Into<RecordData>) -> Result<ProduceOutput>
-    {
+    pub async fn send(
+        &self,
+        key: impl Into<RecordKey>,
+        value: impl Into<RecordData>,
+    ) -> Result<ProduceOutput> {
         let record_key = key.into();
         let record_value = value.into();
         let record = Record::from((record_key, record_value));
@@ -473,12 +476,10 @@ impl TopicProducer {
         skip(self, records),
         fields(topic = %self.inner.topic),
     )]
-    pub async fn send_all<K, V, I>(&self, records: I) -> Result<Vec<ProduceOutput>>
-    where
-        K: Into<RecordKey>,
-        V: Into<RecordData>,
-        I: IntoIterator<Item = (K, V)>,
-    {
+    pub async fn send_all(
+        &self,
+        records: impl IntoIterator<Item = (impl Into<RecordKey>, impl Into<RecordData>)>,
+    ) -> Result<Vec<ProduceOutput>> {
         let mut results = vec![];
         for (key, value) in records {
             let produce_output = self.send(key, value).await?;

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -237,9 +237,9 @@ cfg_if::cfg_if! {
             }
 
             /// Adds a SmartModule filter to this TopicProducer
-            pub async fn with_filter<T: Into<Vec<u8>>>(
+            pub async fn with_filter(
                 self,
-                filter: T,
+                filter: impl  Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
             ) -> Result<Self> {
                 let config = SmartModuleConfig::builder().params(params.into()).build()?;
@@ -247,9 +247,9 @@ cfg_if::cfg_if! {
             }
 
             /// Adds a SmartModule FilterMap to this TopicProducer
-            pub async fn with_filter_map<T: Into<Vec<u8>>>(
+            pub async fn with_filter_map(
                 self,
-                map: T,
+                map: impl Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
             ) -> Result<Self> {
                 let config = SmartModuleConfig::builder().params(params.into()).build()?;
@@ -257,9 +257,9 @@ cfg_if::cfg_if! {
             }
 
             /// Adds a SmartModule map to this TopicProducer
-            pub async fn with_map<T: Into<Vec<u8>>>(
+            pub async fn with_map(
                 self,
-                map: T,
+                map: impl Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
             ) -> Result<Self> {
                 let config = SmartModuleConfig::builder().params(params.into()).build()?;
@@ -267,9 +267,9 @@ cfg_if::cfg_if! {
             }
 
             /// Adds a SmartModule array_map to this TopicProducer
-            pub async fn with_array_map<T: Into<Vec<u8>>>(
+            pub async fn with_array_map(
                 self,
-                map: T,
+                map: impl Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
             ) -> Result<Self> {
                 let config = SmartModuleConfig::builder().params(params.into()).build()?;
@@ -277,9 +277,9 @@ cfg_if::cfg_if! {
             }
 
             /// Adds a SmartModule aggregate to this TopicProducer
-            pub async fn with_aggregate<T: Into<Vec<u8>>>(
+            pub async fn with_aggregate(
                 self,
-                map: T,
+                map: impl Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
                 accumulator: Vec<u8>,
             ) -> Result<Self> {
@@ -290,9 +290,9 @@ cfg_if::cfg_if! {
             }
 
             /// Use generic smartmodule (the type is detected in smartengine)
-            pub async fn with_smartmodule<T: Into<Vec<u8>>>(
+            pub async fn with_smartmodule(
                 self,
-                smartmodule: T,
+                smartmodule: impl Into<Vec<u8>>,
                 params: BTreeMap<String, String>,
                 context: SmartModuleContextData,
             ) -> Result<Self> {
@@ -426,10 +426,7 @@ impl TopicProducer {
         skip(self, key, value),
         fields(topic = %self.inner.topic),
     )]
-    pub async fn send<K, V>(&self, key: K, value: V) -> Result<ProduceOutput>
-    where
-        K: Into<RecordKey>,
-        V: Into<RecordData>,
+    pub async fn send(&self, key: impl Into<RecordKey>, value: impl Into<RecordData>) -> Result<ProduceOutput>
     {
         let record_key = key.into();
         let record_value = value.into();

--- a/crates/fluvio/src/spu.rs
+++ b/crates/fluvio/src/spu.rs
@@ -171,7 +171,7 @@ impl SpuPool {
         Ok(serial_socket)
     }
 
-    pub async fn topic_exists<S: Into<String>>(&self, topic: S) -> Result<bool, FluvioError> {
+    pub async fn topic_exists(&self, topic: impl Into<String>) -> Result<bool, FluvioError> {
         let replica = ReplicaKey::new(topic, 0u32);
         Ok(self
             .metadata


### PR DESCRIPTION
convert many generic based argument conversion like `<S: Into<String>>` into `impl Into<String>`.    This remove unnecessary generic signature and hopefully reduce build time and make code cleaner