### PR TITLE
chore: turn off fvm tests while packageset stabilizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1055,25 +1055,25 @@ jobs:
         run: make CLI_TEST_RETRIES=3 CDK_BIN=~/bin/cdk cli-cdk-smoke
 
       # test fvm
-      - name: Download artifact - fvm
-        if: matrix.test == 'fvm'
-        uses: actions/download-artifact@v3
-        with:
-          name: fvm-x86_64-unknown-linux-musl
-          path: ~/bin
+      # - name: Download artifact - fvm
+      #   if: matrix.test == 'fvm'
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: fvm-x86_64-unknown-linux-musl
+      #     path: ~/bin
 
-      - name: mark fvm
-        if: matrix.test == 'fvm'
-        run: |
-          chmod +x ~/bin/fvm
-          echo "~/bin" >> $GITHUB_PATH
+      # - name: mark fvm
+      #   if: matrix.test == 'fvm'
+      #   run: |
+      #     chmod +x ~/bin/fvm
+      #     echo "~/bin" >> $GITHUB_PATH
 
-      - name: Run FVM smoke tests
-        if: matrix.test == 'fvm'
-        timeout-minutes: 20
-        run: |
-          rm -rf ~/.fvm
-          make CLI_TEST_RETRIES=3 FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+      # - name: Run FVM smoke tests
+      #   if: matrix.test == 'fvm'
+      #   timeout-minutes: 20
+      #   run: |
+      #     rm -rf ~/.fvm
+      #     make CLI_TEST_RETRIES=3 FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
 
       - name: Run diagnostics
         if: ${{ !success() }}

--- a/crates/fluvio-hub-util/src/package.rs
+++ b/crates/fluvio-hub-util/src/package.rs
@@ -69,7 +69,7 @@ fn package_assemble<P: AsRef<Path>, T: AsRef<Path>>(
         augment_arch(&mut pm_clean, target);
     }
 
-    let pkgtarname = outdir.as_ref().join(&pm.packagefile_name_unsigned());
+    let pkgtarname = outdir.as_ref().join(pm.packagefile_name_unsigned());
 
     // crate manifest blob
     //todo: create in tmpdir/tmpfile?


### PR DESCRIPTION
The stable PackageSet is not pointing to the release tag: `0.11.0` because published tag includes SHA which not matches the specific one.

This causes comparisons between tags to fail, resulting in CI failure. To avoid blocking CI these tests are being turn off while PackageSet Stabilizes.