### PR TITLE
fix: short circuit error in `query_metadata_path`

### DIFF
--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -67,7 +67,7 @@ impl FluvioConfig {
     where
         T: Deserialize<'de>,
     {
-        let mut metadata = self.metadata.as_ref().unwrap();
+        let mut metadata = self.metadata.as_ref()?;
 
         let (path, key) = {
             let mut split = path.split(&['[', ']']);


### PR DESCRIPTION
Remove a missing `.unwrap()` in `query_metadata_path`