### PR TITLE
feat(fvm): list included artifacts with `fvm list <channel>`

### DIFF
--- a/crates/fluvio-version-manager/src/command/list.rs
+++ b/crates/fluvio-version-manager/src/command/list.rs
@@ -17,7 +17,7 @@ use crate::common::workdir::fvm_versions_path;
 
 #[derive(Debug, Parser)]
 pub struct ListOpt {
-    /// Version to install: stable, latest, or named-version x.y.z
+    /// List included artifacts for this installed version if available
     #[arg(index = 1)]
     channel: Option<Channel>,
 }

--- a/crates/fluvio-version-manager/src/command/list.rs
+++ b/crates/fluvio-version-manager/src/command/list.rs
@@ -7,6 +7,8 @@ use clap::Parser;
 use colored::Colorize;
 use comfy_table::{Table, Row};
 
+use fluvio_hub_util::fvm::Channel;
+
 use crate::common::manifest::VersionManifest;
 use crate::common::notify::Notify;
 use crate::common::settings::Settings;
@@ -14,7 +16,11 @@ use crate::common::version_directory::VersionDirectory;
 use crate::common::workdir::fvm_versions_path;
 
 #[derive(Debug, Parser)]
-pub struct ListOpt;
+pub struct ListOpt {
+    /// Version to install: stable, latest, or named-version x.y.z
+    #[arg(index = 1)]
+    channel: Option<Channel>,
+}
 
 impl ListOpt {
     pub async fn process(&self, notify: Notify) -> Result<()> {
@@ -28,6 +34,28 @@ impl ListOpt {
             ));
 
             return Err(anyhow!("No versions installed"));
+        }
+
+        if let Some(channel) = &self.channel {
+            let (manifests, _) = VersionDirectory::scan_versions_manifests(versions_path, None)?;
+            if let Some(manifest) = manifests.iter().find(|m| m.channel == *channel) {
+                if let Some(contents) = &manifest.contents {
+                    for art in contents {
+                        println!("{}@{}", art.name, art.version);
+                    }
+
+                    return Ok(());
+                }
+
+                let suggested_command = format!("{} {}", "fvm install", channel);
+
+                notify.help(format!(
+                    "No version contents recorded. You can upadate included artifact details by reinstalling this version. {}",
+                    suggested_command.bold(),
+                ));
+            }
+
+            return Ok(());
         }
 
         let settings = Settings::open()?;
@@ -45,7 +73,6 @@ impl ListOpt {
         }
 
         Self::render_table(manifests, maybe_active);
-
         Ok(())
     }
 

--- a/crates/fluvio-version-manager/src/command/list.rs
+++ b/crates/fluvio-version-manager/src/command/list.rs
@@ -40,6 +40,19 @@ impl ListOpt {
             let (manifests, _) = VersionDirectory::scan_versions_manifests(versions_path, None)?;
             if let Some(manifest) = manifests.iter().find(|m| m.channel == *channel) {
                 if let Some(contents) = &manifest.contents {
+                    if matches!(manifest.channel, Channel::Tag(_)) {
+                        println!(
+                            "Artifacts in version {}",
+                            manifest.version.to_string().bold()
+                        );
+                    } else {
+                        println!(
+                            "Artifacts in channel {} version {}",
+                            manifest.channel.to_string().bold(),
+                            manifest.version.to_string().bold()
+                        );
+                    }
+
                     for art in contents {
                         println!("{}@{}", art.name, art.version);
                     }

--- a/crates/fluvio-version-manager/src/common/manifest.rs
+++ b/crates/fluvio-version-manager/src/common/manifest.rs
@@ -18,14 +18,34 @@ use fluvio_hub_util::fvm::Channel;
 pub const PACKAGE_SET_MANIFEST_FILENAME: &str = "manifest.json";
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct VersionedArtifact {
+    pub name: String,
+    pub version: String,
+}
+
+impl VersionedArtifact {
+    pub fn new<S: Into<String>>(name: S, version: S) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct VersionManifest {
     pub channel: Channel,
     pub version: Version,
+    pub contents: Option<Vec<VersionedArtifact>>,
 }
 
 impl VersionManifest {
-    pub fn new(channel: Channel, version: Version) -> Self {
-        Self { channel, version }
+    pub fn new(channel: Channel, version: Version, contents: Vec<VersionedArtifact>) -> Self {
+        Self {
+            channel,
+            version,
+            contents: Some(contents),
+        }
     }
 
     /// Opens the `manifest.json` file and parses it into a `VersionManifest` struct
@@ -67,7 +87,11 @@ mod test {
   "version": "0.8.0"
 }"#;
         let tempdir = TempDir::new().unwrap();
-        let version_manifest = VersionManifest::new(Channel::Stable, Version::new(0, 8, 0));
+        let version_manifest = VersionManifest::new(
+            Channel::Stable,
+            Version::new(0, 8, 0),
+            vec![VersionedArtifact::new("fluvio", "0.11.4")],
+        );
         let manifest = version_manifest.write(tempdir.path()).unwrap();
         let have = read_to_string(manifest).unwrap();
 
@@ -77,7 +101,11 @@ mod test {
     #[test]
     fn reads_manifest_from_json() {
         let tempdir = TempDir::new().unwrap();
-        let version_manifest = VersionManifest::new(Channel::Stable, Version::new(0, 8, 0));
+        let version_manifest = VersionManifest::new(
+            Channel::Stable,
+            Version::new(0, 8, 0),
+            vec![VersionedArtifact::new("fluvio", "0.11.4")],
+        );
         let json = serde_json::to_string_pretty(&version_manifest).unwrap();
         let manifest = version_manifest.write(tempdir.path()).unwrap();
         let read_manifest = VersionManifest::open(manifest).unwrap();

--- a/crates/fluvio-version-manager/src/common/settings.rs
+++ b/crates/fluvio-version-manager/src/common/settings.rs
@@ -238,6 +238,7 @@ version = "0.12.0"
         let manifest = VersionManifest {
             channel: Channel::Stable,
             version: Version::parse(VERSION).unwrap(),
+            contents: None,
         };
 
         let mut settings = Settings::open().unwrap();

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -422,6 +422,18 @@ setup_file() {
     assert_line --index 2 --partial "    0.10.14  0.10.14"
     assert_success
 
+    # Checks contents for the stable channel
+    run bash -c 'fvm list stable'
+    assert_line --index 0 --partial "Artifacts in channel stable version $STABLE_VERSION"
+    assert_line --index 1 --partial "fluvio@$STABLE_VERSION"
+    assert_success
+
+    # Checks contents for the version 0.10.14
+    run bash -c 'fvm list 0.10.14'
+    assert_line --index 0 --partial "Artifacts in version 0.10.14"
+    assert_line --index 1 --partial "fluvio@0.10.14"
+    assert_success
+
     # Checks current command output
     run bash -c 'fvm current'
     assert_line --index 0 "$STABLE_VERSION (stable)"


### PR DESCRIPTION
Introduces support to list versions of artifacts used in a FVM channel/version.

Given that currently FVM doesn't keeps track of installed artifacts, for previous versions
users are prompted to reinstall the version in order to update this data.

## Demo

https://github.com/infinyon/fluvio/assets/34756077/242a1bf3-d99c-42a0-aadf-2e8582c76456

## Screenshot

**Listing artifacts headers**

![CleanShot 2024-02-23 at 19 44 13@2x](https://github.com/infinyon/fluvio/assets/34756077/fd718267-8384-4dde-bd29-89d191624670)
