### PR TITLE
feat:rename `transform` and `transforms-file` args

### DIFF
--- a/crates/fluvio-cli-common/src/smartmodule.rs
+++ b/crates/fluvio-cli-common/src/smartmodule.rs
@@ -60,7 +60,7 @@ pub struct BaseTestCmd {
     pub params: Vec<(String, String)>,
 
     /// (Optional) File path to transformation specification.
-    #[arg(short, long, group = "TestSmartModule", alias = "transforms_file")]
+    #[arg(short, long, group = "TestSmartModule", alias = "transforms-file")]
     pub transforms: Option<PathBuf>,
 
     /// (Optional) Pass transformation specification as JSON formatted string.

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -201,7 +201,7 @@ mod cmd {
             short,
             long,
             conflicts_with = "smartmodule_group",
-            alias = "transforms_file"
+            alias = "transforms-file"
         )]
         pub transforms: Option<PathBuf>,
 

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -161,13 +161,18 @@ mod cmd {
 
         #[cfg(feature = "producer-file-io")]
         /// (Optional) Path to a file with transformation specification.
-        #[arg(long, conflicts_with = "smartmodule_group")]
-        pub transforms_file: Option<PathBuf>,
+        #[arg(
+            short,
+            long,
+            conflicts_with = "smartmodule_group",
+            alias = "transforms_file"
+        )]
+        pub transforms: Option<PathBuf>,
 
         /// (Optional) Transformation specification as JSON formatted string.
-        /// E.g. fluvio produce topic-name --transform='{"uses":"infinyon/jolt@0.1.0","with":{"spec":"[{\"operation\":\"default\",\"spec\":{\"source\":\"test\"}}]"}}'
-        #[arg(long, short, conflicts_with_all = &["smartmodule_group", "transforms_file"])]
-        pub transform: Vec<String>,
+        /// E.g. fluvio produce topic-name --transforms-line='{"uses":"infinyon/jolt@0.1.0","with":{"spec":"[{\"operation\":\"default\",\"spec\":{\"source\":\"test\"}}]"}}'
+        #[arg(long, conflicts_with_all = &["smartmodule_group", "transforms"], alias = "transform")]
+        pub transforms_line: Vec<String>,
         /*
         #[cfg(feature = "stats")]
         /// Experimental: Collect basic producer session statistics and print in stats bar
@@ -625,20 +630,19 @@ mod cmd {
                 )?]);
             }
 
-            if !self.transform.is_empty() {
-                let config =
-                    TransformationConfig::try_from(self.transform.clone()).map_err(|err| {
+            if !self.transforms_line.is_empty() {
+                let config = TransformationConfig::try_from(self.transforms_line.clone()).map_err(
+                    |err| {
                         CliError::InvalidArg(format!("unable to parse `transform` argument: {err}"))
-                    })?;
+                    },
+                )?;
                 return create_smartmodule_list(config);
             }
 
             #[cfg(feature = "producer-file-io")]
-            if let Some(transforms_file) = &self.transforms_file {
-                let config = TransformationConfig::from_file(transforms_file).map_err(|err| {
-                    CliError::InvalidArg(format!(
-                        "unable to process `transforms_file` argument: {err}"
-                    ))
+            if let Some(transforms) = &self.transforms {
+                let config = TransformationConfig::from_file(transforms).map_err(|err| {
+                    CliError::InvalidArg(format!("unable to process `transforms` argument: {err}"))
                 })?;
 
                 return create_smartmodule_list(config);

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -165,7 +165,7 @@ mod cmd {
             short,
             long,
             conflicts_with = "smartmodule_group",
-            alias = "transforms_file"
+            alias = "transforms-file"
         )]
         pub transforms: Option<PathBuf>,
 

--- a/smartmodule/examples/aggregate-init/README.md
+++ b/smartmodule/examples/aggregate-init/README.md
@@ -16,5 +16,5 @@ smdk load
 
 After that, you can consume from your topic and apply the aggregation as trasnformation:
 ```bash
-fluvio consume test-aggr --transforms-file transforms.yaml
+fluvio consume test-aggr --transforms transforms.yaml
 ```

--- a/smartmodule/examples/filter_hashset/README.md
+++ b/smartmodule/examples/filter_hashset/README.md
@@ -18,6 +18,6 @@ smdk load
 
 After that, you can consume from your topic and apply the aggregation as trasnformation:
 ```bash
-fluvio consume test-filter-hashset --transforms-file transforms.yaml
+fluvio consume test-filter-hashset --transforms transforms.yaml
 ```
 

--- a/smartmodule/examples/filter_look_back/README.md
+++ b/smartmodule/examples/filter_look_back/README.md
@@ -16,6 +16,6 @@ smdk load
 
 After that, you can consume from your topic and apply the aggregation as trasnformation:
 ```bash
-fluvio consume test-filter-lookback --transforms-file transforms.yaml
+fluvio consume test-filter-lookback --transforms transforms.yaml
 ```
 

--- a/smartmodule/examples/filter_look_back_with_timestamps/README.md
+++ b/smartmodule/examples/filter_look_back_with_timestamps/README.md
@@ -16,6 +16,6 @@ smdk load
 
 After that, you can consume from your topic and apply the aggregation as trasnformation:
 ```bash
-fluvio consume test-filter-lookback --transforms-file transforms.yaml
+fluvio consume test-filter-lookback --transforms transforms.yaml
 ```
 


### PR DESCRIPTION
In the following commands: `smdk test`, `fluvio sm test`, `fluvio produce`, `fluvio consume`
Argument `--transform` renamed to `--transforms_line` and `--transforms_file` to `--transforms` with short version `-t`.

Old names will also be supported (but hidden from help) for at least one version to support current CLI tests for cross-version combinations. 

Fixes #3773 
