### PR TITLE
[Merged by Bors] - feat: use local metadata for local clusters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,7 @@ jobs:
         run: cargo test -p ${{ matrix.crate }}
 
   local_cluster_test:
-    name: Local cluster test run (${{ matrix.run }})-${{ matrix.test }}
+    name: Local cluster (mode ${{ matrix.run-mode }}) test run (${{ matrix.run }})-${{ matrix.test }}
     runs-on: ${{ matrix.os }}
     needs:
       - build_primary_binaries
@@ -640,6 +640,7 @@ jobs:
             batch-failure,
             batch,
           ]
+        run-mode: [local, local-k8]
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact - fluvio
@@ -665,18 +666,23 @@ jobs:
           echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
       - name: Print version
         run: fluvio version
+      - name: Set up cluster
+        if: matrix.run-mode == 'local-k8'
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
+          ./k8-util/cluster/reset-k3d.sh
       - name: Start fluvio cluster
-        timeout-minutes: 5
+        timeout-minutes: 10
         if: matrix.test != 'smoke-test-tls'
-        run: fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
+        run: fluvio cluster start --${{ matrix.run-mode }} --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
       - name: Start fluvio cluster TLS
         if: matrix.test == 'smoke-test-tls'
-        timeout-minutes: 5
+        timeout-minutes: 10
         # note that Local config doesn't not support auth and scopes in the argument for now
         run: >
           AUTH_POLICY=${{ env.AUTH_FILE }}
           X509_AUTH_SCOPES=${{ env.X509_SCOPE_FILE }}
-          fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}
+          fluvio cluster start --${{ matrix.run-mode }} --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}
       - name: sleep
         run: sleep 15
       - name: Validate test harness
@@ -743,81 +749,6 @@ jobs:
           name: local-${{ matrix.run }}-${{ matrix.test }}-diag
           path: diagnostics*.gz
           retention-days: 1
-
-  local_k8_cluster_test:
-    name: Local K8s cluster test run (${{ matrix.run }})-${{ matrix.test }}
-    runs-on: ${{ matrix.os }}
-    needs:
-      - build_primary_binaries
-      - config
-    env:
-      UNINSTALL: noclean
-      FLUVIO_BIN: ~/bin/fluvio
-      TEST_BIN: ~/bin/fluvio-test
-      SERVER_LOG: fluvio=info
-    strategy:
- #     fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        rust-target: [x86_64-unknown-linux-musl]
-        run: [r1]
-        spu: [2]
-        test:
-          [
-            smoke-test,
-          ]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download artifact - fluvio
-        uses: actions/download-artifact@v3
-        with:
-          name: fluvio-${{ matrix.rust-target }}
-          path: ~/bin
-      - name: Download artifact - fluvio-run
-        uses: actions/download-artifact@v3
-        with:
-          name: fluvio-run-${{ matrix.rust-target }}
-          path: ~/.fluvio/extensions
-      - name: Download artifact - fluvio-test
-        uses: actions/download-artifact@v3
-        with:
-          name: fluvio-test-${{ matrix.rust-target }}
-          path: ~/bin
-      - name: Set up Fluvio binaries
-        run: |
-          chmod +x ~/bin/fluvio ~/bin/fluvio-test ~/.fluvio/extensions/fluvio-run
-          echo "~/bin" >> $GITHUB_PATH
-          echo "DEFAULT_SPU=${{ matrix.spu }}" | tee -a $GITHUB_ENV
-          echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
-      - name: Print version
-        run: fluvio version
-      - name: Set up cluster
-        run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
-          ./k8-util/cluster/reset-k3d.sh
-      - name: Start fluvio cluster
-        timeout-minutes: 15
-        run: fluvio cluster start --local-k8 --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
-      - name: sleep
-        run: sleep 15
-      - name: Run smoke-test
-        if: matrix.test == 'smoke-test'
-        timeout-minutes: 15
-        run: |
-          make smoke-test-local
-      - name: Run diagnostics
-        if: ${{ !success() }}
-        timeout-minutes: 5
-        run: fluvio cluster diagnostics --local
-      - name: Upload diagnostics
-        uses: actions/upload-artifact@v3
-        timeout-minutes: 5
-        if: ${{ !success() }}
-        with:
-          name: local-${{ matrix.run }}-${{ matrix.test }}-diag
-          path: diagnostics*.gz
-          retention-days: 1
-
 
   build_image:
     name: Build Fluvio Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,17 +665,13 @@ jobs:
           echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
       - name: Print version
         run: fluvio version
-      - name: Set up cluster
-        run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
-          ./k8-util/cluster/reset-k3d.sh
       - name: Start fluvio cluster
-        timeout-minutes: 10
+        timeout-minutes: 5
         if: matrix.test != 'smoke-test-tls'
         run: fluvio cluster start --local --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
       - name: Start fluvio cluster TLS
         if: matrix.test == 'smoke-test-tls'
-        timeout-minutes: 10
+        timeout-minutes: 5
         # note that Local config doesn't not support auth and scopes in the argument for now
         run: >
           AUTH_POLICY=${{ env.AUTH_FILE }}
@@ -747,6 +743,81 @@ jobs:
           name: local-${{ matrix.run }}-${{ matrix.test }}-diag
           path: diagnostics*.gz
           retention-days: 1
