### PR TITLE
feat: added minimal support for docker inst type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/fluvio-cluster/src/cli/check.rs
+++ b/crates/fluvio-cluster/src/cli/check.rs
@@ -42,6 +42,7 @@ impl CheckOpt {
                 ClusterChecker::empty().with_no_k8_checks()
             }
             InstallationType::LocalK8 => ClusterChecker::empty().with_local_checks(),
+            _other => ClusterChecker::empty(),
         };
 
         let pb = ProgressBarFactory::new(false);

--- a/crates/fluvio-cluster/src/cli/delete.rs
+++ b/crates/fluvio-cluster/src/cli/delete.rs
@@ -51,6 +51,11 @@ impl DeleteOpt {
                     builder.uninstall_k8(false);
                     builder.uninstall_sys(false);
                 }
+                other => {
+                    return Err(ClusterCliError::Other(format!(
+                        "delete command is not supported for {other} installation type"
+                    )))
+                }
             }
         }
 

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -84,6 +84,7 @@ impl DiagnosticsOpt {
                     self.spu_disk_usage(Some(&kubectl), temp_path, &spu.spec)?;
                 }
             }
+            _other => {}
         }
 
         self.write_system_info(temp_path)?;

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -239,6 +239,7 @@ impl IntallationTypeOpt {
             InstallationType::Local => (true, false, false, None),
             InstallationType::LocalK8 => (false, true, false, None),
             InstallationType::ReadOnly => (false, false, false, Some(Default::default())),
+            InstallationType::Docker => (false, false, false, None),
         };
         self.local = local;
         self.local_k8 = local_k8;

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -33,6 +33,7 @@ impl UpgradeOpt {
                 ShutdownOpt.process().await?;
                 self.start.process(platform_version, true).await?;
             }
+            other => bail!("upgrade command is not supported for {other} installation type"),
         };
 
         Ok(())

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -389,9 +389,9 @@ impl LocalInstaller {
                     .await?;
                 Ok(())
             }
-            InstallationType::K8 => Err(ClusterCheckError::Other(
-                "Installation type K8 is not supported for local clusters".to_string(),
-            )),
+            other => Err(ClusterCheckError::Other(format!(
+                "Installation type {other} is not supported for local clusters"
+            ))),
         }
     }
 
@@ -491,6 +491,11 @@ impl LocalInstaller {
             InstallationType::LocalK8 | InstallationType::K8 => ScMode::K8s,
             InstallationType::ReadOnly => {
                 ScMode::ReadOnly(self.config.read_only_config.clone().unwrap_or_default())
+            }
+            other => {
+                return Err(LocalInstallError::Other(format!(
+                    "Installation type {other} is not supported for local clusters"
+                )))
             }
         };
 

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"

--- a/crates/fluvio-extension-common/src/installation.rs
+++ b/crates/fluvio-extension-common/src/installation.rs
@@ -13,6 +13,7 @@ pub enum InstallationType {
     Local,
     LocalK8,
     ReadOnly,
+    Docker,
 }
 
 impl FromStr for InstallationType {
@@ -42,6 +43,9 @@ impl FromStr for InstallationType {
         }
         if s.eq_ignore_ascii_case("readonly") {
             return Ok(Self::ReadOnly);
+        }
+        if s.eq_ignore_ascii_case("docker") {
+            return Ok(Self::Docker);
         }
         Err(format!("unsupported instalaltion type '{s}'"))
     }


### PR DESCRIPTION
Added new installation type `Docker` with minimal support: it is only possible to add it manually and it won't allow to do commands that do not support it. It prevents errors if fluvio cli runs against clusters in docker.