### PR TITLE
chore: explicitly set cluster type in CI/CD

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -94,14 +94,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cluster_type: [local, k8s]
+        cluster_type: [local, k8]
     env:
       FLV_SOCKET_WAIT: 600
     steps:
       - uses: actions/checkout@v4
       - name: Setup K3d
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash
       - name: Create K3d cluster
+        if: ${{ matrix.cluster_type == 'k8' }}
         run: |
           ./k8-util/cluster/reset-k3d.sh
 
@@ -119,17 +121,11 @@ jobs:
         run: |
           curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
           echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
-      - name: Pre-Start - local cluster
-        if: matrix.cluster_type == 'local'
-        run: echo "IF_LOCAL=--local" | tee -a $GITHUB_ENV
-      - name: Pre-Start - Kubernetes cluster
-        if: matrix.cluster_type == 'k8s'
-        run: echo "IF_LOCAL=" | tee -a $GITHUB_ENV
       - name: Start cluster
-        timeout-minutes: 3
+        timeout-minutes: 10
         run: |
           fluvio version
-          fluvio cluster start ${IF_LOCAL}
+          fluvio cluster start --${{ matrix.cluster_type }}
       - name: Run diagnostics
         if: failure()
         timeout-minutes: 5
@@ -171,7 +167,7 @@ jobs:
       - name: Install last stable Fluvio CLI and start cluster
         run: |
           curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=$PREV_STABLE_VERSION bash
-          ~/.fluvio/bin/fluvio cluster start
+          ~/.fluvio/bin/fluvio cluster start --k8
           ~/.fluvio/bin/fluvio version
 
       - name: Set the expected fluvio version for upgrade

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,18 +819,18 @@ jobs:
         if: matrix.test == 'smoke-test-k8' || matrix.test == 'stats-test'
         timeout-minutes: 10
         run: |
-          fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}  --namespace ${K8_NAMESPACE}
+          fluvio cluster start --k8 --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }}  --namespace ${K8_NAMESPACE}
       - name: Start fluvio cluster TLS
         timeout-minutes: 10
         if: matrix.test == 'smoke-test-k8-tls'
         run: |
-          fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}  --namespace ${K8_NAMESPACE}
+          fluvio cluster start --k8 --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}  --namespace ${K8_NAMESPACE}
       - name: Start fluvio cluster TLS with root
         timeout-minutes: 10
         if: matrix.test == 'smoke-test-k8-tls-root-unclean'
         run: |
           make smoke-test-k8-tls-policy-setup
-          fluvio cluster start --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}  --namespace ${K8_NAMESPACE} --authorization-config-map authorization
+          fluvio cluster start --k8 --develop --spu ${{ matrix.spu }} --rust-log ${{ env.SERVER_LOG }} ${{ env.TLS_ARGS }}  --namespace ${K8_NAMESPACE} --authorization-config-map authorization
       - name: Run ${{ matrix.test }}
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci_mac.yaml
+++ b/.github/workflows/ci_mac.yaml
@@ -362,7 +362,7 @@ jobs:
         if: ${{ matrix.k8 == 'kind' }}
         timeout-minutes: 3
         run: |
-          fluvio cluster start  --develop --spu-storage-size 1 --proxy-addr  127.0.0.1
+          fluvio cluster start --k8 --develop --spu-storage-size 1 --proxy-addr  127.0.0.1
       # run a simpler configuration to run in a constraint mac
       - name: Run smoke-test-k8
         timeout-minutes: 3

--- a/actions/action-install-fluvio-cluster.sh
+++ b/actions/action-install-fluvio-cluster.sh
@@ -20,6 +20,10 @@ IMAGE=""
 if [ "$CLUSTER_TYPE" = "local" ]; then
     LOCAL_FLAG="--local"
 fi
+# Install K8S Fluvio Cluster
+if [ "$CLUSTER_TYPE" = "k8" ]; then
+    LOCAL_FLAG="--k8"
+fi
 
 # For latest, we need to put image tag
 if [ "$VERSION" = "latest" ]; then

--- a/k8-util/cluster/kind.sh
+++ b/k8-util/cluster/kind.sh
@@ -1,3 +1,3 @@
 kind create cluster --config k8-util/cluster/kind.yaml 
 make build_k8_image
-flvd cluster start  --develop --proxy-addr  127.0.0.1
+flvd cluster start --k8 --develop --proxy-addr  127.0.0.1

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -168,7 +168,7 @@ smoke-test-k8-tls-root: smoke-test-k8-tls-policy-setup smoke-test-k8-tls-policy 
 
 install-test-k8-port-forwarding: build_k8_image
 install-test-k8-port-forwarding:
-	$(FLUVIO_BIN) cluster start --develop --use-k8-port-forwarding
+	$(FLUVIO_BIN) cluster start --k8 --develop --use-k8-port-forwarding
 
 ifeq (${CI},true)
 # In CI, we expect all artifacts to already be built and loaded for the script

--- a/tests/longevity-producer.sh
+++ b/tests/longevity-producer.sh
@@ -50,7 +50,7 @@ function setup() {
 
 
     # Start a cluster
-    $FLUVIO_BIN cluster start --image-version latest
+    $FLUVIO_BIN cluster start --k8 --image-version latest
 
     # Create a topic to delete at the end
     #$FLUVIO_BIN topic create $NEW_TOPIC_NAME || true

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -32,7 +32,7 @@ uninstall-local:
 	$(FLUVIO_BIN) cluster delete
 
 install-k8-tls:
-	$(FLUVIO_BIN) cluster start --develop \
+	$(FLUVIO_BIN) cluster start --k8 --develop \
 		--tls --server-cert tls/certs/server.crt --server-key tls/certs/server.key \
 		--ca-cert tls/certs/ca.crt --client-cert tls/certs/client-root.crt	\
 		--client-key tls/certs/client-root.key --domain fluvio.local


### PR DESCRIPTION
Set explicitly `k8` cluster type where it is required. This is preparation for changing local cluster type as default on cluster start.