### PR TITLE
fix: fvm should allow general pkgset labels

### DIFF
--- a/crates/fluvio-version-manager/src/command/current.rs
+++ b/crates/fluvio-version-manager/src/command/current.rs
@@ -21,7 +21,7 @@ impl CurrentOpt {
         if let (Some(channel), Some(version)) = (settings.channel, settings.version) {
             match channel {
                 Channel::Latest | Channel::Stable => println!("{} ({})", version, channel),
-                Channel::Tag(_) => println!("{}", version),
+                _ => println!("{}", version),
             }
         } else {
             notify.warn("No active version set");

--- a/crates/fluvio-version-manager/src/command/update.rs
+++ b/crates/fluvio-version-manager/src/command/update.rs
@@ -42,10 +42,12 @@ impl UpdateOpt {
             );
             return Ok(());
         };
+        let ch_version = Channel::parse(&version)?; // convert to comparable Channel
+        let ps_version = Channel::parse(latest_pkgset.pkgset.to_string())?;
 
         match channel {
             Channel::Stable => {
-                if latest_pkgset.pkgset > version {
+                if ps_version > ch_version {
                     notify.info(format!(
                         "Updating fluvio {} to version {}. Current version is {}.",
                         channel.to_string().bold(),
@@ -64,7 +66,7 @@ impl UpdateOpt {
                 // The latest tag can be very dynamic, so we just check for this
                 // tag to be different than the current version assuming
                 // upstream is always up to date
-                if latest_pkgset.pkgset != version {
+                if ps_version != ch_version {
                     notify.info(format!(
                         "Updating fluvio {} to version {}. Current version is {}.",
                         channel.to_string().bold(),
@@ -79,7 +81,7 @@ impl UpdateOpt {
 
                 notify.done("You are already up to date");
             }
-            Channel::Tag(_) => {
+            Channel::Tag(_) | Channel::Other(_) => {
                 notify.warn("Static tags cannot be updated. No changes made.");
             }
         }

--- a/crates/fluvio-version-manager/src/common/version_directory.rs
+++ b/crates/fluvio-version-manager/src/common/version_directory.rs
@@ -303,7 +303,10 @@ mod tests {
 
         let settings = Settings::open().unwrap();
 
-        assert_eq!(settings.version.unwrap(), version_dir.manifest.version);
+        assert_eq!(
+            settings.version.unwrap(),
+            version_dir.manifest.version.to_string()
+        );
         assert_eq!(settings.channel.unwrap(), version_dir.manifest.channel);
 
         delete_fvm_dir();


### PR DESCRIPTION
support latest ssdk release label
