### PR TITLE
chore: use individual cli test retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,11 +1015,8 @@ jobs:
       # Run fluvio test
       - name: Run Fluvio CLI smoke tests
         if: matrix.test == 'fluvio'
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: make cli-fluvio-smoke
+        timeout-minutes: 15
+        run: CLI_TEST_RETRIES=3 make cli-fluvio-smoke
 
       # test smdk
       - name: Download artifact - smdk

--- a/tests/cli/test_helper/tools_check.bash
+++ b/tests/cli/test_helper/tools_check.bash
@@ -5,6 +5,10 @@ main() {
     TEST_HELPER_DIR=${TEST_HELPER_DIR:-./test_helper}
     export TEST_HELPER_DIR
 
+    # BATS_TEST_RETRIES is set to default after bats started therefore we set it here
+    BATS_TEST_RETRIES=${CLI_TEST_RETRIES:-0}
+    export BATS_TEST_RETRIES
+
     check_load_bats_libraries;
     check_fluvio_bin_path;
     check_timeout_bin;


### PR DESCRIPTION
Currently, if we use `nick-fields/retry` retries for cli tests it restarts the entire test suite on a failure. In PR we leverage `BATS_TEST_RETRIES` which allows to configure retries for an individual test which is more effective.