### PR TITLE
[Merged by Bors] - fix: clippy as of `1.73`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-package-index"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "http",
  "once_cell",

--- a/crates/fluvio-cli/src/version.rs
+++ b/crates/fluvio-cli/src/version.rs
@@ -98,7 +98,7 @@ impl VersionOpt {
                     .map(|name| name.to_string())
             })
             .map(|name| format!(" ({name})"))
-            .unwrap_or_else(|| "".to_string());
+            .unwrap_or_default();
         format!("{platform_version}{profile_name}")
     }
 

--- a/crates/fluvio-package-index/Cargo.toml
+++ b/crates/fluvio-package-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-package-index"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-package-index/src/package_id.rs
+++ b/crates/fluvio-package-index/src/package_id.rs
@@ -406,7 +406,7 @@ impl fmt::Display for PackageId<MaybeVersion> {
             .version
             .as_ref()
             .map(|it| format!(":{it}"))
-            .unwrap_or_else(|| "".to_string());
+            .unwrap_or_default();
         write!(
             f,
             "{registry}{group}/{name}{version}",


### PR DESCRIPTION
Clippy improvements following the [Rust `1.73.0`](https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html) changes.
