### PR TITLE
feat: fvm uninstall command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-version-manager"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-version-manager"
-version = "0.1.2"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-version-manager"
-version = "0.1.2"
+version = "0.0.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Version Manager"

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-version-manager"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Version Manager"

--- a/crates/fluvio-version-manager/src/command/mod.rs
+++ b/crates/fluvio-version-manager/src/command/mod.rs
@@ -3,5 +3,6 @@ pub mod install;
 pub mod itself;
 pub mod list;
 pub mod switch;
+pub mod uninstall;
 pub mod update;
 pub mod version;

--- a/crates/fluvio-version-manager/src/command/uninstall.rs
+++ b/crates/fluvio-version-manager/src/command/uninstall.rs
@@ -1,0 +1,51 @@
+//! Install Command
+//!
+//! Downloads and stores the sepecific Fluvio Version binaries in the local
+//! FVM cache.
+
+use anyhow::Result;
+use clap::Parser;
+
+use colored::Colorize;
+use fluvio_hub_util::fvm::Channel;
+
+use crate::common::notify::Notify;
+
+use crate::common::version_directory::VersionDirectory;
+
+use crate::common::workdir::fvm_versions_path;
+
+/// The `install` command is responsible of installing the desired Package Set
+#[derive(Debug, Parser)]
+pub struct UninstallOpt {
+    /// Version to install: stable, latest, or named-version x.y.z
+    #[arg(index = 1, default_value_t = Channel::Stable)]
+    version: Channel,
+}
+
+impl UninstallOpt {
+    pub async fn process(&self, notify: Notify) -> Result<()> {
+        let versions_path = fvm_versions_path()?;
+
+        if !versions_path.exists() {
+            notify.warn("No versions installed");
+            return Ok(());
+        }
+
+        let pkgset_path = versions_path.join(self.version.to_string());
+
+        if !pkgset_path.exists() {
+            notify.warn(format!(
+                "Fluvio version {} is not installed",
+                self.version.to_string().bold()
+            ));
+
+            return Ok(());
+        }
+
+        let version_directory = VersionDirectory::open(pkgset_path)?;
+        version_directory.remove()?;
+
+        Ok(())
+    }
+}

--- a/crates/fluvio-version-manager/src/command/version.rs
+++ b/crates/fluvio-version-manager/src/command/version.rs
@@ -6,14 +6,14 @@ use current_platform::CURRENT_PLATFORM;
 use sha2::{Digest, Sha256};
 use sysinfo::SystemExt;
 
