### PR TITLE
chore: use `setup-fluvio` action

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ matrix.cluster_type == 'k8' }}
         run: ./k8-util/cluster/reset-k3d.sh
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: latest
       - name: Install Local Fluvio cluster
@@ -207,7 +207,7 @@ jobs:
           echo "FLUVIO_VERSION=latest" | tee -a $GITHUB_ENV
 
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: ${{ env.FLUVIO_VERSION }}
 
@@ -247,7 +247,7 @@ jobs:
       - name: Setup bin path
         run:  echo "~/.fluvio/bin" >> $GITHUB_PATH
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: ${{ matrix.cluster_version }}
       - name: Start Fluvio Cluster

--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -83,10 +83,10 @@ jobs:
       - name: Set up K8 for ubuntu(kind)
         if: ${{ matrix.cluster_type == 'k8' }}
         run: ./k8-util/cluster/reset-k3d.sh
-      - name: Install Fluvio CLI
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | FLUVIO_VERSION=latest bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: latest
       - name: Install Local Fluvio cluster
         timeout-minutes: 3
         if: ${{ matrix.cluster_type == 'local' }}
@@ -206,9 +206,10 @@ jobs:
         run: |
           echo "FLUVIO_VERSION=latest" | tee -a $GITHUB_ENV
 
-      # Utilizes the env var set in the previous step
-      - name: Curl Install
-        run: curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash | tee /tmp/installer.version
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: ${{ env.FLUVIO_VERSION }}
 
       - name: Verify installer output
         run: |
@@ -245,11 +246,13 @@ jobs:
           bats-version: 1.2.1
       - name: Setup bin path
         run:  echo "~/.fluvio/bin" >> $GITHUB_PATH
-      - name: Install stable CLI and start Fluvio cluster
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: ${{ matrix.cluster_version }}
+      - name: Start Fluvio Cluster
         timeout-minutes: 10
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=${{ matrix.cluster_version }} bash
-          fluvio cluster start --local
+        run: fluvio cluster start --local
       - name: CLI ${{ matrix.cli_version }} x Cluster ${{ matrix.cluster_version }}
         run: |
           make FLUVIO_BIN=~/.fluvio/bin/fluvio SKIP_SETUP=true CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test

--- a/.github/workflows/cd_dev_mac.yaml
+++ b/.github/workflows/cd_dev_mac.yaml
@@ -55,7 +55,7 @@ jobs:
           brew install kind
           kind create cluster --config k8-util/cluster/kind.yaml
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: latest
       - name: Install Local Fluvio cluster

--- a/.github/workflows/cd_dev_mac.yaml
+++ b/.github/workflows/cd_dev_mac.yaml
@@ -54,10 +54,10 @@ jobs:
         run: |
           brew install kind
           kind create cluster --config k8-util/cluster/kind.yaml
