### PR TITLE
feat: use new version api on smdk and fluvio cli

### DIFF
--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -89,7 +89,7 @@ fluvio-package-index = { workspace = true }
 fluvio-extension-common = { workspace = true,  features = ["target", "installation"] }
 fluvio-channel = { workspace = true }
 fluvio-hub-util = { workspace = true, features = ["connector-cmds"] }
-fluvio-cli-common = { workspace = true }
+fluvio-cli-common = { workspace = true, features = ["serde", "version-cmd"] }
 fluvio-smartengine = { workspace = true,  features = ["transformation"]}
 fluvio-protocol = { workspace = true, features=["record","api"] }
 fluvio-smartmodule = { workspace = true  }

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -35,5 +35,5 @@ fluvio-smartengine = { path = "../fluvio-smartengine", features = ["transformati
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
 fluvio-sc-schema = { path = "../fluvio-sc-schema" }
-fluvio-cli-common = { path = "../fluvio-cli-common", features = ["file-records", "version-cmd", "smartmodule-test"] }
+fluvio-cli-common = { path = "../fluvio-cli-common", features = ["file-records", "version-cmd", "serde", "smartmodule-test"] }
 cargo-builder = { path = "../cargo-builder"}


### PR DESCRIPTION
Implements the new version command for the Fluvio CLI and the SMDK CLI.

## Example

### Fluvio CLI

**Before**

```
Fluvio CLI           : 0.11.2
Fluvio CLI Arch      : aarch64-apple-darwin
Fluvio CLI SHA256    : 2db084880a36e9aeed5b28e67f78fa2df3531558e6d8bd9e36a355ca970654ac
Fluvio channel frontend SHA256 : 2db084880a36e9aeed5b28e67f78fa2df3531558e6d8bd9e36a355ca970654ac
Fluvio Platform      : 0.11.2 (dev-infinyon-cloud)
Git Commit           : cddc05388b7a1278837adc506430f339f311212d
OS Details           : Darwin 13.5.2 (kernel 22.6.0)
=== Plugin Versions ===
```

**After**

```
 Fluvio CLI                     : 0.11.3-dev-1
 Fluvio CLI Arch                : aarch64-apple-darwin
 Fluvio CLI SHA256              : 7b97c0641233b2d14a9c6803a62adcb84d1b67aca71a67878aef5ffe2e010975
 OS Details                     : Darwin 13.5.2 (kernel 22.6.0)
 Fluvio Channel Frontend SHA256 : 7b97c0641233b2d14a9c6803a62adcb84d1b67aca71a67878aef5ffe2e010975
 Git Commit                     : 1f5b8b656e1d934044de90b8d6361be06de1c8b9
 Fluvio Platform                : 0.11.2 (dev-infinyon-cloud)
```

### SMKD CLI

**Before**

```
SMDK CLI: 0.11.2
SMDK CLI Arch: aarch64-apple-darwin
SMDK CLI SHA256: a6ad8f9f7e7ad05b26429e1bc94fc4e6c3c6b55e677326b35442a21eb89f3625
OS Details: Darwin 13.5.2 (kernel 22.6.0)
```

**After**

```
 SMDK        : 0.11.3-dev-1
 SMDK Arch   : aarch64-apple-darwin
 SMDK SHA256 : e1b5d470875a46e66786f1fc4cec401ab02830abe6ee98564c40166dfd15237a
 OS Details  : Darwin 13.5.2 (kernel 22.6.0)
```

### Support for JSON Output

**Fluvio CLI**

```bash
fluvio version --json
```

```json
{
  "name": "Fluvio CLI",
  "version": "0.11.3-dev-1",
  "Fluvio Channel Frontend SHA256": "7b97c0641233b2d14a9c6803a62adcb84d1b67aca71a67878aef5ffe2e010975",
  "Git Commit": "1f5b8b656e1d934044de90b8d6361be06de1c8b9",
  "Fluvio Platform": "0.11.2 (dev-infinyon-cloud)",
  "OS Details": "Darwin 13.5.2 (kernel 22.6.0)",
  "Fluvio CLI Arch": "aarch64-apple-darwin",
  "Fluvio CLI SHA256": "7b97c0641233b2d14a9c6803a62adcb84d1b67aca71a67878aef5ffe2e010975"
}
```

**SMDK CLI**

```bash
smdk version --json
```

```json
{
  "name": "SMDK",
  "version": "0.11.3-dev-1",
  "SMDK Arch": "aarch64-apple-darwin",
  "SMDK SHA256": "e1b5d470875a46e66786f1fc4cec401ab02830abe6ee98564c40166dfd15237a",
  "OS Details": "Darwin 13.5.2 (kernel 22.6.0)"
}
```