### PR TITLE
feat: sc-to-sc mirroring connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,7 +2806,6 @@ dependencies = [
  "cfg-if",
  "clap",
  "event-listener 3.1.0",
- "fluvio",
  "fluvio-auth",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
@@ -2916,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "async-channel 1.9.0",
  "async-lock 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "event-listener 3.1.0",
+ "fluvio",
  "fluvio-auth",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",

--- a/crates/fluvio-cli/src/client/topic/create.rs
+++ b/crates/fluvio-cli/src/client/topic/create.rs
@@ -22,8 +22,8 @@ use fluvio::metadata::topic::CompressionAlgorithm;
 use fluvio_controlplane_metadata::topic::config::TopicConfig;
 use fluvio_sc_schema::shared::validate_resource_name;
 use fluvio_sc_schema::mirror::MirrorSpec;
-use fluvio_sc_schema::topic::MirrorConfig;
 use fluvio_sc_schema::topic::HomeMirrorConfig;
+use fluvio_sc_schema::topic::MirrorConfig;
 
 use fluvio::Fluvio;
 use fluvio::FluvioAdmin;

--- a/crates/fluvio-controlplane-metadata/src/lib.rs
+++ b/crates/fluvio-controlplane-metadata/src/lib.rs
@@ -6,6 +6,7 @@ pub mod smartmodule;
 pub mod tableformat;
 pub mod message;
 pub mod mirror;
+pub mod mirroring;
 
 pub use fluvio_stream_model::core;
 

--- a/crates/fluvio-controlplane-metadata/src/mirroring/mod.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirroring/mod.rs
@@ -1,0 +1,118 @@
+use std::fmt::Debug;
+
+use fluvio_stream_model::core::{Spec, Status};
+use fluvio_types::ReplicaMap;
+
+use fluvio_protocol::{Decoder, Encoder};
+use fluvio_protocol::api::Request;
+use fluvio_protocol::link::ErrorCode;
+
+use crate::topic::TopicSpec;
+
+#[derive(Encoder, Decoder, Default, Debug, Clone)]
+pub struct MirroringRemoteClusterRequest<S> {
+    pub request: S,
+}
+
+impl<S> MirroringRemoteClusterSpec for MirroringRemoteClusterRequest<S> where S: Encoder + Decoder {}
+
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct MirrorConnect {
+    pub name: String,
+}
+
+impl MirroringRemoteClusterSpec for MirrorConnect {}
+
+impl Spec for MirrorConnect {
+    const LABEL: &'static str = "MirroringConnect";
+    type IndexKey = String;
+    type Status = MirroringStatus;
+    type Owner = Self;
+}
+
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MirroringStatus {}
+
+impl std::fmt::Display for MirroringStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "MirroringStatus")
+    }
+}
+
+impl Status for MirroringStatus {}
+
+impl Request for MirroringRemoteClusterRequest<MirrorConnect> {
+    const API_KEY: u16 = MirroringApiKey::Connect as u16;
+    type Response = MirroringStatusResponse;
+}
+
+/// API call from client to SPU
+#[repr(u16)]
+#[derive(Encoder, Decoder, Eq, PartialEq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
+#[fluvio(encode_discriminant)]
+pub enum MirroringApiKey {
+    ApiVersion = 1, // version api key
+    Connect = 3000,
+}
+
+impl Default for MirroringApiKey {
+    fn default() -> Self {
+        Self::ApiVersion
+    }
+}
+
+pub trait MirroringRemoteClusterSpec: Encoder + Decoder {}
+
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct MirroringStatusResponse {
+    pub name: String,
+    #[cfg_attr(feature = "use_serde", serde(skip))]
+    pub error_code: ErrorCode,
+    pub error_message: Option<String>,
+    pub topics: Vec<MirroringSpecWrapper<TopicSpec>>,
+}
+
+impl MirroringStatusResponse {
+    pub fn new_ok(name: &str, topics: Vec<MirroringSpecWrapper<TopicSpec>>) -> Self {
+        MirroringStatusResponse {
+            name: name.to_string(),
+            error_code: ErrorCode::None,
+            error_message: None,
+            topics,
+        }
+    }
+}
+
+#[derive(Encoder, Decoder, Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct MirroringSpecWrapper<S> {
+    pub key: String,
+    pub spec: S,
+    pub replica_map: ReplicaMap,
+}
+
+impl<S> MirroringSpecWrapper<S> {
+    pub fn new(key: String, spec: S, replica_map: ReplicaMap) -> Self {
+        Self {
+            key,
+            spec,
+            replica_map,
+        }
+    }
+}

