### PR TITLE
feat: make local cluster as default in cli

### DIFF
--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -40,7 +40,7 @@ pub async fn process_local(
         builder.skip_checks(true);
     }
 
-    builder.installation_type(opt.installation_type.get());
+    builder.installation_type(opt.installation_type.get_or_default());
 
     builder.read_only_config(opt.installation_type.read_only);
 

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -18,9 +18,9 @@ impl UpgradeOpt {
     pub async fn process(mut self, platform_version: Version) -> Result<()> {
         let installation_type = get_installation_type()?;
         debug!(?installation_type);
-        if let Some(requested_installtion_type) = self.start.installation_type.get() {
-            if installation_type != requested_installtion_type {
-                bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested_installtion_type}");
+        if let Some(requested) = self.start.installation_type.get() {
+            if installation_type != requested {
+                bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested}");
             }
         } else {
             self.start.installation_type.set(installation_type.clone());

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -15,12 +15,15 @@ pub struct UpgradeOpt {
 }
 
 impl UpgradeOpt {
-    pub async fn process(self, platform_version: Version) -> Result<()> {
+    pub async fn process(mut self, platform_version: Version) -> Result<()> {
         let installation_type = get_installation_type()?;
         debug!(?installation_type);
-        let requested_installtion_type = self.start.installation_type.get();
-        if installation_type != requested_installtion_type {
-            bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested_installtion_type}");
+        if let Some(requested_installtion_type) = self.start.installation_type.get() {
+            if installation_type != requested_installtion_type {
+                bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested_installtion_type}");
+            }
+        } else {
+            self.start.installation_type.set(installation_type.clone());
         }
         match installation_type {
             InstallationType::K8 => {


### PR DESCRIPTION
Set the `local` cluster as a default one for `fluvio cluster start`.

Closes infinyon/roadmap#160