### PR TITLE
chore: use `surf` and `http-client` as workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ hdrhistogram = "7.0"
 hex = "0.4"
 home = "0.5"
 http = { default-features = false, version = "0.2" }
+http-client = { version = "6.5.3", default-features = false, features = ["h1_client", "rustls"] }
 humantime = "2.0"
 humantime-serde = { version = "1.1.1", default-features = false }
 include_dir = "0.7.2"
@@ -120,7 +121,7 @@ serde_yaml = { version = "0.9.0", default-features = false }
 sha2 = { version = "0.10" }
 siphasher = "1.0.0"
 static_assertions = "1.1.0"
-surf = "2.3.2"
+surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "encoding"] }
 syn = "2.0"
 sysinfo = { version = "0.29.0", default-features = false }
 tar = { version = "0.4.38", default-features = false }

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -16,6 +16,7 @@ dirs = { workspace = true }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 flate2 = { workspace = true }
 hex = { workspace = true }
+http-client = { workspace = true }
 pem = "3.0"
 rand = { workspace = true }
 rand_core = "0.6"
@@ -25,6 +26,7 @@ serde = { workspace = true, features=["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 ssh-key = { version="0.6.1", features=[ "ed25519" ] }
+surf = { workspace = true }
 tar = { workspace = true }
 pathdiff = { version = "0.2.1", default-features = false }
 tempfile = { workspace = true }
@@ -37,17 +39,6 @@ wasmparser = { workspace = true }
 fluvio-future = { workspace = true, features = ["task"]}
 fluvio-hub-protocol = { path = "../fluvio-hub-protocol" }
 fluvio-types = { workspace = true }
-
-# feature control
-[dependencies.surf]
-version = "2.3.2"
-features = ["h1-client-rustls", "encoding"]
-default-features = false
-
-[dependencies.http-client]
-version = "6.5.3"
-features = ["h1_client", "rustls"]
-default-features = false
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true,  features = ["env-filter", "fmt"] }


### PR DESCRIPTION
As these are also being used for FVM on #3576.