### PR TITLE
fix: use a different file for tests updating the config

### DIFF
--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -289,8 +289,9 @@ type = "local"
             typ: String,
         }
 
-        let mut config_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
-            .expect("could not parse config file");
+        let mut config_file =
+            ConfigFile::load(Some("test-data/profiles/updatable_config.toml".to_owned()))
+                .expect("could not parse config file");
         let config = config_file.mut_config();
 
         let cluster = config
@@ -321,8 +322,9 @@ type = "local"
 
         config_file.save().expect("failed to save config file");
 
-        let mut config_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
-            .expect("could not parse config file");
+        let mut config_file =
+            ConfigFile::load(Some("test-data/profiles/updatable_config.toml".to_owned()))
+                .expect("could not parse config file");
         let config = config_file.mut_config();
         let cluster = config
             .cluster_mut("updated")

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -489,7 +489,7 @@ pub mod test {
     fn test_config() {
         // test read & parse
         let mut conf_file = ConfigFile::load(Some("test-data/profiles/config.toml".to_owned()))
-            .expect("parse failed");
+            .expect("failed to parse file");
         let config = conf_file.mut_config();
 
         assert_eq!(config.version(), "1.0");

--- a/crates/fluvio/test-data/profiles/config.toml
+++ b/crates/fluvio/test-data/profiles/config.toml
@@ -13,16 +13,6 @@ cluster = "local"
 cluster = "local"
 topic = "test3"
 
-[cluster.updated]
-endpoint = "127.0.0.1"
-use_spu_local_address = false
-
-[cluster.updated.tls]
-tls_policy = "disabled"
-
-[cluster.updated.metadata.installation]
-type = "local"
-
 [cluster.extra]
 endpoint = "127.0.0.1:9003"
 use_spu_local_address = false

--- a/crates/fluvio/test-data/profiles/updatable_config.toml
+++ b/crates/fluvio/test-data/profiles/updatable_config.toml
@@ -1,0 +1,15 @@
+version = "1.0"
+current_profile = "local"
+
+[profile.local]
+cluster = "updated"
+
+[cluster.updated]
+endpoint = "127.0.0.1"
+use_spu_local_address = false
+
+[cluster.updated.tls]
+tls_policy = "disabled"
+
+[cluster.updated.metadata.installation]
+type = "local"


### PR DESCRIPTION
We have a problem when a test fails intermittently to read the config file.

Most tests only read the config file, but one is also modifying it, so I changed it so that the test has its own config file.

I'm not entirely sure that this solves the issue. I've run the CI a couple of times after the changes, and it didn't fail once, but that could be just luck.

fixes: #3707 