### PR TITLE
[Merged by Bors] - feat: add `cdk hub` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "fluvio-cli-common",
  "fluvio-connector-deployer",
  "fluvio-connector-package",
+ "fluvio-extension-common",
  "fluvio-future",
  "fluvio-hub-util",
  "include_dir",

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -35,5 +35,6 @@ fluvio = { workspace = true }
 fluvio-cli-common = { workspace = true, features = ["version-cmd"] }
 fluvio-connector-deployer = { path = "../fluvio-connector-deployer"}
 fluvio-connector-package = { workspace = true,  features = ["toml"]}
+fluvio-extension-common = { workspace = true }
 fluvio-future = { workspace = true, features = ["subscriber"]}
-fluvio-hub-util = { workspace = true  }
+fluvio-hub-util = { workspace = true, features = ["connector-cmds"] }

--- a/crates/cdk/src/cmd.rs
+++ b/crates/cdk/src/cmd.rs
@@ -9,6 +9,7 @@ use crate::deploy::DeployCmd;
 use crate::test::TestCmd;
 use crate::publish::PublishCmd;
 use crate::set_public::SetPublicCmd;
+use crate::hub::HubCmd;
 
 /// Connector Development Kit
 #[derive(Debug, Parser)]
@@ -19,6 +20,8 @@ pub enum CdkCommand {
     Deploy(DeployCmd),
     Publish(PublishCmd),
     Version(BasicVersionCmd),
+    #[command(subcommand)]
+    Hub(HubCmd),
 
     #[command(name = "set-public")]
     SetPublic(SetPublicCmd),
@@ -34,6 +37,7 @@ impl CdkCommand {
             CdkCommand::SetPublic(opt) => opt.process(),
             CdkCommand::Generate(opt) => opt.process(),
             CdkCommand::Version(opt) => opt.process("CDK"),
+            CdkCommand::Hub(opt) => opt.process(),
         }
     }
 }

--- a/crates/cdk/src/hub.rs
+++ b/crates/cdk/src/hub.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use clap::Parser;
+use fluvio_future::task;
+use fluvio_hub_util::cmd::{ConnectorHubListOpts, ConnectorHubDownloadOpts};
+use fluvio_extension_common::PrintTerminal;
+
+/// Work with Connectors hub
+#[derive(Debug, Parser)]
+pub enum HubCmd {
+    #[command(name = "list")]
+    List(ConnectorHubListOpts),
+    #[command(name = "download")]
+    Download(ConnectorHubDownloadOpts),
+}
+
+impl HubCmd {
+    pub fn process(self) -> Result<()> {
+        let terminal = Arc::new(PrintTerminal::new());
+        match self {
+            HubCmd::List(opt) => task::run_block_on(opt.process(terminal)),
+            HubCmd::Download(opt) => task::run_block_on(opt.process(terminal)),
+        }
+    }
+}

--- a/crates/cdk/src/main.rs
+++ b/crates/cdk/src/main.rs
@@ -7,6 +7,7 @@ mod publish;
 mod set_public;
 
 pub(crate) mod utils;
