### PR TITLE
fix: cdk deploy, fix contention on ipkg binary and/or log path

### DIFF
--- a/connector/json-test-connector/sample-config2-v2.yaml
+++ b/connector/json-test-connector/sample-config2-v2.yaml
@@ -1,0 +1,24 @@
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: my-json-test-connector2
+  type: json-test-source
+  topic:
+    version: 0.1.0
+    meta:
+      name: test-full-topic
+    partition:
+      count: 1
+      max-size: 4.0 KB
+      replication: 1
+      ignore-rack-assignment: true
+    retention:
+      time: 2m
+      segment-size: 2.0 KB
+    compression:
+      type: Lz4
+json:
+  interval: 5
+  timeout: 15
+  template: '{"template":"test"}'
+

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -17,19 +17,19 @@ doc = false
 normal = ["fluvio"]
 
 [dependencies]
-tracing = { workspace = true }
-thiserror = { workspace = true }
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
 cargo-builder = { path = "../cargo-builder"}
-serde = { workspace = true,  features = ["derive"] }
-toml = { workspace = true, features = ["parse", "display", "preserve_order"] }
-comfy-table = { workspace = true  }
-sysinfo = { workspace = true, default-features = false }
 cargo-generate = { workspace = true }
-include_dir = { workspace = true }
-tempfile = { workspace = true }
+clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
+comfy-table = { workspace = true  }
 current_platform = { workspace = true }
+include_dir = { workspace = true }
+serde = { workspace = true,  features = ["derive"] }
+sysinfo = { workspace = true, default-features = false }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true, features = ["parse", "display", "preserve_order"] }
+tracing = { workspace = true }
 
 fluvio = { workspace = true }
 fluvio-cli-common = { workspace = true, features = ["serde", "version-cmd"] }

--- a/crates/cdk/src/test.rs
+++ b/crates/cdk/src/test.rs
@@ -49,7 +49,10 @@ impl TestCmd {
             .config(self.config)
             .secrets(self.secrets)
             .pkg(connector_metadata)
-            .deployment_type(DeploymentType::Local { output_file: None });
+            .deployment_type(DeploymentType::Local {
+                output_file: None,
+                tmp_dir: None,
+            });
         builder.deploy()?;
         Ok(())
     }

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -13,7 +13,12 @@ pub use local::LogLevel;
 
 #[derive(Clone)]
 pub enum DeploymentType {
-    Local { output_file: Option<PathBuf> },
+    Local {
+        output_file: Option<PathBuf>,
+
+        // Some(path) if a tmp dir for ipkg should be cleaned up on shutdown
+        tmp_dir: Option<PathBuf>,
+    },
 }
 
 /// Describe deployment configuration
@@ -41,6 +46,7 @@ pub enum DeploymentResult {
         process_id: u32,
         name: String,
         log_file: Option<PathBuf>,
+        tmp_dir: Option<PathBuf>,
     },
 }
 
