### PR TITLE
chore: remove separate `cdk` installation

### DIFF
--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -50,8 +50,6 @@ jobs:
     steps:
       - name: Setup Fluvio
         uses: infinyon/fluvio/.github/actions/setup-fluvio@master
-      - name: Install Fluvio CDK
-        run: fluvio install cdk --develop
       - name: Fluvio Login
         run: fluvio cloud login --email ${{ secrets.CLOUD_USER_EMAIL }} --password ${{ secrets.CLOUD_USER_PASSWORD }} ${{ inputs.cloud-url != '' && '--remote' || '' }} ${{ inputs.cloud-url }}
       - uses: actions/checkout@v4
@@ -86,8 +84,6 @@ jobs:
     steps:
       - name: Setup Fluvio
         uses: infinyon/fluvio/.github/actions/setup-fluvio@master
-      - name: Install Fluvio CDK
-        run: fluvio install cdk --develop
       - name: Fluvio Login
         run: fluvio cloud login --email ${{ secrets.CLOUD_USER_EMAIL }} --password ${{ secrets.CLOUD_USER_PASSWORD }} ${{ inputs.cloud-url != '' && '--remote' || '' }} ${{ inputs.cloud-url }}
       - uses: actions/checkout@v4


### PR DESCRIPTION
`fluvio install cdk ` is no longer needed as we install all binaris in `fvm install`