### PR TITLE
feat: hide `fvm self install` from and help introduce `fvm self update`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-version-manager"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-version-manager"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Version Manager"

--- a/crates/fluvio-version-manager/src/command/itself/mod.rs
+++ b/crates/fluvio-version-manager/src/command/itself/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod install;
 pub mod uninstall;
+pub mod update;
 
 use anyhow::Result;
 use clap::Parser;
@@ -10,6 +11,7 @@ use crate::common::notify::Notify;
 
 use self::install::SelfInstallOpt;
 use self::uninstall::SelfUninstallOpt;
+use self::update::SelfUpdateOpt;
 
 #[derive(Debug, Parser)]
 pub enum ItselfCommand {
@@ -18,6 +20,8 @@ pub enum ItselfCommand {
     Install(SelfInstallOpt),
     /// Uninstall `fvm` and removes the workspace
     Uninstall(SelfUninstallOpt),
+    /// Prints `fvm` update instructions
+    Update(SelfUpdateOpt),
 }
 
 /// The `install` command is responsible of installing the desired Package Set
@@ -33,6 +37,7 @@ impl SelfOpt {
         match &self.command {
             ItselfCommand::Install(cmd) => cmd.process(notify).await?,
             ItselfCommand::Uninstall(cmd) => cmd.process(notify).await?,
+            ItselfCommand::Update(cmd) => cmd.process(notify).await?,
         }
 
         Ok(())

--- a/crates/fluvio-version-manager/src/command/itself/mod.rs
+++ b/crates/fluvio-version-manager/src/command/itself/mod.rs
@@ -14,6 +14,7 @@ use self::uninstall::SelfUninstallOpt;
 #[derive(Debug, Parser)]
 pub enum ItselfCommand {
     /// Install `fvm` and setup the workspace
+    #[clap(hide = true)]
     Install(SelfInstallOpt),
     /// Uninstall `fvm` and removes the workspace
     Uninstall(SelfUninstallOpt),

--- a/crates/fluvio-version-manager/src/command/itself/update.rs
+++ b/crates/fluvio-version-manager/src/command/itself/update.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::common::notify::Notify;
+
+#[derive(Clone, Debug, Parser)]
+pub struct SelfUpdateOpt;
+
+impl SelfUpdateOpt {
+    pub async fn process(&self, notify: Notify) -> Result<()> {
+        notify.info("To update fvm, please run:");
+        notify.info("curl -fsS https://hub.infinyon.cloud/install/install.sh | bash");
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Hide `fvm self install` as its only used for install script
- Provide update details via `fvm self update`
- Bumps patch version number to `0.1.1`

## Demo

![fvm self update](https://github.com/infinyon/fluvio/assets/34756077/113786bf-787d-46a4-8f4a-0481bfdaafbb)
