### PR TITLE
[Merged by Bors] - chore: bump `fvm` to version `0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-version-manager"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-version-manager"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Version Manager"

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -181,6 +181,9 @@ setup_file() {
         run bash -c 'fvm install "$VERSION"'
         assert_success
 
+        # Sleeps to avoid hiting rate limits
+        sleep 30
+
         for binary in "${binaries[@]}"
         do
             export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
@@ -244,6 +247,9 @@ setup_file() {
         # Installs Fluvio Version
         run bash -c 'fvm install $VERSION'
         assert_success
+
+        # Sleeps to avoid hiting rate limits
+        sleep 30
     done
 
     for version in "${versions[@]}"
@@ -344,9 +350,15 @@ setup_file() {
     run bash -c 'fvm install 0.10.15'
     assert_success
 
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
     # Installs Fluvio at 0.10.14
     run bash -c 'fvm install 0.10.14'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Switch version to use Fluvio at 0.10.15
     run bash -c 'fvm switch 0.10.15'
@@ -389,6 +401,9 @@ setup_file() {
     # Installs Fluvio Stable
     run bash -c 'fvm install stable'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Installs Fluvio at 0.10.14
     run bash -c 'fvm install 0.10.14'
@@ -483,6 +498,9 @@ setup_file() {
     run bash -c 'fvm -q install stable'
     assert_output ""
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Expect output if `-q` is not passed
     run bash -c 'fvm install 0.10.14'
@@ -752,6 +770,9 @@ setup_file() {
     # Installs the stable version
     run bash -c 'fvm install'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Attempts to update Fluvio
     run bash -c 'fvm update'


### PR DESCRIPTION
Prepares `fvm` for official release bumping to version `0.1.0`

## Demo

![CleanShot 2023-11-01 at 10 54 25@2x](https://github.com/infinyon/fluvio/assets/34756077/a7a2d552-6cbd-4947-93f7-53443b24a6fc)