-use crate::{BINARY_NAME, BINARY_VERSION};
+use crate::{BINARY_NAME, VERSION};
 
 #[derive(Debug, Args)]
 pub struct VersionOpt;
 
 impl VersionOpt {
     pub fn process(self) -> Result<()> {
-        println!("{BINARY_NAME} CLI: {BINARY_VERSION}");
+        println!("{BINARY_NAME} CLI: {VERSION}");
         println!("{BINARY_NAME} CLI Arch: {CURRENT_PLATFORM}");
 
         if let Some(sha) = self.format_cli_sha() {

--- a/crates/fluvio-version-manager/src/main.rs
+++ b/crates/fluvio-version-manager/src/main.rs
@@ -17,8 +17,8 @@ use self::common::notify::Notify;
 /// Binary name is read from `Cargo.toml` `[[bin]]` section
 pub const BINARY_NAME: &str = env!("CARGO_BIN_NAME");
 
-/// Binary version is read from `Cargo.toml` `version` field
-pub const BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Binary version is read from `VERSION` file, which is the same as Fluvio version
+pub const VERSION: &str = include_str!("../../../VERSION");
 
 #[async_std::main]
 async fn main() -> Result<()> {

--- a/crates/fluvio-version-manager/src/main.rs
+++ b/crates/fluvio-version-manager/src/main.rs
@@ -3,6 +3,7 @@ mod common;
 
 use anyhow::Result;
 use clap::Parser;
+use command::uninstall::UninstallOpt;
 
 use self::command::current::CurrentOpt;
 use self::command::install::InstallOpt;
@@ -60,6 +61,9 @@ pub enum Command {
     /// Set a installed Fluvio Version as active
     #[command(name = "switch")]
     Switch(SwitchOpt),
+    /// Uninstalls a Fluvio Version
+    #[command(name = "uninstall")]
+    Uninstall(UninstallOpt),
     /// Updates the current channel version to the most recent
     #[command(name = "update")]
     Update(UpdateOpt),
@@ -79,6 +83,7 @@ impl Cli {
             Command::Install(cmd) => cmd.process(notify).await,
             Command::List(cmd) => cmd.process(notify).await,
             Command::Switch(cmd) => cmd.process(notify).await,
+            Command::Uninstall(cmd) => cmd.process(notify).await,
             Command::Update(cmd) => cmd.process(notify).await,
             Command::Version(cmd) => cmd.process(),
         }

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -49,13 +49,9 @@ setup_file() {
     export FLUVIO_BINARIES_DIR
     debug_msg "Fluvio Binaries Directory: $FLUVIO_BINARIES_DIR"
 
-    FVM_CARGO_TOML_VERSION="$(yq -oy '.package.version' ./crates/fluvio-version-manager/Cargo.toml)"
-    export FVM_CARGO_TOML_VERSION
-    debug_msg "FVM Cargo.toml Version: $FVM_CARGO_TOML_VERSION"
-
     VERSION_FILE="$(cat ./VERSION)"
     export VERSION_FILE
-    debug_msg "Version File Value: $FVM_CARGO_TOML_VERSION"
+    debug_msg "Version File Value: $VERSION_FILE"
 }
 
 @test "Install fvm and setup a settings.toml file" {
@@ -679,7 +675,7 @@ setup_file() {
     source ~/.fvm/env
 
     run bash -c 'fvm version'
-    assert_line --index 0 "fvm CLI: $FVM_CARGO_TOML_VERSION"
+    assert_line --index 0 "fvm CLI: $VERSION_FILE"
     assert_line --index 1 --partial "fvm CLI Arch: "
     assert_line --index 2 --partial "fvm CLI SHA256: "
     assert_line --index 3 --partial "OS Details: "

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -809,3 +809,51 @@ setup_file() {
     rm -rf $FLUVIO_HOME_DIR
     assert_success
 }
+
+@test "Uninstall Versions" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Install stable version
+    run bash -c 'fvm install stable'
+    assert_success
+
+    # Install specific 0.11.0 version
+    run bash -c 'fvm install 0.11.0'
+    assert_success
+
+    # Ensure `~/.fvm/versions/stable` is present
+    run bash -c 'test -d $FLUVIO_HOME_DIR/versions/stable'
+    assert_success
+
+    # Ensure `~/.fvm/versions/0.11.0` is present
+    run bash -c 'test -d $FLUVIO_HOME_DIR/versions/0.11.0'
+    assert_success
+
+    # Uninstall stable version
+    run bash -c 'fvm uninstall stable'
+    assert_success
+
+    # Uninstall specific 0.11.0 version
+    run bash -c 'fvm uninstall 0.11.0'
+    assert_success
+
+    # Ensure `~/.fvm/versions/stable` is present
+    run bash -c '!test -d $FLUVIO_HOME_DIR/versions/stable'
+    assert_success
+
+    # Ensure `~/.fvm/versions/0.11.0` is present
+    run bash -c '!test -d $FLUVIO_HOME_DIR/versions/0.11.0'
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -58,757 +58,757 @@ setup_file() {
     debug_msg "Version File Value: $FVM_CARGO_TOML_VERSION"
 }
 
-@test "Install fvm and setup a settings.toml file" {
-    # Ensure the `fvm` directory is not present
-    run bash -c '! test -d ~/.fvm'
-    assert_success
-
-    # Installs FVM which introduces the `~/.fvm` directory and copies the FVM
-    # binary to ~/.fvm/bin/fvm
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Tests FVM to be in the PATH
-    run bash -c 'which fvm'
-    assert_output --partial ".fvm/bin/fvm"
-    assert_success
-
-    # Retrieves Version from FVM
-    run bash -c 'fvm --help'
-    assert_output --partial "Fluvio Version Manager (FVM)"
-    assert_success
-
-    # Ensure the `settings.toml` is available. At this point this is an empty file
-    run bash -c 'cat ~/.fvm/settings.toml'
-    assert_output ""
-    assert_success
-}
-
-@test "Uninstall fvm and removes ~/.fvm dir" {
-    # Ensure the `fvm` directory is present from the previous test
-    run bash -c 'test -d ~/.fvm'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Test the fvm command is present
-    run bash -c 'which fvm'
-    assert_output --partial ".fvm/bin/fvm"
-    assert_success
-
-    # We use `--yes` because prompting is not supported in CI environment,
-    # responding with error `Error: IO error: not a terminal`
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Ensure the `~/.fvm/` directory is not available anymore
-    run bash -c '! test -d ~/.fvm'
-    assert_success
-
-    # Ensure the fvm is not available anymore
-    run bash -c '! fvm'
-    assert_success
-}
-
-@test "Creates the `$VERSIONS_DIR` path if not present when attempting to install" {
-    # Verify the directory is not present initally
-    run bash -c '! test -d $VERSIONS_DIR'
-    assert_success
-
-    # Installs FVM as usual
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Renders warn if attempts to use `fvm list` and no versions are installed
-    run bash -c 'fvm list'
-    assert_line --index 0 "warn: No installed versions found"
-    assert_line --index 1 "help: You can install a Fluvio version using the command fvm install"
-    assert_success
-
-    # Verify the directory is now present
-    run bash -c 'test -d $VERSIONS_DIR'
-    assert_success
-
-    # Remove versions directory
-    rm -rf $VERSIONS_DIR
-
-    # Installs Stable Fluvio
-    run bash -c 'fvm install'
-    assert_success
-
-    # Checks the presence of the binary in the versions directory
-    run bash -c 'test -f $VERSIONS_DIR/stable/fluvio'
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-}
-
-@test "Install Fluvio Versions" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Expected binaries
-    declare -a binaries=(
-        fluvio
-        fluvio-run
-        fluvio-cloud
-        cdk
-        smdk
-    )
-
-    # Expected versions
-    declare -a versions=(
-        $STATIC_VERSION
-        stable
-        latest
-    )
-
-    for version in "${versions[@]}"
-    do
-        export VERSION="$version"
-
-        run bash -c 'fvm install "$VERSION"'
-        assert_success
-
-        # Sleeps to avoid hiting rate limits
-        sleep 30
-
-        for binary in "${binaries[@]}"
-        do
-            export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
-            echo "Checking binary: $BINARY_PATH"
-            run bash -c 'test -f $BINARY_PATH'
-            assert_success
-        done
-
-        if [ "$VERSION" == "stable" ] || [ "$VERSION" == "latest" ]; then
-            run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .channel'
-            assert_output "\"$version\""
-            assert_success
-        else
-            run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .version'
-            assert_output "\"$version\""
-            assert_success
-        fi
-
-        if [ "$VERSION" == "stable" ]; then
-            run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
-            assert_output --partial "$STABLE_VERSION"
-            assert_success
-        fi
-
-        if [ "$VERSION" == "$STATIC_VERSION" ]; then
-            run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
-            assert_output --partial "$STATIC_VERSION"
-            assert_success
-        fi
-    done
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-}
-
-@test "Copies binaries to Fluvio Binaries Directory when using fvm switch" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Removes Fluvio Directory
-    rm -rf $FLUVIO_HOME_DIR
-
-    # Ensure `~/.fluvio` is not present
-    run bash -c '! test -d $FLUVIO_HOME_DIR'
-    assert_success
-
-    declare -a versions=(
-        stable
-        $STATIC_VERSION
-    )
-
-    # Installs Versions
-    for version in "${versions[@]}"
-    do
-        export VERSION="$version"
-
-        # Installs Fluvio Version
-        run bash -c 'fvm install $VERSION'
-        assert_success
-
-        # Sleeps to avoid hiting rate limits
-        sleep 30
-    done
-
-    for version in "${versions[@]}"
-    do
-        export VERSION="$version"
-
-        # Switch version to use
-        run bash -c 'fvm switch $VERSION'
-        assert_success
-
-        # Checks version is set
-        if [ "$VERSION" == "stable" ]; then
-            run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
-            assert_output --partial "$STABLE_VERSION"
-            assert_success
-        fi
-
-        if [ "$VERSION" == "$STATIC_VERSION" ]; then
-            run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
-            assert_output --partial "$STATIC_VERSION"
-            assert_success
-        fi
-
-        # Checks Settings File's Version is updated
-        if [ "$VERSION" == "stable" ]; then
-            run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
-            assert_output --partial "$STABLE_VERSION"
-            assert_success
-        fi
-
-        if [ "$VERSION" == "$STATIC_VERSION" ]; then
-            run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
-            assert_output --partial "$STATIC_VERSION"
-            assert_success
-        fi
-
-        # Checks Settings File's Channel is updated
-        if [ "$VERSION" == "stable" ]; then
-            run bash -c 'yq -oy '.channel' "$SETTINGS_TOML_PATH"'
-            assert_output --partial "stable"
-            assert_success
-        fi
-
-        if [ "$VERSION" == "$STATIC_VERSION" ]; then
-            run bash -c 'yq -oy '.channel.tag' "$SETTINGS_TOML_PATH"'
-            assert_output --partial "$STATIC_VERSION"
-            assert_success
-        fi
-
-        # Expected binaries
-        declare -a binaries=(
-            fluvio
-            fluvio-run
-            fluvio-cloud
-            cdk
-            smdk
-        )
-
-        for binary in "${binaries[@]}"
-        do
-            export FVM_BIN_PATH="$VERSIONS_DIR/$VERSION/$binary"
-            echo "Checking binary: $BINARY_PATH"
-            run bash -c 'test -f $FVM_BIN_PATH'
-            assert_success
-
-            export FLV_BIN_PATH="$FLUVIO_BINARIES_DIR/$binary"
-            echo "Checking binary: $FLV_BIN_PATH"
-            run bash -c 'test -f $FLV_BIN_PATH'
-            assert_success
-
-            export SHASUM_A=$(sha256sum $FVM_BIN_PATH | awk '{ print $1 }')
-            export SHASUM_B=$(sha256sum $FLV_BIN_PATH | awk '{ print $1 }')
-            assert_equal "$SHASUM_A" "$SHASUM_B"
-        done
-    done
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Sets the desired Fluvio Version" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Ensure `~/.fluvio` is not present
-    run bash -c '! test -d $FLUVIO_HOME_DIR'
-    assert_success
-
-    # Installs Fluvio at 0.10.15
-    run bash -c 'fvm install 0.10.15'
-    assert_success
-
-    # Sleeps to avoid hiting rate limits
-    sleep 30
-
-    # Installs Fluvio at 0.10.14
-    run bash -c 'fvm install 0.10.14'
-    assert_success
-
-    # Sleeps to avoid hiting rate limits
-    sleep 30
-
-    # Switch version to use Fluvio at 0.10.15
-    run bash -c 'fvm switch 0.10.15'
-    assert_success
-
-    # Checks version is set
-    run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.15"'
-    assert_output --partial "0.10.15"
-    assert_success
-
-    # Switch version to use Fluvio at 0.10.14
-    run bash -c 'fvm switch 0.10.14'
-    assert_success
-
-    # Checks version is set
-    run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.14"'
-    assert_output --partial "0.10.14"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Keeps track of the active Fluvio Version in settings.toml" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Ensure `~/.fluvio` is not present
-    run bash -c '! test -d $FLUVIO_HOME_DIR'
-    assert_success
-
-    # Installs Fluvio Stable
-    run bash -c 'fvm install stable'
-    assert_success
-
-    # Sleeps to avoid hiting rate limits
-    sleep 30
-
-    # Installs Fluvio at 0.10.14
-    run bash -c 'fvm install 0.10.14'
-    assert_success
-
-    # Switch version to use Fluvio at Stable
-    run bash -c 'fvm switch stable'
-    assert_success
-
-    # Checks channel is set
-    run bash -c 'cat ~/.fvm/settings.toml | grep "channel = \"stable\""'
-    assert_output --partial "channel = \"stable\""
-    assert_success
-
-    # Checks the version is set as active in list list
-    run bash -c 'fvm list'
-    assert_line --index 0 --partial "    CHANNEL  VERSION"
-    assert_line --index 1 --partial " ✓  stable   $STABLE_VERSION"
-    assert_line --index 2 --partial "    0.10.14  0.10.14"
-    assert_success
-
-    # Checks current command output
-    run bash -c 'fvm current'
-    assert_line --index 0 "$STABLE_VERSION (stable)"
-    assert_success
-
-    # Checks version is set
-    run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"$STABLE_VERSION\""'
-    assert_output --partial "version = \"$STABLE_VERSION\""
-    assert_success
-
-    # Switch version to use Fluvio at 0.10.14
-    run bash -c 'fvm switch 0.10.14'
-    assert_success
-
-    # Checks version is set
-    run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"0.10.14\""'
-    assert_output --partial "version = \"0.10.14\""
-    assert_success
-
-    # Checks channel is tag
-    run bash -c 'cat ~/.fvm/settings.toml | grep "tag = \"0.10.14\""'
-    assert_output --partial "tag = \"0.10.14\""
-    assert_success
-
-    # Checks the version is set as active in list
-    run bash -c 'fvm list'
-    assert_line --index 0 --partial "    CHANNEL  VERSION"
-    assert_line --index 1 --partial " ✓  0.10.14  0.10.14"
-    assert_line --index 2 --partial "    stable   $STABLE_VERSION"
-    assert_success
-
-    # Checks current command output
-    run bash -c 'fvm current'
-    assert_line --index 0 "0.10.14"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Recommends using fvm list to list available versions" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm switch'
-    assert_line --index 0 "help: You can use fvm list to see installed versions"
-    assert_line --index 1 "Error: No version provided"
-    assert_failure
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-}
-
-@test "Supress output with '-q' optional argument" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Expect no output if `-q` is passed
-    run bash -c 'fvm -q install stable'
-    assert_output ""
-    assert_success
-
-    # Sleeps to avoid hiting rate limits
-    sleep 30
-
-    # Expect output if `-q` is not passed
-    run bash -c 'fvm install 0.10.14'
-    assert_line --index 0 --partial "info: Downloading (1/5)"
-    assert_output --partial "done: Now using fluvio version 0.10.14"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Renders help text on current command if none active" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm current'
-    assert_line --index 0 "warn: No active version set"
-    assert_line --index 1 "help: You can use fvm switch to set the active version"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Sets the desired version after installing it" {
-    export VERSION="0.10.14"
-
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm current'
-    assert_line --index 0 "warn: No active version set"
-    assert_line --index 1 "help: You can use fvm switch to set the active version"
-    assert_success
-
-    run bash -c 'fvm install $VERSION'
-    assert_success
-
-    run bash -c 'fvm current'
-    assert_line --index 0 "$VERSION"
-    assert_success
-
-    run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$VERSION"'
-    assert_output --partial "$VERSION"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Replaces binary on installs" {
-    # Checks the presence of the binary in the versions directory
-    run bash -c '! test -f "$FVM_HOME_DIR/bin/fvm"'
-    assert_success
-
-    # Create FVM Binaries directory
-    mkdir -p "$FVM_HOME_DIR/bin"
-
-    # Create bash file to check if the binary is present
-    run bash -c 'echo "echo \"Hello World!\"" > "$FVM_HOME_DIR/bin/fvm"'
-    assert_success
-
-    # Store this file Sha256 Checksum
-    export SHASUM_TEST_FILE=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
-
-    # Install FVM using `self install`
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Store FVM Binary Sha256 Checksum
-    export SHASUM_FVM_BIN=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
-
-    # Ensure the checksums are different
-    [[ "$SHASUM_TEST_FILE" != "$SHASUM_FVM_BIN" ]]
-    assert_success
-
-    # Ensure file is not corrupted on updates
-    run bash -c 'fvm --help'
-    assert_output --partial "Fluvio Version Manager (FVM)"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-}
-
-@test "Updating keeps settings files integrity" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm install stable'
-    assert_success
-
-    # Store Settings File Checksum
-    export SHASUM_SETTINGS_BEFORE=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
-
-    # We cannot use `fvm self install` so use other copy of FVM to test binary
-    # replacement
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Store Settings File Checksum
-    export SHASUM_SETTINGS_AFTER=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
-
-    assert_equal "$SHASUM_SETTINGS_BEFORE" "$SHASUM_SETTINGS_AFTER"
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Fails when using 'fvm self install' on itself" {
-    skip "Ubuntu CI does not support this test due to mounted virtual volume path mismatch"
-
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm install stable'
-    assert_success
-
-    # We cannot use `fvm self install` so use other copy of FVM to test binary
-    # replacement
-    run bash -c 'fvm self install'
-    assert_output --partial "Error: FVM is already installed"
-    assert_failure
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Prints version with details on fvm version" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    run bash -c 'fvm version'
-    assert_line --index 0 "fvm CLI: $FVM_CARGO_TOML_VERSION"
-    assert_line --index 1 --partial "fvm CLI Arch: "
-    assert_line --index 2 --partial "fvm CLI SHA256: "
-    assert_line --index 3 --partial "OS Details: "
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Updates version in channel" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Installs the stable version
-    run bash -c 'fvm install stable'
-    assert_success
-
-    # Changes the version set as `stable` channel to $STATIC_VERSION in order to
-    # force an update. $STATIC_VERSION just to reuse the variable to improve
-    # readability, it could be any version tag (but stable of course!)
-    #
-    # This wont work in macOS because the sed command is different there
-    sed -i "s/$STABLE_VERSION/$STATIC_VERSION/g" $FVM_HOME_DIR/settings.toml
-
-    # Checks active version
-    run bash -c 'fvm current'
-    assert_line --index 0 "$STATIC_VERSION (stable)"
-    assert_success
-
-    # Attempts to update Fluvio
-    run bash -c 'fvm update'
-    assert_line --index 0 "info: Updating fluvio stable to version $STABLE_VERSION. Current version is $STATIC_VERSION."
-    assert_success
-
-    # Checks active version
-    run bash -c 'fvm current'
-    assert_line --index 0 "$STABLE_VERSION (stable)"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Do not updates version in static tag" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Installs the stable version
-    run bash -c 'fvm install $STATIC_VERSION'
-    assert_success
-
-    # Attempts to update Fluvio
-    run bash -c 'fvm update'
-    assert_line --index 0 "info: Cannot update a static version tag. You must use a channel."
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Renders message when already up-to-date" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Installs the stable version
-    run bash -c 'fvm install'
-    assert_success
-
-    # Sleeps to avoid hiting rate limits
-    sleep 30
-
-    # Attempts to update Fluvio
-    run bash -c 'fvm update'
-    assert_line --index 0 "done: You are already up to date"
-    assert_success
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
-
-@test "Handles unexistent version error" {
-    run bash -c '$FVM_BIN self install'
-    assert_success
-
-    # Sets `fvm` in the PATH using the "env" file included in the installation
-    source ~/.fvm/env
-
-    # Attempts to install unexistent version
-    run bash -c 'fvm install 0.0.0'
-    assert_line --index 0 "Error: PackageSet 0.0.0 doest not exist"
-    assert_failure
-
-    # Removes FVM
-    run bash -c 'fvm self uninstall --yes'
-    assert_success
-
-    # Removes Fluvio
-    rm -rf $FLUVIO_HOME_DIR
-    assert_success
-}
+# @test "Install fvm and setup a settings.toml file" {
+#     # Ensure the `fvm` directory is not present
+#     run bash -c '! test -d ~/.fvm'
+#     assert_success
+
+#     # Installs FVM which introduces the `~/.fvm` directory and copies the FVM
+#     # binary to ~/.fvm/bin/fvm
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Tests FVM to be in the PATH
+#     run bash -c 'which fvm'
+#     assert_output --partial ".fvm/bin/fvm"
+#     assert_success
+
+#     # Retrieves Version from FVM
+#     run bash -c 'fvm --help'
+#     assert_output --partial "Fluvio Version Manager (FVM)"
+#     assert_success
+
+#     # Ensure the `settings.toml` is available. At this point this is an empty file
+#     run bash -c 'cat ~/.fvm/settings.toml'
+#     assert_output ""
+#     assert_success
+# }
+
+# @test "Uninstall fvm and removes ~/.fvm dir" {
+#     # Ensure the `fvm` directory is present from the previous test
+#     run bash -c 'test -d ~/.fvm'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Test the fvm command is present
+#     run bash -c 'which fvm'
+#     assert_output --partial ".fvm/bin/fvm"
+#     assert_success
+
+#     # We use `--yes` because prompting is not supported in CI environment,
+#     # responding with error `Error: IO error: not a terminal`
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Ensure the `~/.fvm/` directory is not available anymore
+#     run bash -c '! test -d ~/.fvm'
+#     assert_success
+
+#     # Ensure the fvm is not available anymore
+#     run bash -c '! fvm'
+#     assert_success
+# }
+
+# @test "Creates the `$VERSIONS_DIR` path if not present when attempting to install" {
+#     # Verify the directory is not present initally
+#     run bash -c '! test -d $VERSIONS_DIR'
+#     assert_success
+
+#     # Installs FVM as usual
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Renders warn if attempts to use `fvm list` and no versions are installed
+#     run bash -c 'fvm list'
+#     assert_line --index 0 "warn: No installed versions found"
+#     assert_line --index 1 "help: You can install a Fluvio version using the command fvm install"
+#     assert_success
+
+#     # Verify the directory is now present
+#     run bash -c 'test -d $VERSIONS_DIR'
+#     assert_success
+
+#     # Remove versions directory
+#     rm -rf $VERSIONS_DIR
+
+#     # Installs Stable Fluvio
+#     run bash -c 'fvm install'
+#     assert_success
+
+#     # Checks the presence of the binary in the versions directory
+#     run bash -c 'test -f $VERSIONS_DIR/stable/fluvio'
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+# }
+
+# @test "Install Fluvio Versions" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Expected binaries
+#     declare -a binaries=(
+#         fluvio
+#         fluvio-run
+#         fluvio-cloud
+#         cdk
+#         smdk
+#     )
+
+#     # Expected versions
+#     declare -a versions=(
+#         $STATIC_VERSION
+#         stable
+#         latest
+#     )
+
+#     for version in "${versions[@]}"
+#     do
+#         export VERSION="$version"
+
+#         run bash -c 'fvm install "$VERSION"'
+#         assert_success
+
+#         # Sleeps to avoid hiting rate limits
+#         sleep 30
+
+#         for binary in "${binaries[@]}"
+#         do
+#             export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
+#             echo "Checking binary: $BINARY_PATH"
+#             run bash -c 'test -f $BINARY_PATH'
+#             assert_success
+#         done
+
+#         if [ "$VERSION" == "stable" ] || [ "$VERSION" == "latest" ]; then
+#             run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .channel'
+#             assert_output "\"$version\""
+#             assert_success
+#         else
+#             run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .version'
+#             assert_output "\"$version\""
+#             assert_success
+#         fi
+
+#         if [ "$VERSION" == "stable" ]; then
+#             run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
+#             assert_output --partial "$STABLE_VERSION"
+#             assert_success
+#         fi
+
+#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
+#             run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
+#             assert_output --partial "$STATIC_VERSION"
+#             assert_success
+#         fi
+#     done
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+# }
+
+# @test "Copies binaries to Fluvio Binaries Directory when using fvm switch" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Removes Fluvio Directory
+#     rm -rf $FLUVIO_HOME_DIR
+
+#     # Ensure `~/.fluvio` is not present
+#     run bash -c '! test -d $FLUVIO_HOME_DIR'
+#     assert_success
+
+#     declare -a versions=(
+#         stable
+#         $STATIC_VERSION
+#     )
+
+#     # Installs Versions
+#     for version in "${versions[@]}"
+#     do
+#         export VERSION="$version"
+
+#         # Installs Fluvio Version
+#         run bash -c 'fvm install $VERSION'
+#         assert_success
+
+#         # Sleeps to avoid hiting rate limits
+#         sleep 30
+#     done
+
+#     for version in "${versions[@]}"
+#     do
+#         export VERSION="$version"
+
+#         # Switch version to use
+#         run bash -c 'fvm switch $VERSION'
+#         assert_success
+
+#         # Checks version is set
+#         if [ "$VERSION" == "stable" ]; then
+#             run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
+#             assert_output --partial "$STABLE_VERSION"
+#             assert_success
+#         fi
+
+#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
+#             run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
+#             assert_output --partial "$STATIC_VERSION"
+#             assert_success
+#         fi
+
+#         # Checks Settings File's Version is updated
+#         if [ "$VERSION" == "stable" ]; then
+#             run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
+#             assert_output --partial "$STABLE_VERSION"
+#             assert_success
+#         fi
+
+#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
+#             run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
+#             assert_output --partial "$STATIC_VERSION"
+#             assert_success
+#         fi
+
+#         # Checks Settings File's Channel is updated
+#         if [ "$VERSION" == "stable" ]; then
+#             run bash -c 'yq -oy '.channel' "$SETTINGS_TOML_PATH"'
+#             assert_output --partial "stable"
+#             assert_success
+#         fi
+
+#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
+#             run bash -c 'yq -oy '.channel.tag' "$SETTINGS_TOML_PATH"'
+#             assert_output --partial "$STATIC_VERSION"
+#             assert_success
+#         fi
+
+#         # Expected binaries
+#         declare -a binaries=(
+#             fluvio
+#             fluvio-run
+#             fluvio-cloud
+#             cdk
+#             smdk
+#         )
+
+#         for binary in "${binaries[@]}"
+#         do
+#             export FVM_BIN_PATH="$VERSIONS_DIR/$VERSION/$binary"
+#             echo "Checking binary: $BINARY_PATH"
+#             run bash -c 'test -f $FVM_BIN_PATH'
+#             assert_success
+
+#             export FLV_BIN_PATH="$FLUVIO_BINARIES_DIR/$binary"
+#             echo "Checking binary: $FLV_BIN_PATH"
+#             run bash -c 'test -f $FLV_BIN_PATH'
+#             assert_success
+
+#             export SHASUM_A=$(sha256sum $FVM_BIN_PATH | awk '{ print $1 }')
+#             export SHASUM_B=$(sha256sum $FLV_BIN_PATH | awk '{ print $1 }')
+#             assert_equal "$SHASUM_A" "$SHASUM_B"
+#         done
+#     done
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Sets the desired Fluvio Version" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Ensure `~/.fluvio` is not present
+#     run bash -c '! test -d $FLUVIO_HOME_DIR'
+#     assert_success
+
+#     # Installs Fluvio at 0.10.15
+#     run bash -c 'fvm install 0.10.15'
+#     assert_success
+
+#     # Sleeps to avoid hiting rate limits
+#     sleep 30
+
+#     # Installs Fluvio at 0.10.14
+#     run bash -c 'fvm install 0.10.14'
+#     assert_success
+
+#     # Sleeps to avoid hiting rate limits
+#     sleep 30
+
+#     # Switch version to use Fluvio at 0.10.15
+#     run bash -c 'fvm switch 0.10.15'
+#     assert_success
+
+#     # Checks version is set
+#     run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.15"'
+#     assert_output --partial "0.10.15"
+#     assert_success
+
+#     # Switch version to use Fluvio at 0.10.14
+#     run bash -c 'fvm switch 0.10.14'
+#     assert_success
+
+#     # Checks version is set
+#     run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.14"'
+#     assert_output --partial "0.10.14"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Keeps track of the active Fluvio Version in settings.toml" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Ensure `~/.fluvio` is not present
+#     run bash -c '! test -d $FLUVIO_HOME_DIR'
+#     assert_success
+
+#     # Installs Fluvio Stable
+#     run bash -c 'fvm install stable'
+#     assert_success
+
+#     # Sleeps to avoid hiting rate limits
+#     sleep 30
+
+#     # Installs Fluvio at 0.10.14
+#     run bash -c 'fvm install 0.10.14'
+#     assert_success
+
+#     # Switch version to use Fluvio at Stable
+#     run bash -c 'fvm switch stable'
+#     assert_success
+
+#     # Checks channel is set
+#     run bash -c 'cat ~/.fvm/settings.toml | grep "channel = \"stable\""'
+#     assert_output --partial "channel = \"stable\""
+#     assert_success
+
+#     # Checks the version is set as active in list list
+#     run bash -c 'fvm list'
+#     assert_line --index 0 --partial "    CHANNEL  VERSION"
+#     assert_line --index 1 --partial " ✓  stable   $STABLE_VERSION"
+#     assert_line --index 2 --partial "    0.10.14  0.10.14"
+#     assert_success
+
+#     # Checks current command output
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "$STABLE_VERSION (stable)"
+#     assert_success
+
+#     # Checks version is set
+#     run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"$STABLE_VERSION\""'
+#     assert_output --partial "version = \"$STABLE_VERSION\""
+#     assert_success
+
+#     # Switch version to use Fluvio at 0.10.14
+#     run bash -c 'fvm switch 0.10.14'
+#     assert_success
+
+#     # Checks version is set
+#     run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"0.10.14\""'
+#     assert_output --partial "version = \"0.10.14\""
+#     assert_success
+
+#     # Checks channel is tag
+#     run bash -c 'cat ~/.fvm/settings.toml | grep "tag = \"0.10.14\""'
+#     assert_output --partial "tag = \"0.10.14\""
+#     assert_success
+
+#     # Checks the version is set as active in list
+#     run bash -c 'fvm list'
+#     assert_line --index 0 --partial "    CHANNEL  VERSION"
+#     assert_line --index 1 --partial " ✓  0.10.14  0.10.14"
+#     assert_line --index 2 --partial "    stable   $STABLE_VERSION"
+#     assert_success
+
+#     # Checks current command output
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "0.10.14"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Recommends using fvm list to list available versions" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm switch'
+#     assert_line --index 0 "help: You can use fvm list to see installed versions"
+#     assert_line --index 1 "Error: No version provided"
+#     assert_failure
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+# }
+
+# @test "Supress output with '-q' optional argument" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Expect no output if `-q` is passed
+#     run bash -c 'fvm -q install stable'
+#     assert_output ""
+#     assert_success
+
+#     # Sleeps to avoid hiting rate limits
+#     sleep 30
+
+#     # Expect output if `-q` is not passed
+#     run bash -c 'fvm install 0.10.14'
+#     assert_line --index 0 --partial "info: Downloading (1/5)"
+#     assert_output --partial "done: Now using fluvio version 0.10.14"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Renders help text on current command if none active" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "warn: No active version set"
+#     assert_line --index 1 "help: You can use fvm switch to set the active version"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Sets the desired version after installing it" {
+#     export VERSION="0.10.14"
+
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "warn: No active version set"
+#     assert_line --index 1 "help: You can use fvm switch to set the active version"
+#     assert_success
+
+#     run bash -c 'fvm install $VERSION'
+#     assert_success
+
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "$VERSION"
+#     assert_success
+
+#     run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$VERSION"'
+#     assert_output --partial "$VERSION"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Replaces binary on installs" {
+#     # Checks the presence of the binary in the versions directory
+#     run bash -c '! test -f "$FVM_HOME_DIR/bin/fvm"'
+#     assert_success
+
+#     # Create FVM Binaries directory
+#     mkdir -p "$FVM_HOME_DIR/bin"
+
+#     # Create bash file to check if the binary is present
+#     run bash -c 'echo "echo \"Hello World!\"" > "$FVM_HOME_DIR/bin/fvm"'
+#     assert_success
+
+#     # Store this file Sha256 Checksum
+#     export SHASUM_TEST_FILE=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+#     # Install FVM using `self install`
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Store FVM Binary Sha256 Checksum
+#     export SHASUM_FVM_BIN=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+#     # Ensure the checksums are different
+#     [[ "$SHASUM_TEST_FILE" != "$SHASUM_FVM_BIN" ]]
+#     assert_success
+
+#     # Ensure file is not corrupted on updates
+#     run bash -c 'fvm --help'
+#     assert_output --partial "Fluvio Version Manager (FVM)"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+# }
+
+# @test "Updating keeps settings files integrity" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm install stable'
+#     assert_success
+
+#     # Store Settings File Checksum
+#     export SHASUM_SETTINGS_BEFORE=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
+
+#     # We cannot use `fvm self install` so use other copy of FVM to test binary
+#     # replacement
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Store Settings File Checksum
+#     export SHASUM_SETTINGS_AFTER=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
+
+#     assert_equal "$SHASUM_SETTINGS_BEFORE" "$SHASUM_SETTINGS_AFTER"
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Fails when using 'fvm self install' on itself" {
+#     skip "Ubuntu CI does not support this test due to mounted virtual volume path mismatch"
+
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm install stable'
+#     assert_success
+
+#     # We cannot use `fvm self install` so use other copy of FVM to test binary
+#     # replacement
+#     run bash -c 'fvm self install'
+#     assert_output --partial "Error: FVM is already installed"
+#     assert_failure
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Prints version with details on fvm version" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     run bash -c 'fvm version'
+#     assert_line --index 0 "fvm CLI: $FVM_CARGO_TOML_VERSION"
+#     assert_line --index 1 --partial "fvm CLI Arch: "
+#     assert_line --index 2 --partial "fvm CLI SHA256: "
+#     assert_line --index 3 --partial "OS Details: "
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Updates version in channel" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Installs the stable version
+#     run bash -c 'fvm install stable'
+#     assert_success
+
+#     # Changes the version set as `stable` channel to $STATIC_VERSION in order to
+#     # force an update. $STATIC_VERSION just to reuse the variable to improve
+#     # readability, it could be any version tag (but stable of course!)
+#     #
+#     # This wont work in macOS because the sed command is different there
+#     sed -i "s/$STABLE_VERSION/$STATIC_VERSION/g" $FVM_HOME_DIR/settings.toml
+
+#     # Checks active version
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "$STATIC_VERSION (stable)"
+#     assert_success
+
+#     # Attempts to update Fluvio
+#     run bash -c 'fvm update'
+#     assert_line --index 0 "info: Updating fluvio stable to version $STABLE_VERSION. Current version is $STATIC_VERSION."
+#     assert_success
+
+#     # Checks active version
+#     run bash -c 'fvm current'
+#     assert_line --index 0 "$STABLE_VERSION (stable)"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Do not updates version in static tag" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Installs the stable version
+#     run bash -c 'fvm install $STATIC_VERSION'
+#     assert_success
+
+#     # Attempts to update Fluvio
+#     run bash -c 'fvm update'
+#     assert_line --index 0 "info: Cannot update a static version tag. You must use a channel."
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Renders message when already up-to-date" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Installs the stable version
+#     run bash -c 'fvm install'
+#     assert_success
+
+#     # Sleeps to avoid hiting rate limits
+#     sleep 30
+
+#     # Attempts to update Fluvio
+#     run bash -c 'fvm update'
+#     assert_line --index 0 "done: You are already up to date"
+#     assert_success
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
+
+# @test "Handles unexistent version error" {
+#     run bash -c '$FVM_BIN self install'
+#     assert_success
+
+#     # Sets `fvm` in the PATH using the "env" file included in the installation
+#     source ~/.fvm/env
+
+#     # Attempts to install unexistent version
+#     run bash -c 'fvm install 0.0.0'
+#     assert_line --index 0 "Error: PackageSet 0.0.0 doest not exist"
+#     assert_failure
+
+#     # Removes FVM
+#     run bash -c 'fvm self uninstall --yes'
+#     assert_success
+
+#     # Removes Fluvio
+#     rm -rf $FLUVIO_HOME_DIR
+#     assert_success
+# }
 
 @test "Uninstall Versions" {
     run bash -c '$FVM_BIN self install'
@@ -817,36 +817,24 @@ setup_file() {
     # Sets `fvm` in the PATH using the "env" file included in the installation
     source ~/.fvm/env
 
+    # Ensure `~/.fvm/versions/stable` is not present
+    run bash -c '! test -d $FVM_HOME_DIR/versions/stable'
+    assert_success
+
     # Install stable version
     run bash -c 'fvm install stable'
     assert_success
 
-    # Install specific 0.11.0 version
-    run bash -c 'fvm install 0.11.0'
-    assert_success
-
     # Ensure `~/.fvm/versions/stable` is present
-    run bash -c 'test -d $FLUVIO_HOME_DIR/versions/stable'
-    assert_success
-
-    # Ensure `~/.fvm/versions/0.11.0` is present
-    run bash -c 'test -d $FLUVIO_HOME_DIR/versions/0.11.0'
+    run bash -c 'test -d $FVM_HOME_DIR/versions/stable'
     assert_success
 
     # Uninstall stable version
     run bash -c 'fvm uninstall stable'
     assert_success
 
-    # Uninstall specific 0.11.0 version
-    run bash -c 'fvm uninstall 0.11.0'
-    assert_success
-
     # Ensure `~/.fvm/versions/stable` is present
-    run bash -c '!test -d $FLUVIO_HOME_DIR/versions/stable'
-    assert_success
-
-    # Ensure `~/.fvm/versions/0.11.0` is present
-    run bash -c '!test -d $FLUVIO_HOME_DIR/versions/0.11.0'
+    run bash -c '! test -d $FVM_HOME_DIR/versions/stable'
     assert_success
 
     # Removes FVM

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -58,757 +58,757 @@ setup_file() {
     debug_msg "Version File Value: $FVM_CARGO_TOML_VERSION"
 }
 
-# @test "Install fvm and setup a settings.toml file" {
-#     # Ensure the `fvm` directory is not present
-#     run bash -c '! test -d ~/.fvm'
-#     assert_success
-
-#     # Installs FVM which introduces the `~/.fvm` directory and copies the FVM
-#     # binary to ~/.fvm/bin/fvm
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Tests FVM to be in the PATH
-#     run bash -c 'which fvm'
-#     assert_output --partial ".fvm/bin/fvm"
-#     assert_success
-
-#     # Retrieves Version from FVM
-#     run bash -c 'fvm --help'
-#     assert_output --partial "Fluvio Version Manager (FVM)"
-#     assert_success
-
-#     # Ensure the `settings.toml` is available. At this point this is an empty file
-#     run bash -c 'cat ~/.fvm/settings.toml'
-#     assert_output ""
-#     assert_success
-# }
-
-# @test "Uninstall fvm and removes ~/.fvm dir" {
-#     # Ensure the `fvm` directory is present from the previous test
-#     run bash -c 'test -d ~/.fvm'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Test the fvm command is present
-#     run bash -c 'which fvm'
-#     assert_output --partial ".fvm/bin/fvm"
-#     assert_success
-
-#     # We use `--yes` because prompting is not supported in CI environment,
-#     # responding with error `Error: IO error: not a terminal`
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Ensure the `~/.fvm/` directory is not available anymore
-#     run bash -c '! test -d ~/.fvm'
-#     assert_success
-
-#     # Ensure the fvm is not available anymore
-#     run bash -c '! fvm'
-#     assert_success
-# }
-
-# @test "Creates the `$VERSIONS_DIR` path if not present when attempting to install" {
-#     # Verify the directory is not present initally
-#     run bash -c '! test -d $VERSIONS_DIR'
-#     assert_success
-
-#     # Installs FVM as usual
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Renders warn if attempts to use `fvm list` and no versions are installed
-#     run bash -c 'fvm list'
-#     assert_line --index 0 "warn: No installed versions found"
-#     assert_line --index 1 "help: You can install a Fluvio version using the command fvm install"
-#     assert_success
-
-#     # Verify the directory is now present
-#     run bash -c 'test -d $VERSIONS_DIR'
-#     assert_success
-
-#     # Remove versions directory
-#     rm -rf $VERSIONS_DIR
-
-#     # Installs Stable Fluvio
-#     run bash -c 'fvm install'
-#     assert_success
-
-#     # Checks the presence of the binary in the versions directory
-#     run bash -c 'test -f $VERSIONS_DIR/stable/fluvio'
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-# }
-
-# @test "Install Fluvio Versions" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Expected binaries
-#     declare -a binaries=(
-#         fluvio
-#         fluvio-run
-#         fluvio-cloud
-#         cdk
-#         smdk
-#     )
-
-#     # Expected versions
-#     declare -a versions=(
-#         $STATIC_VERSION
-#         stable
-#         latest
-#     )
-
-#     for version in "${versions[@]}"
-#     do
-#         export VERSION="$version"
-
-#         run bash -c 'fvm install "$VERSION"'
-#         assert_success
-
-#         # Sleeps to avoid hiting rate limits
-#         sleep 30
-
-#         for binary in "${binaries[@]}"
-#         do
-#             export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
-#             echo "Checking binary: $BINARY_PATH"
-#             run bash -c 'test -f $BINARY_PATH'
-#             assert_success
-#         done
-
-#         if [ "$VERSION" == "stable" ] || [ "$VERSION" == "latest" ]; then
-#             run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .channel'
-#             assert_output "\"$version\""
-#             assert_success
-#         else
-#             run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .version'
-#             assert_output "\"$version\""
-#             assert_success
-#         fi
-
-#         if [ "$VERSION" == "stable" ]; then
-#             run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
-#             assert_output --partial "$STABLE_VERSION"
-#             assert_success
-#         fi
-
-#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
-#             run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
-#             assert_output --partial "$STATIC_VERSION"
-#             assert_success
-#         fi
-#     done
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-# }
-
-# @test "Copies binaries to Fluvio Binaries Directory when using fvm switch" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Removes Fluvio Directory
-#     rm -rf $FLUVIO_HOME_DIR
-
-#     # Ensure `~/.fluvio` is not present
-#     run bash -c '! test -d $FLUVIO_HOME_DIR'
-#     assert_success
-
-#     declare -a versions=(
-#         stable
-#         $STATIC_VERSION
-#     )
-
-#     # Installs Versions
-#     for version in "${versions[@]}"
-#     do
-#         export VERSION="$version"
-
-#         # Installs Fluvio Version
-#         run bash -c 'fvm install $VERSION'
-#         assert_success
-
-#         # Sleeps to avoid hiting rate limits
-#         sleep 30
-#     done
-
-#     for version in "${versions[@]}"
-#     do
-#         export VERSION="$version"
-
-#         # Switch version to use
-#         run bash -c 'fvm switch $VERSION'
-#         assert_success
-
-#         # Checks version is set
-#         if [ "$VERSION" == "stable" ]; then
-#             run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
-#             assert_output --partial "$STABLE_VERSION"
-#             assert_success
-#         fi
-
-#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
-#             run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
-#             assert_output --partial "$STATIC_VERSION"
-#             assert_success
-#         fi
-
-#         # Checks Settings File's Version is updated
-#         if [ "$VERSION" == "stable" ]; then
-#             run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
-#             assert_output --partial "$STABLE_VERSION"
-#             assert_success
-#         fi
-
-#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
-#             run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
-#             assert_output --partial "$STATIC_VERSION"
-#             assert_success
-#         fi
-
-#         # Checks Settings File's Channel is updated
-#         if [ "$VERSION" == "stable" ]; then
-#             run bash -c 'yq -oy '.channel' "$SETTINGS_TOML_PATH"'
-#             assert_output --partial "stable"
-#             assert_success
-#         fi
-
-#         if [ "$VERSION" == "$STATIC_VERSION" ]; then
-#             run bash -c 'yq -oy '.channel.tag' "$SETTINGS_TOML_PATH"'
-#             assert_output --partial "$STATIC_VERSION"
-#             assert_success
-#         fi
-
-#         # Expected binaries
-#         declare -a binaries=(
-#             fluvio
-#             fluvio-run
-#             fluvio-cloud
-#             cdk
-#             smdk
-#         )
-
-#         for binary in "${binaries[@]}"
-#         do
-#             export FVM_BIN_PATH="$VERSIONS_DIR/$VERSION/$binary"
-#             echo "Checking binary: $BINARY_PATH"
-#             run bash -c 'test -f $FVM_BIN_PATH'
-#             assert_success
-
-#             export FLV_BIN_PATH="$FLUVIO_BINARIES_DIR/$binary"
-#             echo "Checking binary: $FLV_BIN_PATH"
-#             run bash -c 'test -f $FLV_BIN_PATH'
-#             assert_success
-
-#             export SHASUM_A=$(sha256sum $FVM_BIN_PATH | awk '{ print $1 }')
-#             export SHASUM_B=$(sha256sum $FLV_BIN_PATH | awk '{ print $1 }')
-#             assert_equal "$SHASUM_A" "$SHASUM_B"
-#         done
-#     done
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Sets the desired Fluvio Version" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Ensure `~/.fluvio` is not present
-#     run bash -c '! test -d $FLUVIO_HOME_DIR'
-#     assert_success
-
-#     # Installs Fluvio at 0.10.15
-#     run bash -c 'fvm install 0.10.15'
-#     assert_success
-
-#     # Sleeps to avoid hiting rate limits
-#     sleep 30
-
-#     # Installs Fluvio at 0.10.14
-#     run bash -c 'fvm install 0.10.14'
-#     assert_success
-
-#     # Sleeps to avoid hiting rate limits
-#     sleep 30
-
-#     # Switch version to use Fluvio at 0.10.15
-#     run bash -c 'fvm switch 0.10.15'
-#     assert_success
-
-#     # Checks version is set
-#     run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.15"'
-#     assert_output --partial "0.10.15"
-#     assert_success
-
-#     # Switch version to use Fluvio at 0.10.14
-#     run bash -c 'fvm switch 0.10.14'
-#     assert_success
-
-#     # Checks version is set
-#     run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.14"'
-#     assert_output --partial "0.10.14"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Keeps track of the active Fluvio Version in settings.toml" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Ensure `~/.fluvio` is not present
-#     run bash -c '! test -d $FLUVIO_HOME_DIR'
-#     assert_success
-
-#     # Installs Fluvio Stable
-#     run bash -c 'fvm install stable'
-#     assert_success
-
-#     # Sleeps to avoid hiting rate limits
-#     sleep 30
-
-#     # Installs Fluvio at 0.10.14
-#     run bash -c 'fvm install 0.10.14'
-#     assert_success
-
-#     # Switch version to use Fluvio at Stable
-#     run bash -c 'fvm switch stable'
-#     assert_success
-
-#     # Checks channel is set
-#     run bash -c 'cat ~/.fvm/settings.toml | grep "channel = \"stable\""'
-#     assert_output --partial "channel = \"stable\""
-#     assert_success
-
-#     # Checks the version is set as active in list list
-#     run bash -c 'fvm list'
-#     assert_line --index 0 --partial "    CHANNEL  VERSION"
-#     assert_line --index 1 --partial " ✓  stable   $STABLE_VERSION"
-#     assert_line --index 2 --partial "    0.10.14  0.10.14"
-#     assert_success
-
-#     # Checks current command output
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "$STABLE_VERSION (stable)"
-#     assert_success
-
-#     # Checks version is set
-#     run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"$STABLE_VERSION\""'
-#     assert_output --partial "version = \"$STABLE_VERSION\""
-#     assert_success
-
-#     # Switch version to use Fluvio at 0.10.14
-#     run bash -c 'fvm switch 0.10.14'
-#     assert_success
-
-#     # Checks version is set
-#     run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"0.10.14\""'
-#     assert_output --partial "version = \"0.10.14\""
-#     assert_success
-
-#     # Checks channel is tag
-#     run bash -c 'cat ~/.fvm/settings.toml | grep "tag = \"0.10.14\""'
-#     assert_output --partial "tag = \"0.10.14\""
-#     assert_success
-
-#     # Checks the version is set as active in list
-#     run bash -c 'fvm list'
-#     assert_line --index 0 --partial "    CHANNEL  VERSION"
-#     assert_line --index 1 --partial " ✓  0.10.14  0.10.14"
-#     assert_line --index 2 --partial "    stable   $STABLE_VERSION"
-#     assert_success
-
-#     # Checks current command output
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "0.10.14"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Recommends using fvm list to list available versions" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm switch'
-#     assert_line --index 0 "help: You can use fvm list to see installed versions"
-#     assert_line --index 1 "Error: No version provided"
-#     assert_failure
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-# }
-
-# @test "Supress output with '-q' optional argument" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Expect no output if `-q` is passed
-#     run bash -c 'fvm -q install stable'
-#     assert_output ""
-#     assert_success
-
-#     # Sleeps to avoid hiting rate limits
-#     sleep 30
-
-#     # Expect output if `-q` is not passed
-#     run bash -c 'fvm install 0.10.14'
-#     assert_line --index 0 --partial "info: Downloading (1/5)"
-#     assert_output --partial "done: Now using fluvio version 0.10.14"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Renders help text on current command if none active" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "warn: No active version set"
-#     assert_line --index 1 "help: You can use fvm switch to set the active version"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Sets the desired version after installing it" {
-#     export VERSION="0.10.14"
-
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "warn: No active version set"
-#     assert_line --index 1 "help: You can use fvm switch to set the active version"
-#     assert_success
-
-#     run bash -c 'fvm install $VERSION'
-#     assert_success
-
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "$VERSION"
-#     assert_success
-
-#     run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$VERSION"'
-#     assert_output --partial "$VERSION"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Replaces binary on installs" {
-#     # Checks the presence of the binary in the versions directory
-#     run bash -c '! test -f "$FVM_HOME_DIR/bin/fvm"'
-#     assert_success
-
-#     # Create FVM Binaries directory
-#     mkdir -p "$FVM_HOME_DIR/bin"
-
-#     # Create bash file to check if the binary is present
-#     run bash -c 'echo "echo \"Hello World!\"" > "$FVM_HOME_DIR/bin/fvm"'
-#     assert_success
-
-#     # Store this file Sha256 Checksum
-#     export SHASUM_TEST_FILE=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
-
-#     # Install FVM using `self install`
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Store FVM Binary Sha256 Checksum
-#     export SHASUM_FVM_BIN=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
-
-#     # Ensure the checksums are different
-#     [[ "$SHASUM_TEST_FILE" != "$SHASUM_FVM_BIN" ]]
-#     assert_success
-
-#     # Ensure file is not corrupted on updates
-#     run bash -c 'fvm --help'
-#     assert_output --partial "Fluvio Version Manager (FVM)"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-# }
-
-# @test "Updating keeps settings files integrity" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm install stable'
-#     assert_success
-
-#     # Store Settings File Checksum
-#     export SHASUM_SETTINGS_BEFORE=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
-
-#     # We cannot use `fvm self install` so use other copy of FVM to test binary
-#     # replacement
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Store Settings File Checksum
-#     export SHASUM_SETTINGS_AFTER=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
-
-#     assert_equal "$SHASUM_SETTINGS_BEFORE" "$SHASUM_SETTINGS_AFTER"
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Fails when using 'fvm self install' on itself" {
-#     skip "Ubuntu CI does not support this test due to mounted virtual volume path mismatch"
-
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm install stable'
-#     assert_success
-
-#     # We cannot use `fvm self install` so use other copy of FVM to test binary
-#     # replacement
-#     run bash -c 'fvm self install'
-#     assert_output --partial "Error: FVM is already installed"
-#     assert_failure
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Prints version with details on fvm version" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     run bash -c 'fvm version'
-#     assert_line --index 0 "fvm CLI: $FVM_CARGO_TOML_VERSION"
-#     assert_line --index 1 --partial "fvm CLI Arch: "
-#     assert_line --index 2 --partial "fvm CLI SHA256: "
-#     assert_line --index 3 --partial "OS Details: "
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Updates version in channel" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Installs the stable version
-#     run bash -c 'fvm install stable'
-#     assert_success
-
-#     # Changes the version set as `stable` channel to $STATIC_VERSION in order to
-#     # force an update. $STATIC_VERSION just to reuse the variable to improve
-#     # readability, it could be any version tag (but stable of course!)
-#     #
-#     # This wont work in macOS because the sed command is different there
-#     sed -i "s/$STABLE_VERSION/$STATIC_VERSION/g" $FVM_HOME_DIR/settings.toml
-
-#     # Checks active version
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "$STATIC_VERSION (stable)"
-#     assert_success
-
-#     # Attempts to update Fluvio
-#     run bash -c 'fvm update'
-#     assert_line --index 0 "info: Updating fluvio stable to version $STABLE_VERSION. Current version is $STATIC_VERSION."
-#     assert_success
-
-#     # Checks active version
-#     run bash -c 'fvm current'
-#     assert_line --index 0 "$STABLE_VERSION (stable)"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Do not updates version in static tag" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Installs the stable version
-#     run bash -c 'fvm install $STATIC_VERSION'
-#     assert_success
-
-#     # Attempts to update Fluvio
-#     run bash -c 'fvm update'
-#     assert_line --index 0 "info: Cannot update a static version tag. You must use a channel."
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Renders message when already up-to-date" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Installs the stable version
-#     run bash -c 'fvm install'
-#     assert_success
-
-#     # Sleeps to avoid hiting rate limits
-#     sleep 30
-
-#     # Attempts to update Fluvio
-#     run bash -c 'fvm update'
-#     assert_line --index 0 "done: You are already up to date"
-#     assert_success
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
-
-# @test "Handles unexistent version error" {
-#     run bash -c '$FVM_BIN self install'
-#     assert_success
-
-#     # Sets `fvm` in the PATH using the "env" file included in the installation
-#     source ~/.fvm/env
-
-#     # Attempts to install unexistent version
-#     run bash -c 'fvm install 0.0.0'
-#     assert_line --index 0 "Error: PackageSet 0.0.0 doest not exist"
-#     assert_failure
-
-#     # Removes FVM
-#     run bash -c 'fvm self uninstall --yes'
-#     assert_success
-
-#     # Removes Fluvio
-#     rm -rf $FLUVIO_HOME_DIR
-#     assert_success
-# }
+@test "Install fvm and setup a settings.toml file" {
+    # Ensure the `fvm` directory is not present
+    run bash -c '! test -d ~/.fvm'
+    assert_success
+
+    # Installs FVM which introduces the `~/.fvm` directory and copies the FVM
+    # binary to ~/.fvm/bin/fvm
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Tests FVM to be in the PATH
+    run bash -c 'which fvm'
+    assert_output --partial ".fvm/bin/fvm"
+    assert_success
+
+    # Retrieves Version from FVM
+    run bash -c 'fvm --help'
+    assert_output --partial "Fluvio Version Manager (FVM)"
+    assert_success
+
+    # Ensure the `settings.toml` is available. At this point this is an empty file
+    run bash -c 'cat ~/.fvm/settings.toml'
+    assert_output ""
+    assert_success
+}
+
+@test "Uninstall fvm and removes ~/.fvm dir" {
+    # Ensure the `fvm` directory is present from the previous test
+    run bash -c 'test -d ~/.fvm'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Test the fvm command is present
+    run bash -c 'which fvm'
+    assert_output --partial ".fvm/bin/fvm"
+    assert_success
+
+    # We use `--yes` because prompting is not supported in CI environment,
+    # responding with error `Error: IO error: not a terminal`
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Ensure the `~/.fvm/` directory is not available anymore
+    run bash -c '! test -d ~/.fvm'
+    assert_success
+
+    # Ensure the fvm is not available anymore
+    run bash -c '! fvm'
+    assert_success
+}
+
+@test "Creates the `$VERSIONS_DIR` path if not present when attempting to install" {
+    # Verify the directory is not present initally
+    run bash -c '! test -d $VERSIONS_DIR'
+    assert_success
+
+    # Installs FVM as usual
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Renders warn if attempts to use `fvm list` and no versions are installed
+    run bash -c 'fvm list'
+    assert_line --index 0 "warn: No installed versions found"
+    assert_line --index 1 "help: You can install a Fluvio version using the command fvm install"
+    assert_success
+
+    # Verify the directory is now present
+    run bash -c 'test -d $VERSIONS_DIR'
+    assert_success
+
+    # Remove versions directory
+    rm -rf $VERSIONS_DIR
+
+    # Installs Stable Fluvio
+    run bash -c 'fvm install'
+    assert_success
+
+    # Checks the presence of the binary in the versions directory
+    run bash -c 'test -f $VERSIONS_DIR/stable/fluvio'
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+}
+
+@test "Install Fluvio Versions" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Expected binaries
+    declare -a binaries=(
+        fluvio
+        fluvio-run
+        fluvio-cloud
+        cdk
+        smdk
+    )
+
+    # Expected versions
+    declare -a versions=(
+        $STATIC_VERSION
+        stable
+        latest
+    )
+
+    for version in "${versions[@]}"
+    do
+        export VERSION="$version"
+
+        run bash -c 'fvm install "$VERSION"'
+        assert_success
+
+        # Sleeps to avoid hiting rate limits
+        sleep 30
+
+        for binary in "${binaries[@]}"
+        do
+            export BINARY_PATH="$VERSIONS_DIR/$VERSION/$binary"
+            echo "Checking binary: $BINARY_PATH"
+            run bash -c 'test -f $BINARY_PATH'
+            assert_success
+        done
+
+        if [ "$VERSION" == "stable" ] || [ "$VERSION" == "latest" ]; then
+            run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .channel'
+            assert_output "\"$version\""
+            assert_success
+        else
+            run bash -c 'cat "$VERSIONS_DIR/$VERSION/manifest.json" | jq .version'
+            assert_output "\"$version\""
+            assert_success
+        fi
+
+        if [ "$VERSION" == "stable" ]; then
+            run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
+            assert_output --partial "$STABLE_VERSION"
+            assert_success
+        fi
+
+        if [ "$VERSION" == "$STATIC_VERSION" ]; then
+            run bash -c '$VERSIONS_DIR/$VERSION/fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
+            assert_output --partial "$STATIC_VERSION"
+            assert_success
+        fi
+    done
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+}
+
+@test "Copies binaries to Fluvio Binaries Directory when using fvm switch" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Removes Fluvio Directory
+    rm -rf $FLUVIO_HOME_DIR
+
+    # Ensure `~/.fluvio` is not present
+    run bash -c '! test -d $FLUVIO_HOME_DIR'
+    assert_success
+
+    declare -a versions=(
+        stable
+        $STATIC_VERSION
+    )
+
+    # Installs Versions
+    for version in "${versions[@]}"
+    do
+        export VERSION="$version"
+
+        # Installs Fluvio Version
+        run bash -c 'fvm install $VERSION'
+        assert_success
+
+        # Sleeps to avoid hiting rate limits
+        sleep 30
+    done
+
+    for version in "${versions[@]}"
+    do
+        export VERSION="$version"
+
+        # Switch version to use
+        run bash -c 'fvm switch $VERSION'
+        assert_success
+
+        # Checks version is set
+        if [ "$VERSION" == "stable" ]; then
+            run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STABLE_VERSION"'
+            assert_output --partial "$STABLE_VERSION"
+            assert_success
+        fi
+
+        if [ "$VERSION" == "$STATIC_VERSION" ]; then
+            run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$STATIC_VERSION"'
+            assert_output --partial "$STATIC_VERSION"
+            assert_success
+        fi
+
+        # Checks Settings File's Version is updated
+        if [ "$VERSION" == "stable" ]; then
+            run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
+            assert_output --partial "$STABLE_VERSION"
+            assert_success
+        fi
+
+        if [ "$VERSION" == "$STATIC_VERSION" ]; then
+            run bash -c 'yq -oy '.version' "$SETTINGS_TOML_PATH"'
+            assert_output --partial "$STATIC_VERSION"
+            assert_success
+        fi
+
+        # Checks Settings File's Channel is updated
+        if [ "$VERSION" == "stable" ]; then
+            run bash -c 'yq -oy '.channel' "$SETTINGS_TOML_PATH"'
+            assert_output --partial "stable"
+            assert_success
+        fi
+
+        if [ "$VERSION" == "$STATIC_VERSION" ]; then
+            run bash -c 'yq -oy '.channel.tag' "$SETTINGS_TOML_PATH"'
+            assert_output --partial "$STATIC_VERSION"
+            assert_success
+        fi
+
+        # Expected binaries
+        declare -a binaries=(
+            fluvio
+            fluvio-run
+            fluvio-cloud
+            cdk
+            smdk
+        )
+
+        for binary in "${binaries[@]}"
+        do
+            export FVM_BIN_PATH="$VERSIONS_DIR/$VERSION/$binary"
+            echo "Checking binary: $BINARY_PATH"
+            run bash -c 'test -f $FVM_BIN_PATH'
+            assert_success
+
+            export FLV_BIN_PATH="$FLUVIO_BINARIES_DIR/$binary"
+            echo "Checking binary: $FLV_BIN_PATH"
+            run bash -c 'test -f $FLV_BIN_PATH'
+            assert_success
+
+            export SHASUM_A=$(sha256sum $FVM_BIN_PATH | awk '{ print $1 }')
+            export SHASUM_B=$(sha256sum $FLV_BIN_PATH | awk '{ print $1 }')
+            assert_equal "$SHASUM_A" "$SHASUM_B"
+        done
+    done
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Sets the desired Fluvio Version" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Ensure `~/.fluvio` is not present
+    run bash -c '! test -d $FLUVIO_HOME_DIR'
+    assert_success
+
+    # Installs Fluvio at 0.10.15
+    run bash -c 'fvm install 0.10.15'
+    assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
+    # Installs Fluvio at 0.10.14
+    run bash -c 'fvm install 0.10.14'
+    assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
+    # Switch version to use Fluvio at 0.10.15
+    run bash -c 'fvm switch 0.10.15'
+    assert_success
+
+    # Checks version is set
+    run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.15"'
+    assert_output --partial "0.10.15"
+    assert_success
+
+    # Switch version to use Fluvio at 0.10.14
+    run bash -c 'fvm switch 0.10.14'
+    assert_success
+
+    # Checks version is set
+    run bash -c 'fluvio version > active_flv_ver.out && cat active_flv_ver.out | head -n 1 | grep "0.10.14"'
+    assert_output --partial "0.10.14"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Keeps track of the active Fluvio Version in settings.toml" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Ensure `~/.fluvio` is not present
+    run bash -c '! test -d $FLUVIO_HOME_DIR'
+    assert_success
+
+    # Installs Fluvio Stable
+    run bash -c 'fvm install stable'
+    assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
+    # Installs Fluvio at 0.10.14
+    run bash -c 'fvm install 0.10.14'
+    assert_success
+
+    # Switch version to use Fluvio at Stable
+    run bash -c 'fvm switch stable'
+    assert_success
+
+    # Checks channel is set
+    run bash -c 'cat ~/.fvm/settings.toml | grep "channel = \"stable\""'
+    assert_output --partial "channel = \"stable\""
+    assert_success
+
+    # Checks the version is set as active in list list
+    run bash -c 'fvm list'
+    assert_line --index 0 --partial "    CHANNEL  VERSION"
+    assert_line --index 1 --partial " ✓  stable   $STABLE_VERSION"
+    assert_line --index 2 --partial "    0.10.14  0.10.14"
+    assert_success
+
+    # Checks current command output
+    run bash -c 'fvm current'
+    assert_line --index 0 "$STABLE_VERSION (stable)"
+    assert_success
+
+    # Checks version is set
+    run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"$STABLE_VERSION\""'
+    assert_output --partial "version = \"$STABLE_VERSION\""
+    assert_success
+
+    # Switch version to use Fluvio at 0.10.14
+    run bash -c 'fvm switch 0.10.14'
+    assert_success
+
+    # Checks version is set
+    run bash -c 'cat ~/.fvm/settings.toml | grep "version = \"0.10.14\""'
+    assert_output --partial "version = \"0.10.14\""
+    assert_success
+
+    # Checks channel is tag
+    run bash -c 'cat ~/.fvm/settings.toml | grep "tag = \"0.10.14\""'
+    assert_output --partial "tag = \"0.10.14\""
+    assert_success
+
+    # Checks the version is set as active in list
+    run bash -c 'fvm list'
+    assert_line --index 0 --partial "    CHANNEL  VERSION"
+    assert_line --index 1 --partial " ✓  0.10.14  0.10.14"
+    assert_line --index 2 --partial "    stable   $STABLE_VERSION"
+    assert_success
+
+    # Checks current command output
+    run bash -c 'fvm current'
+    assert_line --index 0 "0.10.14"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Recommends using fvm list to list available versions" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm switch'
+    assert_line --index 0 "help: You can use fvm list to see installed versions"
+    assert_line --index 1 "Error: No version provided"
+    assert_failure
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+}
+
+@test "Supress output with '-q' optional argument" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Expect no output if `-q` is passed
+    run bash -c 'fvm -q install stable'
+    assert_output ""
+    assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
+    # Expect output if `-q` is not passed
+    run bash -c 'fvm install 0.10.14'
+    assert_line --index 0 --partial "info: Downloading (1/5)"
+    assert_output --partial "done: Now using fluvio version 0.10.14"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Renders help text on current command if none active" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm current'
+    assert_line --index 0 "warn: No active version set"
+    assert_line --index 1 "help: You can use fvm switch to set the active version"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Sets the desired version after installing it" {
+    export VERSION="0.10.14"
+
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm current'
+    assert_line --index 0 "warn: No active version set"
+    assert_line --index 1 "help: You can use fvm switch to set the active version"
+    assert_success
+
+    run bash -c 'fvm install $VERSION'
+    assert_success
+
+    run bash -c 'fvm current'
+    assert_line --index 0 "$VERSION"
+    assert_success
+
+    run bash -c 'fluvio version > flv_version_$version.out && cat flv_version_$version.out | head -n 1 | grep "$VERSION"'
+    assert_output --partial "$VERSION"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Replaces binary on installs" {
+    # Checks the presence of the binary in the versions directory
+    run bash -c '! test -f "$FVM_HOME_DIR/bin/fvm"'
+    assert_success
+
+    # Create FVM Binaries directory
+    mkdir -p "$FVM_HOME_DIR/bin"
+
+    # Create bash file to check if the binary is present
+    run bash -c 'echo "echo \"Hello World!\"" > "$FVM_HOME_DIR/bin/fvm"'
+    assert_success
+
+    # Store this file Sha256 Checksum
+    export SHASUM_TEST_FILE=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+    # Install FVM using `self install`
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Store FVM Binary Sha256 Checksum
+    export SHASUM_FVM_BIN=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+    # Ensure the checksums are different
+    [[ "$SHASUM_TEST_FILE" != "$SHASUM_FVM_BIN" ]]
+    assert_success
+
+    # Ensure file is not corrupted on updates
+    run bash -c 'fvm --help'
+    assert_output --partial "Fluvio Version Manager (FVM)"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+}
+
+@test "Updating keeps settings files integrity" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm install stable'
+    assert_success
+
+    # Store Settings File Checksum
+    export SHASUM_SETTINGS_BEFORE=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
+
+    # We cannot use `fvm self install` so use other copy of FVM to test binary
+    # replacement
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Store Settings File Checksum
+    export SHASUM_SETTINGS_AFTER=$(sha256sum "$FVM_HOME_DIR/settings.toml" | awk '{ print $1 }')
+
+    assert_equal "$SHASUM_SETTINGS_BEFORE" "$SHASUM_SETTINGS_AFTER"
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Fails when using 'fvm self install' on itself" {
+    skip "Ubuntu CI does not support this test due to mounted virtual volume path mismatch"
+
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm install stable'
+    assert_success
+
+    # We cannot use `fvm self install` so use other copy of FVM to test binary
+    # replacement
+    run bash -c 'fvm self install'
+    assert_output --partial "Error: FVM is already installed"
+    assert_failure
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Prints version with details on fvm version" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    run bash -c 'fvm version'
+    assert_line --index 0 "fvm CLI: $FVM_CARGO_TOML_VERSION"
+    assert_line --index 1 --partial "fvm CLI Arch: "
+    assert_line --index 2 --partial "fvm CLI SHA256: "
+    assert_line --index 3 --partial "OS Details: "
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Updates version in channel" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Installs the stable version
+    run bash -c 'fvm install stable'
+    assert_success
+
+    # Changes the version set as `stable` channel to $STATIC_VERSION in order to
+    # force an update. $STATIC_VERSION just to reuse the variable to improve
+    # readability, it could be any version tag (but stable of course!)
+    #
+    # This wont work in macOS because the sed command is different there
+    sed -i "s/$STABLE_VERSION/$STATIC_VERSION/g" $FVM_HOME_DIR/settings.toml
+
+    # Checks active version
+    run bash -c 'fvm current'
+    assert_line --index 0 "$STATIC_VERSION (stable)"
+    assert_success
+
+    # Attempts to update Fluvio
+    run bash -c 'fvm update'
+    assert_line --index 0 "info: Updating fluvio stable to version $STABLE_VERSION. Current version is $STATIC_VERSION."
+    assert_success
+
+    # Checks active version
+    run bash -c 'fvm current'
+    assert_line --index 0 "$STABLE_VERSION (stable)"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Do not updates version in static tag" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Installs the stable version
+    run bash -c 'fvm install $STATIC_VERSION'
+    assert_success
+
+    # Attempts to update Fluvio
+    run bash -c 'fvm update'
+    assert_line --index 0 "info: Cannot update a static version tag. You must use a channel."
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Renders message when already up-to-date" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Installs the stable version
+    run bash -c 'fvm install'
+    assert_success
+
+    # Sleeps to avoid hiting rate limits
+    sleep 30
+
+    # Attempts to update Fluvio
+    run bash -c 'fvm update'
+    assert_line --index 0 "done: You are already up to date"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Handles unexistent version error" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Attempts to install unexistent version
+    run bash -c 'fvm install 0.0.0'
+    assert_line --index 0 "Error: PackageSet 0.0.0 doest not exist"
+    assert_failure
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
 
 @test "Uninstall Versions" {
     run bash -c '$FVM_BIN self install'


### PR DESCRIPTION
Introduces a `fvm uninstall` command to clean up `~/.fvm/versions` directory by allowing
the user to uninstall specific versions.

Also updates logic to use Fluvio version for Version Output.

## Demo

https://github.com/infinyon/fluvio/assets/34756077/6c9e58a1-6515-4b28-aff5-ce51e6b23e72
