### PR TITLE
Updating fluvio-protocol-derive crate from syn1 to syn2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,7 +3004,7 @@ version = "0.5.4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol-derive"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "bytes 1.5.0",
  "derive_builder",

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol-derive"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -13,12 +13,8 @@ proc-macro = true
 doctest = false
 
 [dependencies]
+syn = { workspace = true, features = ["full"] }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 tracing = { workspace = true }
-
-[dependencies.syn]
-version = "1.0.0"
-features = ["full"]
-
 

--- a/crates/fluvio-protocol-derive/src/ast/container.rs
+++ b/crates/fluvio-protocol-derive/src/ast/container.rs
@@ -35,18 +35,18 @@ impl ContainerAttributes {
                                     let lit_expr = &args_data.value;
                                     if let Some(args_name) = args_data.path.get_ident() {
                                         if args_name == "api_min_version" {
-                                            let value = get_lit_int("api_min_version", &lit_expr)?;
+                                            let value = get_lit_int("api_min_version", lit_expr)?;
                                             cont_attr.api_min_version =
                                                 value.base10_parse::<u16>()?;
                                         } else if args_name == "api_max_version" {
-                                            let value = get_lit_int("api_max_version", &lit_expr)?;
+                                            let value = get_lit_int("api_max_version", lit_expr)?;
                                             cont_attr.api_max_version =
                                                 Some(value.base10_parse::<u16>()?);
                                         } else if args_name == "api_key" {
-                                            let value = get_lit_int("api_key", &lit_expr)?;
+                                            let value = get_lit_int("api_key", lit_expr)?;
                                             cont_attr.api_key = Some(value.base10_parse::<u8>()?);
                                         } else if args_name == "response" {
-                                            let value = get_lit_str("response", &lit_expr)?;
+                                            let value = get_lit_str("response", lit_expr)?;
                                             cont_attr.response = Some(value.value());
                                         } else {
                                             tracing::warn!(

--- a/crates/fluvio-protocol-derive/src/ast/container.rs
+++ b/crates/fluvio-protocol-derive/src/ast/container.rs
@@ -26,70 +26,52 @@ impl ContainerAttributes {
                 if ident == "varint" {
                     cont_attr.varint = true;
                 } else if ident == "fluvio" {
-                    match &attr.meta {
-                        Meta::List(list) => {
-                            if let Ok(list_args) = list
-                                .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
-                            {
-                                for args_meta in list_args.iter() {
-                                    if let Meta::NameValue(args_data) = args_meta {
-                                        let lit_expr = &args_data.value;
-                                        if let Some(args_name) = args_data.path.get_ident() {
-                                            if args_name == "api_min_version" {
-                                                let value = get_lit_int(
-                                                    String::from("api_min_version"),
-                                                    &lit_expr,
-                                                )?;
-                                                cont_attr.api_min_version =
-                                                    value.base10_parse::<u16>()?;
-                                            } else if args_name == "api_max_version" {
-                                                let value = get_lit_int(
-                                                    String::from("api_max_version"),
-                                                    &lit_expr,
-                                                )?;
-                                                cont_attr.api_max_version =
-                                                    Some(value.base10_parse::<u16>()?);
-                                            } else if args_name == "api_key" {
-                                                let value = get_lit_int(
-                                                    String::from("api_key"),
-                                                    &lit_expr,
-                                                )?;
-                                                cont_attr.api_key =
-                                                    Some(value.base10_parse::<u8>()?);
-                                            } else if args_name == "response" {
-                                                let value = get_lit_str(
-                                                    String::from("response"),
-                                                    &lit_expr,
-                                                )?;
-                                                cont_attr.response = Some(value.value());
-                                            } else {
-                                                tracing::warn!(
-                                                    "#[fluvio({})] does nothing on the container.",
-                                                    args_data.to_token_stream().to_string()
-                                                )
-                                            }
+                    if let Meta::List(list) = &attr.meta {
+                        if let Ok(list_args) =
+                            list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                        {
+                            for args_meta in list_args.iter() {
+                                if let Meta::NameValue(args_data) = args_meta {
+                                    let lit_expr = &args_data.value;
+                                    if let Some(args_name) = args_data.path.get_ident() {
+                                        if args_name == "api_min_version" {
+                                            let value = get_lit_int("api_min_version", &lit_expr)?;
+                                            cont_attr.api_min_version =
+                                                value.base10_parse::<u16>()?;
+                                        } else if args_name == "api_max_version" {
+                                            let value = get_lit_int("api_max_version", &lit_expr)?;
+                                            cont_attr.api_max_version =
+                                                Some(value.base10_parse::<u16>()?);
+                                        } else if args_name == "api_key" {
+                                            let value = get_lit_int("api_key", &lit_expr)?;
+                                            cont_attr.api_key = Some(value.base10_parse::<u8>()?);
+                                        } else if args_name == "response" {
+                                            let value = get_lit_str("response", &lit_expr)?;
+                                            cont_attr.response = Some(value.value());
+                                        } else {
+                                            tracing::warn!(
+                                                "#[fluvio({})] does nothing on the container.",
+                                                args_data.to_token_stream().to_string()
+                                            )
                                         }
-                                    } else if let Meta::Path(path) = args_meta {
-                                        if let Some(nested_ident) = path.get_ident() {
-                                            if nested_ident == "default" {
-                                                cont_attr.default = true;
-                                            } else if nested_ident == "trace" {
-                                                cont_attr.trace = true;
-                                            } else if nested_ident == "encode_discriminant" {
-                                                cont_attr.encode_discriminant = true;
-                                            } else {
-                                                tracing::warn!(
-                                                    "#[fluvio({})] does nothing on the container.",
-                                                    nested_ident.to_token_stream().to_string()
-                                                )
-                                            }
+                                    }
+                                } else if let Meta::Path(path) = args_meta {
+                                    if let Some(nested_ident) = path.get_ident() {
+                                        if nested_ident == "default" {
+                                            cont_attr.default = true;
+                                        } else if nested_ident == "trace" {
+                                            cont_attr.trace = true;
+                                        } else if nested_ident == "encode_discriminant" {
+                                            cont_attr.encode_discriminant = true;
+                                        } else {
+                                            tracing::warn!(
+                                                "#[fluvio({})] does nothing on the container.",
+                                                nested_ident.to_token_stream().to_string()
+                                            )
                                         }
                                     }
                                 }
                             }
-                        }
-                        _ => {
-                            unimplemented!()
                         }
                     }
                 } else if ident == "repr" {

--- a/crates/fluvio-protocol-derive/src/ast/container.rs
+++ b/crates/fluvio-protocol-derive/src/ast/container.rs
@@ -28,22 +28,39 @@ impl ContainerAttributes {
                 } else if ident == "fluvio" {
                     match &attr.meta {
                         Meta::List(list) => {
-                            if let Ok(list_args) = list .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+                            if let Ok(list_args) = list
+                                .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                            {
                                 for args_meta in list_args.iter() {
                                     if let Meta::NameValue(args_data) = args_meta {
                                         let lit_expr = &args_data.value;
                                         if let Some(args_name) = args_data.path.get_ident() {
                                             if args_name == "api_min_version" {
-                                                let value = get_lit_int(String::from("api_min_version"), &lit_expr)?;
-                                                cont_attr.api_min_version = value.base10_parse::<u16>()?;
+                                                let value = get_lit_int(
+                                                    String::from("api_min_version"),
+                                                    &lit_expr,
+                                                )?;
+                                                cont_attr.api_min_version =
+                                                    value.base10_parse::<u16>()?;
                                             } else if args_name == "api_max_version" {
-                                                let value = get_lit_int(String::from("api_max_version"), &lit_expr)?;
-                                                cont_attr.api_max_version = Some(value.base10_parse::<u16>()?);
+                                                let value = get_lit_int(
+                                                    String::from("api_max_version"),
+                                                    &lit_expr,
+                                                )?;
+                                                cont_attr.api_max_version =
+                                                    Some(value.base10_parse::<u16>()?);
                                             } else if args_name == "api_key" {
-                                                let value = get_lit_int(String::from("api_key"), &lit_expr)?;
-                                                cont_attr.api_key = Some(value.base10_parse::<u8>()?);
+                                                let value = get_lit_int(
+                                                    String::from("api_key"),
+                                                    &lit_expr,
+                                                )?;
+                                                cont_attr.api_key =
+                                                    Some(value.base10_parse::<u8>()?);
                                             } else if args_name == "response" {
-                                                let value = get_lit_str(String::from("response"), &lit_expr)?;
+                                                let value = get_lit_str(
+                                                    String::from("response"),
+                                                    &lit_expr,
+                                                )?;
                                                 cont_attr.response = Some(value.value());
                                             } else {
                                                 tracing::warn!(
@@ -52,7 +69,7 @@ impl ContainerAttributes {
                                                 )
                                             }
                                         }
-                                    } else if let Meta::Path(path) = args_meta { 
+                                    } else if let Meta::Path(path) = args_meta {
                                         if let Some(nested_ident) = path.get_ident() {
                                             if nested_ident == "default" {
                                                 cont_attr.default = true;
@@ -77,13 +94,15 @@ impl ContainerAttributes {
                     }
                 } else if ident == "repr" {
                     if let Meta::List(list) = &attr.meta {
-                        if let Ok(list_args) = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+                        if let Ok(list_args) =
+                            list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                        {
                             for args_meta in list_args.iter() {
                                 if let Meta::Path(path) = args_meta {
                                     if let Some(int_type) = path.get_ident() {
                                         cont_attr.repr_type_name = Some(int_type.to_string());
                                     }
-                                } 
+                                }
                             }
                         }
                     }

--- a/crates/fluvio-protocol-derive/src/ast/enum.rs
+++ b/crates/fluvio-protocol-derive/src/ast/enum.rs
@@ -71,7 +71,7 @@ impl EnumProp {
         for attr in &variant.attrs {
             if attr.path().is_ident("fluvio") {
                 if let Some(meta_name_value) = find_name_value_from_meta(&attr.meta, "tag") {
-                    let value = get_lit_int(String::from("tag"), &meta_name_value.value)?;
+                    let value = get_lit_int("tag", &meta_name_value.value)?;
                     prop.tag = Some(value.base10_digits().to_owned());
                 }
             }

--- a/crates/fluvio-protocol-derive/src/ast/enum.rs
+++ b/crates/fluvio-protocol-derive/src/ast/enum.rs
@@ -3,7 +3,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{
-    Error, Expr, ExprLit, ExprUnary, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, ItemEnum, Variant,
+    Error, Expr, ExprLit, ExprUnary, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, ItemEnum,
+    Variant,
 };
 
 use super::container::ContainerAttributes;

--- a/crates/fluvio-protocol-derive/src/ast/prop.rs
+++ b/crates/fluvio-protocol-derive/src/ast/prop.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, Field, Lit, Meta, Type, Token, Expr};
+use syn::{Attribute, Error, Expr, Field, Lit, Meta, Token, Type};
 
 use crate::util::{get_lit_int, get_lit_str};
 
@@ -198,25 +198,28 @@ impl PropAttrs {
                 prop_attrs.varint = true;
             } else if attribute.path().is_ident("fluvio") {
                 if let Meta::List(list) = &attribute.meta {
-                    if let Ok(list_args) = list
-                        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                    if let Ok(list_args) =
+                        list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                     {
                         for args_meta in list_args.iter() {
                             if let Meta::NameValue(args_data) = args_meta {
                                 let lit_expr = &args_data.value;
-                                
+
                                 if let Some(args_name) = args_data.path.get_ident() {
                                     if args_name == "min_version" {
                                         if let Expr::Lit(lit_expr) = &lit_expr {
                                             if let Lit::Int(lit_int) = &lit_expr.lit {
-                                                prop_attrs.min_version = lit_int.base10_parse::<i16>()?;
+                                                prop_attrs.min_version =
+                                                    lit_int.base10_parse::<i16>()?;
                                             }
                                         }
                                     } else if args_name == "max_version" {
-                                        let value = get_lit_int(String::from("max_version"), &lit_expr)?;
+                                        let value =
+                                            get_lit_int(String::from("max_version"), &lit_expr)?;
                                         prop_attrs.max_version = Some(value.base10_parse::<i16>()?);
                                     } else if args_name == "default" {
-                                        let value = get_lit_str(String::from("default"), &lit_expr)?;
+                                        let value =
+                                            get_lit_str(String::from("default"), &lit_expr)?;
                                         prop_attrs.default_value = Some(value.value());
                                     } else {
                                         tracing::warn!(

--- a/crates/fluvio-protocol-derive/src/ast/prop.rs
+++ b/crates/fluvio-protocol-derive/src/ast/prop.rs
@@ -208,7 +208,7 @@ impl PropAttrs {
                                 if let Some(args_name) = args_data.path.get_ident() {
                                     if args_name == "min_version" {
                                         let value = get_lit_int("min_version", &lit_expr)?;
-                                        prop_attrs.max_version = Some(value.base10_parse::<i16>()?);
+                                        prop_attrs.min_version = value.base10_parse::<i16>()?;
                                     } else if args_name == "max_version" {
                                         let value = get_lit_int("max_version", &lit_expr)?;
                                         prop_attrs.max_version = Some(value.base10_parse::<i16>()?);

--- a/crates/fluvio-protocol-derive/src/ast/prop.rs
+++ b/crates/fluvio-protocol-derive/src/ast/prop.rs
@@ -207,13 +207,13 @@ impl PropAttrs {
 
                                 if let Some(args_name) = args_data.path.get_ident() {
                                     if args_name == "min_version" {
-                                        let value = get_lit_int("min_version", &lit_expr)?;
+                                        let value = get_lit_int("min_version", lit_expr)?;
                                         prop_attrs.min_version = value.base10_parse::<i16>()?;
                                     } else if args_name == "max_version" {
-                                        let value = get_lit_int("max_version", &lit_expr)?;
+                                        let value = get_lit_int("max_version", lit_expr)?;
                                         prop_attrs.max_version = Some(value.base10_parse::<i16>()?);
                                     } else if args_name == "default" {
-                                        let value = get_lit_str("default", &lit_expr)?;
+                                        let value = get_lit_str("default", lit_expr)?;
                                         prop_attrs.default_value = Some(value.value());
                                     } else {
                                         tracing::warn!(

--- a/crates/fluvio-protocol-derive/src/ast/prop.rs
+++ b/crates/fluvio-protocol-derive/src/ast/prop.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Attribute, Error, Expr, Field, Lit, Meta, Token, Type};
+use syn::{Attribute, Error, Field, Meta, Token, Type};
 
 use crate::util::{get_lit_int, get_lit_str};
 
@@ -207,19 +207,13 @@ impl PropAttrs {
 
                                 if let Some(args_name) = args_data.path.get_ident() {
                                     if args_name == "min_version" {
-                                        if let Expr::Lit(lit_expr) = &lit_expr {
-                                            if let Lit::Int(lit_int) = &lit_expr.lit {
-                                                prop_attrs.min_version =
-                                                    lit_int.base10_parse::<i16>()?;
-                                            }
-                                        }
+                                        let value = get_lit_int("min_version", &lit_expr)?;
+                                        prop_attrs.max_version = Some(value.base10_parse::<i16>()?);
                                     } else if args_name == "max_version" {
-                                        let value =
-                                            get_lit_int(String::from("max_version"), &lit_expr)?;
+                                        let value = get_lit_int("max_version", &lit_expr)?;
                                         prop_attrs.max_version = Some(value.base10_parse::<i16>()?);
                                     } else if args_name == "default" {
-                                        let value =
-                                            get_lit_str(String::from("default"), &lit_expr)?;
+                                        let value = get_lit_str("default", &lit_expr)?;
                                         prop_attrs.default_value = Some(value.value());
                                     } else {
                                         tracing::warn!(

--- a/crates/fluvio-protocol-derive/src/util.rs
+++ b/crates/fluvio-protocol-derive/src/util.rs
@@ -67,12 +67,10 @@ pub(crate) fn find_name_value_from_meta_list(
 }
 
 pub(crate) fn find_name_value_from_meta(meta: &Meta, attr_name: &str) -> Option<MetaNameValue> {
-    let mut result_meta: Option<MetaNameValue> = None;
     if let Meta::List(list) = meta {
-        result_meta = find_name_value_from_meta_list(list, attr_name);
+        return find_name_value_from_meta_list(list, attr_name);
     }
-
-    result_meta
+    None
 }
 
 /// find name value with str value

--- a/crates/fluvio-protocol-derive/src/util.rs
+++ b/crates/fluvio-protocol-derive/src/util.rs
@@ -1,75 +1,113 @@
-use syn::{Attribute, Lit, LitStr, Meta, MetaNameValue, NestedMeta};
+use syn::{Attribute, Expr, Lit, LitStr, Meta, punctuated::Punctuated, Token, MetaNameValue, MetaList};
+pub fn get_lit_int(attr_name: String, value: &Expr) -> syn::Result<&syn::LitInt> {
+    match &value {
+        Expr::Lit(lit_expr) => {
+            if let Lit::Int(lit) = &lit_expr.lit {
+                Ok(lit)
+             } else {
+                 Err(syn::Error::new_spanned(
+                     value,
+                     format!("Expected {attr_name} attribute to be a int: `{attr_name} = \"...\"`"),
+                 ))
+             }
+        },
+        _ => {
+            Err(syn::Error::new_spanned(
+                value,
+                format!("Expected {attr_name} attribute to be Path or Lit: `{attr_name} = \"...\"`"),
+            ))
+        },
+    }
+}
+pub fn get_lit_str(attr_name: String, value: &Expr) -> syn::Result<&syn::LitStr> {
+    match &value {
+        Expr::Lit(lit_expr) => {
+            if let Lit::Str(lit) = &lit_expr.lit {
+                Ok(lit)
+             } else {
+                 Err(syn::Error::new_spanned(
+                     value,
+                     format!("Expected {attr_name} attribute to be a string: `{attr_name} = \"...\"`"),
+                 ))
+             }
+        },
+        _ => {
+            Err(syn::Error::new_spanned(
+                value,
+                format!("Expected {attr_name} attribute to be Path or string: `{attr_name} = \"...\"`"),
+            ))
+        },
+    }
+}
 
 pub(crate) fn find_attr(attrs: &[Attribute], name: &str) -> Option<Meta> {
     attrs.iter().find_map(|a| {
-        if let Ok(meta) = a.parse_meta() {
-            if meta.path().is_ident(name) {
-                Some(meta)
-            } else {
-                //println!("attr name: {}",meta.name());
-                None
-            }
+        if a.meta.path().is_ident(name) {
+            Some(a.meta.clone())
         } else {
-            //println!("unrecog attribute");
+            //println!("attr name: {}",meta.name());
             None
         }
     })
 }
-
-pub(crate) fn find_name_attribute<'a>(meta: &'a Meta, name: &str) -> Option<&'a MetaNameValue> {
-    find_meta(meta, name).map(|meta| match meta {
-        Meta::NameValue(name_value) => name_value,
-        _ => panic!("should not happen"),
-    })
-}
-
-pub(crate) fn find_meta<'a>(meta: &'a Meta, name: &str) -> Option<&'a Meta> {
-    if let Meta::List(list) = meta {
-        for attr in list.nested.iter() {
-            if let NestedMeta::Meta(named_meta) = attr {
-                match named_meta {
-                    Meta::NameValue(meta_name_value) => {
-                        if meta_name_value.path.is_ident(name) {
-                            return Some(named_meta);
-                        }
-                    }
-                    Meta::Path(path) => {
-                        if path.is_ident(name) {
-                            return Some(named_meta);
-                        }
-                    }
-                    Meta::List(_) => {}
+pub(crate) fn find_name_value_from_meta_list(meta_list: &MetaList, attr_name: &str) -> Option<MetaNameValue> {
+    let mut result_meta: Option<MetaNameValue> = None;
+    for item in meta_list
+        .parse_args_with(Punctuated::<syn::Meta, Token![,]>::parse_terminated)
+        .unwrap_or_else(|err| panic!("Invalid #[new] attribute: {}", err))
+    {
+        match &item {
+            Meta::NameValue(kv) => {
+                if kv.path.is_ident(attr_name) {
+                    result_meta = Some(kv.clone());
+                    break;
                 }
             }
-        }
+            _ => {  }
+        };
+
     }
 
-    None
+    result_meta
 }
 
-/// find name value with integer value
-pub(crate) fn find_int_name_value(version_meta: &Meta, attr_name: &str) -> Option<u64> {
-    if let Some(attr) = find_name_attribute(version_meta, attr_name) {
-        match &attr.lit {
-            Lit::Int(version_val) => {
-                //  println!("version value: {}",version_val.value());
-                version_val.base10_parse::<u64>().ok()
-            }
-            _ => unimplemented!(),
-        }
-    } else {
-        None
+pub(crate) fn find_name_value_from_meta(meta: &Meta, attr_name: &str) -> Option<MetaNameValue> {
+    let mut result_meta: Option<MetaNameValue> = None;
+    if let Meta::List(list) = meta {
+        result_meta = find_name_value_from_meta_list(list, attr_name);
     }
+
+    result_meta
 }
 
 /// find name value with str value
-pub(crate) fn find_string_name_value(version_meta: &Meta, attr_name: &str) -> Option<LitStr> {
-    if let Some(attr) = find_name_attribute(version_meta, attr_name) {
-        match &attr.lit {
-            Lit::Str(val) => Some(val.clone()),
-            _ => unimplemented!(),
+pub(crate) fn find_string_name_value(meta: &Meta, attr_name: &str) -> Option<LitStr> {
+    let mut value: Option<LitStr> = None;
+    if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
+        let data = get_lit_str(String::from(attr_name), &meta_name_value.value);
+        value = match data {
+            Ok(val) => {
+                Some(val.clone())
+            },
+            Err(_) => None,
         }
-    } else {
-        None
     }
+    
+    value
+}
+
+pub(crate) fn find_int_name_value(meta: &Meta, attr_name: &str) -> Option<u64> {
+    let mut value: Option<u64> = None;
+    if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
+
+        let data = get_lit_int(String::from(attr_name), &meta_name_value.value);
+        value = match data {
+            Ok(val) => {
+                val.base10_parse::<u64>().ok()
+            },
+            Err(_) => None,
+        }
+    }
+
+    value
 }

--- a/crates/fluvio-protocol-derive/src/util.rs
+++ b/crates/fluvio-protocol-derive/src/util.rs
@@ -1,22 +1,22 @@
-use syn::{Attribute, Expr, Lit, LitStr, Meta, punctuated::Punctuated, Token, MetaNameValue, MetaList};
+use syn::{
+    punctuated::Punctuated, Attribute, Expr, Lit, LitStr, Meta, MetaList, MetaNameValue, Token,
+};
 pub fn get_lit_int(attr_name: String, value: &Expr) -> syn::Result<&syn::LitInt> {
     match &value {
         Expr::Lit(lit_expr) => {
             if let Lit::Int(lit) = &lit_expr.lit {
                 Ok(lit)
-             } else {
-                 Err(syn::Error::new_spanned(
-                     value,
-                     format!("Expected {attr_name} attribute to be a int: `{attr_name} = \"...\"`"),
-                 ))
-             }
-        },
-        _ => {
-            Err(syn::Error::new_spanned(
-                value,
-                format!("Expected {attr_name} attribute to be Path or Lit: `{attr_name} = \"...\"`"),
-            ))
-        },
+            } else {
+                Err(syn::Error::new_spanned(
+                    value,
+                    format!("Expected {attr_name} attribute to be a int: `{attr_name} = \"...\"`"),
+                ))
+            }
+        }
+        _ => Err(syn::Error::new_spanned(
+            value,
+            format!("Expected {attr_name} attribute to be Path or Lit: `{attr_name} = \"...\"`"),
+        )),
     }
 }
 pub fn get_lit_str(attr_name: String, value: &Expr) -> syn::Result<&syn::LitStr> {
@@ -24,19 +24,19 @@ pub fn get_lit_str(attr_name: String, value: &Expr) -> syn::Result<&syn::LitStr>
         Expr::Lit(lit_expr) => {
             if let Lit::Str(lit) = &lit_expr.lit {
                 Ok(lit)
-             } else {
-                 Err(syn::Error::new_spanned(
-                     value,
-                     format!("Expected {attr_name} attribute to be a string: `{attr_name} = \"...\"`"),
-                 ))
-             }
-        },
-        _ => {
-            Err(syn::Error::new_spanned(
-                value,
-                format!("Expected {attr_name} attribute to be Path or string: `{attr_name} = \"...\"`"),
-            ))
-        },
+            } else {
+                Err(syn::Error::new_spanned(
+                    value,
+                    format!(
+                        "Expected {attr_name} attribute to be a string: `{attr_name} = \"...\"`"
+                    ),
+                ))
+            }
+        }
+        _ => Err(syn::Error::new_spanned(
+            value,
+            format!("Expected {attr_name} attribute to be Path or string: `{attr_name} = \"...\"`"),
+        )),
     }
 }
 
@@ -50,7 +50,10 @@ pub(crate) fn find_attr(attrs: &[Attribute], name: &str) -> Option<Meta> {
         }
     })
 }
-pub(crate) fn find_name_value_from_meta_list(meta_list: &MetaList, attr_name: &str) -> Option<MetaNameValue> {
+pub(crate) fn find_name_value_from_meta_list(
+    meta_list: &MetaList,
+    attr_name: &str,
+) -> Option<MetaNameValue> {
     let mut result_meta: Option<MetaNameValue> = None;
     for item in meta_list
         .parse_args_with(Punctuated::<syn::Meta, Token![,]>::parse_terminated)
@@ -63,9 +66,8 @@ pub(crate) fn find_name_value_from_meta_list(meta_list: &MetaList, attr_name: &s
                     break;
                 }
             }
-            _ => {  }
+            _ => {}
         };
-
     }
 
     result_meta
@@ -86,25 +88,20 @@ pub(crate) fn find_string_name_value(meta: &Meta, attr_name: &str) -> Option<Lit
     if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
         let data = get_lit_str(String::from(attr_name), &meta_name_value.value);
         value = match data {
-            Ok(val) => {
-                Some(val.clone())
-            },
+            Ok(val) => Some(val.clone()),
             Err(_) => None,
         }
     }
-    
+
     value
 }
 
 pub(crate) fn find_int_name_value(meta: &Meta, attr_name: &str) -> Option<u64> {
     let mut value: Option<u64> = None;
     if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
-
         let data = get_lit_int(String::from(attr_name), &meta_name_value.value);
         value = match data {
-            Ok(val) => {
-                val.base10_parse::<u64>().ok()
-            },
+            Ok(val) => val.base10_parse::<u64>().ok(),
             Err(_) => None,
         }
     }

--- a/crates/fluvio-protocol-derive/src/util.rs
+++ b/crates/fluvio-protocol-derive/src/util.rs
@@ -1,7 +1,7 @@
 use syn::{
     punctuated::Punctuated, Attribute, Expr, Lit, LitStr, Meta, MetaList, MetaNameValue, Token,
 };
-pub fn get_lit_int(attr_name: String, value: &Expr) -> syn::Result<&syn::LitInt> {
+pub fn get_lit_int<'a>(attr_name: &'a str, value: &'a Expr) -> syn::Result<&'a syn::LitInt> {
     match &value {
         Expr::Lit(lit_expr) => {
             if let Lit::Int(lit) = &lit_expr.lit {
@@ -9,17 +9,17 @@ pub fn get_lit_int(attr_name: String, value: &Expr) -> syn::Result<&syn::LitInt>
             } else {
                 Err(syn::Error::new_spanned(
                     value,
-                    format!("Expected {attr_name} attribute to be a int: `{attr_name} = \"...\"`"),
+                    format!("Expected {attr_name} attribute to be an int: `{attr_name} = \"...\"`"),
                 ))
             }
         }
         _ => Err(syn::Error::new_spanned(
             value,
-            format!("Expected {attr_name} attribute to be Path or Lit: `{attr_name} = \"...\"`"),
+            format!("Expected {attr_name} attribute to be a Lit: `{attr_name} = \"...\"`"),
         )),
     }
 }
-pub fn get_lit_str(attr_name: String, value: &Expr) -> syn::Result<&syn::LitStr> {
+pub fn get_lit_str<'a>(attr_name: &'a str, value: &'a Expr) -> syn::Result<&'a syn::LitStr> {
     match &value {
         Expr::Lit(lit_expr) => {
             if let Lit::Str(lit) = &lit_expr.lit {
@@ -35,7 +35,7 @@ pub fn get_lit_str(attr_name: String, value: &Expr) -> syn::Result<&syn::LitStr>
         }
         _ => Err(syn::Error::new_spanned(
             value,
-            format!("Expected {attr_name} attribute to be Path or string: `{attr_name} = \"...\"`"),
+            format!("Expected {attr_name} attribute to be a Lit: `{attr_name} = \"...\"`"),
         )),
     }
 }
@@ -45,7 +45,6 @@ pub(crate) fn find_attr(attrs: &[Attribute], name: &str) -> Option<Meta> {
         if a.meta.path().is_ident(name) {
             Some(a.meta.clone())
         } else {
-            //println!("attr name: {}",meta.name());
             None
         }
     })
@@ -54,23 +53,17 @@ pub(crate) fn find_name_value_from_meta_list(
     meta_list: &MetaList,
     attr_name: &str,
 ) -> Option<MetaNameValue> {
-    let mut result_meta: Option<MetaNameValue> = None;
     for item in meta_list
         .parse_args_with(Punctuated::<syn::Meta, Token![,]>::parse_terminated)
         .unwrap_or_else(|err| panic!("Invalid #[new] attribute: {}", err))
     {
-        match &item {
-            Meta::NameValue(kv) => {
-                if kv.path.is_ident(attr_name) {
-                    result_meta = Some(kv.clone());
-                    break;
-                }
+        if let Meta::NameValue(kv) = &item {
+            if kv.path.is_ident(attr_name) {
+                return Some(kv.clone());
             }
-            _ => {}
         };
     }
-
-    result_meta
+    None
 }
 
 pub(crate) fn find_name_value_from_meta(meta: &Meta, attr_name: &str) -> Option<MetaNameValue> {
@@ -84,27 +77,14 @@ pub(crate) fn find_name_value_from_meta(meta: &Meta, attr_name: &str) -> Option<
 
 /// find name value with str value
 pub(crate) fn find_string_name_value(meta: &Meta, attr_name: &str) -> Option<LitStr> {
-    let mut value: Option<LitStr> = None;
-    if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
-        let data = get_lit_str(String::from(attr_name), &meta_name_value.value);
-        value = match data {
-            Ok(val) => Some(val.clone()),
-            Err(_) => None,
-        }
-    }
-
-    value
+    let meta_name_value = find_name_value_from_meta(meta, attr_name)?;
+    get_lit_str(attr_name, &meta_name_value.value).ok().cloned()
 }
 
 pub(crate) fn find_int_name_value(meta: &Meta, attr_name: &str) -> Option<u64> {
-    let mut value: Option<u64> = None;
-    if let Some(meta_name_value) = find_name_value_from_meta(meta, attr_name) {
-        let data = get_lit_int(String::from(attr_name), &meta_name_value.value);
-        value = match data {
-            Ok(val) => val.base10_parse::<u64>().ok(),
-            Err(_) => None,
-        }
-    }
-
-    value
+    let meta_name_value = find_name_value_from_meta(meta, attr_name)?;
+    let value = get_lit_int(attr_name, &meta_name_value.value)
+        .ok()
+        .cloned()?;
+    value.base10_parse::<u64>().ok()
 }

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/produce/request.rs
+++ b/crates/fluvio-spu-schema/src/produce/request.rs
@@ -41,7 +41,7 @@ pub struct ProduceRequest<R> {
     /// Each topic to produce to.
     pub topics: Vec<TopicProduceData<R>>,
 
-    #[fluvio(min_version = PRODUCER_TRANSFORMATION_API)]
+    #[fluvio(min_version = 8)]
     pub smartmodules: Vec<SmartModuleInvocation>,
 
     pub data: PhantomData<R>,


### PR DESCRIPTION
Hello, I took on updating the  `fluvio-protocol-derive` from `syn1` to `syn2` from #3577

I checked all the tests and of course are passing, but there is something I am not sure about.

Here it is expecting `Literal` value

https://github.com/infinyon/fluvio/blob/d0dd8595583c0dd4651713beb637fb0b5c48c7fb/crates/fluvio-protocol-derive/src/ast/prop.rs#L200C29-L200C29

but there is one place in the code in the `fluvio-spu-schema` crate, that `PRODUCER_TRANSFORMATION_API` is being passed as a value. Because this is not a `Literal` but a `Path` it actually never goes inside the if statement.  Also not sure but I couldn't find this constant anywhere. 

https://github.com/infinyon/fluvio/blob/d0dd8595583c0dd4651713beb637fb0b5c48c7fb/crates/fluvio-spu-schema/src/produce/request.rs#L44C16-L44C16

So because of that I have also set this place the same way, with an if statement and a literal, but it just will never go in there. Can you tell me how would you like me to handle that.  

Other than that please tell me if I have missed on something.