### PR TITLE
[Merged by Bors] - feat: make consumer config public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer.rs
+++ b/crates/fluvio/src/consumer.rs
@@ -564,9 +564,9 @@ pub struct ConsumerConfig {
     #[builder(default)]
     disable_continuous: bool,
     #[builder(default = "*MAX_FETCH_BYTES")]
-    pub(crate) max_bytes: i32,
+    pub max_bytes: i32,
     #[builder(default)]
-    pub(crate) isolation: Isolation,
+    pub isolation: Isolation,
     #[builder(default)]
     pub(crate) smartmodule: Vec<SmartModuleInvocation>,
 }


### PR DESCRIPTION
Change Fluvio's ConsumerConfig to be public.  This allows the inspection of config by application.  `smartmodule` field will be kept private until more stable API is ready