### PR TITLE
feat: update fvm to use new hub endpoints on fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,24 +1056,24 @@ jobs:
         run: make CDK_BIN=~/bin/cdk cli-cdk-smoke
 
       # test fvm
-      # - name: Download artifact - fvm
-      #   if: matrix.test == 'fvm'
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: fvm-x86_64-unknown-linux-musl
-      #     path: ~/bin
+      - name: Download artifact - fvm
+        if: matrix.test == 'fvm'
+        uses: actions/download-artifact@v3
+        with:
+          name: fvm-x86_64-unknown-linux-musl
+          path: ~/bin
 
-      # - name: mark fvm
-      #   if: matrix.test == 'fvm'
-      #   run: |
-      #     chmod +x ~/bin/fvm
-      #     echo "~/bin" >> $GITHUB_PATH
+      - name: mark fvm
+        if: matrix.test == 'fvm'
+        run: |
+          chmod +x ~/bin/fvm
+          echo "~/bin" >> $GITHUB_PATH
 
-      # - name: Run FVM smoke tests
-      #   if: matrix.test == 'fvm'
-      #   timeout-minutes: 20
-      #   run: |
-      #     make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+      - name: Run FVM smoke tests
+        if: matrix.test == 'fvm'
+        timeout-minutes: 20
+        run: |
+          make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
 
       - name: Run diagnostics
         if: ${{ !success() }}

--- a/crates/fluvio-hub-util/src/fvm/api/client.rs
+++ b/crates/fluvio-hub-util/src/fvm/api/client.rs
@@ -3,7 +3,7 @@
 use anyhow::{Error, Result};
 use url::Url;
 