-      - name: Install Fluvio CLI
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=latest bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: latest
       - name: Install Local Fluvio cluster
         timeout-minutes: 3
         if: ${{ matrix.cluster_type == 'local' }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -71,11 +71,10 @@ jobs:
       - name: Curl Install - Version number
         if: matrix.version == 'semver'
         run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
-
-        # Utilizes the env var set in the previous step
-      - name: Curl Install
-        run: curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash | tee /tmp/installer.version
-
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: ${{ env.VERSION }}
       - name: Verify installer output
         run: |
           INSTALLER_VERSION=$(cat /tmp/installer.version | grep "fluvio@" | awk '{print $4}' | cut -b 8-)
@@ -117,10 +116,8 @@ jobs:
           echo "EXPECTED_VERSION: $EXPECTED_VERSION"
 
       - run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
-      - name: Install Fluvio
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
       - name: Start cluster
         timeout-minutes: 10
         run: |
@@ -164,9 +161,14 @@ jobs:
           echo "PREV_STABLE_VERSION=$(gh release list | awk '{print $1}' | sed 's/^dev//' |  grep "v" | sed 's/^v//' | head -2 | tail -1)" | tee -a $GITHUB_ENV
           PREV_STABLE_VERSION=$(gh release list | awk '{print $1}' | sed 's/^dev//' |  grep "v" | sed 's/^v//' | head -2 | tail -1)
 
-      - name: Install last stable Fluvio CLI and start cluster
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: ${{ env.PREV_STABLE_VERSION }}
+
+      - name: Start cluster
+        timeout-minutes: 10
         run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh | FLUVIO_VERSION=$PREV_STABLE_VERSION bash
           ~/.fluvio/bin/fluvio cluster start --k8
           ~/.fluvio/bin/fluvio version
 

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.version == 'semver'
         run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: ${{ env.VERSION }}
       - name: Verify installer output
@@ -117,7 +117,7 @@ jobs:
 
       - run: echo "VERSION=$EXPECTED_VERSION" | tee -a $GITHUB_ENV
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
       - name: Start cluster
         timeout-minutes: 10
         run: |
@@ -162,7 +162,7 @@ jobs:
           PREV_STABLE_VERSION=$(gh release list | awk '{print $1}' | sed 's/^dev//' |  grep "v" | sed 's/^v//' | head -2 | tail -1)
 
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: ${{ env.PREV_STABLE_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -947,7 +947,7 @@ jobs:
       # Download stable, this will load into ~/.fluvio/bin which will be in PATH
       # from now, fluvio will be stable
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
 
       # Download artifacts from development build
       - name: Download artifact - fluvio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,10 +946,8 @@ jobs:
 
       # Download stable, this will load into ~/.fluvio/bin which will be in PATH
       # from now, fluvio will be stable
-      - name: Install stable CLI and start Fluvio cluster
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "~/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
 
       # Download artifacts from development build
       - name: Download artifact - fluvio

--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -48,10 +48,8 @@ jobs:
     env:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
-      - name: Install Fluvio
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
       - name: Install Fluvio CDK
         run: fluvio install cdk --develop
       - name: Fluvio Login
@@ -86,10 +84,8 @@ jobs:
     env:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
-      - name: Install Fluvio
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
       - name: Install Fluvio CDK
         run: fluvio install cdk --develop
       - name: Fluvio Login

--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -49,7 +49,7 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
       - name: Install Fluvio CDK
         run: fluvio install cdk --develop
       - name: Fluvio Login
@@ -85,7 +85,7 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
       - name: Install Fluvio CDK
         run: fluvio install cdk --develop
       - name: Fluvio Login

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           ./k8-util/cluster/reset-k3d.sh
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
         with:
           version: latest
       - name: Start Fluvio Cluster

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -151,10 +151,10 @@ jobs:
         if: ${{ matrix.cluster_type == 'k8' }}
         run: |
           ./k8-util/cluster/reset-k3d.sh
-      - name: Install Fluvio CLI and start cluster
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=latest bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        with:
+          version: latest
       - name: Start Fluvio Cluster
         # --image-version is only used in the k8 cluster_type
         run: |

--- a/.github/workflows/smartmodule-publish.yml
+++ b/.github/workflows/smartmodule-publish.yml
@@ -31,10 +31,8 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       CLOUD_LOGIN_PW:  ${{ !inputs.target_prod && secrets.ORG_HUB_SA_PASSWD_DEV || secrets.ORG_HUB_SA_PASSWD_PROD }}
     steps:
-      - name: Install Fluvio
-        run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
-          echo "$HOME/.fluvio/bin" >> $GITHUB_PATH
+      - name: Setup Fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio
       - name: Install Fluvio SMDK
         run: fluvio install smdk
       - name: Fluvio Login

--- a/.github/workflows/smartmodule-publish.yml
+++ b/.github/workflows/smartmodule-publish.yml
@@ -32,7 +32,7 @@ jobs:
       CLOUD_LOGIN_PW:  ${{ !inputs.target_prod && secrets.ORG_HUB_SA_PASSWD_DEV || secrets.ORG_HUB_SA_PASSWD_PROD }}
     steps:
       - name: Setup Fluvio
-        uses: infinyon/fluvio/.github/actions/setup-fluvio
+        uses: infinyon/fluvio/.github/actions/setup-fluvio@master
       - name: Install Fluvio SMDK
         run: fluvio install smdk
       - name: Fluvio Login


### PR DESCRIPTION
Uses `setup-fluvio` instead of in-situ cURL call to install Fluvio.