### PR TITLE
fix: properly pass owner references in conversions

### DIFF
--- a/crates/fluvio-stream-dispatcher/src/metadata/k8.rs
+++ b/crates/fluvio-stream-dispatcher/src/metadata/k8.rs
@@ -163,7 +163,7 @@ impl<T: K8MetadataClient> MetadataClient<K8MetaItem> for T {
         let k8_input: InputK8Obj<S::K8Spec> = InputK8Obj {
             api_version: S::K8Spec::api_version(),
             kind: S::K8Spec::kind(),
-            metadata: metadata.inner().clone().into(),
+            metadata: metadata.inner().as_input(),
             spec: k8_spec,
             ..Default::default()
         };


### PR DESCRIPTION
There were two places where `owner_references` were lost after conversions:
1. From `ObjectMeta` to `K8MetaItem` if `resource_version` is empty.
2. `InputObjectMeta` = `ObjectMeta::into()` does not pass `owner_references`, instead need to use `ObjectMeta::as_input()` 
