### PR TITLE
fix: map `BPKG_TOKEN` for `bump_fluvio` job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Bump latest version of Fluvio CLI with fluvio-packages
         env:
+          BPKG_TOKEN: ${{ secrets.BPKG_TOKEN }}
           FLUVIO_BIN: ~/.fluvio/bin/fluvio
         run: make bump-fluvio-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,8 +277,11 @@ jobs:
       - name: Bump Fluvio CLI
         # This should work until we support graceful failure
         continue-on-error: true
+        env:
+          BPKG_TOKEN: ${{ secrets.BPKG_TOKEN }}
         run: |
           make bump-fluvio-stable
+
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         if: failure()


### PR DESCRIPTION
Add `BPKG_TOKEN` environment variable for `bump-fluvio-stable` and `bump-fluvio-latest`.