+mod hub;
 
 fn main() -> anyhow::Result<()> {
     use clap::Parser;

--- a/crates/fluvio-cli/src/client/hub/connector/mod.rs
+++ b/crates/fluvio-cli/src/client/hub/connector/mod.rs
@@ -8,6 +8,12 @@ use anyhow::Result;
 
 use fluvio_extension_common::Terminal;
 
+const CONNECTOR_HUB_DOWNLOAD_REDIRECT_MESSAGE: &str = r#"Connectors running on `InfinyOn Cloud` are automatically downloaded during `fluvio cloud connector create ...`.
+Connectors running locally require `cdk` to download and deploy:
+1. Install cdk: `fluvio install cdk`
+2. Download connector: `cdk hub download ...`
+3. Deploy connector: `cdk deploy start ...`"#;
+
 /// List available Connectors in the hub
 #[derive(Debug, Parser)]
 pub enum ConnectorHubSubCmd {
@@ -22,13 +28,55 @@ impl ConnectorHubSubCmd {
         match self {
             ConnectorHubSubCmd::List(opts) => opts.process(out).await,
             ConnectorHubSubCmd::Download(_) => {
-                out.println("Connectors running on `InfinyOn Cloud` are automatically downloaded during `fluvio cloud connector create ...`.");
-                out.println("Connectors running locally require `cdk` to download and deploy:");
-                out.println("1. Install cdk: `fluvio install cdk`");
-                out.println("2. Download connector: `cdk hub download ...`");
-                out.println("3. Deploy connector: `cdk deploy start ...`");
+                out.println(CONNECTOR_HUB_DOWNLOAD_REDIRECT_MESSAGE);
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::{RwLock, Arc};
+
+    use clap::Parser;
+    use fluvio_extension_common::Terminal;
+    use fluvio_future::task::run_block_on;
+
+    use crate::client::hub::connector::CONNECTOR_HUB_DOWNLOAD_REDIRECT_MESSAGE;
+
+    use super::ConnectorHubSubCmd;
+
+    #[derive(Default, Debug)]
+    struct MockTerminal(Arc<RwLock<String>>);
+    impl Terminal for MockTerminal {
+        fn print(&self, msg: &str) {
+            self.0
+                .write()
+                .expect("could not print to MockTerminal")
+                .push_str(msg);
+        }
+
+        fn println(&self, msg: &str) {
+            self.0
+                .write()
+                .expect("could not println to MockTerminal")
+                .push_str(&format!("{msg}\n"));
+        }
+    }
+
+    #[test]
+    fn test_calling_fluvio_hub_download_displays_a_help_message() {
+        let terminal = Arc::new(MockTerminal::default());
+        let cmd =
+            ConnectorHubSubCmd::parse_from(["conn", "download", "infinyon/duckdb-sink@0.1.0"]);
+
+        assert!(matches!(cmd, ConnectorHubSubCmd::Download(_)));
+
+        run_block_on(cmd.process(terminal.clone())).expect("command failed to process");
+
+        let x = terminal.0.read().unwrap();
+        let x = x.as_str().trim_end();
+        assert_eq!(x, CONNECTOR_HUB_DOWNLOAD_REDIRECT_MESSAGE);
     }
 }

--- a/crates/fluvio-cli/src/client/hub/connector/mod.rs
+++ b/crates/fluvio-cli/src/client/hub/connector/mod.rs
@@ -21,7 +21,14 @@ impl ConnectorHubSubCmd {
     pub async fn process<O: Terminal + Debug + Send + Sync>(self, out: Arc<O>) -> Result<()> {
         match self {
             ConnectorHubSubCmd::List(opts) => opts.process(out).await,
-            ConnectorHubSubCmd::Download(opts) => opts.process(out).await,
+            ConnectorHubSubCmd::Download(_) => {
+                out.println("Connectors running on `InfinyOn Cloud` are automatically downloaded during `fluvio cloud connector create ...`.");
+                out.println("Connectors running locally require `cdk` to download and deploy:");
+                out.println("1. Install cdk: `fluvio install cdk`");
+                out.println("2. Download connector: `cdk hub download ...`");
+                out.println("3. Deploy connector: `cdk deploy start ...`");
+                Ok(())
+            }
         }
     }
 }

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -160,7 +160,9 @@ setup_file() {
     assert_output --partial "Connector runs with process id"
 }
 
-@test "List connectors from hub" {
-    run timeout 15s $CDK_BIN hub list
-    assert_success
-}
+# fix CI authentication to hub service first:
+# https://github.com/infinyon/fluvio/issues/3634
+# @test "List connectors from hub" {
+#     run timeout 15s $CDK_BIN hub list
+#     assert_success
+# }

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -117,6 +117,9 @@ setup_file() {
     # Ensure the correct path is added
     cat ./.hub/package-meta.yaml | grep '../../testing/README.md'
     assert_success
+
+    # clean up
+    rm -r ../testing
 }
 
 @test "Run connector with --ipkg" {
@@ -157,3 +160,7 @@ setup_file() {
     assert_output --partial "Connector runs with process id"
 }
 
+@test "List connectors from hub" {
+    run timeout 15s $CDK_BIN hub list
+    assert_success
+}


### PR DESCRIPTION
This is the second PR of a two-part feature related to #3578. The first part can be found in #3611.

Reuse the code from #3611 at `cdk hub`.



CI is expected to fail, see the comment below.

Closes #3578