### PR TITLE
[Merged by Bors] - docs: improve hub credential error message

### DIFF
--- a/crates/fluvio-cli/src/client/hub/connector/download.rs
+++ b/crates/fluvio-cli/src/client/hub/connector/download.rs
@@ -63,7 +63,9 @@ impl ConnectorHubDownloadOpts {
         let data = fluvio_hub_util::get_package(&url, &access)
             .await
             .map_err(|err| {
-                CliError::HubError(format!("downloading {package_name} failed\nServer: {err}"))
+                CliError::HubError(format!(
+                    "downloading {package_name} failed\nHub error: {err}"
+                ))
             })?;
 
         std::fs::write(file_path, data).map_err(|err| {

--- a/crates/fluvio-hub-protocol/src/infinyon_tok.rs
+++ b/crates/fluvio-hub-protocol/src/infinyon_tok.rs
@@ -20,7 +20,7 @@ type InfinyonRemote = String;
 
 #[derive(thiserror::Error, Debug)]
 pub enum InfinyonCredentialError {
-    #[error("Read error {0}")]
+    #[error("{0}")]
     Read(String),
 
     #[error("unable to parse credentials")]
@@ -69,9 +69,10 @@ impl Credentials {
     /// Try to load credentials from disk
     fn try_load<P: AsRef<Path>>(base_path: P) -> Result<Self, InfinyonCredentialError> {
         let current_login_path = base_path.as_ref().join(CURRENT_LOGIN_FILE_NAME);
-        let cfg_path = fs::read_to_string(&current_login_path).map_err(|_| {
-            let strpath = current_login_path.to_string_lossy().to_string();
-            InfinyonCredentialError::Read(strpath)
+        let cfg_path = fs::read_to_string(current_login_path).map_err(|_| {
+            InfinyonCredentialError::Read(
+                "no access credentials, try 'fluvio cloud login'".to_owned(),
+            )
         })?;
         let cred_path = base_path.as_ref().join(cfg_path);
         Self::load(&cred_path)
@@ -79,8 +80,9 @@ impl Credentials {
 
     fn load(cred_path: &Path) -> Result<Self, InfinyonCredentialError> {
         let file_str = fs::read_to_string(cred_path).map_err(|_| {
-            let strpath = cred_path.to_string_lossy().to_string();
-            InfinyonCredentialError::Read(strpath)
+            InfinyonCredentialError::Read(
+                "no access credentials, try 'fluvio cloud login'".to_owned(),
+            )
         })?;
         let creds: Credentials = toml::from_str(&file_str)
             .map_err(|_| InfinyonCredentialError::UnableToParseCredentials)?;


### PR DESCRIPTION
Related to https://github.com/infinyon/roadmap/issues/194

Changes the error message like the diff:

```diff
$ fluvio hub sm download infinyon/jolt@0.3.0
downloading infinyon/jolt@0.3.0 to infinyon-jolt-0.3.0.ipkg
Hub error: downloading infinyon/jolt@0.3.0
-Server: Read error /home/user/.fluvio/logins/current
+Hub error: no access credentials, try 'fluvio cloud login'
```