### PR TITLE
chore: remove implicit cluster start from tests

### DIFF
--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/cli-platform-cross-version.bats
+++ b/tests/cli/cli-platform-cross-version.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/cluster-delete.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/cluster-delete.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../../test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-SKIP_CLUSTER_START=true
-export SKIP_CLUSTER_START
-
 TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
 export TEST_HELPER_DIR
 

--- a/tests/cli/test_helper/tools_check.bash
+++ b/tests/cli/test_helper/tools_check.bash
@@ -12,14 +12,6 @@ main() {
     check_load_bats_libraries;
     check_fluvio_bin_path;
     check_timeout_bin;
-
-    if [[ -n $SKIP_CLUSTER_START ]]; then
-        #echo "# Skipping cluster start" >&3
-        :
-    else
-        #echo "# Starting cluster" >&3
-        check_fluvio_cluster;
-    fi
 }
 
 function check_fluvio_bin_path() {


### PR DESCRIPTION
Currently, unless explicitly disabled, it tries to run Fluvio cluster on every run of bats test file. It is often forgotten which led to wasting a lot of time in CI. 