### PR TITLE
fix: restrict cluster commands based on profile

### DIFF
--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -188,6 +188,7 @@ impl ConfigFile {
     }
 }
 
+pub const CLOUD_PROFILE: &str = "cloud";
 pub const LOCAL_PROFILE: &str = "local";
 const CONFIG_VERSION: &str = "2.0";
 
@@ -250,7 +251,7 @@ impl Config {
 
     /// current profile
     pub fn current_profile_name(&self) -> Option<&str> {
-        self.current_profile.as_ref().map(|c| c.as_ref())
+        self.current_profile.as_deref()
     }
 
     /// set current profile, if profile doesn't exists return false

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -202,6 +202,7 @@ cli-partition-test-multiple-partitions:
 cli-fluvio-smoke:
 	bats $(shell ls -1 ./tests/cli/fluvio_smoke_tests/*.bats | sort -R)
 	bats ./tests/cli/fluvio_smoke_tests/non-concurrent/cluster-delete.bats
+	bats ./tests/cli/fluvio_smoke_tests/non-concurrent/cluster-profile.bats
 
 cli-fluvio-read-only-smoke:
 	bats $(shell ls -1 ./tests/cli/fluvio_read_only/*.bats | sort -R)

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/cluster-profile.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/cluster-profile.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup() {
+    # * PROFILE   CLUSTER   [ADDRESS]             TLS
+    LOCAL_ADDRESS=$($FLUVIO_BIN profile list | grep '*' | awk '{print $4}')
+    # create fake `cloud` profile that points to local cluster address
+    $FLUVIO_BIN profile add "cloud" $LOCAL_ADDRESS
+}
+
+@test "local profile can run cluster command" {
+    run $FLUVIO_BIN profile switch local
+    refute_output "profile local not found"
+    run $FLUVIO_BIN profile
+    assert_output "local"
+
+    run $FLUVIO_BIN cluster status
+    assert_success
+}
+
+@test "cloud profile cannot run cluster command" {
+    run $FLUVIO_BIN profile switch cloud
+    assert_success
+
+    run $FLUVIO_BIN cluster spu list
+    assert_output --partial "Invalid command on \`cloud\` profile."
+}
+
+@test "cloud profile can run \`cluster start\` command" {
+    run $FLUVIO_BIN profile switch cloud
+    assert_success
+
+    run timeout 1s $FLUVIO_BIN cluster start
+    refute_output --partial "Invalid command"
+}


### PR DESCRIPTION
Closes #3619

Check the current profile to restrict which commands are available.

Also, improve the error message when there's no profile:

```diff
$ fluvio cluster check
-Config error: Config has no active profile
+no profile available, create a local cluster or log in to InfinyOn Cloud
```