### PR TITLE
feat: support cluster upgrade/check/status for local cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,7 +1139,7 @@ jobs:
 
   # Runs tests on `tests/cli/partition_test`
   partition_test:
-    name: Partitions Test (${{ matrix.test }} with ${{ matrix.spu }} SPUs, ${{ matrix.partitions }} Partitions and ${{ matrix.replication }} Replicas) on ${{ matrix.os }} for ${{ matrix.rust-target }}
+    name: Partitions Test (${{ matrix.test }} with ${{ matrix.spu }} SPUs, ${{ matrix.partitions }} Partitions and ${{ matrix.replication }} Replicas), Run Mode ${{ matrix.run-mode }} 
     runs-on: ${{ matrix.os }}
     env:
       FLUVIO_BIN: "~/bin/fluvio"

--- a/crates/fluvio-cluster/src/cli/delete.rs
+++ b/crates/fluvio-cluster/src/cli/delete.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
-use fluvio::config::ConfigFile;
 use tracing::debug;
 
-use crate::InstallationType;
+use crate::{InstallationType, cli::get_installation_type};
 use crate::delete::ClusterUninstallConfig;
 use crate::cli::ClusterCliError;
 
@@ -34,9 +33,7 @@ impl DeleteOpt {
             builder.uninstall_k8(true);
             builder.uninstall_sys(false);
         } else {
-            let config_file = ConfigFile::load_default_or_new()?;
-            let installation_type =
-                InstallationType::load_or_default(config_file.config().current_cluster()?);
+            let installation_type = get_installation_type()?;
             debug!(?installation_type);
             match installation_type {
                 InstallationType::K8 => {

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -9,11 +9,10 @@ use sysinfo::{System, SystemExt, NetworkExt, ProcessExt, DiskExt, PidExt};
 use which::which;
 use anyhow::Result;
 
-use fluvio::config::ConfigFile;
 use fluvio::metadata::{topic::TopicSpec, partition::PartitionSpec, spg::SpuGroupSpec, spu::SpuSpec};
 use fluvio_sc_schema::objects::Metadata;
 
-use crate::InstallationType;
+use crate::{InstallationType, cli::get_installation_type};
 use crate::cli::ClusterCliError;
 use crate::cli::start::get_log_directory;
 use crate::start::local::{DEFAULT_DATA_DIR as DEFAULT_LOCAL_DIR, DEFAULT_METADATA_SUB_DIR};
@@ -26,7 +25,7 @@ pub struct DiagnosticsOpt {
 
 impl DiagnosticsOpt {
     pub async fn process(self) -> Result<()> {
-        let installation_ty = self.get_installation_ty()?;
+        let installation_ty = get_installation_type()?;
         println!("Using installation: {installation_ty:#?}");
         let temp_dir = tempfile::Builder::new()
             .prefix("fluvio-diagnostics")
@@ -97,13 +96,6 @@ impl DiagnosticsOpt {
 
         println!("Wrote diagnostics to {}", diagnostic_path.display());
         Ok(())
-    }
-
-    fn get_installation_ty(&self) -> Result<InstallationType> {
-        let config = ConfigFile::load_default_or_new()?;
-        Ok(InstallationType::load_or_default(
-            config.config().current_cluster()?,
-        ))
     }
 
     fn zip_files(&self, source: &Path, output: &mut std::fs::File) -> Result<(), std::io::Error> {

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use clap::ValueEnum;
 use clap::Parser;
+use common::installation::InstallationType;
+use fluvio::config::ConfigFile;
 use semver::Version;
 use tracing::debug;
 
@@ -15,9 +17,9 @@ mod error;
 mod diagnostics;
 mod status;
 mod shutdown;
+mod upgrade;
 
 use start::StartOpt;
-use start::UpgradeOpt;
 use delete::DeleteOpt;
 use check::CheckOpt;
 use group::SpuGroupCmd;
@@ -25,6 +27,7 @@ use spu::SpuCmd;
 use diagnostics::DiagnosticsOpt;
 use status::StatusOpt;
 use shutdown::ShutdownOpt;
+use upgrade::UpgradeOpt;
 
 pub use self::error::ClusterCliError;
 
@@ -55,9 +58,7 @@ pub enum ClusterCmd {
     /// Check that all requirements for cluster startup are met.
     ///
     /// This command is useful to check if user has all the required dependencies and permissions to run
-    /// fluvio on the current Kubernetes context.
-    ///
-    /// It is not intended to be used in scenarios where user does not have access to Kubernetes resources (eg. Cloud)
+    /// fluvio cluster.
     #[command(name = "check")]
     Check(CheckOpt),
 
@@ -163,4 +164,11 @@ impl ClusterCmd {
 
         Ok(())
     }
+}
+
+pub(crate) fn get_installation_type() -> Result<InstallationType, ClusterCliError> {
+    let config = ConfigFile::load_default_or_new()?;
+    Ok(InstallationType::load_or_default(
+        config.config().current_cluster()?,
+    ))
 }

--- a/crates/fluvio-cluster/src/cli/shutdown.rs
+++ b/crates/fluvio-cluster/src/cli/shutdown.rs
@@ -2,7 +2,6 @@ use std::fs::remove_file;
 use std::process::Command;
 
 use clap::Parser;
-use fluvio::config::ConfigFile;
 use tracing::debug;
 use sysinfo::{ProcessExt, System, SystemExt};
 
@@ -12,7 +11,7 @@ use fluvio_command::CommandExt;
 use crate::render::ProgressRenderer;
 use crate::cli::ClusterCliError;
 use crate::progress::ProgressBarFactory;
-use crate::{ClusterError, UninstallError, InstallationType};
+use crate::{ClusterError, UninstallError, InstallationType, cli::get_installation_type};
 
 #[derive(Debug, Parser)]
 pub struct ShutdownOpt;
@@ -29,9 +28,7 @@ impl ShutdownOpt {
                 ))
             }
         };
-        let config_file = ConfigFile::load_default_or_new()?;
-        let installation_type =
-            InstallationType::load_or_default(config_file.config().current_cluster()?);
+        let installation_type = get_installation_type()?;
         debug!(?installation_type);
 
         match installation_type {

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -219,25 +219,12 @@ impl IntallationTypeOpt {
         self.local || self.local_k8 || self.read_only.is_some()
     }
 
-    fn get(&self) -> InstallationType {
+    pub fn get(&self) -> InstallationType {
         match (self.local, self.local_k8, &self.read_only) {
             (true, _, _) => InstallationType::Local,
             (_, true, _) => InstallationType::LocalK8,
             (_, _, Some(_)) => InstallationType::ReadOnly,
             _ => InstallationType::K8,
         }
-    }
-}
-
-#[derive(Debug, Parser)]
-pub struct UpgradeOpt {
-    #[clap(flatten)]
-    pub start: StartOpt,
-}
-
-impl UpgradeOpt {
-    pub async fn process(self, platform_version: Version) -> Result<()> {
-        self.start.process(platform_version, true).await?;
-        Ok(())
     }
 }

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -1,0 +1,37 @@
+use clap::Parser;
+use fluvio_extension_common::installation::InstallationType;
+use semver::Version;
+use anyhow::{Result, bail};
+use tracing::debug;
+
+use crate::{cli::shutdown::ShutdownOpt, cli::get_installation_type};
+
+use super::start::StartOpt;
+
+#[derive(Debug, Parser)]
+pub struct UpgradeOpt {
+    #[clap(flatten)]
+    pub start: StartOpt,
+}
+
+impl UpgradeOpt {
+    pub async fn process(self, platform_version: Version) -> Result<()> {
+        let installation_type = get_installation_type()?;
+        debug!(?installation_type);
+        let requested_installtion_type = self.start.installation_type.get();
+        if installation_type != requested_installtion_type {
+            bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested_installtion_type}");
+        }
+        match installation_type {
+            InstallationType::K8 => {
+                self.start.process(platform_version, true).await?;
+            }
+            InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
+                ShutdownOpt.process().await?;
+                self.start.process(platform_version, true).await?;
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -660,6 +660,10 @@ impl ClusterInstaller {
             self.discover_sc_external_host_and_port(&sc_service).await?;
         let external_host_and_port = format!("{external_host}:{external_port}");
 
+        if self.config.save_profile {
+            self.update_profile(&external_host_and_port)?;
+        }
+
         self.wait_for_sc_availability().await?;
 
         let (install_host_and_port, pf_process) = if self.config.use_k8_port_forwarding {
@@ -682,10 +686,6 @@ impl ClusterInstaller {
         pb.println(format!("✅ Connected to SC: {install_host_and_port}"));
         pb.finish_and_clear();
         drop(pb);
-
-        if self.config.save_profile {
-            self.update_profile(&external_host_and_port)?;
-        }
 
         // Create a managed SPU cluster
         self.create_managed_spu_group(&fluvio).await?;

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -443,13 +443,12 @@ impl LocalInstaller {
         pb.finish_and_clear();
         drop(pb);
 
+        self.set_profile()?;
+
         let pb = self.pb_factory.create()?;
         let fluvio = self.launch_sc(&address, port, &pb).await?;
         pb.println(InstallProgressMessage::ScLaunched.msg());
         pb.finish_and_clear();
-
-        // set profile as long as sc is up
-        self.set_profile()?;
 
         let pb: ProgressRenderer = self.pb_factory.create()?;
 


### PR DESCRIPTION
Cluster operations `upgrade`, `check`, and `status` should be aware of the installation type of the cluster.

Additionally, setting the profile during the installation is put before any actual actions to the system, so in case of failure, the delete command will clean up accordingly. 