### PR TITLE
[Merged by Bors] - fix(fvm): partially assert on cli output

### DIFF
--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -473,13 +473,8 @@ setup_file() {
 
     # Expect output if `-q` is not passed
     run bash -c 'fvm install 0.10.14'
-    assert_line --index 0 "info: Downloading (1/5): fluvio@0.10.14"
-    assert_line --index 1 "info: Downloading (2/5): fluvio-run@0.10.14"
-    assert_line --index 2 "info: Downloading (3/5): fluvio-cloud@0.2.15"
-    assert_line --index 3 "info: Downloading (4/5): cdk@0.10.14"
-    assert_line --index 4 "info: Downloading (5/5): smdk@0.10.14"
-    assert_line --index 5 "done: Installed fluvio version 0.10.14"
-    assert_line --index 6 "done: Now using fluvio version 0.10.14"
+    assert_line --index 0 --partial "info: Downloading (1/5)"
+    assert_output --partial "done: Now using fluvio version 0.10.14"
     assert_success
 
     # Removes FVM


### PR DESCRIPTION
Currently our tests expects download output in a specific order when executing
`fvm install`. This breaks if changes on responses are introduced, to avoid this
we could partially assert on the text output.

This only happens on the `fvm install` command as it depends on server response
to render its output.

## Example of Broken Test

```
2023-10-18T15:25:09.8470954Z not ok 9 Supress output with '-q' optional argument
2023-10-18T15:25:09.8483122Z # (from function `assert_line' in file tests/cli/fvm_smoke_tests/../test_helper/bats-assert/src/assert_line.bash, line 202,
2023-10-18T15:25:09.8487786Z #  in test file tests/cli/fvm_smoke_tests/fvm_basic.bats, line 479)
2023-10-18T15:25:09.8546282Z #   `assert_line --index 3 "info: Downloading (4/5): cdk@0.10.14"' failed
2023-10-18T15:25:09.8554999Z #
2023-10-18T15:25:09.8555778Z # -- line differs --
2023-10-18T15:25:09.8556427Z # index    : 3
2023-10-18T15:25:09.8557991Z # expected : info: Downloading (4/5): cdk@0.10.14
2023-10-18T15:25:09.8558937Z # actual   : info: Downloading (4/5): smdk@0.10.14
2023-10-18T15:25:09.8607628Z # -
```