### PR TITLE
[Merged by Bors] - fix: replace `fvm` binary on `fvm self install`

### DIFF
--- a/crates/fluvio-version-manager/src/common/workdir.rs
+++ b/crates/fluvio-version-manager/src/common/workdir.rs
@@ -38,7 +38,7 @@ pub fn fvm_workdir_path() -> Result<PathBuf> {
     }
 }
 
-/// Retrieves the path to the `~/.fvm/bin/fvm` directory in the host system
+/// Retrieves the path to the `~/.fvm/bin/fvm` binary in the host system
 pub fn fvm_bin_path() -> Result<PathBuf> {
     Ok(fvm_workdir_path()?.join("bin").join(FVM_BINARY_NAME))
 }


### PR DESCRIPTION
Ensures the FVM binary is replaced when running `fvm self install`

The approach involves making sure FVM where `self install` is executed is not
the same as `fvm` which is already installed. Otherwise `bus` errors will occur by
trying to replace the ongoing process binary.