### PR TITLE
feat: setup fluvio gh action

### DIFF
--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: Check Platform Compatibility
       if: runner.os != 'Linux' && runner.os != 'macOS'
+      shell: bash
       run: |
         echo "Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
         echo "Please use a Linux or macOS runner."
@@ -18,6 +19,7 @@ runs:
         exit 1
 
     - name: Install Fluvio
+      shell: bash
       run: |
         curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=${{ inputs.version }} bash
         echo "$HOME/.fluvio/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -13,6 +13,8 @@ runs:
       if: runner.os != 'Linux' && runner.os != 'macOS'
       run: |
         echo "Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
+        echo "Please use a Linux or macOS runner."
+        echo "For further details on Fluvio Installation, please visit https://fluvio.io/docs/install/"
         exit 1
 
     - name: Install Fluvio

--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -13,10 +13,9 @@ runs:
       if: runner.os != 'Linux' && runner.os != 'macOS'
       shell: bash
       run: |
-        echo "Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
-        echo "Please use a Linux or macOS runner."
-        echo "For further details on Fluvio Installation, please visit https://fluvio.io/docs/install/"
-        exit 1
+        echo "::warning Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
+        echo "::warning Please use a Linux or macOS runner."
+        echo "::warning For further details on Fluvio Installation, please visit https://fluvio.io/docs/install/"
 
     - name: Install Fluvio
       shell: bash

--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -13,9 +13,9 @@ runs:
       if: runner.os != 'Linux' && runner.os != 'macOS'
       shell: bash
       run: |
-        echo "::warning Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
-        echo "::warning Please use a Linux or macOS runner."
-        echo "::warning For further details on Fluvio Installation, please visit https://fluvio.io/docs/install/"
+        echo "::warning::Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
+        echo "::warning::Please use a Linux or macOS runner."
+        echo "::warning::For further details on Fluvio Installation, please visit https://fluvio.io/docs/install/"
 
     - name: Install Fluvio
       shell: bash

--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -1,0 +1,21 @@
+name: Setup Fluvio
+description: "Download and install Fluvio CLI via FVM"
+inputs:
+  version:
+    description: "Fluvio version to install"
+    required: false
+    default: "stable"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check Platform Compatibility
+      if: runner.os != 'Linux' && runner.os != 'macOS'
+      run: |
+        echo "Current platform $env:RUNNER_OS, is not supported by Fluvio CLI Installer."
+        exit 1
+
+    - name: Install Fluvio
+      run: |
+        curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=${{ inputs.version }} bash
+        echo "$HOME/.fluvio/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-fluvio/action.yml
+++ b/.github/actions/setup-fluvio/action.yml
@@ -21,5 +21,5 @@ runs:
     - name: Install Fluvio
       shell: bash
       run: |
-        curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=${{ inputs.version }} bash
+        curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | FLUVIO_VERSION=${{ inputs.version }} bash
         echo "$HOME/.fluvio/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Setups a GitHub Action to install Fluvio using the installation script and FVM.

## Usage

```diff
-     - name: Install stable CLI and start Fluvio cluster
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "~/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
```

> Open Question: Perhaps we can also host the action file on root dir, which would result in a slightly change from: `infinyon/fluvio/.github/actions/setup-fluvio`  to: `infinyon/fluvio/actions/setup-fluvio`

## Example

The following is an example from tho repository fork, where the option `version` is supported and defaults to `stable`.

![Screenshot 2023-12-12 at 4 02 15 PM](https://github.com/infinyon/fluvio/assets/34756077/ee8b4e07-b9d1-4a2e-999b-0c77e9f00143)

Refer to workflow run here: https://github.com/infinyon/fluvio/actions/runs/7185354341/job/19570442003?pr=3776#step:5:1