### PR TITLE
[Merged by Bors] - feat: add support for cluster metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.2"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes 1.5.0",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.2"
+version = "0.21.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -62,6 +62,74 @@ impl FluvioConfig {
         self.tls = tls.into();
         self
     }
+
+    pub fn query_metadata_path<'de, T>(&self, path: &str) -> Option<T>
+    where
+        T: Deserialize<'de>,
+    {
+        let mut metadata = self.metadata.as_ref().unwrap();
+
+        let (path, key) = {
+            let mut split = path.split(&['[', ']']);
+            (split.next().unwrap_or(path), split.next())
+        };
+
+        for part in path.split('.') {
+            if let toml::Value::Table(table) = metadata {
+                metadata = table.get(part)?;
+            }
+        }
+
+        if let Some(key) = key {
+            metadata = metadata.as_table()?.get(key)?;
+        }
+
+        T::deserialize(metadata.clone()).ok()
+    }
+
+    pub fn update_metadata_path<S>(&mut self, path: &str, data: S) -> anyhow::Result<()>
+    where
+        S: Serialize,
+    {
+        use toml::{Value, map::Map};
+
+        let (path, key) = {
+            let mut split = path.split(&['[', ']']);
+            (split.next().unwrap_or(path), split.next())
+        };
+
+        if let Some(mut metadata) = self.metadata.as_mut() {
+            for part in path.split('.') {
+                let Value::Table(table) = metadata else {
+                    break;
+                };
+                let nested = table
+                    .entry(part)
+                    .or_insert_with(|| Value::Table(Map::new()));
+                metadata = nested;
+            }
+
+            if let Some(key) = key {
+                metadata = metadata
+                    .as_table_mut()
+                    .expect("metadata should be a table at this point")
+                    .get_mut(key)
+                    .ok_or_else(|| anyhow::anyhow!("key does not exist"))?;
+            }
+
+            *metadata = Value::try_from(data)?;
+        } else {
+            // insert new metadata
+            if path.contains(|c| c == '.' || c == '[') {
+                return Err(anyhow::anyhow!("not supported"));
+            }
+
+            let table = Map::from_iter([(path.to_string(), Value::try_from(data)?)]).into();
+            self.metadata = Some(table);
+        }
+
+        Ok(())
+    }
 }
 
 impl TryFrom<FluvioConfig> for fluvio_socket::ClientConfig {
@@ -73,5 +141,257 @@ impl TryFrom<FluvioConfig> for fluvio_socket::ClientConfig {
             connector,
             config.use_spu_local_address,
         ))
+    }
+}
+
+#[cfg(test)]
+mod test_metadata {
+    use serde::{Deserialize, Serialize};
+    use crate::config::Config;
+
+    #[test]
+    fn test_get_metadata_path() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.metadata.custom]
+name = "foo"
+"#;
+        let profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster("name").unwrap();
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct Custom {
+            name: String,
+        }
+
+        let custom: Option<Custom> = config.query_metadata_path("custom");
+
+        assert_eq!(
+            custom,
+            Some(Custom {
+                name: "foo".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn test_query_specific_field_of_metadata() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.metadata.deep.nested]
+name = "foo"
+"#;
+        let profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster("name").unwrap();
+
+        let custom: Option<String> = config.query_metadata_path("deep.nested[name]");
+
+        assert_eq!(custom, Some("foo".to_owned()));
+    }
+
+    #[test]
+    fn test_create_metadata() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+        struct Preference {
+            connection: String,
+        }
+
+        let preference = Preference {
+            connection: "wired".to_owned(),
+        };
+
+        config
+            .update_metadata_path("preference", preference.clone())
+            .expect("failed to add metadata");
+
+        let metadata = config.query_metadata_path("preference").expect("");
+
+        assert_eq!(preference, metadata);
+    }
+
+    #[test]
+    fn test_update_old_metadata() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.metadata.installation]
+type = "local"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        struct Installation {
+            #[serde(rename = "type")]
+            typ: String,
+        }
+
+        let mut install = config
+            .query_metadata_path::<Installation>("installation")
+            .expect("message");
+
+        assert_eq!(
+            install,
+            Installation {
+                typ: "local".to_owned()
+            }
+        );
+
+        install.typ = "cloud".to_owned();
+
+        config
+            .update_metadata_path("installation", install)
+            .expect("failed to add metadata");
+
+        let metadata = config
+            .query_metadata_path::<Installation>("installation")
+            .expect("");
+
+        assert_eq!("cloud", metadata.typ);
+    }
+
+    #[test]
+    fn test_update_with_new_metadata() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.metadata.installation]
+type = "local"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+        struct Preference {
+            connection: String,
+        }
+
+        let preference = Preference {
+            connection: "wired".to_owned(),
+        };
+
+        config
+            .update_metadata_path("preference", preference.clone())
+            .expect("failed to add metadata");
+
+        let installation_type: String = config
+            .query_metadata_path("installation.type")
+            .expect("could not get installation metadata");
+        assert_eq!(installation_type, "local");
+
+        let preference_connection: String = config
+            .query_metadata_path("preference.connection")
+            .expect("could not get preference metadata");
+        assert_eq!(preference_connection, "wired");
+    }
+
+    #[test]
+    fn test_update_specific_field() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.metadata.installation]
+type = "local"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        config
+            .update_metadata_path("installation[type]", "cloud")
+            .expect("could not find installation type field");
+
+        let installation_type: String = config
+            .query_metadata_path("installation[type]")
+            .expect("could not find installation type field");
+        assert_eq!(installation_type, "cloud");
+    }
+
+    #[test]
+    fn test_create_dynamic_nested_field_errors() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        let update = config.update_metadata_path("deep.nested[field]", "value");
+
+        assert!(update.is_err());
+    }
+
+    #[test]
+    fn test_update_partial_existant_path_errors() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.deep.nested]
+key = "value"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        let update = config.update_metadata_path("deep.nonexistent[key]", "value");
+
+        assert!(update.is_err());
+    }
+
+    #[test]
+    fn test_update_path_with_no_key_errors() {
+        let toml = r#"version = "2"
+[profile.local]
+cluster = "name"
+
+[cluster.name]
+endpoint = "127.0.0.1:9003"
+
+[cluster.name.deep.nested]
+key = "value"
+"#;
+        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let config = profile.cluster_mut("name").unwrap();
+
+        let update = config.update_metadata_path("deep.nested[nonexistent]", "value");
+
+        assert!(update.is_err());
     }
 }

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -3,8 +3,6 @@
 //!
 //! Stores configuration parameter retrieved from the default or custom profile file.
 //!
