### PR TITLE
[Merged by Bors] - chore: revert fluvio version changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.22.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ k8-types = { version = "0.8.3" }
 trybuild = { branch = "check_option", git = "https://github.com/infinyon/trybuild" }
 
 # Internal fluvio dependencies
-fluvio = { version = "0.22.0", path = "crates/fluvio" }
+fluvio = { version = "0.21.0", path = "crates/fluvio" }
 fluvio-auth = { path = "crates/fluvio-auth" }
 fluvio-channel = { path = "crates/fluvio-channel" }
 fluvio-cli-common = { path = "crates/fluvio-cli-common"}

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.22.0"
+version = "0.21.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]


### PR DESCRIPTION
Revert unnecessary bump up of fluvio  https://github.com/infinyon/fluvio/pull/3529.   There was no of release 0.21