### PR TITLE
fix: clippy warnings in tests

### DIFF
--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -276,8 +276,7 @@ type = "local"
 
             [installation]
             type = "local"
-        }
-        .into();
+        };
 
         assert_eq!(cluster.metadata, table);
     }
@@ -301,8 +300,7 @@ type = "local"
         let table: toml::Table = toml::toml! {
             [installation]
             type = "local"
-        }
-        .into();
+        };
         assert_eq!(cluster.metadata, table);
 
         cluster
@@ -317,8 +315,7 @@ type = "local"
         let updated_table: toml::Table = toml::toml! {
             [installation]
             type = "cloud"
-        }
-        .into();
+        };
 
         assert_eq!(cluster.metadata, updated_table.clone());
 


### PR DESCRIPTION
Remove unnecessary conversion in some tests to fix Clippy error.