### PR TITLE
feat: `FluvioVersionPrinter` support for json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,6 +2436,8 @@ dependencies = [
  "home",
  "http",
  "semver 1.0.20",
+ "serde",
+ "serde_json",
  "sha2 0.10.8",
  "sysinfo",
  "tempfile",

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = { workspace = true }
 current_platform = { workspace = true }
 
 fluvio = { workspace = true }
-fluvio-cli-common = { workspace = true, features = ["version-cmd"] }
+fluvio-cli-common = { workspace = true, features = ["serde", "version-cmd"] }
 fluvio-connector-deployer = { path = "../fluvio-connector-deployer"}
 fluvio-connector-package = { workspace = true,  features = ["toml"]}
 fluvio-extension-common = { workspace = true }

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -17,6 +17,7 @@ default = ["fluvio-types"]
 file-records = ["fluvio-protocol/record", "fluvio-protocol/api"]
 version-cmd = ["dep:current_platform", "dep:clap", "dep:sysinfo"]
 smartmodule-test = ["file-records", "dep:fluvio-sc-schema", "dep:fluvio-smartmodule", "dep:fluvio", "dep:fluvio-smartengine", "dep:clap"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -28,6 +29,8 @@ comfy-table = { workspace = true }
 home = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 semver = { workspace = true }
 sha2 = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "dep:serde_json"]
 [dependencies]
 anyhow = { workspace = true }
 current_platform = { workspace = true, optional = true }
-clap = { workspace = true, optional = true }
+clap = { workspace = true, optional = true, features = ["derive", "std"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
 comfy-table = { workspace = true }

--- a/crates/fluvio-cli-common/src/version_cmd/basic.rs
+++ b/crates/fluvio-cli-common/src/version_cmd/basic.rs
@@ -10,7 +10,12 @@ const VERSION: &str = include_str!("../../../../VERSION");
 /// Display version information for local Fluvio CLIs using this build of
 /// Fluvio details such as `VERSION`, `GIT_HASH`, and `FLUVIO_RELEASE_CHANNEL`.
 #[derive(Debug, Args)]
-pub struct BasicVersionCmd;
+pub struct BasicVersionCmd {
+    #[cfg(feature = "serde")]
+    #[clap(short, long)]
+    /// Output in JSON format
+    pub json: bool,
+}
 
 impl BasicVersionCmd {
     /// Display basic information about the current fluvio installation
@@ -35,6 +40,14 @@ impl BasicVersionCmd {
 
         if let Some(info) = os_info() {
             fluvio_version_printer.append_extra("OS Details", info);
+        }
+
+        #[cfg(feature = "serde")]
+        {
+            if self.json {
+                println!("{}", fluvio_version_printer.to_json_pretty()?);
+                return Ok(());
+            }
         }
 
         println!("{}", fluvio_version_printer);

--- a/crates/fluvio-cli-common/src/version_cmd/mod.rs
+++ b/crates/fluvio-cli-common/src/version_cmd/mod.rs
@@ -63,6 +63,7 @@ pub fn os_info() -> Option<String> {
 /// ```
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FluvioVersionPrinter {
     name: String,
     version: String,
@@ -89,6 +90,13 @@ impl FluvioVersionPrinter {
     pub fn append_extra(&mut self, key: impl AsRef<str>, value: impl AsRef<str>) {
         self.extra
             .push((key.as_ref().to_string(), value.as_ref().to_string()));
+    }
+}
+
+#[cfg(feature = "serde")]
+impl FluvioVersionPrinter {
+    pub fn to_json(&self) -> String {
+        serde_json::to_json(&self)
     }
 }
 

--- a/crates/fluvio-cli-common/src/version_cmd/mod.rs
+++ b/crates/fluvio-cli-common/src/version_cmd/mod.rs
@@ -99,16 +99,35 @@ impl FluvioVersionPrinter {
 
     #[cfg(feature = "serde")]
     pub fn to_json(&self) -> Result<String> {
-        serde_json::to_string(&self).map_err(|err| {
+        let with_extras = self.with_dynamic_extras();
+
+        serde_json::to_string(&with_extras).map_err(|err| {
             anyhow::anyhow!("Failed to serialize FluvioVersionPrinter to JSON: {}", err)
         })
     }
 
     #[cfg(feature = "serde")]
     pub fn to_json_pretty(&self) -> Result<String> {
-        serde_json::to_string_pretty(&self).map_err(|err| {
+        let with_extras = self.with_dynamic_extras();
+
+        serde_json::to_string_pretty(&with_extras).map_err(|err| {
             anyhow::anyhow!("Failed to serialize FluvioVersionPrinter to JSON: {}", err)
         })
+    }
+
+    /// Appends dynamically computed values such as `arch` and `sha256` to the
+    /// `extra` field in a new copy of this [`FluvioVersionPrinter`].
+    #[cfg(feature = "serde")]
+    fn with_dynamic_extras(&self) -> Self {
+        let mut printer = self.clone();
+
+        printer.append_extra(format!("{} Arch", self.name), self.arch());
+
+        if let Some(sha256) = self.sha256() {
+            printer.append_extra(format!("{} SHA256", self.name), sha256);
+        }
+
+        printer
     }
 }
 


### PR DESCRIPTION
Provides an optional `--json` parameter to the `BasicVersionCmd` to have `version` details
printed in JSON. This is useful when used along with `jq` on CI/CD/Automation.

This capability is used behind a _feature flag_ that uses `serde` and `serde_json` so
its not automatically added and can be skipped if not needed in some scenarios.

## Example

```
Desktop cdk version
 CDK        : 0.11.3-dev-1
 CDK Arch   : aarch64-apple-darwin
 CDK SHA256 : 180a8184267524a3797675470d1e6e94a0607979b6cd36e580e2d842aba6a51a
 OS Details : Darwin 13.5.2 (kernel 22.6.0)
➜  Desktop cdk version --json
{
  "name": "CDK",
  "version": "0.11.3-dev-1",
  "OS Details": "Darwin 13.5.2 (kernel 22.6.0)",
  "CDK Arch": "aarch64-apple-darwin",
  "CDK SHA256": "180a8184267524a3797675470d1e6e94a0607979b6cd36e580e2d842aba6a51a"
}
➜  Desktop cdk version --json | jq '.version'
"0.11.3-dev-1"
```

## Demo

https://github.com/infinyon/fluvio/assets/34756077/a726dc5f-948c-43c7-b443-8d80f3140007