### PR TITLE
perfor: switch to high perform allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "k8-client",
  "k8-config",
  "k8-types",
+ "mimalloc",
  "semver 1.0.20",
  "serde",
  "serde_json",
@@ -2806,6 +2807,7 @@ dependencies = [
  "flv-util",
  "futures-util",
  "k8-client",
+ "mimalloc",
  "once_cell",
  "rand",
  "regex",
@@ -2960,6 +2962,7 @@ dependencies = [
  "flv-tls-proxy",
  "flv-util",
  "futures-util",
+ "mimalloc",
  "nix 0.27.1",
  "once_cell",
  "portpicker",
@@ -4504,6 +4507,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,6 +4766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ humantime-serde = { version = "1.1.1", default-features = false }
 include_dir = "0.7.2"
 indicatif = "0.17.0"
 inventory = "0.3"
+mimalloc = "0.1.39"
 mime = "0.3"
 nix = { version = "0.27.1", default-features = false }
 once_cell = "1.7.2"

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -64,6 +64,7 @@ tui = { workspace = true, features = ['crossterm'] }
 futures = { workspace = true }
 futures-util = { workspace = true, features = ["sink"] }
 humantime = { workspace = true }
+mimalloc = { workspace = true }
 static_assertions = { workspace = true }
 sysinfo = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/fluvio-cli/src/bin/main.rs
+++ b/crates/fluvio-cli/src/bin/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::Parser;
 use anyhow::Result;
 

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -32,6 +32,7 @@ cfg-if = { workspace = true }
 clap = { workspace = true,features = ["std", "derive", "env"]}
 event-listener = { workspace = true }
 futures-util = { workspace = true }
+mimalloc = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/crates/fluvio-sc/src/bin/main.rs
+++ b/crates/fluvio-sc/src/bin/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::Parser;
 
 use fluvio_sc::cli::ScOpt;

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -46,7 +46,7 @@ adaptive_backoff = { workspace = true }
 once_cell = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
-
+mimalloc = { workspace = true }
 
 # Fluvio dependencies
 fluvio = { workspace = true }

--- a/crates/fluvio-spu/src/main.rs
+++ b/crates/fluvio-spu/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::Parser;
 
 fn main() {


### PR DESCRIPTION
Switch to [mimalloc](https://crates.io/crates/mimalloc) to improve performance.
Only add to main to reduce allocator conflict in library