### PR TITLE
feat: set old consumer API deprecated

### DIFF
--- a/crates/fluvio-test-util/test_runner/test_driver/mod.rs
+++ b/crates/fluvio-test-util/test_runner/test_driver/mod.rs
@@ -1,12 +1,13 @@
 //use fluvio::consumer::{PartitionSelectionStrategy, ConsumerConfig};
 
+use fluvio::dataplane::link::ErrorCode;
 use tracing::debug;
 use anyhow::Result;
 
-use fluvio::consumer::PartitionSelectionStrategy;
-use fluvio::Fluvio;
+use fluvio::consumer::{ConsumerConfigExt, ConsumerConfigExtBuilder, ConsumerStream, Record};
+use fluvio::{Fluvio, Offset};
 use fluvio::metadata::topic::TopicSpec;
-use fluvio::{TopicProducer, RecordKey, PartitionConsumer, MultiplePartitionConsumer};
+use fluvio::{TopicProducer, RecordKey};
 use fluvio::TopicProducerConfig;
 use fluvio::metadata::topic::CleanupPolicy;
 use fluvio::metadata::topic::SegmentBasedPolicy;
@@ -130,12 +131,12 @@ impl TestDriver {
         Ok(())
     }
 
-    pub async fn get_consumer(&self, topic: &str, partition: PartitionId) -> PartitionConsumer {
+    pub async fn get_consumer_with_config(
+        &self,
+        config: ConsumerConfigExt,
+    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> + Unpin {
         let fluvio_client = self.create_client().await.expect("cant' create client");
-        match fluvio_client
-            .partition_consumer(topic.to_string(), partition)
-            .await
-        {
+        match fluvio_client.consumer_with_config(config).await {
             Ok(client) => {
                 //self.consumer_num += 1;
                 client
@@ -146,21 +147,19 @@ impl TestDriver {
         }
     }
 
-    // TODO: Create a multi-partition api w/ a list of partitions based off this
-    pub async fn get_all_partitions_consumer(&self, topic: &str) -> MultiplePartitionConsumer {
-        let fluvio_client = self.create_client().await.expect("cant' create client");
-        match fluvio_client
-            .consumer(PartitionSelectionStrategy::All(topic.to_string()))
-            .await
-        {
-            Ok(client) => {
-                //self.consumer_num += 1;
-                client
-            }
-            Err(err) => {
-                panic!("can't create consumer: {err:#?}");
-            }
-        }
+    pub async fn get_consumer_with_start(
+        &self,
+        topic: &str,
+        partition: PartitionId,
+        offset_start: Offset,
+    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> + Unpin {
+        let config = ConsumerConfigExtBuilder::default()
+            .topic(topic)
+            .partition(partition)
+            .offset_start(offset_start)
+            .build()
+            .expect("config");
+        self.get_consumer_with_config(config).await
     }
 
     // Re-enable when we re-enable metrics

--- a/crates/fluvio-test/src/tests/batching/mod.rs
+++ b/crates/fluvio-test/src/tests/batching/mod.rs
@@ -34,11 +34,9 @@ pub async fn batching(
 
     println!("Found leader {leader}");
 
-    let consumer = test_driver.get_consumer(&topic_name, 0).await;
-    let mut stream = consumer
-        .stream(Offset::end())
-        .await
-        .expect("Failed to create consumer stream");
+    let mut stream = test_driver
+        .get_consumer_with_start(&topic_name, 0, Offset::end())
+        .await;
 
     for _ in 0..150 {
         // Ensure record is sent after the linger time even if we dont call flush()

--- a/crates/fluvio-test/src/tests/concurrent/consumer.rs
+++ b/crates/fluvio-test/src/tests/concurrent/consumer.rs
@@ -13,10 +13,13 @@ pub async fn consumer_stream(
     option: MyTestCase,
     digests: Receiver<String>,
 ) {
-    let consumer = test_driver
-        .get_consumer(&option.environment.base_topic_name(), 0)
+    let mut stream = test_driver
+        .get_consumer_with_start(
+            &option.environment.base_topic_name(),
+            0,
+            Offset::beginning(),
+        )
         .await;
-    let mut stream = consumer.stream(Offset::beginning()).await.unwrap();
 
     let mut index: i32 = 0;
     while let Some(Ok(record)) = stream.next().await {

--- a/crates/fluvio-test/src/tests/consumer.rs
+++ b/crates/fluvio-test/src/tests/consumer.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 
 use clap::Parser;
@@ -9,8 +8,8 @@ use tokio::select;
 use hdrhistogram::Histogram;
 
 use fluvio_protocol::link::ErrorCode;
-use fluvio::consumer::Record;
-use fluvio::{ConsumerConfig, MultiplePartitionConsumer, PartitionConsumer, RecordKey};
+use fluvio::consumer::{ConsumerConfigExtBuilder, Record};
+use fluvio::RecordKey;
 use fluvio::Offset;
 
 use fluvio_test_derive::fluvio_test;
@@ -113,13 +112,11 @@ impl TestOption for ConsumerTestOption {
     }
 }
 
-async fn consume_work<S: ?Sized>(
-    mut stream: Pin<Box<S>>,
-    consumer_id: u32,
-    test_case: ConsumerTestCase,
-) where
+async fn consume_work<S: ?Sized>(stream: &mut S, consumer_id: u32, test_case: ConsumerTestCase)
+where
     //S: Stream<Item = Result<Record, FluvioError>> + std::marker::Unpin,
     S: Stream<Item = Result<Record, ErrorCode>>,
+    S: Unpin,
 {
     let mut records_recvd = 0;
 
@@ -207,52 +204,6 @@ async fn consume_work<S: ?Sized>(
     println!(
         "[consumer-{consumer_id}] Consume P99: {consume_p99:?} Peak Throughput: {throughput_p99:?} kB/s. # Records: {records_recvd}"
     );
-}
-
-fn build_consumer_config(test_case: ConsumerTestCase) -> ConsumerConfig {
-    let mut config = ConsumerConfig::builder();
-
-    // continuous
-    if test_case.option.num_records == 0 {
-        config.disable_continuous(true);
-    }
-
-    // max bytes
-    if let Some(max_bytes) = test_case.option.max_bytes {
-        config.max_bytes(max_bytes as i32);
-    }
-
-    config.build().expect("Couldn't build consumer config")
-}
-
-async fn get_single_stream(
-    consumer: PartitionConsumer,
-    offset: Offset,
-    test_case: ConsumerTestCase,
-) -> Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>>>> {
-    let config = build_consumer_config(test_case);
-
-    Box::pin(
-        consumer
-            .stream_with_config(offset, config)
-            .await
-            .expect("Unable to open stream"),
-    )
-}
-
-async fn get_multi_stream(
-    consumer: MultiplePartitionConsumer,
-    offset: Offset,
-    test_case: ConsumerTestCase,
-) -> Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>>>> {
-    let config = build_consumer_config(test_case);
-
-    Box::pin(
-        consumer
-            .stream_with_config(offset, config)
-            .await
-            .expect("Unable to open stream"),
-    )
 }
 
 #[fluvio_test(name = "consumer", topic = "consumer-test")]
@@ -345,24 +296,27 @@ pub fn run(mut test_driver: FluvioTestDriver, mut test_case: TestCase) {
                     .expect("Connecting to cluster failed");
 
                 // TODO: Support multiple topics
-
-                if is_multi {
-                    let consumer = test_driver
-                        .get_all_partitions_consumer(&test_case.environment.base_topic_name())
-                        .await;
-                    let stream: Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>>>> =
-                        get_multi_stream(consumer, offset, test_case.clone()).await;
-
-                    consume_work(Box::pin(stream), n.into(), test_case).await
-                } else {
-                    let consumer = test_driver
-                        .get_consumer(&test_case.environment.base_topic_name(), partition)
-                        .await;
-                    let stream: Pin<Box<dyn Stream<Item = Result<Record, ErrorCode>>>> =
-                        get_single_stream(consumer, offset, test_case.clone()).await;
-
-                    consume_work(stream, n.into(), test_case).await
+                let mut config_builder = ConsumerConfigExtBuilder::default();
+                config_builder
+                    .topic(test_case.environment.base_topic_name())
+                    .offset_start(offset);
+                if !is_multi {
+                    config_builder.partition(partition);
                 }
+                // continuous
+                if test_case.option.num_records == 0 {
+                    config_builder.disable_continuous(true);
+                }
+
+                // max bytes
+                if let Some(max_bytes) = test_case.option.max_bytes {
+                    config_builder.max_bytes(max_bytes as i32);
+                }
+
+                let mut stream = test_driver
+                    .get_consumer_with_config(config_builder.build().expect("config"))
+                    .await;
+                consume_work(&mut stream, n.into(), test_case).await
             },
             format!("consumer-{n}")
         );

--- a/crates/fluvio-test/src/tests/data_generator/mod.rs
+++ b/crates/fluvio-test/src/tests/data_generator/mod.rs
@@ -108,14 +108,7 @@ pub fn data_generator(test_driver: FluvioTestDriver, test_case: TestCase) {
 
             println!("setup");
 
-            let sync_consumer = test_driver
-                .get_consumer(&sync_topic, 0)
-                .await;
-
-            let mut sync_stream = sync_consumer
-                .stream(Offset::from_end(0))
-                .await
-                .expect("Unable to open stream");
+            let mut sync_stream = test_driver.get_consumer_with_start(&sync_topic, 0, Offset::from_end(0)).await;
 
             let sync_producer = test_driver
                 .create_producer(&sync_topic)

--- a/crates/fluvio-test/src/tests/data_generator/producer.rs
+++ b/crates/fluvio-test/src/tests/data_generator/producer.rs
@@ -96,12 +96,9 @@ pub async fn producer(
     // Create the syncing producer/consumer
 
     let sync_producer = test_driver.create_producer(&sync_topic).await;
-    let sync_consumer = test_driver.get_consumer(&sync_topic, 0).await;
-
-    let mut sync_stream = sync_consumer
-        .stream(Offset::from_end(0))
-        .await
-        .expect("Unable to open stream");
+    let mut sync_stream = test_driver
+        .get_consumer_with_start(&sync_topic, 0, Offset::from_end(0))
+        .await;
 
     // Let syncing process know this producer is ready
     sync_producer.send(RecordKey::NULL, "ready").await.unwrap();

--- a/crates/fluvio-test/src/tests/election/mod.rs
+++ b/crates/fluvio-test/src/tests/election/mod.rs
@@ -122,11 +122,9 @@ pub async fn election(mut test_driver: TestDriver, mut test_case: TestCase) {
         assert_eq!(leader_status.spec.leader, leader);
     }
 
-    let consumer = test_driver.get_consumer(&topic_name, 0).await;
-    let mut stream = consumer
-        .stream(Offset::absolute(0).expect("offset"))
-        .await
-        .expect("stream");
+    let mut stream = test_driver
+        .get_consumer_with_start(&topic_name, 0, Offset::absolute(0).expect("offset"))
+        .await;
 
     println!("checking msg1");
     let records = stream.next().await.expect("get next").expect("next");

--- a/crates/fluvio-test/src/tests/multiple_partitions/consumer.rs
+++ b/crates/fluvio-test/src/tests/multiple_partitions/consumer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use fluvio::consumer::ConsumerConfigExtBuilder;
 use fluvio_test_util::test_meta::environment::EnvDetail;
 use fluvio_test_util::test_runner::test_driver::TestDriver;
 use futures_lite::StreamExt;
@@ -7,11 +8,12 @@ use fluvio::Offset;
 use super::MyTestCase;
 
 pub async fn consumer_stream(test_driver: &TestDriver, option: MyTestCase) {
-    let consumer = test_driver
-        .get_all_partitions_consumer(&option.environment.base_topic_name())
-        .await;
-    let mut stream = consumer.stream(Offset::beginning()).await.unwrap();
-
+    let config = ConsumerConfigExtBuilder::default()
+        .topic(option.environment.base_topic_name())
+        .offset_start(Offset::beginning())
+        .build()
+        .expect("config");
+    let mut stream = test_driver.get_consumer_with_config(config).await;
     let mut index = 0;
 
     let mut set = HashSet::new();

--- a/crates/fluvio-test/src/tests/reconnection/mod.rs
+++ b/crates/fluvio-test/src/tests/reconnection/mod.rs
@@ -71,11 +71,9 @@ pub async fn reconnection(mut test_driver: TestDriver, mut test_case: TestCase) 
 
     producer.flush().await.expect("flushing");
 
-    let consumer = test_driver.get_consumer(&topic_name, 0).await;
-    let mut stream = consumer
-        .stream(Offset::absolute(0).expect("offset"))
-        .await
-        .expect("stream");
+    let mut stream = test_driver
+        .get_consumer_with_start(&topic_name, 0, Offset::absolute(0).expect("offset"))
+        .await;
 
     println!("checking msg1");
     let records = stream.next().await.expect("get next").expect("next");

--- a/crates/fluvio-test/src/tests/smoke/consume.rs
+++ b/crates/fluvio-test/src/tests/smoke/consume.rs
@@ -80,15 +80,14 @@ pub async fn validate_consume_message_api(
             "starting fetch stream for: {topic_name} base offset: {base_offset}, expected new records: {producer_iteration}"
         );
 
-        let consumer = test_driver.get_consumer(&topic_name, 0).await;
-
-        let mut stream = consumer
-            .stream(
+        let mut stream = test_driver
+            .get_consumer_with_start(
+                &topic_name,
+                0,
                 Offset::absolute(*base_offset)
                     .unwrap_or_else(|_| panic!("creating stream for iteration: {i}")),
             )
-            .await
-            .expect("stream");
+            .await;
 
         let mut total_records: u32 = 0;
 
@@ -206,15 +205,14 @@ pub async fn validate_consume_message_api(
             "performing complete  fetch stream for: {topic_name} base offset: {base_offset}, expected new records: {producer_iteration}"
         );
 
-        let consumer = test_driver.get_consumer(&topic_name, 0).await;
-
-        let mut stream = consumer
-            .stream(
+        let mut stream = test_driver
+            .get_consumer_with_start(
+                &topic_name,
+                0,
                 Offset::absolute(*base_offset)
                     .unwrap_or_else(|_| panic!("creating stream for iteration: {i}")),
             )
-            .await
-            .expect("stream");
+            .await;
 
         let mut total_records: u32 = 0;
 

--- a/crates/fluvio/src/consumer/config.rs
+++ b/crates/fluvio/src/consumer/config.rs
@@ -121,8 +121,9 @@ impl ConsumerConfigExt {
 }
 
 impl ConsumerConfigExtBuilder {
-    pub fn partition(&mut self, value: PartitionId) {
+    pub fn partition(&mut self, value: PartitionId) -> &mut Self {
         self.partition.get_or_insert(Vec::new()).push(value);
+        self
     }
 }
 

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -142,6 +142,11 @@ where
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     /// [`stream_with_config`]: struct.ConsumerConfig.html#method.stream_with_config
     #[instrument(skip(self, offset))]
+    #[deprecated(
+        since = "0.21.8",
+        note = "use `Fluvio::consumer_with_config()` instead"
+    )]
+    #[allow(deprecated)]
     pub async fn stream(
         &self,
         offset: Offset,
@@ -191,6 +196,10 @@ where
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     #[instrument(skip(self, offset, config))]
+    #[deprecated(
+        since = "0.21.8",
+        note = "use `Fluvio::consumer_with_config()` instead"
+    )]
     pub async fn stream_with_config(
         &self,
         offset: Offset,
@@ -246,6 +255,10 @@ where
     /// # }
     /// ```
     #[instrument(skip(self, offset, config))]
+    #[deprecated(
+        since = "0.21.8",
+        note = "use `Fluvio::consumer_with_config()` instead"
+    )]
     pub async fn stream_batches_with_config(
         &self,
         offset: Offset,
@@ -743,6 +756,11 @@ impl MultiplePartitionConsumer {
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     /// [`stream_with_config`]: struct.ConsumerConfig.html#method.stream_with_config
     #[instrument(skip(self, offset))]
+    #[deprecated(
+        since = "0.21.8",
+        note = "use `Fluvio::consumer_with_config()` instead"
+    )]
+    #[allow(deprecated)]
     pub async fn stream(
         &self,
         offset: Offset,
@@ -792,6 +810,11 @@ impl MultiplePartitionConsumer {
     /// [`Offset`]: struct.Offset.html
     /// [`ConsumerConfig`]: struct.ConsumerConfig.html
     #[instrument(skip(self, offset, config))]
+    #[deprecated(
+        since = "0.21.8",
+        note = "use `Fluvio::consumer_with_config()` instead"
+    )]
+    #[allow(deprecated)]
     pub async fn stream_with_config(
         &self,
         offset: Offset,

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -193,6 +193,7 @@ impl Fluvio {
     /// all of the events in all of the partitions, use `consumer` instead.
     ///
     ///
+    #[deprecated(since = "0.21.8", note = "use `consumer_with_config()` instead")]
     pub async fn partition_consumer(
         &self,
         topic: impl Into<String>,
@@ -228,6 +229,7 @@ impl Fluvio {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(since = "0.21.8", note = "use `consumer_with_config()` instead")]
     pub async fn consumer(
         &self,
         strategy: PartitionSelectionStrategy,

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -141,7 +141,12 @@ pub async fn producer(topic: impl Into<String>) -> anyhow::Result<TopicProducer>
 /// ```
 ///
 /// [`Fluvio`]: ./struct.Fluvio.html
+#[deprecated(
+    since = "0.21.8",
+    note = "use `Fluvio::consumer_with_config()` instead"
+)]
 #[instrument(skip(topic, partition))]
+#[allow(deprecated)]
 pub async fn consumer(
     topic: impl Into<String>,
     partition: PartitionId,


### PR DESCRIPTION
Set the old consumer API as deprecated and replace its usages with the new one.

Fixes infinyon/roadmap#234