### PR TITLE
chore: ci, perms for publish trigger on repo_dispatch to cd_dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1393,6 +1393,8 @@ jobs:
   # Used by Bors to detect that all required jobs have completed successfully
   done:
     name: Done
+    permissions:
+      contents: write
     if: github.event_name == 'merge_group'
     needs:
       - check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,8 @@ jobs:
   bump_fluvio:
     name: Bump Fluvio CLI version
     needs: [setup, docker, fluvio]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
while ci merge is still occuring on failed CI, go back to repo dispatch that only publishs on successful done step