### PR TITLE
[Merged by Bors] - chore: disable fvm on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,22 +1052,24 @@ jobs:
         run: make CDK_BIN=~/bin/cdk cli-cdk-smoke
 
       # test fvm
-      - name: Download artifact - fvm
-        if: matrix.test == 'fvm'
-        uses: actions/download-artifact@v3
-        with:
-          name: fvm-x86_64-unknown-linux-musl
-          path: ~/bin
-      - name: mark fvm
-        if: matrix.test == 'fvm'
-        run: |
-          chmod +x ~/bin/fvm
-          echo "~/bin" >> $GITHUB_PATH
-      - name: Run FVM smoke tests
-        if: matrix.test == 'fvm'
-        timeout-minutes: 20
-        run: |
-          make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+      # - name: Download artifact - fvm
+      #   if: matrix.test == 'fvm'
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: fvm-x86_64-unknown-linux-musl
+      #     path: ~/bin
+
+      # - name: mark fvm
+      #   if: matrix.test == 'fvm'
+      #   run: |
+      #     chmod +x ~/bin/fvm
+      #     echo "~/bin" >> $GITHUB_PATH
+
+      # - name: Run FVM smoke tests
+      #   if: matrix.test == 'fvm'
+      #   timeout-minutes: 20
+      #   run: |
+      #     make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
 
       - name: Run diagnostics
         if: ${{ !success() }}


### PR DESCRIPTION
Disable FVM tests while Mock Server is introduced. Refer to https://github.com/infinyon/fluvio/issues/3657 for Mock Server Tracking.