### PR TITLE
fix: render errors from Hub API accordingly

### DIFF
--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -791,3 +791,24 @@ setup_file() {
     rm -rf $FLUVIO_HOME_DIR
     assert_success
 }
+
+@test "Handles unexistent version error" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Attempts to install unexistent version
+    run bash -c 'fvm install 0.0.0'
+    assert_line --index 0 "Error: PackageSet 0.0.0 doest not exist"
+    assert_failure
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}


### PR DESCRIPTION
Update Hub FVM API Client to bubble up `ApiError` responses as messages.

## Demo

<div align=center>
  <img src="https://github.com/infinyon/fluvio/assets/34756077/59f8499e-6794-49cd-a643-6c93f01bc998" />
  <br />
  <small>Message errors from API are now rendered</small>
</div>

<div align=center>
  <img src="https://github.com/infinyon/fluvio/assets/34756077/51d9a4ef-f52a-44e9-a799-ffd14928fb54" />
  <br />
  <small>Using `RUST_LOG=debug` messages from API will be shown</small>
</div>