+
+  local_k8_cluster_test:
+    name: Local K8s cluster test run (${{ matrix.run }})-${{ matrix.test }}
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build_primary_binaries
+      - config
+    env:
+      UNINSTALL: noclean
+      FLUVIO_BIN: ~/bin/fluvio
+      TEST_BIN: ~/bin/fluvio-test
+      SERVER_LOG: fluvio=info
+    strategy:
+ #     fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust-target: [x86_64-unknown-linux-musl]
+        run: [r1]
+        spu: [2]
+        test:
+          [
+            smoke-test,
+          ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v3
+        with:
+          name: fluvio-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Download artifact - fluvio-run
+        uses: actions/download-artifact@v3
+        with:
+          name: fluvio-run-${{ matrix.rust-target }}
+          path: ~/.fluvio/extensions
+      - name: Download artifact - fluvio-test
+        uses: actions/download-artifact@v3
+        with:
+          name: fluvio-test-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Set up Fluvio binaries
+        run: |
+          chmod +x ~/bin/fluvio ~/bin/fluvio-test ~/.fluvio/extensions/fluvio-run
+          echo "~/bin" >> $GITHUB_PATH
+          echo "DEFAULT_SPU=${{ matrix.spu }}" | tee -a $GITHUB_ENV
+          echo "REPL=${{ matrix.spu }}" | tee -a $GITHUB_ENV
+      - name: Print version
+        run: fluvio version
+      - name: Set up cluster
+        run: |
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
+          ./k8-util/cluster/reset-k3d.sh
+      - name: Start fluvio cluster
+        timeout-minutes: 15
+        run: fluvio cluster start --local-k8 --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}
+      - name: sleep
+        run: sleep 15
+      - name: Run smoke-test
+        if: matrix.test == 'smoke-test'
+        timeout-minutes: 15
+        run: |
+          make smoke-test-local
+      - name: Run diagnostics
+        if: ${{ !success() }}
+        timeout-minutes: 5
+        run: fluvio cluster diagnostics --local
+      - name: Upload diagnostics
+        uses: actions/upload-artifact@v3
+        timeout-minutes: 5
+        if: ${{ !success() }}
+        with:
+          name: local-${{ matrix.run }}-${{ matrix.test }}-diag
+          path: diagnostics*.gz
+          retention-days: 1
+
 
   build_image:
     name: Build Fluvio Docker image

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -5,6 +5,7 @@ use fluvio::config::TlsPolicy;
 
 use crate::check::ClusterCheckError;
 use crate::cli::ClusterCliError;
+use crate::start::local::LocalMode;
 use crate::{LocalInstaller, LocalConfig, LocalInstallError};
 
 use super::StartOpt;
@@ -40,7 +41,13 @@ pub async fn process_local(
         builder.skip_checks(true);
     }
 
-    builder.read_only(opt.read_only);
+    let mode = match (opt.local, opt.local_k8, opt.read_only) {
+        (_, _, Some(path)) => LocalMode::ReadOnly(path),
+        (_, true, _) => LocalMode::LocalK8,
+        _ => LocalMode::Local,
+    };
+
+    builder.mode(mode);
 
     let config = builder.build()?;
     let installer = LocalInstaller::from_config(config);

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -149,10 +149,6 @@ pub struct StartOpt {
     /// installing/upgrade sys only
     sys_only: bool,
 
-    /// install local spu/sc(custom)
-    #[arg(long)]
-    local: bool,
-
     #[clap(flatten)]
     pub tls: TlsOpt,
 
@@ -174,8 +170,20 @@ pub struct StartOpt {
     #[arg(long)]
     pub service_type: Option<String>,
 
-    /// Start SC in read only mode
+    /// install local spu/sc
+    #[arg(long, conflicts_with_all = &["k8", "local_k8", "read_only"])]
+    local: bool,
+
+    /// install local spu/sc with metadata stored in K8s
     #[arg(long)]
+    local_k8: bool,
+
+    /// install on K8s
+    #[arg(long, default_value = "true", conflicts_with_all = &["local", "local_k8", "read_only"])]
+    k8: bool,
+
+    /// Start SC in read only mode
+    #[arg(long, conflicts_with_all = &["k8", "local", "local_k8"], value_name = "config path")]
     read_only: Option<PathBuf>,
 }
 
@@ -187,7 +195,7 @@ impl StartOpt {
 
         if self.sys_only {
             process_sys(&self, upgrade)?;
-        } else if self.local || self.read_only.is_some() {
+        } else if self.local || self.local_k8 || self.read_only.is_some() {
             process_local(self, platform_version).await?;
         } else {
             process_k8(self, platform_version, upgrade).await?;

--- a/crates/fluvio-stream-dispatcher/src/dispatcher/metadata.rs
+++ b/crates/fluvio-stream-dispatcher/src/dispatcher/metadata.rs
@@ -214,7 +214,7 @@ where
                         .update_spec_by_key(key, &self.namespace, spec)
                         .await
                     {
-                        error!("error: {:#?}, update spec {:#?}", S::LABEL, err);
+                        error!("error: {:#?}, update spec by key {:#?}", S::LABEL, err);
                     }
                 };
             }


### PR DESCRIPTION
Use `LocalMetadataStorage` as a metadata backend for local clusters created by `fluvio cluster start --local`. It allows running fluvio cluster without K8.

To use K8 as a metadata backend for local clusters introduced `fluvio cluster start --local-k8` option.