### PR TITLE
fix: limit fluvio cluster cmds from operating on a fluvio cloud cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.7"
+version = "0.21.8"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/fluvio-cli/src/profile/list.rs
+++ b/crates/fluvio-cli/src/profile/list.rs
@@ -74,7 +74,7 @@ impl TableOutputHandler for ListConfig<'_> {
                             &*profile.cluster,
                             &*it.endpoint,
                             format_tls(&it.tls),
-                            InstallationType::load_or_default(it).to_string(),
+                            InstallationType::load(it).to_string(),
                         )
                     })
                     .unwrap_or(("", "", "", String::new()));

--- a/crates/fluvio-cluster/src/cli/check.rs
+++ b/crates/fluvio-cluster/src/cli/check.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use anyhow::Result;
 use fluvio_extension_common::installation::InstallationType;
 use semver::Version;
@@ -26,7 +27,7 @@ impl CheckOpt {
                 .bold()
                 .yellow()
         );
-        let installation_ty = get_installation_type().ok().unwrap_or_default();
+        let (installation_ty, config) = get_installation_type()?;
         debug!(?installation_ty);
 
         let checker = match installation_ty {
@@ -43,6 +44,11 @@ impl CheckOpt {
                 ClusterChecker::empty().with_no_k8_checks()
             }
             InstallationType::LocalK8 => ClusterChecker::empty().with_local_checks(),
+            InstallationType::Cloud => {
+                let profile = config.config().current_profile_name().unwrap_or("none");
+                bail!("'fluvio cluster check' is invalid with cloud cluster \"{profile}\", use 'fluvio cloud ...' commands");
+            }
+
             _other => ClusterChecker::empty(),
         };
 

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -25,8 +25,9 @@ pub struct DiagnosticsOpt {
 
 impl DiagnosticsOpt {
     pub async fn process(self) -> Result<()> {
-        let installation_ty = get_installation_type()?;
-        println!("Using installation: {installation_ty:#?}");
+        let (installation_ty, config) = get_installation_type()?;
+        let profile = config.config().current_profile_name().unwrap_or("none");
+        println!("Installation type: {installation_ty:#?}\nProfile: {profile}");
         let temp_dir = tempfile::Builder::new()
             .prefix("fluvio-diagnostics")
             .tempdir()?;
@@ -35,7 +36,7 @@ impl DiagnosticsOpt {
         let spu_specs = match self.copy_fluvio_specs(temp_path).await {
             Ok(specs) => specs,
             Err(err) => {
-                eprintln!("error copying fluivo specs: {err:#?}");
+                eprintln!("error copying fluvio specs: {err:#?}");
                 vec![]
             }
         };

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -166,9 +166,9 @@ impl ClusterCmd {
     }
 }
 
-pub(crate) fn get_installation_type() -> Result<InstallationType> {
+pub(crate) fn get_installation_type() -> Result<(InstallationType, ConfigFile)> {
     let config = ConfigFile::load_default_or_new()?;
-    Ok(InstallationType::load_or_default(
-        config.config().current_cluster()?,
-    ))
+    let fc = config.config().current_cluster()?;
+    let itype = InstallationType::load(fc);
+    Ok((itype, config))
 }

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -240,6 +240,7 @@ impl IntallationTypeOpt {
             InstallationType::LocalK8 => (false, true, false, None),
             InstallationType::ReadOnly => (false, false, false, Some(Default::default())),
             InstallationType::Docker => (false, false, false, None),
+            InstallationType::Cloud => (false, false, false, None),
         };
         self.local = local;
         self.local_k8 = local_k8;

--- a/crates/fluvio-cluster/src/cli/status.rs
+++ b/crates/fluvio-cluster/src/cli/status.rs
@@ -36,8 +36,7 @@ impl StatusOpt {
 
         let fluvio_config = target.load()?;
         let config_file = ConfigFile::load_default_or_new()?;
-        let installation_type =
-            InstallationType::load_or_default(config_file.config().current_cluster()?);
+        let installation_type = InstallationType::load(config_file.config().current_cluster()?);
         debug!(?installation_type);
 
         pb_factory.println(format!(

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -16,7 +16,7 @@ pub struct UpgradeOpt {
 
 impl UpgradeOpt {
     pub async fn process(mut self, platform_version: Version) -> Result<()> {
-        let installation_type = get_installation_type()?;
+        let (installation_type, config) = get_installation_type()?;
         debug!(?installation_type);
         if let Some(requested) = self.start.installation_type.get() {
             if installation_type != requested {
@@ -32,6 +32,10 @@ impl UpgradeOpt {
             InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
                 ShutdownOpt.process().await?;
                 self.start.process(platform_version, true).await?;
+            }
+            InstallationType::Cloud => {
+                let profile = config.config().current_profile_name().unwrap_or("none");
+                bail!("Fluvio cluster upgrade does not operate on cloud cluster \"{profile}\", use 'fluvio cloud ...' commands")
             }
             other => bail!("upgrade command is not supported for {other} installation type"),
         };

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.7"
+version = "0.21.8"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -91,6 +91,10 @@ impl FluvioConfig {
 
         Ok(())
     }
+
+    pub fn has_metadata(&self, name: &str) -> bool {
+        self.metadata.get(name).is_some()
+    }
 }
 
 impl TryFrom<FluvioConfig> for fluvio_socket::ClientConfig {


### PR DESCRIPTION
Limit confusing crossovers of fluvio local clusters  w/ fluvio cloud clusters

`fluvio profile list` will also correctly identify Cloud cluster
profiles
