### PR TITLE
feat: `fluvio version` cleanup

### DIFF
--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -181,6 +181,9 @@ setup_file() {
         run bash -c 'fvm install "$VERSION"'
         assert_success
 
+        # Sleeps to avoid hiting rate limits
+        sleep 30
+
         for binary in "${binaries[@]}"
         do
             export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
@@ -244,6 +247,9 @@ setup_file() {
         # Installs Fluvio Version
         run bash -c 'fvm install $VERSION'
         assert_success
+
+        # Sleeps to avoid hiting rate limits
+        sleep 30
     done
 
     for version in "${versions[@]}"
@@ -344,9 +350,15 @@ setup_file() {
     run bash -c 'fvm install 0.10.15'
     assert_success
 
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
     # Installs Fluvio at 0.10.14
     run bash -c 'fvm install 0.10.14'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Switch version to use Fluvio at 0.10.15
     run bash -c 'fvm switch 0.10.15'
@@ -389,6 +401,9 @@ setup_file() {
     # Installs Fluvio Stable
     run bash -c 'fvm install stable'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Installs Fluvio at 0.10.14
     run bash -c 'fvm install 0.10.14'
@@ -483,6 +498,9 @@ setup_file() {
     run bash -c 'fvm -q install stable'
     assert_output ""
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Expect output if `-q` is not passed
     run bash -c 'fvm install 0.10.14'
@@ -752,6 +770,9 @@ setup_file() {
     # Installs the stable version
     run bash -c 'fvm install'
     assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
 
     # Attempts to update Fluvio
     run bash -c 'fvm update'


### PR DESCRIPTION
Improvements on `fluvio version` output.

## Change set

- [x] Removes `Fluvio channel SHA256 : <Your SHA Here>`
- [x] Removes `=== Plugin Versions ===` listing

## Output Example

```
Fluvio CLI           : 0.11.0-dev-1
Fluvio CLI Arch      : aarch64-apple-darwin
Fluvio CLI SHA256    : d532f947fe6dac56ca19c85635aae4dd3f325405283c5a5687322d2eddb69211
Fluvio Cluster       : Not available
Git Commit           : 5ee2d68ec5b1f263431784d6ffd7057295b5b6ac
OS Details           : Darwin 13.5.2 (kernel 22.6.0)
```