@@ -64,15 +70,19 @@ impl DeploymentBuilder {
         let config = deployment.pkg.validate_config(config_file)?;
 
         match &deployment.deployment_type {
-            DeploymentType::Local { output_file } => {
+            DeploymentType::Local {
+                output_file,
+                tmp_dir,
+            } => {
                 let name = config.meta().name().to_owned();
                 let process_id = local::deploy_local(&deployment, output_file.as_ref(), &name)?;
                 let log_file = output_file.clone();
-
+                let tmp_dir = tmp_dir.clone();
                 Ok(DeploymentResult::Local {
                     process_id,
                     name,
                     log_file,
+                    tmp_dir,
                 })
             }
         }

--- a/tests/cli/cdk_smoke_tests/cdk-basic.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-basic.bats
@@ -27,7 +27,7 @@ setup_file() {
     # Test
     cd $CONNECTOR_DIR
     run $CDK_BIN test --target x86_64-unknown-linux-gnu \
-        $CONFIG_FILE_FLAG 
+        $CONFIG_FILE_FLAG
     assert_success
 
     assert_output --partial "Connector runs with process id"
@@ -39,7 +39,7 @@ setup_file() {
     # Test
     cd $CONNECTOR_DIR
     run $CDK_BIN test --target x86_64-unknown-linux-gnu \
-        $CONFIG_FILE_FLAG_V2 
+        $CONFIG_FILE_FLAG_V2
     assert_success
 
     assert_output --partial "Connector runs with process id"
@@ -56,15 +56,18 @@ setup_file() {
     # Deploy
     cd $CONNECTOR_DIR
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
-        $CONFIG_FILE_FLAG 
+        $CONFIG_FILE_FLAG
     assert_success
 
     assert_output --partial "Connector runs with process id"
 
     sleep 10
 
-    run cat json-test-connector.log
+    run cat my-json-test-connector.log
     assert_output --partial "producing a value"
+    assert_success
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
     assert_success
 }
 
@@ -77,15 +80,18 @@ setup_file() {
     # Deploy
     cd $CONNECTOR_DIR
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
-        $CONFIG_FILE_FLAG_V2 
+        $CONFIG_FILE_FLAG_V2
     assert_success
 
     assert_output --partial "Connector runs with process id"
 
     sleep 10
 
-    run cat json-test-connector.log
+    run cat my-json-test-connector.log
     assert_output --partial "producing a value"
+    assert_success
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
     assert_success
 }
 
@@ -105,6 +111,7 @@ setup_file() {
     # Creates a directory to store the dummy readme
     cd $CONNECTOR_DIR
 
+    rm -rf ../testing
     mkdir ../testing
     echo "# Testing Connector Readme" > ../testing/README.md
 
@@ -129,13 +136,16 @@ setup_file() {
 
     mkdir $IPKG_DIR
     cp .hub/json-test-connector-0.1.0.ipkg $IPKG_DIR
-    cp sample-config.yaml $IPKG_DIR 
+    cp sample-config.yaml $IPKG_DIR
 
     cd $IPKG_DIR
 
     run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config.yaml
     assert_success
     assert_output --partial "Connector runs with process id"
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
+    assert_success
 }
 
 @test "Run connector with --ipkg V2" {
@@ -148,13 +158,16 @@ setup_file() {
 
     mkdir $IPKG_DIR
     cp .hub/json-test-connector-0.1.0.ipkg $IPKG_DIR
-    cp sample-config-v2.yaml $IPKG_DIR 
+    cp sample-config-v2.yaml $IPKG_DIR
 
     cd $IPKG_DIR
 
     run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config-v2.yaml
     assert_success
     assert_output --partial "Connector runs with process id"
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
+    assert_success
 }
 
 # fix CI authentication to hub service first:

--- a/tests/cli/cdk_smoke_tests/cdk-multi-deploy.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-deploy.bats
@@ -53,6 +53,12 @@ setup_file() {
     run cat my-json-test-connector2.log
     assert_output --partial "producing a value"
     assert_success
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
+    assert_success
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector2
+    assert_success
 }
 
 @test "Run multiple connectors with --ipkg" {
@@ -77,4 +83,10 @@ setup_file() {
     run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config2-v2.yaml
     assert_success
     assert_output --partial "Connector runs with process id"
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector
+    assert_success
+
+    run $CDK_BIN deploy shutdown --name my-json-test-connector2
+    assert_success
 }

--- a/tests/cli/cdk_smoke_tests/cdk-multi-deploy.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-deploy.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup_file() {
+    PROJECT_NAME_PREFIX="$(random_string)"
+    export PROJECT_NAME_PREFIX
+    TEST_DIR="$(mktemp -d -t cdk-test.XXXXX)"
+    export TEST_DIR
+
+    CONNECTOR_DIR="$(pwd)/connector/json-test-connector"
+    export CONNECTOR_DIR
+
+    CONFIG_FILE_FLAG="--config sample-config.yaml"
+    export CONFIG_FILE_FLAG
+    CONFIG_FILE_FLAG_V2="--config sample-config-v2.yaml"
+    export CONFIG_FILE_FLAG_V2
+    CONFIG2_FILE_FLAG_V2="--config sample-config2-v2.yaml"
+    export CONFIG2_FILE_FLAG_V2
+}
+
+@test "Build and deploy multiple connectors" {
+    # Build
+    cd $CONNECTOR_DIR
+    run $CDK_BIN build --target x86_64-unknown-linux-gnu
+    assert_success
+
+    # Deploy
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
+        $CONFIG_FILE_FLAG_V2
+    assert_success
+
+    assert_output --partial "Connector runs with process id"
+
+    # Deploy the same config, with a different connector name
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start \
+        $CONFIG2_FILE_FLAG_V2
+    assert_success
+    assert_output --partial "Connector runs with process id"
+    sleep 10
+
+    run cat my-json-test-connector.log
+    assert_output --partial "producing a value"
+    assert_success
+
+    run cat my-json-test-connector2.log
+    assert_output --partial "producing a value"
+    assert_success
+}
+
+@test "Run multiple connectors with --ipkg" {
+    # create package meta doesn't exist
+    cd $CONNECTOR_DIR
+    run $CDK_BIN publish --pack --target x86_64-unknown-linux-gnu
+    assert_success
+
+    IPKG_DIR=$TEST_DIR/ipkg_v2
+
+    mkdir $IPKG_DIR
+    cp .hub/json-test-connector-0.1.0.ipkg $IPKG_DIR
+    cp sample-config-v2.yaml $IPKG_DIR
+    cp sample-config2-v2.yaml $IPKG_DIR
+
+    cd $IPKG_DIR
+
+    run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config-v2.yaml
+    assert_success
+    assert_output --partial "Connector runs with process id"
+
+    run $CDK_BIN deploy start --ipkg json-test-connector-0.1.0.ipkg --config sample-config2-v2.yaml
+    assert_success
+    assert_output --partial "Connector runs with process id"
+}

--- a/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
@@ -16,27 +16,25 @@ setup_file() {
 
     CONNECTOR_DIR="$(pwd)/connector/sink-test-connector"
     export CONNECTOR_DIR
-    LOG_PATH="$CONNECTOR_DIR/sink-test-connector.log"
-    export LOG_PATH
-
-}
-
-setup() {
-    rm $LOG_PATH | true
 }
 
 @test "Topic with 2 partitions. Consumer reads one partition" {
     # Prepare config
     TOPIC_NAME=$(random_string)
     debug_msg "Topic name: $TOPIC_NAME"
+    CONNECTOR_NAME="my-$TOPIC_NAME"
+    debug_msg "Connector name: $CONNECTOR_NAME"
+    export LOG_PATH="$CONNECTOR_NAME.log"
+    debug_msg "Log path: $LOG_PATH"
+
     CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
     cat <<EOF >$CONFIG_PATH
 apiVersion: 0.2.0
 meta:
   version: 0.1.0
-  name: $TOPIC_NAME
+  name: $CONNECTOR_NAME
   type: test-sink
-  topic: 
+  topic:
     meta:
       name: $TOPIC_NAME
     partition:
@@ -52,7 +50,7 @@ EOF
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info
     assert_success
     assert_output --partial "Connector runs with process id"
-    
+
     wait_for_line_in_file "succesfully created" $LOG_PATH 30
     wait_for_line_in_file "monitoring started" $LOG_PATH 30
 
@@ -65,7 +63,7 @@ EOF
 
     refute_output --partial 'Received record: 1'
 
-    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    run $CDK_BIN deploy shutdown --name $CONNECTOR_NAME
     assert_success
 }
 
@@ -73,14 +71,19 @@ EOF
     # Prepare config
     TOPIC_NAME=$(random_string)
     debug_msg "Topic name: $TOPIC_NAME"
+    CONNECTOR_NAME="my-$TOPIC_NAME"
+    debug_msg "Connector name: $CONNECTOR_NAME"
+    export LOG_PATH="$CONNECTOR_NAME.log"
+    debug_msg "Log path: $LOG_PATH"
+
     CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
     cat <<EOF >$CONFIG_PATH
 apiVersion: 0.2.0
 meta:
   version: 0.1.0
-  name: $TOPIC_NAME
+  name: $CONNECTOR_NAME
   type: test-sink
-  topic: 
+  topic:
     meta:
       name: $TOPIC_NAME
     partition:
@@ -96,7 +99,7 @@ EOF
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
     assert_success
     assert_output --partial "Connector runs with process id"
-    
+
     wait_for_line_in_file "succesfully created" $LOG_PATH 30
     wait_for_line_in_file "monitoring started" $LOG_PATH 30
 
@@ -106,7 +109,7 @@ EOF
     wait_for_line_in_file "Received record: 4" $LOG_PATH 30
     wait_for_line_in_file "Received record: 1" $LOG_PATH 2
 
-    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    run $CDK_BIN deploy shutdown --name $CONNECTOR_NAME
     assert_success
 }
 
@@ -114,20 +117,25 @@ EOF
     # Prepare config
     TOPIC_NAME=$(random_string)
     debug_msg "Topic name: $TOPIC_NAME"
+    CONNECTOR_NAME="my-$TOPIC_NAME"
+    debug_msg "Connector name: $CONNECTOR_NAME"
+    export LOG_PATH="$CONNECTOR_NAME.log"
+    debug_msg "Log path: $LOG_PATH"
+
     CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
     cat <<EOF >$CONFIG_PATH
 apiVersion: 0.2.0
 meta:
   version: 0.1.0
-  name: $TOPIC_NAME
+  name: $CONNECTOR_NAME
   type: test-sink
-  topic: 
+  topic:
     meta:
       name: $TOPIC_NAME
     partition:
       count: 3
   consumer:
-    partition: 
+    partition:
       - 1
       - 2
 custom:
@@ -139,7 +147,7 @@ EOF
     run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
     assert_success
     assert_output --partial "Connector runs with process id"
-    
+
     wait_for_line_in_file "succesfully created" $LOG_PATH 30
     wait_for_line_in_file "monitoring started" $LOG_PATH 30
 
@@ -153,7 +161,7 @@ EOF
     run cat $LOG_PATH
     refute_output --partial 'Received record: 3'
 
-    run $CDK_BIN deploy shutdown --name $TOPIC_NAME
+    run $CDK_BIN deploy shutdown --name $CONNECTOR_NAME
     assert_success
 }
 


### PR DESCRIPTION
- **chore: sort Cargo.toml dep section**
- **fix: cdk deploy, fix contention on ipkg binary and/or log path**
- **add cdk multi connector coverage tests**
- **cdk: cleanup ipkg tmp files on 'deploy shutdown**

fixes #3903