--- a/crates/fluvio-controlplane-metadata/src/mirroring/mod.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirroring/mod.rs
@@ -23,7 +23,7 @@ impl<S> MirroringRemoteClusterSpec for MirroringRemoteClusterRequest<S> where S:
     serde(rename_all = "camelCase")
 )]
 pub struct MirrorConnect {
-    pub name: String,
+    pub remote_id: String,
 }
 
 impl MirroringRemoteClusterSpec for MirrorConnect {}

--- a/crates/fluvio-sc-schema/src/apis.rs
+++ b/crates/fluvio-sc-schema/src/apis.rs
@@ -22,6 +22,7 @@ pub enum AdminPublicApiKey {
     Delete = 1002,
     List = 1003,
     Watch = 1004,
+    Mirroring = 1005,
 }
 
 impl Default for AdminPublicApiKey {

--- a/crates/fluvio-sc-schema/src/lib.rs
+++ b/crates/fluvio-sc-schema/src/lib.rs
@@ -9,6 +9,7 @@ pub mod objects;
 pub mod shared;
 pub mod tableformat;
 pub mod mirror;
+pub mod mirroring;
 
 pub mod remote_file;
 

--- a/crates/fluvio-sc-schema/src/mirroring/mod.rs
+++ b/crates/fluvio-sc-schema/src/mirroring/mod.rs
@@ -1,0 +1,36 @@
+use std::fmt::Debug;
+
+use anyhow::Result;
+
+use fluvio_controlplane_metadata::mirroring::{
+    MirroringRemoteClusterRequest, MirroringRemoteClusterSpec, MirroringStatusResponse,
+};
+use fluvio_protocol::{Decoder, Encoder, Version};
+use fluvio_protocol::api::Request;
+
+use crate::{AdminPublicApiKey, TryEncodableFrom};
+use crate::objects::{COMMON_VERSION, TypeBuffer};
+
+#[derive(Encoder, Decoder, Default, Debug)]
+pub struct ObjectMirroringRequest(TypeBuffer);
+
+impl Request for ObjectMirroringRequest {
+    const API_KEY: u16 = AdminPublicApiKey::Mirroring as u16;
+    const MIN_API_VERSION: i16 = 14;
+    const DEFAULT_API_VERSION: i16 = COMMON_VERSION;
+    type Response = MirroringStatusResponse;
+}
+
+impl<S> TryEncodableFrom<MirroringRemoteClusterRequest<S>> for ObjectMirroringRequest
+where
+    MirroringRemoteClusterRequest<S>: Encoder + Decoder + Debug,
+    S: MirroringRemoteClusterSpec + fluvio_controlplane_metadata::core::Spec,
+{
+    fn try_encode_from(input: MirroringRemoteClusterRequest<S>, version: Version) -> Result<Self> {
+        Ok(Self(TypeBuffer::encode::<S, _>(input, version)?))
+    }
+
+    fn downcast(&self) -> Result<Option<MirroringRemoteClusterRequest<S>>> {
+        self.0.downcast::<S, _>()
+    }
+}

--- a/crates/fluvio-sc-schema/src/request.rs
+++ b/crates/fluvio-sc-schema/src/request.rs
@@ -16,6 +16,7 @@ use fluvio_protocol::api::api_decode;
 use fluvio_protocol::core::{Decoder};
 use fluvio_protocol::link::versions::ApiVersionsRequest;
 
+use crate::mirroring::ObjectMirroringRequest;
 use crate::AdminPublicApiKey;
 use crate::objects::{
     ObjectApiCreateRequest, ObjectApiDeleteRequest, ObjectApiListRequest, ObjectApiWatchRequest,
@@ -29,6 +30,7 @@ pub enum AdminPublicDecodedRequest {
     DeleteRequest(RequestMessage<ObjectApiDeleteRequest>),
     ListRequest(RequestMessage<ObjectApiListRequest>),
     WatchRequest(RequestMessage<ObjectApiWatchRequest>),
+    MirroringRequest(RequestMessage<ObjectMirroringRequest>),
 }
 
 impl Default for AdminPublicDecodedRequest {
@@ -80,6 +82,10 @@ impl ApiMessage for AdminPublicDecodedRequest {
             AdminPublicApiKey::Watch => Ok(Self::WatchRequest(RequestMessage::new(
                 header,
                 ObjectApiWatchRequest::decode_from(src, version)?,
+            ))),
+            AdminPublicApiKey::Mirroring => Ok(Self::MirroringRequest(RequestMessage::new(
+                header,
+                ObjectMirroringRequest::decode_from(src, version)?,
             ))),
         }
     }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -66,6 +66,7 @@ fluvio-protocol = { workspace = true }
 fluvio-socket = { workspace = true }
 fluvio-service = { workspace = true  }
 flv-tls-proxy = { workspace = true }
+fluvio = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -66,7 +66,6 @@ fluvio-protocol = { workspace = true }
 fluvio-socket = { workspace = true }
 fluvio-service = { workspace = true  }
 flv-tls-proxy = { workspace = true }
-fluvio = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/fluvio-sc/src/controllers/mirroring/controller.rs
+++ b/crates/fluvio-sc/src/controllers/mirroring/controller.rs
@@ -1,0 +1,220 @@
+use std::time::{Duration, SystemTime};
+use fluvio_controlplane_metadata::mirroring::{MirrorConnect, MirroringRemoteClusterRequest};
+
+use fluvio_socket::{ClientConfig, MultiplexerSocket};
+use futures_util::StreamExt;
+use fluvio_future::{task::spawn, timer::sleep};
+use fluvio_sc_schema::{
+    core::MetadataItem,
+    mirror::{ConnectionStatus, MirrorPairStatus, MirrorSpec, MirrorStatus, MirrorType},
+    mirroring::ObjectMirroringRequest,
+    topic::{MirrorConfig, RemoteMirrorConfig, ReplicaSpec, TopicSpec},
+    TryEncodableFrom,
+};
+use fluvio_stream_dispatcher::store::StoreContext;
+use tracing::{debug, error, info, instrument};
+use anyhow::{anyhow, Context, Result};
+
+use crate::core::SharedContext;
+
+const MIRRORING_CONTROLLER_INTERVAL: u64 = 5;
+const MIRRORING_CONTROLLER_RETRY_INTERVAL: u64 = 10;
+
+// This is the main controller for the mirroring feature.
+// Remote Clusters will connect to the home clusters.
+pub struct MirroringController<C: MetadataItem> {
+    mirrors: StoreContext<MirrorSpec, C>,
+    topics: StoreContext<TopicSpec, C>,
+}
+
+impl<C: MetadataItem> MirroringController<C> {
+    pub fn start(ctx: SharedContext<C>) {
+        let controller = Self {
+            mirrors: ctx.mirrors().clone(),
+            topics: ctx.topics().clone(),
+        };
+
+        info!("starting mirroring controller");
+        spawn(controller.dispatch_loop());
+    }
+
+    #[instrument(skip(self), name = "MirroringControllerLoop")]
+    async fn dispatch_loop(self) {
+        info!("started");
+        loop {
+            if let Err(err) = self.inner_loop().await {
+                error!("error with inner loop: {:#?}", err);
+                debug!(
+                    "sleeping {} seconds try again",
+                    MIRRORING_CONTROLLER_RETRY_INTERVAL
+                );
+                sleep(Duration::from_secs(MIRRORING_CONTROLLER_RETRY_INTERVAL)).await;
+            }
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn inner_loop(&self) -> Result<()> {
+        debug!("initializing listeners");
+
+        loop {
+            let mirrors_from_home = self
+                .mirrors
+                .store()
+                .read()
+                .await
+                .values()
+                .filter_map(|r| match r.spec().mirror_type.clone() {
+                    MirrorType::Home(h) => Some(h),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            //TODO: we need to have a strategy to choose which home to connect
+            if let Some(mirror) = mirrors_from_home.first() {
+                //send to home cluster the connect request
+                //TODO: handle TLS
+
+                let home_config = ClientConfig::with_addr(mirror.public_endpoint.clone());
+                let versioned_socket = home_config.connect().await?;
+                let (socket, config, versions) = versioned_socket.split();
+                info!("connecting to home: {}", mirror.public_endpoint);
+
+                let request = MirrorConnect {
+                    name: mirror.remote_id.clone(),
+                };
+                debug!("sending connect request: {:#?}", request);
+
+                let mut stream_socket = fluvio::stream_socket::StreamSocket::new(
+                    config,
+                    MultiplexerSocket::shared(socket),
+                    versions.clone(),
+                );
+
+                let version = versions
+                    .lookup_version::<ObjectMirroringRequest>()
+                    .ok_or(anyhow!("no version found for mirroring request"))?;
+
+                let req = ObjectMirroringRequest::try_encode_from(
+                    MirroringRemoteClusterRequest { request },
+                    version,
+                )?;
+
+                let mut stream = stream_socket
+                    .create_stream_with_version(req, version)
+                    .await?;
+
+                while let Some(response) = stream.next().await {
+                    // Change status to connected
+                    let now = SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)?
+                        .as_millis();
+                    match response {
+                        Ok(response) => {
+                            debug!("received response: {:#?}", response);
+                            for topic in response.topics.iter() {
+                                // Check if the topic already exists
+                                if self.topics.store().read().await.contains_key(&topic.key) {
+                                    debug!("topic {} already exists", topic.key);
+                                    continue;
+                                }
+
+                                // find home spu id
+                                let remote_topic_spec =
+                                    if let ReplicaSpec::Mirror(MirrorConfig::Home(mirror_config)) =
+                                        topic.spec.replicas()
+                                    {
+                                        // generate topic spec for remote topic
+                                        // count all remote clusters that are pointing to the given mirror cluster
+                                        let partition = mirror_config
+                                            .partitions()
+                                            .iter()
+                                            .position(|rc| rc.remote_cluster == mirror.remote_id);
+
+                                        if partition.is_none() {
+                                            return Err(anyhow::anyhow!(
+                                                "Topic {} is not a mirror home for cluster {}",
+                                                topic.key,
+                                                mirror.id
+                                            ));
+                                        }
+
+                                        let partition = partition.unwrap() as u32;
+
+                                        let topic_replica_map = &topic.replica_map;
+                                        let home_spu_id = topic_replica_map
+                                            .get(&partition)
+                                            .context(
+                                                "Topic does not have a replica for {partition}",
+                                            )?
+                                            .first()
+                                            .context("Topic does not have any replicas")?;
+
+                                        let replica: ReplicaSpec = ReplicaSpec::Mirror(
+                                            MirrorConfig::Remote(RemoteMirrorConfig {
+                                                home_spus: vec![*home_spu_id; 1],
+                                                home_cluster: mirror.id.clone(),
+                                            }),
+                                        );
+
+                                        let mut remote_topic: TopicSpec = replica.into();
+                                        if let Some(cleanup_policy) = topic.spec.get_clean_policy()
+                                        {
+                                            remote_topic.set_cleanup_policy(cleanup_policy.clone())
+                                        }
+
+                                        remote_topic.set_compression_type(
+                                            topic.spec.get_compression_type().clone(),
+                                        );
+
+                                        remote_topic.set_deduplication(
+                                            topic.spec.get_deduplication().cloned(),
+                                        );
+
+                                        if let Some(storage) = topic.spec.get_storage() {
+                                            remote_topic.set_storage(storage.clone());
+                                        }
+                                        remote_topic
+                                    } else {
+                                        return Err(anyhow::anyhow!("Topic is not a mirror home"));
+                                    };
+
+                                self.topics
+                                    .create_spec(topic.key.clone(), remote_topic_spec)
+                                    .await?;
+                            }
+
+                            let status = MirrorStatus::new(
+                                MirrorPairStatus::Succesful,
+                                ConnectionStatus::Online,
+                                now as u64,
+                            );
+                            self.mirrors
+                                .update_status(mirror.id.clone(), status)
+                                .await?;
+                        }
+                        Err(err) => {
+                            debug!("received error: {:#?}", err);
+                            let status = MirrorStatus::new(
+                                MirrorPairStatus::Failed,
+                                ConnectionStatus::Online,
+                                now as u64,
+                            );
+                            self.mirrors
+                                .update_status(mirror.id.clone(), status)
+                                .await?;
+
+                            return Err(err.into());
+                        }
+                    }
+                }
+            }
+
+            debug!(
+                "sleeping {} seconds before next iteration",
+                MIRRORING_CONTROLLER_INTERVAL
+            );
+            sleep(Duration::from_secs(MIRRORING_CONTROLLER_INTERVAL)).await;
+        }
+    }
+}

--- a/crates/fluvio-sc/src/controllers/mirroring/mod.rs
+++ b/crates/fluvio-sc/src/controllers/mirroring/mod.rs
@@ -1,0 +1,1 @@
+pub mod controller;

--- a/crates/fluvio-sc/src/controllers/mod.rs
+++ b/crates/fluvio-sc/src/controllers/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod partitions;
 pub(crate) mod spus;
 pub(crate) mod topics;
 pub(crate) mod scheduler;
+pub(crate) mod mirroring;

--- a/crates/fluvio-sc/src/init.rs
+++ b/crates/fluvio-sc/src/init.rs
@@ -10,7 +10,7 @@ use fluvio_sc_schema::mirror::MirrorSpec;
 use fluvio_stream_dispatcher::metadata::{SharedClient, MetadataClient};
 use fluvio_stream_model::core::MetadataItem;
 
-use crate::controllers::mirroring::controller::MirroringController;
+use crate::controllers::mirroring::controller::RemoteMirrorController;
 use crate::core::Context;
 use crate::core::SharedContext;
 use crate::controllers::partitions::PartitionController;
@@ -113,7 +113,11 @@ where
         "public",
         pub_server::start(ctx.clone(), auth_policy)
     );
-    whitelist!(config, "mirroring", MirroringController::start(ctx.clone()));
+    whitelist!(
+        config,
+        "mirroring",
+        RemoteMirrorController::start(ctx.clone())
+    );
 
     mod pub_server {
 

--- a/crates/fluvio-sc/src/init.rs
+++ b/crates/fluvio-sc/src/init.rs
@@ -10,6 +10,7 @@ use fluvio_sc_schema::mirror::MirrorSpec;
 use fluvio_stream_dispatcher::metadata::{SharedClient, MetadataClient};
 use fluvio_stream_model::core::MetadataItem;
 
+use crate::controllers::mirroring::controller::MirroringController;
 use crate::core::Context;
 use crate::core::SharedContext;
 use crate::controllers::partitions::PartitionController;
@@ -112,6 +113,7 @@ where
         "public",
         pub_server::start(ctx.clone(), auth_policy)
     );
+    whitelist!(config, "mirroring", MirroringController::start(ctx.clone()));
 
     mod pub_server {
 

--- a/crates/fluvio-sc/src/services/public_api/api_version.rs
+++ b/crates/fluvio-sc/src/services/public_api/api_version.rs
@@ -1,3 +1,4 @@
+use fluvio_sc_schema::mirroring::ObjectMirroringRequest;
 use tracing::{trace, instrument, debug};
 use semver::Version;
 use once_cell::sync::Lazy;
@@ -50,6 +51,12 @@ pub async fn handle_api_versions_request(
         AdminPublicApiKey::Watch,
         ObjectApiWatchRequest::MIN_API_VERSION,
         ObjectApiWatchRequest::MAX_API_VERSION,
+    ));
+
+    response.api_keys.push(make_version_key(
+        AdminPublicApiKey::Mirroring,
+        ObjectMirroringRequest::MIN_API_VERSION,
+        ObjectMirroringRequest::MAX_API_VERSION,
     ));
 
     trace!("flv api versions response: {:#?}", response);

--- a/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
+++ b/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
@@ -1,0 +1,169 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use fluvio_controlplane_metadata::mirroring::{
+    MirrorConnect, MirroringStatusResponse, MirroringSpecWrapper,
+};
+use fluvio_future::{task::spawn, timer::sleep};
+use fluvio_protocol::api::{RequestHeader, ResponseMessage};
+use fluvio_sc_schema::{
+    core::MetadataItem,
+    mirror::{ConnectionStatus, MirrorPairStatus, MirrorStatus},
+    store::ChangeListener,
+    topic::{MirrorConfig, ReplicaSpec, TopicSpec},
+};
+use fluvio_socket::ExclusiveFlvSink;
+use fluvio_types::event::StickyEvent;
+use tracing::{debug, error, info, instrument, trace};
+use anyhow::{Result, anyhow};
+
+use crate::core::Context;
+
+// This is the entry point for handling mirroring requests
+// Home clusters will receive requests from remote clusters
+pub struct MirroringConnectController<C: MetadataItem> {
+    req: MirrorConnect,
+    response_sink: ExclusiveFlvSink,
+    end_event: Arc<StickyEvent>,
+    ctx: Arc<Context<C>>,
+    header: RequestHeader,
+}
+
+const MIRRORING_CONTROLLER_INTERVAL: u64 = 5;
+
+impl<C: MetadataItem> MirroringConnectController<C> {
+    pub fn start(
+        req: MirrorConnect,
+        response_sink: ExclusiveFlvSink,
+        end_event: Arc<StickyEvent>,
+        ctx: Arc<Context<C>>,
+        header: RequestHeader,
+    ) {
+        let controller = Self {
+            req: req.clone(),
+            response_sink,
+            end_event,
+            ctx,
+            header,
+        };
+
+        spawn(controller.dispatch_loop());
+    }
+
+    #[instrument(skip(self), name = "MirroringConnectControllerLoop")]
+    async fn dispatch_loop(mut self) {
+        use tokio::select;
+        info!(name = self.req.name, "received mirroring connect request");
+
+        let mut topics_listener = self.ctx.topics().change_listener();
+
+        loop {
+            if self
+                .sync_and_send_topics(&mut topics_listener)
+                .await
+                .is_err()
+            {
+                self.end_event.notify();
+                break;
+            }
+
+            trace!("{}: waiting for changes", self.req.name);
+            select! {
+                _ = self.end_event.listen() => {
+                    debug!("connection has been terminated");
+                    break;
+                },
+
+                _ = topics_listener.listen() => {
+                    debug!("mirroring: {}, topic changes has been detected", self.req.name);
+                }
+            }
+
+            // sleep for a while
+            debug!("sleeping for {} seconds", MIRRORING_CONTROLLER_INTERVAL);
+            sleep(Duration::from_secs(MIRRORING_CONTROLLER_INTERVAL)).await;
+        }
+    }
+
+    #[instrument(skip(self, topics_listener))]
+    async fn sync_and_send_topics(
+        &mut self,
+        topics_listener: &mut ChangeListener<TopicSpec, C>,
+    ) -> Result<()> {
+        if !topics_listener.has_change() {
+            debug!("no changes, skipping");
+            return Ok(());
+        }
+
+        let topics = self.ctx.topics().store().clone_values().await;
+        let mirror_topics = topics
+            .into_iter()
+            .map(|topic| {
+                MirroringSpecWrapper::new(topic.key.clone(), topic.spec, topic.status.replica_map)
+            })
+            .filter(|topic| match topic.spec.replicas() {
+                ReplicaSpec::Mirror(MirrorConfig::Home(t)) => t
+                    .partitions()
+                    .iter()
+                    .any(|p| p.remote_cluster == self.req.name),
+                _ => false,
+            })
+            .collect::<Vec<_>>();
+
+        match self.ctx.mirrors().store().value(&self.req.name).await {
+            Some(remote) => {
+                let now = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis();
+
+                let remote_name = remote.spec().to_string();
+                let response = MirroringStatusResponse::new_ok(&remote_name, mirror_topics);
+                let resp_msg = ResponseMessage::from_header(&self.header, response);
+
+                // try to send response
+                if let Err(err) = self
+                    .response_sink
+                    .send_response(&resp_msg, self.header.api_version())
+                    .await
+                {
+                    let status = MirrorStatus::new(
+                        MirrorPairStatus::Failed,
+                        ConnectionStatus::Online,
+                        now as u64,
+                    );
+
+                    self.ctx
+                        .mirrors()
+                        .update_status(remote.key.clone(), status)
+                        .await?;
+                    error!(
+                        "error mirroring sending {}, correlation_id: {}, err: {}",
+                        self.req.name,
+                        self.header.correlation_id(),
+                        err
+                    );
+                    return Err(anyhow!("error sending response, err: {}", err));
+                }
+
+                // update status
+                let status = MirrorStatus::new(
+                    MirrorPairStatus::Succesful,
+                    ConnectionStatus::Online,
+                    now as u64,
+                );
+                self.ctx
+                    .mirrors()
+                    .update_status(remote.key.clone(), status)
+                    .await?;
+
+                return Ok(());
+            }
+            None => {
+                error!("remote cluster not found: {}", self.req.name);
+                return Err(anyhow!("remote cluster not found: {}", self.req.name));
+            }
+        }
+    }
+}

--- a/crates/fluvio-sc/src/services/public_api/mirroring/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/mirroring/mod.rs
@@ -1,0 +1,53 @@
+mod connect;
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use fluvio_controlplane_metadata::mirroring::{MirroringRemoteClusterRequest, MirrorConnect};
+use fluvio_socket::ExclusiveFlvSink;
+use tracing::{info, instrument};
+use fluvio_auth::AuthContext;
+use fluvio_protocol::api::RequestMessage;
+use fluvio_stream_model::core::MetadataItem;
+use fluvio_sc_schema::mirroring::ObjectMirroringRequest;
+use fluvio_sc_schema::TryEncodableFrom;
+use fluvio_types::event::StickyEvent;
+use crate::services::auth::AuthServiceContext;
+use crate::services::public_api::mirroring::connect::MirroringConnectController;
+
+pub enum MirrorRequests {
+    Connect(MirrorConnect),
+}
+
+#[instrument(skip(request, auth_ctx, sink, end_event))]
+pub fn handle_mirroring_request<AC: AuthContext, C: MetadataItem>(
+    request: RequestMessage<ObjectMirroringRequest>,
+    auth_ctx: &AuthServiceContext<AC, C>,
+    sink: ExclusiveFlvSink,
+    end_event: Arc<StickyEvent>,
+) -> Result<()> {
+    info!("remote cluster register request {:?}", request);
+
+    let (header, req) = request.get_header_request();
+    let ctx = auth_ctx.global_ctx.clone();
+
+    let Ok(req) = try_convert_to_reqs(req) else {
+        return Err(anyhow!("unable to decode request"));
+    };
+
+    match req {
+        MirrorRequests::Connect(req) => {
+            MirroringConnectController::start(req, sink, end_event, ctx, header);
+        }
+    };
+
+    Ok(())
+}
+
+pub fn try_convert_to_reqs(ob: ObjectMirroringRequest) -> Result<MirrorRequests> {
+    if let Some(req) = ob.downcast()? as Option<MirroringRemoteClusterRequest<MirrorConnect>> {
+        return Ok(MirrorRequests::Connect(req.request));
+    }
+
+    Err(anyhow!("Invalid Mirroring Request"))
+}

--- a/crates/fluvio-sc/src/services/public_api/mirroring/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/mirroring/mod.rs
@@ -13,7 +13,7 @@ use fluvio_sc_schema::mirroring::ObjectMirroringRequest;
 use fluvio_sc_schema::TryEncodableFrom;
 use fluvio_types::event::StickyEvent;
 use crate::services::auth::AuthServiceContext;
-use crate::services::public_api::mirroring::connect::MirroringConnectController;
+use crate::services::public_api::mirroring::connect::RemoteFetchingFromHomeController;
 
 pub enum MirrorRequests {
     Connect(MirrorConnect),
@@ -37,7 +37,7 @@ pub fn handle_mirroring_request<AC: AuthContext, C: MetadataItem>(
 
     match req {
         MirrorRequests::Connect(req) => {
-            MirroringConnectController::start(req, sink, end_event, ctx, header);
+            RemoteFetchingFromHomeController::start(req, sink, end_event, ctx, header);
         }
     };
 

--- a/crates/fluvio-sc/src/services/public_api/mod.rs
+++ b/crates/fluvio-sc/src/services/public_api/mod.rs
@@ -12,6 +12,7 @@ mod watch;
 mod tableformat;
 mod derivedstream;
 mod mirror;
+mod mirroring;
 
 pub use server::start_public_server;
 

--- a/crates/fluvio-sc/src/services/public_api/public_server.rs
+++ b/crates/fluvio-sc/src/services/public_api/public_server.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use fluvio_service::ConnectInfo;
 use fluvio_types::event::StickyEvent;
 use fluvio_auth::Authorization;
-//use fluvio_service::aAuthorization;
 use fluvio_stream_model::core::MetadataItem;
 use fluvio_service::api_loop;
 use fluvio_service::call_service;
@@ -110,8 +109,9 @@ where
                 shared_sink,
                 "list handler"
             ),
+            AdminPublicDecodedRequest::MirroringRequest(request) =>
+                super::mirroring::handle_mirroring_request(request, &service_context, shared_sink.clone(), end_event.clone())?,
             AdminPublicDecodedRequest::WatchRequest(request) =>
-
                 super::watch::handle_watch_request(
                     request,
                     &service_context,

--- a/crates/fluvio-sc/src/services/public_api/topic/create.rs
+++ b/crates/fluvio-sc/src/services/public_api/topic/create.rs
@@ -63,6 +63,7 @@ pub(crate) async fn handle_create_topics_request<AC: AuthContext, C: MetadataIte
     if status.is_error() {
         return Ok(status);
     }
+
     if !create.dry_run {
         status = process_topic_request(auth_ctx, name, topic).await;
     }

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/lib.rs
+++ b/crates/fluvio-socket/src/lib.rs
@@ -4,6 +4,7 @@ mod sink;
 mod socket;
 mod stream;
 mod versioned;
+mod stream_socket;
 
 #[cfg(test)]
 pub mod test_request;
@@ -15,6 +16,7 @@ pub use multiplexing::*;
 pub use sink::*;
 
 pub use stream::*;
+pub use stream_socket::*;
 pub use versioned::*;
 
 use fluvio_protocol::api::Request;

--- a/crates/fluvio-socket/src/stream_socket.rs
+++ b/crates/fluvio-socket/src/stream_socket.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use fluvio_protocol::api::{Request, RequestMessage};
-use fluvio_socket::{
-    AsyncResponse, ClientConfig, SharedMultiplexerSocket, VersionedSerialSocket, Versions,
+use crate::{
+    AsyncResponse, ClientConfig, SharedMultiplexerSocket, SocketError, VersionedSerialSocket,
+    Versions,
 };
 
-use crate::FluvioError;
 const DEFAULT_STREAM_QUEUE_SIZE: usize = 10;
 
 /// Stream Socket
@@ -45,7 +45,7 @@ impl StreamSocket {
         &mut self,
         request: R,
         version: i16,
-    ) -> Result<AsyncResponse<R>, FluvioError> {
+    ) -> Result<AsyncResponse<R>, SocketError> {
         let mut req_msg = RequestMessage::new_request(request);
         req_msg.header.set_api_version(version);
         req_msg
@@ -54,6 +54,5 @@ impl StreamSocket {
         self.socket
             .create_stream(req_msg, DEFAULT_STREAM_QUEUE_SIZE)
             .await
-            .map_err(|err| err.into())
     }
 }

--- a/crates/fluvio-spu/src/core/leader_client.rs
+++ b/crates/fluvio-spu/src/core/leader_client.rs
@@ -4,11 +4,10 @@ use async_lock::Mutex;
 use async_trait::async_trait;
 
 use fluvio::metrics::ClientMetrics;
-use fluvio::stream_socket::StreamSocket;
 use fluvio::{FluvioError, PartitionConsumer};
 use fluvio::spu::SpuDirectory;
 use fluvio_controlplane_metadata::partition::ReplicaKey;
-use fluvio_socket::{MultiplexerSocket, ClientConfig, VersionedSerialSocket};
+use fluvio_socket::{ClientConfig, MultiplexerSocket, StreamSocket, VersionedSerialSocket};
 use fluvio_types::{SpuId, PartitionId};
 use tracing::{debug, instrument};
 
@@ -116,7 +115,8 @@ impl SpuDirectory for LeaderConnections {
             if let Some(spu_socket) = client_lock.get_mut(&leader_id) {
                 return spu_socket
                     .create_stream_with_version(request, version)
-                    .await;
+                    .await
+                    .map_err(|err| err.into());
             }
 
             let mut spu_socket = self.connect_to_leader(leader_id).await?;

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -16,7 +16,6 @@ pub mod config;
 pub mod consumer;
 pub mod metrics;
 pub mod spu;
-pub mod stream_socket;
 
 pub use error::FluvioError;
 pub use config::FluvioConfig;


### PR DESCRIPTION
Needs: 

- [x] https://github.com/infinyon/fluvio/pull/3940
- [x] https://github.com/infinyon/fluvio/pull/3959
- [x] https://github.com/infinyon/fluvio/pull/3962
- [x] https://github.com/infinyon/fluvio/pull/3958




What is changed:
- [x] sc-to-sc connection


What is missing for futures pull requests:
- update topic commands: `--mirror-add`, `--mirror-delete`, `--mirror-apply`
- handling TLS
- delete topic on remote when delete it on home
- spu-to-spu connection


# Testing

On home side:
```bash
$ flvd cluster start --k8 --develop
$ flvd remote register remote1
$ echo '[                                                                                                                                                                                                               
    "remote1"
]' > remote_devices.json 
$ flvd topic create mirror-topic --mirror-apply remote_devices.json
$ flvd remote export remote1 --file remote1.json
```

On remote side:

```bash
$ flvd cluster start --local --develop
$ flvd home connect --file remote1.json 
```


Then check:
- the topics and partitions are on both sides with: `flvd topic list` and `flvd partition list`
- only topics that are mirror topics and assigned to the remote1 are sync on remote side.
- check status on remote side with: `flvd home status`
- check status on home side with: `flvd remote list`

