### PR TITLE
feat: do not allow version switching when process are running

### DIFF
--- a/crates/fluvio-version-manager/src/common/version_directory.rs
+++ b/crates/fluvio-version-manager/src/common/version_directory.rs
@@ -1,7 +1,7 @@
 use std::fs::{read_dir, copy, create_dir_all};
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use sysinfo::{System, SystemExt};
 
 use fluvio_hub_util::fvm::Channel;
@@ -127,9 +127,7 @@ impl VersionDirectory {
         let fluvio_run_running = system.processes_by_exact_name("fluvio-run").count();
 
         if fluvio_running > 0 || fluvio_run_running > 0 {
-            return Err(anyhow::anyhow!(
-                "Cannot uninstall fluvio while fluvio or fluvio-run are running"
-            ));
+            bail!("Cannot switch versions while `fluvio` or `fluvio-run` are running");
         }
 
         Ok(())

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -818,7 +818,7 @@ setup_file() {
     source ~/.fvm/env
 
     # Starts Fluvio Cluster
-    fluvio cluster delete || true
+    fluvio cluster delete --local || true
 
     # Installs Fluvio Stable
     run bash -c 'fvm install'

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -817,6 +817,9 @@ setup_file() {
     # Sets `fvm` in the PATH using the "env" file included in the installation
     source ~/.fvm/env
 
+    # Starts Fluvio Cluster
+    fluvio cluster delete || true
+
     # Installs Fluvio Stable
     run bash -c 'fvm install'
     assert_success

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -822,8 +822,7 @@ setup_file() {
     assert_success
 
     # Starts Fluvio Cluster
-    run bash -c 'fluvio cluster start --local' &
-    sleep 10
+    run bash -c 'fluvio cluster start --local'
     assert_success
 
     # Attempts to switch version


### PR DESCRIPTION
When either `fluvio` or `fluvio-run` are running, switching versions via FVM,
will break pipes thus causing `fluvio` process to be killed on every execution.

To avoid this, check if theres any processes on these two binaries running
before switching versions with FVM.

## Demo

https://github.com/infinyon/fluvio/assets/34756077/6917d96a-b5ae-4d5b-8844-afedacb67261

