### PR TITLE
feat: mock fvm server on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,24 +1061,29 @@ jobs:
         run: make CDK_BIN=~/bin/cdk cli-cdk-smoke
 
       # test fvm
-      # - name: Download artifact - fvm
-      #   if: matrix.test == 'fvm'
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: fvm-x86_64-unknown-linux-musl
-      #     path: ~/bin
+      - name: Download artifact - fvm
+        if: matrix.test == 'fvm'
+        uses: actions/download-artifact@v3
+        with:
+          name: fvm-x86_64-unknown-linux-musl
+          path: ~/bin
 
-      # - name: mark fvm
-      #   if: matrix.test == 'fvm'
-      #   run: |
-      #     chmod +x ~/bin/fvm
-      #     echo "~/bin" >> $GITHUB_PATH
+      - name: mark fvm
+        if: matrix.test == 'fvm'
+        run: |
+          chmod +x ~/bin/fvm
+          echo "~/bin" >> $GITHUB_PATH
 
-      # - name: Run FVM smoke tests
-      #   if: matrix.test == 'fvm'
-      #   timeout-minutes: 20
-      #   run: |
-      #     make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+      - name: Run FVM Mock Server
+        if: matrix.test == 'fvm'
+        run: |
+           cargo run --bin hub-fvm &
+
+      - name: Run FVM smoke tests
+        if: matrix.test == 'fvm'
+        timeout-minutes: 20
+        run: |
+          make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://localhost:9000" cli-fvm-smoke
 
       - name: Run diagnostics
         if: ${{ !success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,7 +931,7 @@ jobs:
         os: [ubuntu-latest]
         cluster_version: [stable, dev]
         cli_version: [stable, dev]
-        test: [fluvio,smdk,cdk,fvm]
+        test: [fvm]
         # no need to test stable to stable
         exclude:
           - cluster_version:  stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +1919,25 @@ dependencies = [
  "serde",
  "tokio",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "debugid"
@@ -3690,6 +3719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,8 +4278,8 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "dashmap",
- "deadpool",
- "futures 0.3.29",
+ "deadpool 0.7.0",
+ "futures 0.3.28",
  "http-types",
  "log",
  "rustls 0.18.1",
@@ -4262,6 +4297,7 @@ dependencies = [
  "base64 0.13.1",
  "cookie",
  "futures-lite",
+ "http",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -4283,6 +4319,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hub-fvm"
+version = "0.0.0"
+dependencies = [
+ "async-std",
+ "surf",
+ "wiremock",
+]
 
 [[package]]
 name = "humantime"
@@ -6275,6 +6320,12 @@ dependencies = [
  "webpki-roots 0.25.2",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -8874,6 +8925,28 @@ checksum = "357bb8e2932df531f83b052264b050b81ba0df90ee5a59b2d1d3949f344f81e5"
 dependencies = [
  "bitflags 2.4.1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.4",
+ "deadpool 0.9.5",
+ "futures 0.3.28",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "const-random",
  "getrandom 0.2.10",
  "once_cell",
@@ -226,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,16 +283,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -402,7 +398,7 @@ checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-lite",
  "log",
@@ -485,8 +481,8 @@ dependencies = [
  "async-lock",
  "async-signal",
  "blocking",
- "cfg-if",
- "event-listener 3.0.1",
+ "cfg-if 1.0.0",
+ "event-listener 2.5.3",
  "futures-lite",
  "rustix 0.38.21",
  "windows-sys 0.48.0",
@@ -513,21 +509,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-signal"
-version = "0.2.5"
+name = "async-session"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "345022a2eed092cd105cc1b26fd61c341e100bd5fcbbd792df4baf31c2cc631f"
 dependencies = [
- "async-io 2.1.0",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 0.38.21",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.48.0",
+ "anyhow",
+ "async-std",
+ "async-trait",
+ "base64 0.12.3",
+ "bincode",
+ "blake3",
+ "chrono",
+ "hmac 0.8.1",
+ "kv-log-macro",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "async-sse"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bba003996b8fd22245cd0c59b869ba764188ed435392cf2796d03b805ade10"
+dependencies = [
+ "async-channel",
+ "async-std",
+ "http-types",
+ "log",
+ "memchr",
+ "pin-project-lite 0.1.12",
 ]
 
 [[package]]
@@ -552,7 +565,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -630,7 +643,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -702,6 +715,21 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "blake3"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1057,6 +1085,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1279,7 +1313,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -1334,6 +1368,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "consume"
@@ -1402,7 +1442,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1576,7 +1616,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1621,7 +1661,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1631,7 +1671,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1643,7 +1683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.9.0",
  "scopeguard",
@@ -1655,7 +1695,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1665,7 +1705,7 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1736,6 +1776,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1822,7 +1872,7 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -1849,7 +1899,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1893,8 +1943,8 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
- "hashbrown 0.14.2",
+ "cfg-if 1.0.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
@@ -1919,25 +1969,6 @@ dependencies = [
  "serde",
  "tokio",
 ]
-
-[[package]]
-name = "deadpool"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
-dependencies = [
- "async-trait",
- "deadpool-runtime",
- "num_cpus",
- "retain_mut",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "debugid"
@@ -2085,7 +2116,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -2306,7 +2337,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2362,6 +2393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,7 +2425,7 @@ checksum = "01cec0252c2afff729ee6f00e903d479fba81784c8e2bd77447673471fdfaea1"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
 ]
 
 [[package]]
@@ -2434,9 +2474,25 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
- "cfg-if",
- "rustix 0.38.21",
+ "cfg-if 1.0.0",
+ "rustix 0.38.17",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "femme"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2461,7 +2517,7 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
@@ -2498,7 +2554,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.5",
  "bytes 1.5.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chrono",
  "derive_builder",
  "dirs 5.0.1",
@@ -2575,7 +2631,7 @@ name = "fluvio-channel"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clap",
  "dirs 5.0.1",
  "fluvio-types",
@@ -2592,7 +2648,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clap",
  "colored",
  "dirs 5.0.1",
@@ -2898,7 +2954,7 @@ dependencies = [
  "async-rustls",
  "async-std",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "fluvio-test-derive 0.1.1",
  "fluvio-wasm-timer",
  "futures-lite",
@@ -3062,8 +3118,8 @@ dependencies = [
  "async-lock",
  "async-net",
  "async-trait",
- "base64 0.21.5",
- "cfg-if",
+ "base64 0.21.4",
+ "cfg-if 1.0.0",
  "clap",
  "event-listener 3.0.1",
  "fluvio-auth",
@@ -3134,7 +3190,7 @@ name = "fluvio-smartengine"
 version = "0.7.8"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.0",
  "derive_builder",
  "fluvio-future",
  "fluvio-protocol",
@@ -3182,8 +3238,8 @@ dependencies = [
  "async-trait",
  "built",
  "bytes 1.5.0",
- "cfg-if",
- "event-listener 3.0.1",
+ "cfg-if 1.0.0",
+ "event-listener 3.0.0",
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-types",
@@ -3212,7 +3268,7 @@ dependencies = [
  "async-rwlock",
  "async-trait",
  "bytes 1.5.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chrono",
  "clap",
  "derive_builder",
@@ -3533,13 +3589,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282f382e62a7e429ee2fbb50ecfa919de2aa4a20a9134e1b7d70e026599ec35"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "event-listener 2.5.3",
  "fluvio-future",
  "futures-lite",
  "futures-util",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "serde",
  "serde_json",
  "tokio",
@@ -3613,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982f82cc75107eef84f417ad6c53ae89bf65b561937ca4a3b3b0fd04d0aa2425"
 dependencies = [
  "aligned",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cvt",
  "libc",
  "nix 0.26.4",
@@ -3691,7 +3747,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "waker-fn",
 ]
 
@@ -3719,12 +3775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,7 +3788,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "pin-utils",
  "slab",
  "tokio-io",
@@ -3783,7 +3833,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -3794,7 +3844,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -4212,11 +4262,21 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "digest 0.9.0",
 ]
 
@@ -4263,7 +4323,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.5.0",
  "http",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
 ]
 
 [[package]]
@@ -4276,9 +4336,9 @@ dependencies = [
  "async-std",
  "async-tls",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "dashmap",
- "deadpool 0.7.0",
+ "deadpool",
  "futures 0.3.28",
  "http-types",
  "log",
@@ -4297,9 +4357,8 @@ dependencies = [
  "base64 0.13.1",
  "cookie",
  "futures-lite",
- "http",
  "infer",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -4325,8 +4384,8 @@ name = "hub-fvm"
 version = "0.0.0"
 dependencies = [
  "async-std",
- "surf",
- "wiremock",
+ "serde",
+ "tide",
 ]
 
 [[package]]
@@ -4361,8 +4420,8 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite",
- "socket2 0.4.10",
+ "pin-project-lite 0.2.13",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -4545,7 +4604,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4723,7 +4782,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes 1.5.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "fluvio-future",
  "futures-util",
  "http",
@@ -4866,7 +4925,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -5033,6 +5092,7 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
+ "serde",
  "value-bag",
 ]
 
@@ -5099,7 +5159,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
 ]
 
@@ -5270,7 +5330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -5282,8 +5342,8 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -5501,8 +5561,8 @@ version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -5634,7 +5694,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -5648,7 +5708,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
@@ -5787,6 +5847,12 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
@@ -5877,11 +5943,11 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "windows-sys 0.48.0",
 ]
 
@@ -6269,7 +6335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23895cfadc1917fed9c6ed76a8c2903615fa3704f7493ff82b364c6540acc02b"
 dependencies = [
  "aligned",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cvt",
  "fs_at",
  "lazy_static",
@@ -6302,8 +6368,8 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.8",
+ "pin-project-lite 0.2.13",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6320,12 +6386,6 @@ dependencies = [
  "webpki-roots 0.25.2",
  "winreg",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -6379,8 +6439,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.5"
+name = "route-recognizer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
+
+[[package]]
+name = "rsa"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
@@ -6736,6 +6802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6846,7 +6921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -6858,7 +6933,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -7275,7 +7350,7 @@ checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
 dependencies = [
  "async-std",
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "encoding_rs",
  "futures-util",
  "getrandom 0.2.10",
@@ -7284,11 +7359,79 @@ dependencies = [
  "log",
  "mime_guess",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "rustls 0.18.1",
  "serde",
  "serde_json",
  "web-sys",
+]
+
+[[package]]
+name = "sval"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15df12a8db7c216a04b4b438f90d50d5335cd38f161b56389c9f5c9d96d0873"
+
+[[package]]
+name = "sval_buffer"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e80556bc8acea0446e574ce542ad6114a76a0237f28a842bc01ca3ea98f479"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d93d2259edb1d7b4316179f0a98c62e3ffc726f47ab200e07cfe382771f57b8"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532f7f882226f7a5a4656f5151224aaebf8217e0d539cb1595b831bace921343"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e03bd8aa0ae6ee018f7ae95c9714577687a4415bd1a5f19b26e34695f7e072"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ed054f2fb8c2a0ab5d36c1ec57b412919700099fc5e32ad8e7a38b23e1a9e1"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff191c4ff05b67e3844c161021427646cde5d6624597958be158357d9200586"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_buffer",
+ "sval_fmt",
 ]
 
 [[package]]
@@ -7331,7 +7474,7 @@ version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -7398,7 +7541,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix 0.38.21",
@@ -7456,8 +7599,31 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "tide"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c459573f0dd2cc734b539047f57489ea875af8ee950860ded20cf93a79a1dee0"
+dependencies = [
+ "async-h1",
+ "async-session",
+ "async-sse",
+ "async-std",
+ "async-trait",
+ "femme",
+ "futures-util",
+ "http-client",
+ "http-types",
+ "kv-log-macro",
+ "log",
+ "pin-project-lite 0.2.13",
+ "route-recognizer",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7574,8 +7740,8 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "pin-project-lite",
- "socket2 0.5.5",
+ "pin-project-lite 0.2.13",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -7632,7 +7798,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "tokio",
  "tracing",
 ]
@@ -7727,8 +7893,9 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.13",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -7846,7 +8013,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -7988,7 +8155,37 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 name = "value-bag"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba39dc791ecb35baad371a3fc04c6eab688c04937d2e0ac6c22b612c0357bf"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e06c10810a57bbf45778d023d432a50a1daa7d185991ae06bcfb6c654d0945"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -8097,7 +8294,9 @@ version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -8122,7 +8321,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -8240,7 +8439,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bumpalo",
- "cfg-if",
+ "cfg-if 1.0.0",
  "encoding_rs",
  "fxprof-processed-profile",
  "indexmap 2.1.0",
@@ -8276,7 +8475,7 @@ version = "14.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54984bc0b5689da87a43d7c181d23092b4d5cfcbb7ae3eb6b917dd55865d95e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -8327,7 +8526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf3cee8be02f5006d21b773ffd6802f96a0b7d661ff2ad8a01fb93df458b1aa"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -8391,8 +8590,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345a8b061c9eab459e10b9112df9fc357d5a9e8b5b1004bc5fc674fba9be6d2a"
 dependencies = [
  "cc",
- "cfg-if",
- "rustix 0.38.21",
+ "cfg-if 1.0.0",
+ "rustix 0.38.17",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.48.0",
@@ -8407,7 +8606,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli",
  "ittapi",
@@ -8443,7 +8642,7 @@ version = "14.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67e6be36375c39cff57ed3b137ab691afbf2d9ba8ee1c01f77888413f218749"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -8456,7 +8655,7 @@ checksum = "1d07986b2327b5e7f535ed638fbde25990fc8f85400194fda0d26db71c7b685e"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "encoding_rs",
  "indexmap 2.1.0",
  "libc",
@@ -8913,7 +9112,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 
@@ -8925,28 +9124,6 @@ checksum = "357bb8e2932df531f83b052264b050b81ba0df90ee5a59b2d1d3949f344f81e5"
 dependencies = [
  "bitflags 2.4.1",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "wiremock"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
-dependencies = [
- "assert-json-diff",
- "async-trait",
- "base64 0.21.4",
- "deadpool 0.9.5",
- "futures 0.3.28",
- "futures-timer",
- "http-types",
- "hyper",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ name = "hub-fvm"
 version = "0.0.0"
 dependencies = [
  "async-std",
+ "fluvio-hub-util",
  "serde",
  "tide",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/cargo-builder",
     "connector/json-test-connector",
     "connector/sink-test-connector",
+    "tests/mocks/hub-fvm"
 ]
 resolver = "2"
 

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -15,9 +15,7 @@ setup_file() {
     # Tests in this file are executed in order and rely on the previous test
     # to be successful.
 
-    # Retrieves the latest stable version from the GitHub API and removes the
-    # `v` prefix from the tag name.
-    STABLE_VERSION=$(curl "https://api.github.com/repos/infinyon/fluvio/releases/latest" | jq -r .tag_name | cut -c2-)
+    STABLE_VERSION="0.10.17"
     export STABLE_VERSION
     debug_msg "Stable Version: $STABLE_VERSION"
 

--- a/tests/mocks/hub-fvm/Cargo.toml
+++ b/tests/mocks/hub-fvm/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wiremock = "0.5"
+serde = { version = "1.0", default-features = false, features = ["derive"]}
+tide = { version = "0.16" }
 
 # Workspace dependencies
 async-std = { workspace = true }
-surf = { workspace = true }

--- a/tests/mocks/hub-fvm/Cargo.toml
+++ b/tests/mocks/hub-fvm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hub-fvm"
+version = "0.0.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wiremock = "0.5"
+
+# Workspace dependencies
+async-std = { workspace = true }
+surf = { workspace = true }

--- a/tests/mocks/hub-fvm/Cargo.toml
+++ b/tests/mocks/hub-fvm/Cargo.toml
@@ -13,3 +13,6 @@ tide = { version = "0.16" }
 
 # Workspace dependencies
 async-std = { workspace = true }
+
+# Fluvio dependencies
+fluvio-hub-util = { workspace = true }

--- a/tests/mocks/hub-fvm/Cargo.toml
+++ b/tests/mocks/hub-fvm/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"]}
 tide = { version = "0.16" }
 
 # Workspace dependencies
-async-std = { workspace = true }
+async-std = { workspace = true, features = ["attributes"] }
 
 # Fluvio dependencies
 fluvio-hub-util = { workspace = true }

--- a/tests/mocks/hub-fvm/fixtures/default/0.10.14.json
+++ b/tests/mocks/hub-fvm/fixtures/default/0.10.14.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.10.14",
+  "arch": "x86_64-unknown-linux-musl",
+  "artifacts": [
+    {
+      "name": "fluvio",
+      "version": "0.10.14",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.10.14/x86_64-unknown-linux-musl/fluvio",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.10.14/x86_64-unknown-linux-musl/fluvio.sha256"
+    },
+    {
+      "name": "fluvio-run",
+      "version": "0.10.14",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.10.14/x86_64-unknown-linux-musl/fluvio-run",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.10.14/x86_64-unknown-linux-musl/fluvio-run.sha256"
+    },
+    {
+      "name": "fluvio-cloud",
+      "version": "0.2.15",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud.sha256"
+    },
+    {
+      "name": "smdk",
+      "version": "0.10.14",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.10.14/x86_64-unknown-linux-musl/smdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.10.14/x86_64-unknown-linux-musl/smdk.sha256"
+    },
+    {
+      "name": "cdk",
+      "version": "0.10.14",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.10.14/x86_64-unknown-linux-musl/cdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.10.14/x86_64-unknown-linux-musl/cdk.sha256"
+    }
+  ]
+}

--- a/tests/mocks/hub-fvm/fixtures/default/latest.json
+++ b/tests/mocks/hub-fvm/fixtures/default/latest.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c",
+  "arch": "x86_64-unknown-linux-musl",
+  "artifacts": [
+    {
+      "name": "fluvio",
+      "version": "0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/fluvio",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/fluvio.sha256"
+    },
+    {
+      "name": "fluvio-run",
+      "version": "0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/fluvio-run",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/fluvio-run.sha256"
+    },
+    {
+      "name": "fluvio-cloud",
+      "version": "0.2.15",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud.sha256"
+    },
+    {
+      "name": "smdk",
+      "version": "0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/smdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/smdk.sha256"
+    },
+    {
+      "name": "cdk",
+      "version": "0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/cdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.11.0-dev-1+4549d588cd5377d32174a7374b3aec3e19f8859c/x86_64-unknown-linux-musl/cdk.sha256"
+    }
+  ]
+}

--- a/tests/mocks/hub-fvm/fixtures/default/stable.json
+++ b/tests/mocks/hub-fvm/fixtures/default/stable.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.10.17",
+  "arch": "x86_64-unknown-linux-musl",
+  "artifacts": [
+    {
+      "name": "fluvio",
+      "version": "0.10.17",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.10.17/x86_64-unknown-linux-musl/fluvio",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio/0.10.17/x86_64-unknown-linux-musl/fluvio.sha256"
+    },
+    {
+      "name": "fluvio-run",
+      "version": "0.10.17",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.10.17/x86_64-unknown-linux-musl/fluvio-run",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-run/0.10.17/x86_64-unknown-linux-musl/fluvio-run.sha256"
+    },
+    {
+      "name": "fluvio-cloud",
+      "version": "0.2.15",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/fluvio-cloud/0.2.15/x86_64-unknown-linux-musl/fluvio-cloud.sha256"
+    },
+    {
+      "name": "smdk",
+      "version": "0.10.17",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.10.17/x86_64-unknown-linux-musl/smdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/smdk/0.10.17/x86_64-unknown-linux-musl/smdk.sha256"
+    },
+    {
+      "name": "cdk",
+      "version": "0.10.17",
+      "download_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.10.17/x86_64-unknown-linux-musl/cdk",
+      "sha256_url": "https://packages.fluvio.io/v1/packages/fluvio/cdk/0.10.17/x86_64-unknown-linux-musl/cdk.sha256"
+    }
+  ]
+}

--- a/tests/mocks/hub-fvm/src/fixtures.rs
+++ b/tests/mocks/hub-fvm/src/fixtures.rs
@@ -1,0 +1,3 @@
+pub const DEFAULT_LATEST: &str = include_str!("../fixtures/default/latest.json");
+pub const DEFAULT_STABLE: &str = include_str!("../fixtures/default/stable.json");
+pub const DEFAULT_0_10_14: &str = include_str!("../fixtures/default/0.10.14.json");

--- a/tests/mocks/hub-fvm/src/main.rs
+++ b/tests/mocks/hub-fvm/src/main.rs
@@ -1,18 +1,31 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::str::FromStr;
 
 use tide::Request;
+
+use fluvio_hub_util::fvm::Channel;
 
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut app = tide::new();
 
-    app.at("/get").get(resolve);
+    app.at("/hub/v1/fvm/pkgset/:package/:version/:arch")
+        .get(get_pkgset);
 
-    app.listen("127.0.0.1:8080").await?;
+    app.listen("127.0.0.1:9000").await?;
 
     Ok(())
 }
 
-async fn resolve(mut req: Request<()>) -> tide::Result {
-    Ok(format!("Hello").into())
+async fn get_pkgset(mut req: Request<()>) -> tide::Result {
+    let arch = req.param("arch")?;
+    let package = req.param("package")?;
+    let version = req.param("version")?;
+    let channel = Channel::from_str(version)?;
+    let mocked_pkgset = make_pkgset_mock(arch, package, channel);
+    
+    todo!()
+}
+
+fn make_pkgset_mock(arch: &str, package: &str, channel: Channel) {
+    
 }

--- a/tests/mocks/hub-fvm/src/main.rs
+++ b/tests/mocks/hub-fvm/src/main.rs
@@ -1,6 +1,8 @@
+mod fixtures;
+
 use std::str::FromStr;
 
-use tide::Request;
+use tide::{Request, Response};
 
 use fluvio_hub_util::fvm::Channel;
 
@@ -16,16 +18,17 @@ async fn main() -> tide::Result<()> {
     Ok(())
 }
 
-async fn get_pkgset(mut req: Request<()>) -> tide::Result {
-    let arch = req.param("arch")?;
-    let package = req.param("package")?;
+async fn get_pkgset(req: Request<()>) -> tide::Result {
     let version = req.param("version")?;
     let channel = Channel::from_str(version)?;
-    let mocked_pkgset = make_pkgset_mock(arch, package, channel);
-    
-    todo!()
-}
+    let body = match channel {
+        Channel::Latest => fixtures::DEFAULT_LATEST,
+        Channel::Stable => fixtures::DEFAULT_STABLE,
+        _ => fixtures::DEFAULT_0_10_14,
+    };
 
-fn make_pkgset_mock(arch: &str, package: &str, channel: Channel) {
-    
+    Ok(Response::builder(200)
+        .body(body)
+        .content_type("application/json")
+        .build())
 }

--- a/tests/mocks/hub-fvm/src/main.rs
+++ b/tests/mocks/hub-fvm/src/main.rs
@@ -1,0 +1,29 @@
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::{method, path};
+
+#[async_std::main]
+async fn main() {
+    // Start a background HTTP server on a random local port
+    let mock_server = MockServer::start().await;
+
+    // Arrange the behaviour of the MockServer adding a Mock:
+    // when it receives a GET request on '/hello' it will respond with a 200.
+    Mock::given(method("GET"))
+        .and(path("/hello"))
+        .respond_with(ResponseTemplate::new(200))
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&mock_server)
+        .await;
+
+    // If we probe the MockServer using any HTTP client it behaves as expected.
+    let status = surf::get(format!("{}/hello", &mock_server.uri()))
+        .await
+        .unwrap()
+        .status();
+
+    // If the request doesn't match any `Mock` mounted on our `MockServer` a 404 is returned.
+    let status = surf::get(format!("{}/missing", &mock_server.uri()))
+        .await
+        .unwrap()
+        .status();
+}

--- a/tests/mocks/hub-fvm/src/main.rs
+++ b/tests/mocks/hub-fvm/src/main.rs
@@ -1,29 +1,18 @@
-use wiremock::{MockServer, Mock, ResponseTemplate};
-use wiremock::matchers::{method, path};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tide::Request;
 
 #[async_std::main]
-async fn main() {
-    // Start a background HTTP server on a random local port
-    let mock_server = MockServer::start().await;
+async fn main() -> tide::Result<()> {
+    let mut app = tide::new();
 
-    // Arrange the behaviour of the MockServer adding a Mock:
-    // when it receives a GET request on '/hello' it will respond with a 200.
-    Mock::given(method("GET"))
-        .and(path("/hello"))
-        .respond_with(ResponseTemplate::new(200))
-        // Mounting the mock on the mock server - it's now effective!
-        .mount(&mock_server)
-        .await;
+    app.at("/get").get(resolve);
 
-    // If we probe the MockServer using any HTTP client it behaves as expected.
-    let status = surf::get(format!("{}/hello", &mock_server.uri()))
-        .await
-        .unwrap()
-        .status();
+    app.listen("127.0.0.1:8080").await?;
 
-    // If the request doesn't match any `Mock` mounted on our `MockServer` a 404 is returned.
-    let status = surf::get(format!("{}/missing", &mock_server.uri()))
-        .await
-        .unwrap()
-        .status();
+    Ok(())
+}
+
+async fn resolve(mut req: Request<()>) -> tide::Result {
+    Ok(format!("Hello").into())
 }


### PR DESCRIPTION
Introduces a small HTTP Server to serve mocked responses on FVM API.
https://github.com/infinyon/fluvio/pull/3658/files#diff-e7abc446d77e9879a105046f49adf0277d92e001a4c9d7b4455b2833e1ddbc64

Then updates CI to spin up this server in the background to use for FVM tests.