### PR TITLE
[Merged by Bors] - chore: revert back adding component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,10 +391,14 @@ jobs:
           key: ${{ matrix.rust-target }}-${{ matrix.check }}
       - name: Fmt
         if: matrix.check == 'fmt'
-        run: make check-fmt
+        run: |
+          rustup component add rustfmt
+          make check-fmt
       - name: Clippy
         if: matrix.check == 'clippy'
-        run: make check-clippy
+        run: |
+          rustup component add clippy
+          make check-clippy
       - name: Doc
         if: matrix.check == 'doc'
         run: make check-docs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.73.0"
-components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Further cleanup of the CI toolchain
remove clippy and fmt from toolchain and add back to only place necessary in CI