-use crate::fvm::{Channel, PackageSet};
+use crate::fvm::{Channel, PackageSet, PackageSetRecord};
 
 /// HTTP Client for interacting with the Hub FVM API
 pub struct Client {
@@ -24,16 +24,17 @@ impl Client {
         let mut res = surf::get(url)
             .await
             .map_err(|err| Error::msg(err.to_string()))?;
-        let pkg = res.body_json::<PackageSet>().await.map_err(|err| {
+        let pkgset_record = res.body_json::<PackageSetRecord>().await.map_err(|err| {
+            tracing::error!(?err, "Failed to parse PackageSet from Hub");
             Error::msg(format!(
                 "Server responded with status code {}",
                 err.status()
             ))
         })?;
 
-        tracing::info!(?pkg, "Found PackageSet");
+        tracing::info!(?pkgset_record, "Found PackageSet");
 
-        Ok(pkg)
+        Ok(pkgset_record.into())
     }
 
     /// Builds the URL to the Hub API for fetching a [`PackageSet`] using the

--- a/crates/fluvio-hub-util/src/fvm/api/client.rs
+++ b/crates/fluvio-hub-util/src/fvm/api/client.rs
@@ -19,13 +19,8 @@ impl Client {
     }
 
     /// Fetches a [`PackageSet`] from the Hub with the specific [`Channel`]
-    pub async fn fetch_package_set(
-        &self,
-        name: impl AsRef<str>,
-        channel: &Channel,
-        arch: &str,
-    ) -> Result<PackageSet> {
-        let url = self.make_fetch_package_set_url(name, channel, arch)?;
+    pub async fn fetch_package_set(&self, channel: &Channel, arch: &str) -> Result<PackageSet> {
+        let url = self.make_fetch_package_set_url(channel, arch)?;
         let mut res = surf::get(url)
             .await
             .map_err(|err| Error::msg(err.to_string()))?;
@@ -43,16 +38,10 @@ impl Client {
 
     /// Builds the URL to the Hub API for fetching a [`PackageSet`] using the
     /// [`Client`]'s `api_url`.
-    fn make_fetch_package_set_url(
-        &self,
-        name: impl AsRef<str>,
-        channel: &Channel,
-        arch: &str,
-    ) -> Result<Url> {
+    fn make_fetch_package_set_url(&self, channel: &Channel, arch: &str) -> Result<Url> {
         let url = format!(
-            "{}hub/v1/fvm/pkgset/{name}/{channel}/{arch}",
+            "{}hub/v1/fvm/pkgset/{channel}?arch={arch}",
             self.api_url,
-            name = name.as_ref(),
             channel = channel,
             arch = arch
         );
@@ -84,10 +73,13 @@ mod tests {
     fn builds_url_for_fetching_pkgsets() {
         let client = Client::new("https://hub.infinyon.cloud").unwrap();
         let url = client
-            .make_fetch_package_set_url("fluvio", &Channel::Stable, "arm-unknown-linux-gnueabihf")
+            .make_fetch_package_set_url(&Channel::Stable, "arm-unknown-linux-gnueabihf")
             .unwrap();
 
-        assert_eq!(url.as_str(), "https://hub.infinyon.cloud/hub/v1/fvm/pkgset/fluvio/stable/arm-unknown-linux-gnueabihf");
+        assert_eq!(
+            url.as_str(),
+            "https://hub.infinyon.cloud/hub/v1/fvm/pkgset/stable?arch=arm-unknown-linux-gnueabihf"
+        );
     }
 
     #[test]
@@ -95,12 +87,11 @@ mod tests {
         let client = Client::new("https://hub.infinyon.cloud").unwrap();
         let url = client
             .make_fetch_package_set_url(
-                "fluvio",
                 &Channel::Tag(Version::from_str("0.10.14-dev+123345abc").unwrap()),
                 "arm-unknown-linux-gnueabihf",
             )
             .unwrap();
 
-        assert_eq!(url.as_str(), "https://hub.infinyon.cloud/hub/v1/fvm/pkgset/fluvio/0.10.14-dev+123345abc/arm-unknown-linux-gnueabihf");
+        assert_eq!(url.as_str(), "https://hub.infinyon.cloud/hub/v1/fvm/pkgset/0.10.14-dev+123345abc?arch=arm-unknown-linux-gnueabihf");
     }
 }

--- a/crates/fluvio-hub-util/src/fvm/mod.rs
+++ b/crates/fluvio-hub-util/src/fvm/mod.rs
@@ -124,7 +124,7 @@ impl From<PackageSetRecord> for PackageSet {
     fn from(value: PackageSetRecord) -> Self {
         let fluvio_artifact = value.artifacts.iter().find(|art| art.name == "fluvio");
         let fluvio_version = fluvio_artifact
-            .and_then(|art| Some(art.version.clone()))
+            .map(|art| art.version.clone())
             .unwrap_or_else(|| Version::new(0, 0, 0));
 
         PackageSet {

--- a/crates/fluvio-hub-util/src/fvm/mod.rs
+++ b/crates/fluvio-hub-util/src/fvm/mod.rs
@@ -114,6 +114,29 @@ pub struct Artifact {
 
 /// Fluvio Version Manager Package for a specific architecture and version.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PackageSetRecord {
+    pub pkgset: String,
+    pub arch: String,
+    pub artifacts: Vec<Artifact>,
+}
+
+impl From<PackageSetRecord> for PackageSet {
+    fn from(value: PackageSetRecord) -> Self {
+        let fluvio_artifact = value.artifacts.iter().find(|art| art.name == "fluvio");
+        let fluvio_version = fluvio_artifact
+            .and_then(|art| Some(art.version.clone()))
+            .unwrap_or_else(|| Version::new(0, 0, 0));
+
+        PackageSet {
+            pkgset: fluvio_version,
+            arch: value.arch,
+            artifacts: value.artifacts,
+        }
+    }
+}
+
+/// Fluvio Version Manager Package for a specific architecture and version.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PackageSet {
     pub pkgset: Version,
     pub arch: String,

--- a/crates/fluvio-version-manager/src/command/install.rs
+++ b/crates/fluvio-version-manager/src/command/install.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use url::Url;
 
 use fluvio_hub_util::HUB_REMOTE;
-use fluvio_hub_util::fvm::{Client, DEFAULT_PKGSET, Channel};
+use fluvio_hub_util::fvm::{Client, Channel};
 
 use crate::common::TARGET;
 use crate::common::notify::Notify;
@@ -39,7 +39,7 @@ impl InstallOpt {
 
         let client = Client::new(self.registry.as_str())?;
         let pkgset = client
-            .fetch_package_set(DEFAULT_PKGSET, &self.version, TARGET)
+            .fetch_package_set(&self.version, TARGET)
             .await?;
 
         VersionInstaller::new(self.version.to_owned(), pkgset, notify)

--- a/crates/fluvio-version-manager/src/command/install.rs
+++ b/crates/fluvio-version-manager/src/command/install.rs
@@ -38,9 +38,7 @@ impl InstallOpt {
         }
 
         let client = Client::new(self.registry.as_str())?;
-        let pkgset = client
-            .fetch_package_set(&self.version, TARGET)
-            .await?;
+        let pkgset = client.fetch_package_set(&self.version, TARGET).await?;
 
         VersionInstaller::new(self.version.to_owned(), pkgset, notify)
             .install()

--- a/crates/fluvio-version-manager/src/command/update.rs
+++ b/crates/fluvio-version-manager/src/command/update.rs
@@ -95,9 +95,7 @@ impl UpdateOpt {
         }
 
         let client = Client::new(self.registry.as_str())?;
-        let pkgset = client
-            .fetch_package_set(channel, TARGET)
-            .await?;
+        let pkgset = client.fetch_package_set(channel, TARGET).await?;
 
         Ok(pkgset)
     }

--- a/crates/fluvio-version-manager/src/command/update.rs
+++ b/crates/fluvio-version-manager/src/command/update.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use url::Url;
 
 use fluvio_hub_util::HUB_REMOTE;
-use fluvio_hub_util::fvm::{Client, DEFAULT_PKGSET, Channel, PackageSet};
+use fluvio_hub_util::fvm::{Client, Channel, PackageSet};
 
 use crate::common::TARGET;
 use crate::common::notify::Notify;
@@ -96,7 +96,7 @@ impl UpdateOpt {
 
         let client = Client::new(self.registry.as_str())?;
         let pkgset = client
-            .fetch_package_set(DEFAULT_PKGSET, channel, TARGET)
+            .fetch_package_set(channel, TARGET)
             .await?;
 
         Ok(pkgset)

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -14,6 +14,10 @@ load "$TEST_HELPER_DIR"/bats-assert/load.bash
 setup_file() {
     # Tests in this file are executed in order and rely on the previous test
     # to be successful.
+    
+    HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud"
+    export HUB_REGISTRY_URL
+    debug_msg "Using Hub Registry URL: $HUB_REGISTRY_URL"
 
     # Retrieves the latest stable version from the GitHub API and removes the
     # `v` prefix from the tag name.


### PR DESCRIPTION
Updates FVM internals, specifically the Hub Client, to use the new endpoint for fetching
Package Sets.

This change does not affect user facing state.