### PR TITLE
chore: update local clusters setup on CD and Hourly

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -77,20 +77,12 @@ jobs:
         with:
           ref: ${{ needs.setup.pub_sha }}
       - name: Set up K3d for Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: |
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Set up K8 for ubuntu(kind)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: ./k8-util/cluster/reset-k3d.sh
-      - name: Install Docker for Mac
-        if: ${{ matrix.os == 'macos-12' }}
-        uses: docker-practice/actions-setup-docker@master
-      - name: Set up Kind for Mac
-        if: ${{ matrix.os == 'macos-12' }}
-        run: |
-          brew install kind
-          kind create cluster --config k8-util/cluster/kind.yaml
       - name: Install Fluvio CLI
         run: |
           curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=latest bash
@@ -103,13 +95,8 @@ jobs:
         timeout-minutes: 3
         if: ${{ matrix.cluster_type == 'k8' }}
         run: |
-          if [[ ${{ matrix.os }} == 'macos-12' ]]; then
-              export PROXY="--proxy-addr  127.0.0.1"
-            else
-              export PROXY=""
-          fi
           FLUVIO_IMAGE_TAG_STRATEGY=version-git \
-          fluvio cluster start  --spu-storage-size 1 $PROXY
+          fluvio cluster start --k8 --spu-storage-size 1 
       - name: Run E2E Test
         timeout-minutes: 2
         run: |
@@ -121,9 +108,7 @@ jobs:
             date +"%Y-%m-%dT%H:%M:%S%z"
             echo foo | fluvio produce ${{ env.TOPIC }}
             fluvio consume ${{ env.TOPIC }} --start 0 -d | grep -F -w "foo"
-            # Delete the topic afterword but this looks to not work right now.
-            # fluvio topic delete "${{ env.TOPIC }}"
-
+            fluvio topic delete "${{ env.TOPIC }}"
       - name: Run diagnostics
         if: ${{ !success() }}
         timeout-minutes: 5
@@ -258,18 +243,13 @@ jobs:
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.2.1
-      - name: Setup K3d
-        run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
-      - name: Create K3d cluster
-        run: |
-          ./k8-util/cluster/reset-k3d.sh
       - name: Setup bin path
         run:  echo "~/.fluvio/bin" >> $GITHUB_PATH
       - name: Install stable CLI and start Fluvio cluster
         timeout-minutes: 10
         run: |
           curl -fsS https://hub.infinyon.cloud/install/install.sh | VERSION=${{ matrix.cluster_version }} bash
-          fluvio cluster start
+          fluvio cluster start --local
       - name: CLI ${{ matrix.cli_version }} x Cluster ${{ matrix.cluster_version }}
         run: |
           make FLUVIO_BIN=~/.fluvio/bin/fluvio SKIP_SETUP=true CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test

--- a/.github/workflows/cd_dev_mac.yaml
+++ b/.github/workflows/cd_dev_mac.yaml
@@ -45,19 +45,12 @@ jobs:
       TOPIC: foobar
     steps:
       - uses: actions/checkout@v4
-      - name: Set up K3d for Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
-      - name: Set up K8 for ubuntu(kind)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: ./k8-util/cluster/reset-k3d.sh
       - name: Install Docker for Mac
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.cluster_type == 'k8' }}
         uses: docker-practice/actions-setup-docker@master
         timeout-minutes: 5
       - name: Set up Kind for Mac
-        if: ${{ matrix.os == 'macos-12' }}
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: |
           brew install kind
           kind create cluster --config k8-util/cluster/kind.yaml
@@ -73,12 +66,7 @@ jobs:
         timeout-minutes: 3
         if: ${{ matrix.cluster_type == 'k8' }}
         run: |
-          if [[ ${{ matrix.os }} == 'macos-12' ]]; then
-              export PROXY="--proxy-addr  127.0.0.1"
-            else
-              export PROXY=""
-          fi
-          fluvio cluster start  --spu-storage-size 1 --image-version latest $PROXY
+          fluvio cluster start --k8 --spu-storage-size 1 --image-version latest --proxy-addr 127.0.0.1
       - name: Run E2E Test
         timeout-minutes: 2
         run: |
@@ -90,9 +78,7 @@ jobs:
             date +"%Y-%m-%dT%H:%M:%S%z"
             echo foo | fluvio produce ${{ env.TOPIC }}
             fluvio consume ${{ env.TOPIC }} --start 0 -d | grep -F -w "foo"
-            # Delete the topic afterword but this looks to not work right now.
-            # fluvio topic delete "${{ env.TOPIC }}"
-
+            fluvio topic delete "${{ env.TOPIC }}"
       - name: Run diagnostics
         if: ${{ !success() }}
         timeout-minutes: 5

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -9,7 +9,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *"
   # pull_request:
   #   branches: [master]
   workflow_dispatch:
@@ -96,6 +96,7 @@ jobs:
         topic: [1, 10]
         topic_segment_bytes: [500000] # 500KB
         topic_retention: [15s]
+        cluster_type: [local,k8]
     env:
       TEST_BINARY: fluvio-test-x86_64-unknown-linux-musl
 
@@ -145,8 +146,10 @@ jobs:
       # If they don't match, then let's run the test
 
       - name: Setup K3d
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: |
           ./k8-util/cluster/reset-k3d.sh
       - name: Install Fluvio CLI and start cluster
@@ -156,7 +159,7 @@ jobs:
       - name: Start Fluvio Cluster
         run: |
           fluvio version
-          fluvio cluster start
+          fluvio cluster start --${{ matrix.cluster_type}}
 
       # Disabled for now bc data load is unstable in CI
       #- name: Look for longevity data

--- a/tests/cli/cli-platform-cross-version.bats
+++ b/tests/cli/cli-platform-cross-version.bats
@@ -37,7 +37,7 @@ setup_file() {
     if [[ -z "$CI" ]];
     then
         echo "# Deleting cluster" >&3
-        $FLUVIO_BIN cluster delete
+        "$FLUVIO_BIN" cluster delete --local || "$FLUVIO_BIN" cluster delete
     else
         echo "# [CI MODE] Skipping initial cleanup" >&3
     fi;
@@ -60,7 +60,7 @@ teardown_file() {
     if [[ -z "$SKIP_CLEANUP" ]];
     then
         echo "# Deleting cluster" >&3
-        "$FLUVIO_BIN" cluster delete
+        "$FLUVIO_BIN" cluster delete --local || "$FLUVIO_BIN" cluster delete
     else
         echo "# Skipping cleanup" >&3
     fi

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -75,7 +75,7 @@ function validate_cluster_stable() {
     ~/.fvm/bin/fvm switch stable
 
     echo "Installing stable fluvio cluster"
-    $STABLE_FLUVIO cluster start
+    $STABLE_FLUVIO cluster start --k8
     ci_check;
 
     # Baseline: CLI version and platform version are expected to be the same


### PR DESCRIPTION
1. `CD_DEV` and `CD_DEV_Mac` - do not install k8s for local clusters, explicitly set installation type so it won't be broken when defaults change.
2. `Hourly` - added local cluster to longevity tests, set it to every 2 hours instead of every hour to compensate for increased CI time.