### PR TITLE
chore: exit when there is no unzip cmd

### DIFF
--- a/crates/fluvio-version-manager/tests/install-fvm.sh
+++ b/crates/fluvio-version-manager/tests/install-fvm.sh
@@ -18,6 +18,7 @@ _fluvio_version="${FLUVIO_VERSION:-${VERSION:-}}"
 # install fvm
 main() {
     need_cmd curl
+    need_cmd unzip
 
 	# Detect architecture and ensure it's supported
 	get_architecture || return 1


### PR DESCRIPTION
I installed fluvio on my two machines this weekend with: 

```bash
curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
```

Worked well on my MacBook, but the installation crashed on my Debian which didn't have `unzip` command installed. 


I am not sure if this is the correct installation bash script.