-use std::collections::HashMap;
-
 use serde::{Serialize, Deserialize};
 
 use crate::{config::TlsPolicy, FluvioError};
@@ -13,7 +11,7 @@ use super::ConfigFile;
 
 /// Fluvio Cluster Target Configuration
 /// This is part of profile
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct FluvioConfig {
     /// The address to connect to the Fluvio cluster
@@ -31,9 +29,8 @@ pub struct FluvioConfig {
     #[serde(default)]
     pub tls: TlsPolicy,
 
-    /// Custom annotations attached to clusters
-    #[serde(default)]
-    pub annotations: HashMap<String, String>,
+    /// Cluster custom metadata
+    pub metadata: Option<toml::Value>,
 
     /// This is not part of profile and doesn't persist.
     /// It is purely to override client id when creating ClientConfig
@@ -55,7 +52,7 @@ impl FluvioConfig {
             endpoint: addr.into(),
             use_spu_local_address: false,
             tls: TlsPolicy::Disabled,
-            annotations: HashMap::new(),
+            metadata: None,
             client_id: None,
         }
     }

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -3,6 +3,8 @@
 //!
 //! Stores configuration parameter retrieved from the default or custom profile file.
 //!
+use std::collections::HashMap;
+
 use serde::{Serialize, Deserialize};
 
 use crate::{config::TlsPolicy, FluvioError};
@@ -29,6 +31,10 @@ pub struct FluvioConfig {
     #[serde(default)]
     pub tls: TlsPolicy,
 
+    /// Custom annotations attached to clusters
+    #[serde(default)]
+    pub annotations: HashMap<String, String>,
+
     /// This is not part of profile and doesn't persist.
     /// It is purely to override client id when creating ClientConfig
     #[serde(skip)]
@@ -49,6 +55,7 @@ impl FluvioConfig {
             endpoint: addr.into(),
             use_spu_local_address: false,
             tls: TlsPolicy::Disabled,
+            annotations: HashMap::new(),
             client_id: None,
         }
     }

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -191,7 +191,7 @@ impl ConfigFile {
 pub const LOCAL_PROFILE: &str = "local";
 const CONFIG_VERSION: &str = "2.0";
 
-#[derive(Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {
     version: String,
     current_profile: Option<String>,
@@ -570,6 +570,8 @@ pub mod test {
 
     #[test]
     fn test_profile_with_metadata() {
+        use std::collections::BTreeMap;
+
         let config_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
             .expect("could not parse config file");
         let config = config_file.config();

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -559,14 +559,6 @@ pub mod test {
         );
     }
 
-    /*
-    #[test]
-    fn test_topic_config() {
-        let conf_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned())).expect("parse failed");
-        let config = conf_file.config().resolve_replica_config("test3",0);
-    }
-    */
-
     #[test]
     fn test_local_cluster() {
         let config = Config::new_with_local_cluster("localhost:9003".to_owned());
@@ -574,5 +566,34 @@ pub mod test {
         assert_eq!(config.current_profile_name().unwrap(), "local");
         let cluster = config.current_cluster().expect("cluster should exists");
         assert_eq!(cluster.endpoint, "localhost:9003");
+    }
+
+    #[test]
+    fn test_cluster_with_custom_annotations() {
+        let config_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
+            .expect("could not parse config file");
+        let config = config_file.config();
+
+        let cluster = config
+            .cluster("with_annotations")
+            .expect("could not find `with_annotations` cluster in test file");
+
+        assert_eq!(
+            cluster.annotations.get("custom"),
+            Some(&"annotation".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_cluster_without_annotations() {
+        let config_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
+            .expect("could not parse config file");
+        let config = config_file.config();
+
+        let cluster = config
+            .cluster("no_annotations")
+            .expect("could not find `with_annotations` cluster in test file");
+
+        assert_eq!(cluster.annotations.len(), 0);
     }
 }

--- a/crates/fluvio/test-data/profiles/config.toml
+++ b/crates/fluvio/test-data/profiles/config.toml
@@ -1,52 +1,51 @@
 version = "1.0"
-
 current_profile = "local"
 
-[cluster.local]
-endpoint = "127.0.0.1:9003"
-
-
-[cluster.ec2]
-endpoint = "sandbox.xxxx.eksctl.io:9003"
-
-
-# no default topic
-[profile.local]
-cluster = "local"
-
-# use topic test3 as default
 [profile.local2]
 cluster = "local"
 topic = "test3"
 
-# use topic test3 and partition 3
 [profile.local3]
 cluster = "local"
 topic = "test3"
 partition = 3
-client_id = "local"
 
+[profile.local]
+cluster = "local"
 
-# default for all topics, this has lowest precedent
-[topic."*"]
-isolation = "uncommitted"
-fetch_max_bytes = 10000
+[cluster.updated]
+endpoint = "127.0.0.1"
+use_spu_local_address = false
 
-# apply for all partition of test3
-[topic.test3]
-isolation = "read_committed"
+[cluster.updated.tls]
+tls_policy = "disabled"
 
+[cluster.updated.metadata.installation]
+type = "local"
 
-# only for topic test=3,replication=2
-[topic.test4.2]
-isolation = "uncommitted"
-
-# cluster metadata
 [cluster.extra]
 endpoint = "127.0.0.1:9003"
+use_spu_local_address = false
+
+[cluster.extra.tls]
+tls_policy = "disabled"
 
 [cluster.extra.metadata.deep.nesting.example]
 key = "custom field"
 
 [cluster.extra.metadata.installation]
 type = "local"
+
+[cluster.local]
+endpoint = "127.0.0.1:9003"
+use_spu_local_address = false
+
+[cluster.local.tls]
+tls_policy = "disabled"
+
+[cluster.ec2]
+endpoint = "sandbox.xxxx.eksctl.io:9003"
+use_spu_local_address = false
+
+[cluster.ec2.tls]
+tls_policy = "disabled"

--- a/crates/fluvio/test-data/profiles/config.toml
+++ b/crates/fluvio/test-data/profiles/config.toml
@@ -40,3 +40,13 @@ isolation = "read_committed"
 # only for topic test=3,replication=2
 [topic.test4.2]
 isolation = "uncommitted"
+
+# cluster annotations
+[cluster.with_annotations]
+endpoint = "127.0.0.1:9003"
+
+[cluster.with_annotations.annotations]
+custom = "annotation"
+
+[cluster.no_annotations]
+endpoint = "127.0.0.1:9003"

--- a/crates/fluvio/test-data/profiles/config.toml
+++ b/crates/fluvio/test-data/profiles/config.toml
@@ -41,12 +41,12 @@ isolation = "read_committed"
 [topic.test4.2]
 isolation = "uncommitted"
 
-# cluster annotations
-[cluster.with_annotations]
+# cluster metadata
+[cluster.extra]
 endpoint = "127.0.0.1:9003"
 
-[cluster.with_annotations.annotations]
-custom = "annotation"
+[cluster.extra.metadata.deep.nesting.example]
+key = "custom field"
 
-[cluster.no_annotations]
-endpoint = "127.0.0.1:9003"
+[cluster.extra.metadata.installation]
+type = "local"


### PR DESCRIPTION
Add support for custom metadata in the cluster configuration.

```toml
[cluster.my_favorite_cluster]
endpoint = "127.0.0.1:9003"

[cluster.my_favorite_cluster.metadata.installation]
"fluvio.io/cluster-type" = "local-k8"
```

This will be important for other tasks, such as #3620.

These changes are retrocompatible.

Closes #3627