### PR TITLE
ci: fvm_basic.bats, smoke test adjustment

### DIFF
--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -14,8 +14,8 @@ load "$TEST_HELPER_DIR"/bats-assert/load.bash
 setup_file() {
     # Tests in this file are executed in order and rely on the previous test
     # to be successful.
-    
-    HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud"
+
+    HUB_REGISTRY_URL="https://hub.infinyon.cloud"
     export HUB_REGISTRY_URL
     debug_msg "Using Hub Registry URL: $HUB_REGISTRY_URL"
 


### PR DESCRIPTION
Mixing artifact state w/ dev-hub status instead of hub objects was causing failures.  