### PR TITLE
fix: properly propagate sm errors on produce

### DIFF
--- a/tests/cli/fluvio_smoke_tests/producer-smartmodule.bats
+++ b/tests/cli/fluvio_smoke_tests/producer-smartmodule.bats
@@ -293,12 +293,6 @@ setup_file() {
     echo "cmd: $BATS_RUN_COMMAND" >&2
     assert_output "topic \"$TOPIC_NAME\" created"
 
-    # create a transforms yaml
-    INPUT_FILE="$(mktemp -t producer_aggregate_test_input.XXXXXX)"
-    export INPUT_FILE
-    echo "transforms:" > "$INPUT_FILE"
-    echo "  - uses: uppercase" >> "$INPUT_FILE"
-
     # Produce to topic with transforms file
     TEST_MESSAGE="Banana"
     export TEST_MESSAGE
@@ -314,9 +308,6 @@ setup_file() {
     assert_output "$EXPECTED_OUTPUT"
     assert_success
 
-
-
-
     # Delete topic
     run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
     echo "cmd: $BATS_RUN_COMMAND" >&2
@@ -326,6 +317,33 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" smartmodule delete "$SMARTMODULE_NAME"
     assert_success
 }
+
+@test "invoke smartmodule in producer with transform json - Negative test" {
+    if [ "$FLUVIO_CLUSTER_RELEASE_CHANNEL" == "stable" ]; then
+        skip "don't run on cluster stable version"
+    fi
+    # Create topic
+    TOPIC_NAME="$(random_string)"
+    export TOPIC_NAME
+    run timeout 15s "$FLUVIO_BIN" topic create "$TOPIC_NAME"
+    echo "cmd: $BATS_RUN_COMMAND" >&2
+    assert_output "topic \"$TOPIC_NAME\" created"
+
+    # Produce to topic with transforms file
+    TEST_MESSAGE="Banana"
+    export TEST_MESSAGE
+    run bash -c 'echo "$TEST_MESSAGE" | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME" \
+        --transform "{\"uses\":\"wrong\"}"'
+    echo "cmd: $BATS_RUN_COMMAND" >&2
+    assert_failure
+    assert_output --partial "SmartModule wrong was not found"
+
+    # Delete topic
+    run timeout 15s "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    echo "cmd: $BATS_RUN_COMMAND" >&2
+    assert_success
+}
+
 
 @test "invoke map smartmodule in producer with compression algorithm" {
     # Create topic


### PR DESCRIPTION
Currently, errors related to SM on produce requests are not properly propagated to the Fluvio client. It leads to the produce request just hanging and is killed by timeout. This includes when smartmodule does not exist but is used in transformation. 