### PR TITLE
[Merged by Bors] - fix: crate pub for fluvio-spu-schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "bytes 1.5.0",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.7.0", path = "crates/fluvio-smartengine", default-features = false }
 fluvio-smartmodule = { version = "0.7.0", path = "crates/fluvio-smartmodule", default-features = false }
 fluvio-socket = { version = "0.14.3", path = "crates/fluvio-socket", default-features = false }
-fluvio-spu-schema = { version = "0.14.0", path = "crates/fluvio-spu-schema", default-features  = false }
+fluvio-spu-schema = { version = "0.14.5", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.11.0", path = "crates/fluvio-stream-dispatcher" }
 fluvio-stream-model = { version = "0.9.3", path = "crates/fluvio-stream-model", default-features = false }

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"


### PR DESCRIPTION
bump version because previous version was released w/ older fluvio-future incompatible version