### PR TITLE
feat: support subset of partitions in consumer ext

### DIFF
--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -80,7 +80,7 @@ mod cmd {
 
         /// Partition id
         #[arg(short = 'p', long, value_name = "integer")]
-        pub partition: Option<PartitionId>,
+        pub partition: Vec<PartitionId>,
 
         /// Consume records from all partitions
         #[arg(short = 'A', long = "all-partitions", conflicts_with_all = &["partition"])]
@@ -303,10 +303,10 @@ mod cmd {
             let offset = self.calculate_offset()?;
 
             let mut builder = ConsumerConfigExt::builder();
-            builder.topic(self.topic.clone());
+            builder.topic(&self.topic);
             builder.offset_start(offset);
-            if let Some(partition) = self.partition {
-                builder.partition(partition);
+            for partition in &self.partition {
+                builder.partition(*partition);
             }
             if let Some(ref consumer) = self.consumer {
                 builder.offset_consumer(consumer.clone());

--- a/crates/fluvio-test/src/tests/consumer_offsets/mod.rs
+++ b/crates/fluvio-test/src/tests/consumer_offsets/mod.rs
@@ -93,8 +93,8 @@ async fn produce_records(client: &Fluvio, topic: &str, partitions: usize) -> Res
 
 async fn test_strategy_none(client: &Fluvio, topic: &str, partitions: usize) -> Result<()> {
     let mut builder = ConsumerConfigExtBuilder::default();
-    if partitions == 1 {
-        builder.partition(0);
+    for partition in 0..partitions {
+        builder.partition(partition as u32);
     }
     let mut stream = client
         .consumer_with_config(

--- a/crates/fluvio/src/consumer/config.rs
+++ b/crates/fluvio/src/consumer/config.rs
@@ -55,10 +55,11 @@ pub enum OffsetManagementStrategy {
 
 #[derive(Debug, Builder, Clone)]
 pub struct ConsumerConfigExt {
+    #[builder(setter(into))]
     pub topic: String,
-    #[builder(default, setter(strip_option))]
-    pub partition: Option<PartitionId>,
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(custom))]
+    pub partition: Vec<PartitionId>,
+    #[builder(default, setter(strip_option, into))]
     pub offset_consumer: Option<String>,
     pub offset_start: Offset,
     #[builder(default)]
@@ -116,6 +117,12 @@ impl ConsumerConfigExt {
             offset_strategy,
             offset_flush,
         )
+    }
+}
+
+impl ConsumerConfigExtBuilder {
+    pub fn partition(&mut self, value: PartitionId) {
+        self.partition.get_or_insert(Vec::new()).push(value);
     }
 }
 

--- a/tests/cli/fluvio_smoke_tests/e2e-basic.bats
+++ b/tests/cli/fluvio_smoke_tests/e2e-basic.bats
@@ -318,9 +318,6 @@ teardown_file() {
 }
 
 @test "Consume all partitions by default" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
     run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_14" -B -d
 
     assert_output --partial "1"
@@ -329,14 +326,11 @@ teardown_file() {
     assert_success
 }
 
-@test "Consume one partition only" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on stable version"
-    fi
-    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_14" -p 1 -B -d
+@test "Consume subset of partitions" {
+    run timeout 15s "$FLUVIO_BIN" consume "$TOPIC_NAME_14" -p 1 -p 2 -B -d
 
     assert_output --partial "1"
-    refute_output --partial "2"
+    assert_output --partial "2"
     refute_output --partial "3"
     assert_success
 }


### PR DESCRIPTION
Added support for a list of partitions instead of just "one" or "all". This is supported in the old API, and we would want to keep it.

Reverted one CLI test that was previously changed.