### PR TITLE
[Merged by Bors] - chore: add `--truncate` arg to `fluvio consume` and pretty print json output

### DIFF
--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -777,6 +777,7 @@ mod cmd {
                 beginning: Default::default(),
                 transforms_file: Default::default(),
                 transform: Default::default(),
+                truncate: Default::default(),
             }
         }
         #[test]

--- a/crates/fluvio-cli/src/client/consume/record_format.rs
+++ b/crates/fluvio-cli/src/client/consume/record_format.rs
@@ -27,7 +27,7 @@ pub fn format_json(value: &[u8], suppress: bool) -> Option<String> {
         _ => None,
     };
 
-    maybe_json.and_then(|json| serde_json::to_string(&json).ok())
+    maybe_json.and_then(|json| serde_json::to_string_pretty(&json).ok())
 }
 
 // -----------------------------------

--- a/crates/fluvio-cli/src/render.rs
+++ b/crates/fluvio-cli/src/render.rs
@@ -12,7 +12,7 @@ impl ProgressRenderer {
     pub fn println(&self, msg: &str) {
         match self {
             ProgressRenderer::Std => println!("{msg}"),
-            ProgressRenderer::Indicatiff(pb) => pb.println(msg),
+            ProgressRenderer::Indicatiff(pb) => pb.suspend(|| println!("{msg}")),
         }
     }
 }


### PR DESCRIPTION
Closes #3534
Fixes #3536 

- Pretty print json outputs when `-O json` is passed
- Defaults to display the entire message, even when it's longer than the terminal width
- Adds `--truncate` to opt-in back to old behavior