### PR TITLE
Enhance `topic list` output

### DIFF
--- a/crates/fluvio-cli/src/client/topic/list.rs
+++ b/crates/fluvio-cli/src/client/topic/list.rs
@@ -32,41 +32,52 @@ impl ListTopicsOpt {
         let output_type = self.output.format;
         debug!("list topics {:#?} ", output_type);
         let admin = fluvio.admin().await;
-
         let topics = admin.all::<TopicSpec>().await?;
-        display::format_response_output(out, topics, output_type)?;
+        display::format_response_output(out, topics, output_type, fluvio)?;
         Ok(())
     }
 }
 
 mod display {
+    use std::time::{Duration, UNIX_EPOCH};
 
-    use std::time::Duration;
-
-    use humantime::{format_duration};
     use comfy_table::{Row, Cell, CellAlignment};
+    use humantime::{format_duration, format_rfc3339_millis};
     use serde::Serialize;
 
-    use fluvio::metadata::objects::Metadata;
-    use fluvio::metadata::topic::TopicSpec;
+    use fluvio::{
+        Fluvio,
+        metadata::{objects::Metadata, topic::TopicSpec},
+    };
+    use fluvio_future::task::run_block_on;
 
     use crate::common::output::{OutputType, TableOutputHandler, Terminal, OutputError};
     use crate::common::t_println;
+    use super::utils::latest_record_timestamp;
 
     #[derive(Serialize)]
-    struct ListTopics(Vec<Metadata<TopicSpec>>);
+    struct ListTopics<'a> {
+        inner: Vec<Metadata<TopicSpec>>,
+
+        #[serde(skip_serializing)]
+        fluvio: &'a Fluvio,
+    }
 
     /// Process server based on output type
     pub fn format_response_output<O>(
         out: std::sync::Arc<O>,
         list_topics: Vec<Metadata<TopicSpec>>,
         output_type: OutputType,
+        fluvio: &Fluvio,
     ) -> Result<(), OutputError>
     where
         O: Terminal,
     {
         if !list_topics.is_empty() {
-            let table_list = ListTopics(list_topics);
+            let table_list = ListTopics {
+                inner: list_topics,
+                fluvio,
+            };
             out.render_list(&table_list, output_type)
         } else {
             t_println!(out, "No topics found");
@@ -77,7 +88,7 @@ mod display {
     // -----------------------------------
     // Output Handlers
     // -----------------------------------
-    impl TableOutputHandler for ListTopics {
+    impl TableOutputHandler for ListTopics<'_> {
         /// table header implementation
         fn header(&self) -> Row {
             Row::from([
@@ -89,6 +100,7 @@ mod display {
                 "COMPRESSION",
                 "DEDUPLICATION",
                 "STATUS",
+                "LAST MODIFIED",
                 "REASON",
             ])
         }
@@ -100,10 +112,24 @@ mod display {
 
         /// table content implementation
         fn content(&self) -> Vec<Row> {
-            self.0
+            self.inner
                 .iter()
                 .map(|metadata| -> Row {
                     let topic = &metadata.spec;
+
+                    let topic_name = metadata.name.to_string();
+
+                    let modified_at = run_block_on(async move {
+                        latest_record_timestamp(topic_name, self.fluvio)
+                            .await
+                            .map(|ts| {
+                                let ts_ms = UNIX_EPOCH
+                                    + u64::try_from(ts)
+                                        .map(Duration::from_millis)
+                                        .unwrap_or_default();
+                                format!("{}", format_rfc3339_millis(ts_ms))
+                            })
+                    });
 
                     Row::from([
                         Cell::new(metadata.name.to_string()),
@@ -120,11 +146,45 @@ mod display {
                                 .map(|d| d.filter.transform.uses.as_str())
                                 .unwrap_or("none"),
                         ),
-                        Cell::new(metadata.status.resolution.to_string()),
+                        Cell::new(metadata.status.resolution.resolution_label()),
+                        Cell::new(modified_at.unwrap_or_else(String::new)),
                         Cell::new(metadata.status.reason.to_string()),
                     ])
                 })
                 .collect()
+        }
+    }
+}
+
+mod utils {
+    use fluvio::{
+        consumer::{ConsumerConfigBuilder, PartitionSelectionStrategy},
+        Fluvio, Offset,
+    };
+    use fluvio_types::Timestamp;
+    use futures_util::stream::StreamExt;
+
+    /// A utility function to get the timestamp of the `Offset::from_end(1)` record across all
+    /// partitions for a given `topic_name`.
+    pub async fn latest_record_timestamp(topic_name: String, fluvio: &Fluvio) -> Option<Timestamp> {
+        let consumer = fluvio
+            .consumer(PartitionSelectionStrategy::All(topic_name))
+            .await
+            .ok()?;
+
+        let consumer_config = ConsumerConfigBuilder::default()
+            .disable_continuous(true)
+            .build()
+            .ok()?;
+
+        let stream_future = consumer.stream_with_config(Offset::from_end(1), consumer_config);
+
+        let mut stream = stream_future.await.ok()?;
+
+        if let Some(Ok(record)) = stream.next().await {
+            Some(record.timestamp())
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/infinyon/fluvio/issues/2271

This PR enhances `$ fluvio topic list` by adding an additional column to the output table called `LAST MODIFIED` which surfaces information about the creation time of the most recent record for a given topic across all partitions. Additionally, `STATUS` was fixed to be more human readable: `resolution::provisioned` -> `provisioned`, etc..

**Note**: ~Right now the timestamp is included by default in the output but that will not be the case once this branch is ready to be merged. The mechanism whereby we optionally include `MODIFIED AT` in the output is currently being discussed in the aforementioned issue.~

**Example**:
<img width="1398" alt="Screen Shot 2023-10-19 at 9 19 53 AM" src="https://github.com/infinyon/fluvio/assets/45523555/2a25964c-be34-4d08-a7fe-0191a8d6d0a1">


**Questions for reviewers**:
1. How do you folks prefer to log/handle errors in the CLI? Right now I am converting `Result`s to `Option`s when trying to query the latest record to retrieve the timestamp.
2. Do you folks have a preferred timestamp format? Right now It's using `rfc3339`.
3. ~How we feel about `MODIFIED AT` as the header name?~

**To-do before merge**:
- [ ] Assess correctness with reviewers.
- [ ] Ask team about best logging practices for the CLI.
- [x] Discuss with team preferred header name. It is currently `MODIFIED AT`.
- [ ] Discuss preferred timestamp format. Do we like `rfc3339`?
- [x] Hash out how to handle `--verbose`.
- [ ] Squash and rebase.