### PR TITLE
fix: check if batch size exceeds segment size

### DIFF
--- a/crates/fluvio-spu/src/services/public/produce_handler.rs
+++ b/crates/fluvio-spu/src/services/public/produce_handler.rs
@@ -203,6 +203,13 @@ async fn handle_produce_partition(
                     error!(%replica_id, "Batch is too big: {:#?}", err);
                     PartitionWriteResult::error(replica_id, ErrorCode::MessageTooLarge)
                 }
+                Some(StorageError::BatchExceededSegment {
+                    batch_size,
+                    max_segment_size,
+                }) => {
+                    error!(%replica_id, batch_size, max_segment_size, "Batch size exceeded max segment size");
+                    PartitionWriteResult::error(replica_id, ErrorCode::MessageTooLarge)
+                }
                 _ => {
                     error!(%replica_id, "Error writing to replica: {:#?}", err);
                     PartitionWriteResult::error(replica_id, ErrorCode::StorageError)

--- a/crates/fluvio-storage/src/error.rs
+++ b/crates/fluvio-storage/src/error.rs
@@ -21,6 +21,11 @@ pub enum StorageError {
     SendFile(#[from] SendFileError),
     #[error("Batch exceeded maximum bytes: {0}")]
     BatchTooBig(usize),
+    #[error("Batch size {batch_size} exceeded max segment size {max_segment_size}")]
+    BatchExceededSegment {
+        batch_size: u64,
+        max_segment_size: u64,
+    },
     #[error("Batch is empty")]
     EmptyBatch,
 }


### PR DESCRIPTION
If the batch size exceeds the max segment size, the storage never will be able to store the data.

Added a check to validate and prevent this situation before writing to the segment. 

Fixes #3891