### PR TITLE
fix: use `INFINYON_HUB_REMOTE`  over `HUB_REGISTRY_URL` for FVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1088,7 +1088,7 @@ jobs:
         timeout-minutes: 20
         run: |
           rm -rf ~/.fvm
-          make FVM_BIN=~/bin/fvm HUB_REGISTRY_URL="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+          make FVM_BIN=~/bin/fvm INFINYON_HUB_REMOTE="https://hub-dev.infinyon.cloud" cli-fvm-smoke
 
 
   read_only_test:

--- a/crates/fluvio-version-manager/src/command/install.rs
+++ b/crates/fluvio-version-manager/src/command/install.rs
@@ -21,7 +21,7 @@ use crate::common::workdir::fvm_versions_path;
 #[derive(Debug, Parser)]
 pub struct InstallOpt {
     /// Registry used to fetch Fluvio Versions
-    #[arg(long, env = "HUB_REGISTRY_URL", default_value = HUB_REMOTE)]
+    #[arg(long, env = "INFINYON_HUB_REMOTE", default_value = HUB_REMOTE)]
     registry: Url,
     /// Version to install: stable, latest, or named-version x.y.z
     #[arg(index = 1, default_value_t = Channel::Stable)]

--- a/crates/fluvio-version-manager/src/command/update.rs
+++ b/crates/fluvio-version-manager/src/command/update.rs
@@ -16,7 +16,7 @@ use crate::common::version_installer::VersionInstaller;
 #[derive(Debug, Args)]
 pub struct UpdateOpt {
     /// Registry used to fetch Fluvio Versions
-    #[arg(long, env = "HUB_REGISTRY_URL", default_value = HUB_REMOTE)]
+    #[arg(long, env = "INFINYON_HUB_REMOTE", default_value = HUB_REMOTE)]
     registry: Url,
 }
 

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -12,9 +12,9 @@ setup_file() {
     # Tests in this file are executed in order and rely on the previous test
     # to be successful.
 
-    HUB_REGISTRY_URL="https://hub.infinyon.cloud"
-    export HUB_REGISTRY_URL
-    debug_msg "Using Hub Registry URL: $HUB_REGISTRY_URL"
+    INFINYON_HUB_REMOTE="https://hub.infinyon.cloud"
+    export INFINYON_HUB_REMOTE
+    debug_msg "Using Hub Registry URL: $INFINYON_HUB_REMOTE"
 
     # Retrieves the latest stable version from the GitHub API and removes the
     # `v` prefix from the tag name.


### PR DESCRIPTION
Uses `INFINYON_HUB_REMOTE` over `HUB_REGISTRY_URL` to follow other solutions convention.