### PR TITLE
feat: fvm user interface improvements

### DIFF
--- a/crates/fluvio-version-manager/src/command/list.rs
+++ b/crates/fluvio-version-manager/src/command/list.rs
@@ -14,9 +14,9 @@ use crate::common::version_directory::VersionDirectory;
 use crate::common::workdir::fvm_versions_path;
 
 #[derive(Debug, Parser)]
-pub struct ShowOpt;
+pub struct ListOpt;
 
-impl ShowOpt {
+impl ListOpt {
     pub async fn process(&self, notify: Notify) -> Result<()> {
         let versions_path = fvm_versions_path()?;
 

--- a/crates/fluvio-version-manager/src/command/mod.rs
+++ b/crates/fluvio-version-manager/src/command/mod.rs
@@ -1,7 +1,7 @@
 pub mod current;
 pub mod install;
 pub mod itself;
-pub mod show;
+pub mod list;
 pub mod switch;
 pub mod update;
 pub mod version;

--- a/crates/fluvio-version-manager/src/command/switch.rs
+++ b/crates/fluvio-version-manager/src/command/switch.rs
@@ -69,10 +69,18 @@ impl SwitchOpt {
 
         version_dir.set_active()?;
 
-        notify.done(format!(
-            "Now using Fluvio version {}",
-            version.to_string().bold(),
-        ));
+        if version.is_version_tag() {
+            notify.done(format!(
+                "Now using Fluvio version {}",
+                version.to_string().bold(),
+            ));
+        } else {
+            notify.done(format!(
+                "Now using Fluvio {} ({})",
+                version.to_string().bold(),
+                version_dir.manifest.version.to_string().bold(),
+            ));
+        }
 
         Ok(())
     }

--- a/crates/fluvio-version-manager/src/command/switch.rs
+++ b/crates/fluvio-version-manager/src/command/switch.rs
@@ -24,7 +24,7 @@ impl SwitchOpt {
         let Some(version) = &self.version else {
             notify.help(format!(
                 "You can use {} to see installed versions",
-                "fvm show".bold()
+                "fvm list".bold()
             ));
 
             return Err(anyhow::anyhow!("No version provided"));

--- a/crates/fluvio-version-manager/src/main.rs
+++ b/crates/fluvio-version-manager/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use self::command::current::CurrentOpt;
 use self::command::install::InstallOpt;
 use self::command::itself::SelfOpt;
-use self::command::show::ShowOpt;
+use self::command::list::ListOpt;
 use self::command::switch::SwitchOpt;
 use self::command::update::UpdateOpt;
 use self::command::version::VersionOpt;
@@ -55,8 +55,8 @@ pub enum Command {
     #[command(name = "install")]
     Install(InstallOpt),
     /// List installed Fluvio Versions
-    #[command(name = "show")]
-    Show(ShowOpt),
+    #[command(name = "list")]
+    List(ListOpt),
     /// Set a installed Fluvio Version as active
     #[command(name = "switch")]
     Switch(SwitchOpt),
@@ -77,7 +77,7 @@ impl Cli {
             Command::Current(cmd) => cmd.process(notify).await,
             Command::Itself(cmd) => cmd.process(notify).await,
             Command::Install(cmd) => cmd.process(notify).await,
-            Command::Show(cmd) => cmd.process(notify).await,
+            Command::List(cmd) => cmd.process(notify).await,
             Command::Switch(cmd) => cmd.process(notify).await,
             Command::Update(cmd) => cmd.process(notify).await,
             Command::Version(cmd) => cmd.process(),

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -129,8 +129,8 @@ setup_file() {
     # Sets `fvm` in the PATH using the "env" file included in the installation
     source ~/.fvm/env
 
-    # Renders warn if attempts to use `fvm show` and no versions are installed
-    run bash -c 'fvm show'
+    # Renders warn if attempts to use `fvm list` and no versions are installed
+    run bash -c 'fvm list'
     assert_line --index 0 "warn: No installed versions found"
     assert_line --index 1 "help: You can install a Fluvio version using the command fvm install"
     assert_success
@@ -422,8 +422,8 @@ setup_file() {
     assert_output --partial "channel = \"stable\""
     assert_success
 
-    # Checks the version is set as active in show list
-    run bash -c 'fvm show'
+    # Checks the version is set as active in list list
+    run bash -c 'fvm list'
     assert_line --index 0 --partial "    CHANNEL  VERSION"
     assert_line --index 1 --partial " ✓  stable   $STABLE_VERSION"
     assert_line --index 2 --partial "    0.10.14  0.10.14"
@@ -453,8 +453,8 @@ setup_file() {
     assert_output --partial "tag = \"0.10.14\""
     assert_success
 
-    # Checks the version is set as active in show list
-    run bash -c 'fvm show'
+    # Checks the version is set as active in list
+    run bash -c 'fvm list'
     assert_line --index 0 --partial "    CHANNEL  VERSION"
     assert_line --index 1 --partial " ✓  0.10.14  0.10.14"
     assert_line --index 2 --partial "    stable   $STABLE_VERSION"
@@ -474,7 +474,7 @@ setup_file() {
     assert_success
 }
 
-@test "Recommends using fvm show to list available versions" {
+@test "Recommends using fvm list to list available versions" {
     run bash -c '$FVM_BIN self install'
     assert_success
 
@@ -482,7 +482,7 @@ setup_file() {
     source ~/.fvm/env
 
     run bash -c 'fvm switch'
-    assert_line --index 0 "help: You can use fvm show to see installed versions"
+    assert_line --index 0 "help: You can use fvm list to see installed versions"
     assert_line --index 1 "Error: No version provided"
     assert_failure
 


### PR DESCRIPTION
These are a couple of very small changes in FVM to make the UI more intuitive.

- [x] Use `fvm list` over `fvm show` for listing installed versions (4ad1b9138aefca96825e2c6f15411dbf60ec1dd2)
- [x] After switching between channels (e.g. fvm switch stable or fvm switch latest), render the underlying tag (82621f2)

## Demo

<div align=center>
  <img src="https://github.com/infinyon/fluvio/assets/34756077/e8fb2d93-9cfe-4d4f-9376-39c67491d460" />
  <br />
  <small>Using switch on Channels now prints the underlying tag</small>
</div>

<div align=center>
  <img src="https://github.com/infinyon/fluvio/assets/34756077/e2c3bb54-3723-4500-ad69-bfa3d5e1aa88" />
  <br />
  <small>Now `fvm list` is used to list versions</small>
</div>