### PR TITLE
chore: updates Rust 1.74 (#3713)

### DIFF
--- a/crates/fluvio-hub-util/src/package.rs
+++ b/crates/fluvio-hub-util/src/package.rs
@@ -69,7 +69,7 @@ fn package_assemble<P: AsRef<Path>, T: AsRef<Path>>(
         augment_arch(&mut pm_clean, target);
     }
 
-    let pkgtarname = outdir.as_ref().join(&pm.packagefile_name_unsigned());
+    let pkgtarname = outdir.as_ref().join(pm.packagefile_name_unsigned());
 
     // crate manifest blob
     //todo: create in tmpdir/tmpfile?

--- a/crates/fluvio-version-manager/src/common/version_installer.rs
+++ b/crates/fluvio-version-manager/src/common/version_installer.rs
@@ -72,7 +72,7 @@ impl VersionInstaller {
         tmp_dir: &TempDir,
         package_set: &PackageSet,
     ) -> Result<PathBuf> {
-        let version_path = fvm_versions_path()?.join(&self.channel.to_string());
+        let version_path = fvm_versions_path()?.join(self.channel.to_string());
 
         if !version_path.exists() {
             create_dir(&version_path)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.0"


### PR DESCRIPTION
clippy updates from @matheus-consoli! Provided on #3713.

---

This used to turn off FVM tests and also includes fixes on Rust update by @matheus-consoli but given that PackageSet is now fixed by hotpatch (kudos to @digikata), this only includes @matheus-consoli update!