### PR TITLE
chore: ci publish patch

### DIFF
--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -122,7 +122,10 @@ install-fluvio-latest: curl-install-fluvio
 
 install-fluvio-package: FLUVIO_BIN=$(HOME)/.fluvio/bin/fluvio
 install-fluvio-package:
-	$(FLUVIO_BIN) install fluvio-package
+	# temporarily remove deadlock on fluvio-package install
+	# $(FLUVIO_BIN) install fluvio-package
+	curl https://packages.fluvio.io/v1/packages/fluvio/fluvio-package/0.1.9/x86_64-unknown-linux-musl/fluvio-package \
+	-o ${HOME}/.fluvio/bin/fluvio-packages
 
 # Requires GH_TOKEN set or `gh auth login`
 download-fluvio-release:


### PR DESCRIPTION
This needs to be patched into CI for fluvio-packages until the next stable release completes (because stable is used for fluvio-packages d/l).

In theory this should fix the hourly test failures