### PR TITLE
Scaffold resume - local config persisted between runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,8 +3186,10 @@ version = "0.4.5"
 dependencies = [
  "event-listener 3.1.0",
  "fluvio-future",
+ "serde",
  "thiserror",
  "tokio",
+ "toml 0.8.8",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "event-listener 3.1.0",
  "fluvio-future",

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -10,6 +10,7 @@ use tracing::debug;
 mod group;
 mod spu;
 mod start;
+mod resume;
 mod delete;
 mod util;
 mod check;
@@ -20,6 +21,7 @@ mod shutdown;
 mod upgrade;
 
 use start::StartOpt;
+use resume::ResumeOpt;
 use delete::DeleteOpt;
 use check::CheckOpt;
 use group::SpuGroupCmd;
@@ -46,6 +48,10 @@ pub enum ClusterCmd {
     /// Install Fluvio cluster
     #[command(name = "start")]
     Start(Box<StartOpt>),
+
+    /// Resume Fluvio cluster
+    #[command(name = "resume")]
+    Resume(ResumeOpt),
 
     /// Upgrades an already-started Fluvio cluster
     #[command(name = "upgrade")]
@@ -120,6 +126,9 @@ impl ClusterCmd {
                 };
 
                 start.process(platform_version, false).await?;
+            }
+            Self::Resume(opt) => {
+                opt.process(platform_version).await?;
             }
             Self::Upgrade(mut upgrade) => {
                 if let Ok(tag_strategy_value) = std::env::var(FLUVIO_IMAGE_TAG_STRATEGY) {

--- a/crates/fluvio-cluster/src/cli/resume.rs
+++ b/crates/fluvio-cluster/src/cli/resume.rs
@@ -13,7 +13,6 @@ use crate::{InstallationType, cli::get_installation_type};
 #[derive(Debug, Parser)]
 pub struct ResumeOpt;
 
-
 impl ResumeOpt {
     pub async fn process(self, _platform_version: Version) -> Result<()> {
         let pb_factory = ProgressBarFactory::new(false);
@@ -41,15 +40,15 @@ impl ResumeOpt {
     }
 
     async fn resume() -> Result<()> {
-        
         let local_conf = match LOCAL_CONFIG_PATH.as_ref() {
-            None => return Err(ClusterCliError::Other("Can't find older config".to_string()).into()),
-            Some(local_config_path) => LocalConfig::load_from(local_config_path)
+            None => {
+                return Err(ClusterCliError::Other("Can't find older config".to_string()).into())
+            }
+            Some(local_config_path) => LocalConfig::load_from(local_config_path),
         }?;
 
         let installer = LocalInstaller::from_config(local_conf);
         _ = installer.install().await?;
         Ok(())
     }
-
 }

--- a/crates/fluvio-cluster/src/cli/resume.rs
+++ b/crates/fluvio-cluster/src/cli/resume.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use clap::Parser;
+use fluvio_types::config_file::SaveLoadConfig;
+use semver::Version;
+use tracing::debug;
+
+use crate::cli::ClusterCliError;
+use crate::progress::ProgressBarFactory;
+use crate::start::local::LOCAL_CONFIG_PATH;
+use crate::LocalConfig;
+use crate::LocalInstaller;
+use crate::{InstallationType, cli::get_installation_type};
+#[derive(Debug, Parser)]
+pub struct ResumeOpt;
+
+
+impl ResumeOpt {
+    pub async fn process(self, _platform_version: Version) -> Result<()> {
+        let pb_factory = ProgressBarFactory::new(false);
+
+        let pb = match pb_factory.create() {
+            Ok(pb) => pb,
+            Err(_) => {
+                return Err(
+                    ClusterCliError::Other("Failed to create progress bar".to_string()).into(),
+                )
+            }
+        };
+        let (installation_type, _config) = get_installation_type()?;
+        debug!(?installation_type);
+
+        match installation_type {
+            InstallationType::Local | InstallationType::ReadOnly => {
+                Self::resume().await?;
+            }
+            _ => {
+                pb.println("❌ Resume is only implemented for local clusters.");
+            }
+        };
+        Ok(())
+    }
+
+    async fn resume() -> Result<()> {
+        
+        let local_conf = match LOCAL_CONFIG_PATH.as_ref() {
+            None => return Err(ClusterCliError::Other("Can't find older config".to_string()).into()),
+            Some(local_config_path) => LocalConfig::load_from(local_config_path)
+        }?;
+
+        let installer = LocalInstaller::from_config(local_conf);
+        _ = installer.install().await?;
+        Ok(())
+    }
+
+}

--- a/crates/fluvio-cluster/src/cli/resume.rs
+++ b/crates/fluvio-cluster/src/cli/resume.rs
@@ -32,9 +32,7 @@ impl ResumeOpt {
 
         let resume_result = match installation_type {
             InstallationType::Local | InstallationType::ReadOnly => {
-                let resume = LocalResume {
-                    pb_factory,
-                };
+                let resume = LocalResume { pb_factory };
                 resume.resume().await
             }
             _ => {

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::Command;
 use std::fs::{remove_dir_all, remove_file};
 
@@ -15,7 +16,7 @@ use crate::progress::ProgressBarFactory;
 use crate::render::ProgressRenderer;
 use crate::DEFAULT_NAMESPACE;
 use crate::error::UninstallError;
-use crate::start::local::DEFAULT_DATA_DIR;
+use crate::start::local::{DEFAULT_DATA_DIR, LOCAL_CONFIG_PATH};
 use anyhow::Result;
 
 /// Uninstalls different flavors of fluvio
@@ -176,35 +177,36 @@ impl ClusterUninstaller {
         kill_proc("fluvio", Some(&["run".into()]));
         kill_proc("fluvio-run", None);
 
-        // delete fluvio file
-        debug!("Removing fluvio directory");
-        match &*DEFAULT_DATA_DIR {
-            Some(data_dir) => match remove_dir_all(data_dir) {
-                Ok(_) => {
-                    debug!("Removed data dir: {}", data_dir.display());
+        fn delete_fs<T: AsRef<Path>>(path: Option<T>, tag: &'static str, is_file: bool, pb: Option<&ProgressRenderer>) {
+            match path {
+                Some(path) => {
+                    let path_ref = path.as_ref();
+                    match if is_file {remove_file(path_ref)} else {remove_dir_all(path_ref)} {
+                        Ok(_) => {
+                            debug!("Removed {}: {}", tag, path_ref.display());
+                            pb.map(|pb| pb.println(format!("Removed {}", tag)));
+                        }
+                        Err(err) => {
+                            warn!("{} can't be removed: {}", tag, err);
+                            pb.map(|pb| pb.println(format!("{tag}, can't be removed: {err}")));
+                        }
+                    }
+                },
+                None => {
+                    warn!("Unable to find {}, cannot remove", tag);
                 }
-                Err(err) => {
-                    warn!("fluvio dir can't be removed: {}", err);
-                }
-            },
-            None => {
-                warn!("Unable to find data dir, cannot remove");
             }
         }
 
+        // delete fluvio file
+        debug!("Removing fluvio directory");
+        delete_fs(DEFAULT_DATA_DIR.as_ref(), "data dir", false, None);
+
+        // delete local cluster config file
+        delete_fs(LOCAL_CONFIG_PATH.as_ref(), "local cluster config", true, None);
+
         // remove monitoring socket
-        match remove_file(SPU_MONITORING_UNIX_SOCKET) {
-            Ok(_) => {
-                pb.println(format!(
-                    "Removed spu monitoring socket: {SPU_MONITORING_UNIX_SOCKET}"
-                ));
-            }
-            Err(err) => {
-                pb.println(format!(
-                    "SPU monitoring socket  {SPU_MONITORING_UNIX_SOCKET}, can't be removed: {err}"
-                ));
-            }
-        }
+        delete_fs(Some(SPU_MONITORING_UNIX_SOCKET), "SPU monitoring socket", true, Some(&pb));
 
         pb.println("Uninstalled fluvio local components");
         pb.finish_and_clear();

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -177,21 +177,30 @@ impl ClusterUninstaller {
         kill_proc("fluvio", Some(&["run".into()]));
         kill_proc("fluvio-run", None);
 
-        fn delete_fs<T: AsRef<Path>>(path: Option<T>, tag: &'static str, is_file: bool, pb: Option<&ProgressRenderer>) {
+        fn delete_fs<T: AsRef<Path>>(
+            path: Option<T>,
+            tag: &'static str,
+            is_file: bool,
+            pb: Option<&ProgressRenderer>,
+        ) {
             match path {
                 Some(path) => {
                     let path_ref = path.as_ref();
-                    match if is_file {remove_file(path_ref)} else {remove_dir_all(path_ref)} {
+                    match if is_file {
+                        remove_file(path_ref)
+                    } else {
+                        remove_dir_all(path_ref)
+                    } {
                         Ok(_) => {
                             debug!("Removed {}: {}", tag, path_ref.display());
-                            pb.map(|pb| pb.println(format!("Removed {}", tag)));
+                            if let Some(pb) = pb { pb.println(format!("Removed {}", tag)) }
                         }
                         Err(err) => {
                             warn!("{} can't be removed: {}", tag, err);
-                            pb.map(|pb| pb.println(format!("{tag}, can't be removed: {err}")));
+                            if let Some(pb) = pb { pb.println(format!("{tag}, can't be removed: {err}")) }
                         }
                     }
-                },
+                }
                 None => {
                     warn!("Unable to find {}, cannot remove", tag);
                 }
@@ -203,10 +212,20 @@ impl ClusterUninstaller {
         delete_fs(DEFAULT_DATA_DIR.as_ref(), "data dir", false, None);
 
         // delete local cluster config file
-        delete_fs(LOCAL_CONFIG_PATH.as_ref(), "local cluster config", true, None);
+        delete_fs(
+            LOCAL_CONFIG_PATH.as_ref(),
+            "local cluster config",
+            true,
+            None,
+        );
 
         // remove monitoring socket
-        delete_fs(Some(SPU_MONITORING_UNIX_SOCKET), "SPU monitoring socket", true, Some(&pb));
+        delete_fs(
+            Some(SPU_MONITORING_UNIX_SOCKET),
+            "SPU monitoring socket",
+            true,
+            Some(&pb),
+        );
 
         pb.println("Uninstalled fluvio local components");
         pb.finish_and_clear();

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -193,11 +193,15 @@ impl ClusterUninstaller {
                     } {
                         Ok(_) => {
                             debug!("Removed {}: {}", tag, path_ref.display());
-                            if let Some(pb) = pb { pb.println(format!("Removed {}", tag)) }
+                            if let Some(pb) = pb {
+                                pb.println(format!("Removed {}", tag))
+                            }
                         }
                         Err(err) => {
                             warn!("{} can't be removed: {}", tag, err);
-                            if let Some(pb) = pb { pb.println(format!("{tag}, can't be removed: {err}")) }
+                            if let Some(pb) = pb {
+                                pb.println(format!("{tag}, can't be removed: {err}"))
+                            }
                         }
                     }
                 }

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -105,7 +105,7 @@ impl ClusterUninstaller {
 
         let pb = self.pb_factory.create()?;
         pb.set_message("Uninstalling fluvio kubernetes components");
-        let uninstall = UninstallArg::new(self.config.app_chart_name.to_owned())
+        let uninstall: UninstallArg = UninstallArg::new(self.config.app_chart_name.to_owned())
             .namespace(self.config.namespace.to_owned())
             .ignore_not_found();
         self.helm_client

--- a/crates/fluvio-cluster/src/lib.rs
+++ b/crates/fluvio-cluster/src/lib.rs
@@ -60,6 +60,7 @@ mod common {
 
     use anyhow::Result;
     use fluvio::config::{TlsPaths, TlsConfig};
+    use serde::{Serialize, Deserialize};
 
     /// The result of a successful startup of a Fluvio cluster
     ///
@@ -90,7 +91,7 @@ mod common {
     }
 
     /// User configuration chart location
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum UserChartLocation {
         /// Local charts must be located at a valid filesystem path.
         Local(PathBuf),

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -473,7 +473,7 @@ impl LocalInstaller {
             .println("🎯 Successfully installed Local Fluvio cluster");
 
         self.save_config_file();
-        
+
         Ok(StartStatus { address, port })
     }
 
@@ -693,8 +693,8 @@ impl LocalInstaller {
             None => {
                 warn!("Local config path");
                 return;
-            },
-            Some(local_config_path) => self.config.save_to(local_config_path)
+            }
+            Some(local_config_path) => self.config.save_to(local_config_path),
         };
 
         if let Err(err) = save_to_res {

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -14,7 +14,8 @@ events = ["event-listener"]
 event-listener = { workspace = true,  optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-
+serde = { workspace = true }
+toml = { workspace = true, features = ["display", "preserve_order"] }
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture", "subscriber"] }

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -15,7 +15,7 @@ event-listener = { workspace = true,  optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
-toml = { workspace = true, features = ["display", "preserve_order"] }
+toml = { workspace = true, features = ["display", "preserve_order", "parse"] }
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture", "subscriber"] }

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/config_file.rs
+++ b/crates/fluvio-types/src/config_file.rs
@@ -14,16 +14,22 @@ pub enum LoadConfigError {
     #[error("IoError: {0}")]
     IoError(IoError),
     #[error("TomlError: {0}")]
-    TomlError(toml::de::Error)
+    TomlError(toml::de::Error),
 }
 
 pub trait SaveLoadConfig {
     fn save_to<T: AsRef<Path>>(&self, path: T) -> Result<(), IoError>;
-    fn load_from<T: AsRef<Path>>(path: T) -> Result<Self, LoadConfigError> where Self: Sized;
+    fn load_from<T: AsRef<Path>>(path: T) -> Result<Self, LoadConfigError>
+    where
+        Self: Sized;
+    fn load_str(config: &str) -> Result<Self, LoadConfigError>
+    where
+        Self: Sized;
 }
 
 impl<S> SaveLoadConfig for S
-    where S: Serialize + DeserializeOwned + Debug
+where
+    S: Serialize + DeserializeOwned + Debug,
 {
     // save to file
     fn save_to<T: AsRef<Path>>(&self, path: T) -> Result<(), IoError> {
@@ -42,10 +48,17 @@ impl<S> SaveLoadConfig for S
         let path_ref = path.as_ref();
         debug!(?path_ref, "loading from");
 
-        let file_str = read_to_string(path_ref)
-            .map_err(LoadConfigError::IoError)?;
+        let file_str = read_to_string(path_ref).map_err(LoadConfigError::IoError)?;
 
         let config = toml::from_str(&file_str).map_err(LoadConfigError::TomlError)?;
+        Ok(config)
+    }
+
+    fn load_str(config: &str) -> Result<Self, LoadConfigError>
+    where
+        Self: Sized,
+    {
+        let config = toml::from_str(&config).map_err(LoadConfigError::TomlError)?;
         Ok(config)
     }
 }

--- a/crates/fluvio-types/src/config_file.rs
+++ b/crates/fluvio-types/src/config_file.rs
@@ -1,0 +1,51 @@
+use std::fmt::Debug;
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+use std::io::Write;
+use std::path::Path;
+use std::fs::{File, read_to_string};
+
+use tracing::debug;
+use serde::{Serialize, de::DeserializeOwned};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LoadConfigError {
+    #[error("IoError: {0}")]
+    IoError(IoError),
+    #[error("TomlError: {0}")]
+    TomlError(toml::de::Error)
+}
+
+pub trait SaveLoadConfig {
+    fn save_to<T: AsRef<Path>>(&self, path: T) -> Result<(), IoError>;
+    fn load_from<T: AsRef<Path>>(path: T) -> Result<Self, LoadConfigError> where Self: Sized;
+}
+
+impl<S> SaveLoadConfig for S
+    where S: Serialize + DeserializeOwned + Debug
+{
+    // save to file
+    fn save_to<T: AsRef<Path>>(&self, path: T) -> Result<(), IoError> {
+        let path_ref = path.as_ref();
+        debug!("saving config: {:#?} to: {:#?}", self, path_ref);
+        let toml = toml::to_string(self)
+            .map_err(|err| IoError::new(ErrorKind::Other, format!("{err}")))?;
+
+        let mut file = File::create(path_ref)?;
+        file.write_all(toml.as_bytes())?;
+        // On windows flush() is noop, but sync_all() calls FlushFileBuffers.
+        file.sync_all()
+    }
+
+    fn load_from<T: AsRef<Path>>(path: T) -> Result<Self, LoadConfigError> {
+        let path_ref = path.as_ref();
+        debug!(?path_ref, "loading from");
+
+        let file_str = read_to_string(path_ref)
+            .map_err(LoadConfigError::IoError)?;
+
+        let config = toml::from_str(&file_str).map_err(LoadConfigError::TomlError)?;
+        Ok(config)
+    }
+}

--- a/crates/fluvio-types/src/config_file.rs
+++ b/crates/fluvio-types/src/config_file.rs
@@ -58,7 +58,7 @@ where
     where
         Self: Sized,
     {
-        let config = toml::from_str(&config).map_err(LoadConfigError::TomlError)?;
+        let config = toml::from_str(config).map_err(LoadConfigError::TomlError)?;
         Ok(config)
     }
 }

--- a/crates/fluvio-types/src/lib.rs
+++ b/crates/fluvio-types/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 pub mod defaults;
 pub mod macros;
 pub mod partition;
+pub mod config_file;
 
 #[cfg(feature = "events")]
 pub mod event;

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -111,6 +111,8 @@ impl TryFrom<FluvioConfig> for fluvio_socket::ClientConfig {
 
 #[cfg(test)]
 mod test_metadata {
+    use fluvio_types::config_file::SaveLoadConfig;
+
     use serde::{Deserialize, Serialize};
     use crate::config::{Config, ConfigFile};
 
@@ -126,7 +128,7 @@ endpoint = "127.0.0.1:9003"
 [cluster.local.metadata.custom]
 name = "foo"
 "#;
-        let profile: Config = toml::de::from_str(toml).unwrap();
+        let profile = Config::load_str(toml).unwrap();
         let config = profile.cluster("local").unwrap();
 
         #[derive(Deserialize, Debug, PartialEq)]
@@ -153,7 +155,7 @@ cluster = "local"
 [cluster.local]
 endpoint = "127.0.0.1:9003"
 "#;
-        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let mut profile = Config::load_str(toml).unwrap();
         let config = profile.cluster_mut("local").unwrap();
 
         #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -186,7 +188,7 @@ endpoint = "127.0.0.1:9003"
 [cluster.local.metadata.installation]
 type = "local"
 "#;
-        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let mut profile = Config::load_str(toml).unwrap();
         let config = profile.cluster_mut("local").unwrap();
 
         #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -231,7 +233,7 @@ endpoint = "127.0.0.1:9003"
 [cluster.local.metadata.installation]
 type = "local"
 "#;
-        let mut profile: Config = toml::de::from_str(toml).unwrap();
+        let mut profile = Config::load_str(toml).unwrap();
         let config = profile.cluster_mut("local").unwrap();
 
         #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -95,15 +95,15 @@ impl ConfigFile {
     /// read from file
     fn from_file<T: AsRef<Path>>(path: T) -> Result<Self, FluvioError> {
         let path_ref = path.as_ref();
-        let config = Config::load_from(path_ref).map_err(|e|
-            match e {
-                LoadConfigError::IoError(e) => config_file_error(&format!("{:?}", path_ref.as_os_str()), e),
-                LoadConfigError::TomlError(e) => ConfigError::TomlError {
-                    msg: path_ref.display().to_string(),
-                    source: e,
-                },
+        let config = Config::load_from(path_ref).map_err(|e| match e {
+            LoadConfigError::IoError(e) => {
+                config_file_error(&format!("{:?}", path_ref.as_os_str()), e)
             }
-        )?;
+            LoadConfigError::TomlError(e) => ConfigError::TomlError {
+                msg: path_ref.display().to_string(),
+                source: e,
+            },
+        })?;
 
         Ok(Self::new(path_ref.to_owned(), config))
     }

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -4,15 +4,13 @@
 //! Contains contexts, profiles
 //!
 use std::env;
-use std::fs::read_to_string;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
-use std::fs::File;
 use std::fs::create_dir_all;
 
+use fluvio_types::config_file::LoadConfigError;
 use thiserror::Error;
 
 use tracing::debug;
@@ -28,6 +26,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use fluvio_types::defaults::CLI_CONFIG_PATH;
+use fluvio_types::config_file::SaveLoadConfig;
 use crate::{FluvioConfig, FluvioError};
 
 use super::TlsPolicy;
@@ -96,13 +95,16 @@ impl ConfigFile {
     /// read from file
     fn from_file<T: AsRef<Path>>(path: T) -> Result<Self, FluvioError> {
         let path_ref = path.as_ref();
-        debug!(?path_ref, "loading from");
-        let file_str: String = read_to_string(path_ref)
-            .map_err(|e| config_file_error(&format!("{:?}", path_ref.as_os_str()), e))?;
-        let config = toml::from_str(&file_str).map_err(|e| ConfigError::TomlError {
-            msg: path_ref.display().to_string(),
-            source: e,
-        })?;
+        let config = Config::load_from(path_ref).map_err(|e|
+            match e {
+                LoadConfigError::IoError(e) => config_file_error(&format!("{:?}", path_ref.as_os_str()), e),
+                LoadConfigError::TomlError(e) => ConfigError::TomlError {
+                    msg: path_ref.display().to_string(),
+                    source: e,
+                },
+            }
+        )?;
+
         Ok(Self::new(path_ref.to_owned(), config))
     }
 
@@ -229,19 +231,6 @@ impl Config {
 
     pub fn add_profile(&mut self, profile: Profile, name: String) {
         self.profile.insert(name, profile);
-    }
-
-    // save to file
-    fn save_to<T: AsRef<Path>>(&self, path: T) -> Result<(), IoError> {
-        let path_ref = path.as_ref();
-        debug!("saving config: {:#?} to: {:#?}", self, path_ref);
-        let toml = toml::to_string(self)
-            .map_err(|err| IoError::new(ErrorKind::Other, format!("{err}")))?;
-
-        let mut file = File::create(path_ref)?;
-        file.write_all(toml.as_bytes())?;
-        // On windows flush() is noop, but sync_all() calls FlushFileBuffers.
-        file.sync_all()
     }
 
     pub fn version(&self) -> &str {

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -202,6 +202,7 @@ cli-partition-test-multiple-partitions:
 
 cli-fluvio-smoke:
 	bats $(shell ls -1 ./tests/cli/fluvio_smoke_tests/*.bats | sort -R)
+	bats ./tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
 	bats ./tests/cli/fluvio_smoke_tests/non-concurrent/cluster-delete.bats
 
 cli-fluvio-read-only-smoke:

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.10.7"
+version = "0.10.11"
 dependencies = [
  "bytes",
  "content_inspector",
@@ -200,7 +206,7 @@ dependencies = [
  "eyre",
  "fluvio-compression 0.3.2",
  "fluvio-protocol-derive 0.5.4",
- "fluvio-types 0.4.4",
+ "fluvio-types 0.4.6",
  "flv-util",
  "once_cell",
  "semver",
@@ -246,7 +252,7 @@ name = "fluvio-smartmodule"
 version = "0.7.3"
 dependencies = [
  "eyre",
- "fluvio-protocol 0.10.7",
+ "fluvio-protocol 0.10.11",
  "fluvio-smartmodule-derive 0.6.2",
  "thiserror",
  "tracing",
@@ -388,9 +394,11 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.4.4"
+version = "0.4.6"
 dependencies = [
+ "serde",
  "thiserror",
+ "toml",
  "tracing",
 ]
 
@@ -607,6 +615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,7 +633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -869,12 +893,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -955,6 +988,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1108,6 +1176,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ws_stream_wasm"

--- a/tests/cli/fluvio_smoke_tests/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/local-resume.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+run_list_spus() {
+    # Pipe the CLI into jq to control the output.
+    # We must fail with `fluvio cluster` (hence -o pipefail) to propagate whether the command failed.
+    run bash -o pipefail -c "\"$FLUVIO_BIN\" cluster spu list -O json | jq 'length'"
+}
+
+run_resume() {
+    # Since `fluvio run sc` runs sc as a child process without daemonizing it, all the FDs
+    # are inherited to the children. That includes FD3 and other FDs that causes the test to hang. 
+    # see: https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+    # To circumvent it, we kill the parent process (with nohup) and close all of the inherited file descriptors.
+    # Note the current approach is hacky because it blindly closes FDs in the range of [3, 100]
+    # An alternative approach would be to list and close only the non 0,1,2 FDs. However it bloats the test.
+    # Example: https://github.com/bats-core/bats-core/blob/master/test/fixtures/bats/issue-205.bats
+    # TODO: Consider daemonizing the local cluster SC, which should solve this problem properly.
+    close_fd_cmd='for fd in $(seq 3 100); do eval exec "$fd>&-"; done'
+    run_resume_cmd="nohup $FLUVIO_BIN cluster resume 0<&-"
+    run bash -c "${close_fd_cmd} && ${run_resume_cmd} &" 3>&-
+}
+
+setup_file() {
+    run_list_spus
+    # Expecting to have a running cluster
+    assert_success
+    CLUSTER_SPUS=$output
+    export CLUSTER_SPUS
+
+    BATS_TEST_TIMEOUT=10
+    export BATS_TEST_TIMEOUT
+}
+
+@test "Resume SPU instances" {
+    run timeout 15s "$FLUVIO_BIN" cluster shutdown
+    assert_success
+
+    run_list_spus
+    # Cluster is not running so run should fail
+    assert_failure
+
+    run_resume
+
+    for retry in $(seq 1 5); do
+        run_list_spus
+        if [ "$status" -ne 0 ]; then 
+            debug_msg "retry listing SPUs..."
+            sleep 1
+        else
+            debug_msg "Got $output SPUs after ${retry} retries. It is expected to be the same as $CLUSTER_SPUS"
+            current_spus=$output
+            break;
+        fi;
+    done;
+
+    assert_equal $CLUSTER_SPUS $current_spus
+}

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../../test_helper"
 export TEST_HELPER_DIR
 
 load "$TEST_HELPER_DIR"/tools_check.bash

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
@@ -49,13 +49,13 @@ setup_file() {
 
     run_resume
 
-    for retry in $(seq 1 5); do
+    for retry in $(seq 1 10); do
         run_list_spus
         if [ "$status" -ne 0 ]; then 
-            debug_msg "retry listing SPUs..."
-            sleep 1
+            echo "retry listing SPUs..." >&3
+            sleep 3
         else
-            debug_msg "Got $output SPUs after ${retry} retries. It is expected to be the same as $CLUSTER_SPUS"
+            echo "Got $output SPUs after ${retry} retries. It is expected to be the same as $CLUSTER_SPUS" >&3
             current_spus=$output
             break;
         fi;

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
@@ -36,9 +36,6 @@ setup_file() {
     assert_success
     CLUSTER_SPUS=$output
     export CLUSTER_SPUS
-
-    BATS_TEST_TIMEOUT=10
-    export BATS_TEST_TIMEOUT
 }
 
 @test "Resume SPU instances" {

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
@@ -39,10 +39,7 @@ setup_file() {
 }
 
 @test "Resume cluster maintains SPU replica number" {
-    run "$FLUVIO_BIN" cluster resume --help
-    if [ "$status" -ne 0 ]; then 
-        skip "don't run when resume is not available (i.e: stable)"
-    fi
+    skip "until 'resume' is released into a stable version; Otherwise, the CLI can't separate between stable and dev clusters, and the former is yet to support the new command"
 
     run timeout 15s "$FLUVIO_BIN" cluster shutdown
     assert_success

--- a/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
+++ b/tests/cli/fluvio_smoke_tests/non-concurrent/local-resume.bats
@@ -38,7 +38,12 @@ setup_file() {
     export CLUSTER_SPUS
 }
 
-@test "Resume SPU instances" {
+@test "Resume cluster maintains SPU replica number" {
+    run "$FLUVIO_BIN" cluster resume --help
+    if [ "$status" -ne 0 ]; then 
+        skip "don't run when resume is not available (i.e: stable)"
+    fi
+
     run timeout 15s "$FLUVIO_BIN" cluster shutdown
     assert_success
 


### PR DESCRIPTION
This is a draft first change for [issue 3810](https://github.com/infinyon/fluvio/issues/3810)
If we agree that we need to store the local cluster configuration in a file - this commit is the first step before adding more edge cases and error handling 