### PR TITLE
fix: smdk generate on linux, startup error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6426,6 +6426,7 @@ name = "smartmodule-development-kit"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-std",
  "cargo-builder",
  "cargo-generate",
  "clap",
@@ -6444,7 +6445,6 @@ dependencies = [
  "include_dir",
  "lib-cargo-crate",
  "tempfile",
- "tokio",
  "toml 0.8.8",
  "tracing",
 ]

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -14,19 +14,18 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-tracing = { workspace = true }
 anyhow = { workspace = true }
+async-std = { features = ["attributes", "tokio1"], workspace = true }
+cargo-generate = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
 current_platform = { workspace = true }
 dirs = { workspace = true }
-toml = { workspace = true }
-tokio = { workspace = true }
-cargo-generate = { workspace = true }
 include_dir = { workspace = true }
+lib-cargo-crate = "0.2.1"
+toml = { workspace = true }
 tempfile = { workspace = true }
 enum-display = "0.1.3"
-lib-cargo-crate = "0.2.1"
-
+tracing = { workspace = true }
 
 fluvio = { path = "../fluvio", default-features = false }
 fluvio-hub-util = { path = "../fluvio-hub-util" }


### PR DESCRIPTION
removing tokio as a top level dependency adding async-std with a compat flag fixes a linux tokio reactor crash on "smdk generate" when the cli invokes

fixes #3921