### PR TITLE
feat: use `ConsumerStream` trait in connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.21.8"
+version = "0.21.9"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/connector/sink-test-connector/sample-config-v2.yaml
+++ b/connector/sink-test-connector/sample-config-v2.yaml
@@ -20,6 +20,10 @@ meta:
   secrets:
     - name: TEST_API_KEY
     - name: TEST_API_CLIENT_ID
+  consumer:
+    id: "sink-test-connector"
+    offset:
+      strategy: manual
 custom:
   api_key:
     secret:

--- a/connector/sink-test-connector/sample-config.yaml
+++ b/connector/sink-test-connector/sample-config.yaml
@@ -6,6 +6,10 @@ meta:
   secrets:
     - name: TEST_API_KEY
     - name: TEST_API_CLIENT_ID
+  consumer:
+    id: "sink-test-connector"
+    offset:
+      strategy: manual
 custom:
   api_key:
     secret:

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -1,7 +1,7 @@
 mod sink;
 
 use fluvio_connector_common::{connector, Result, consumer::ConsumerStream, Sink, secret::SecretString};
-use futures::SinkExt;
+use futures::{SinkExt, StreamExt};
 use sink::TestSink;
 
 #[connector(sink)]
@@ -11,6 +11,8 @@ async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<
     while let Some(item) = stream.next().await {
         let str = String::from_utf8(item?.as_ref().to_vec())?;
         sink.send(str).await?;
+        stream.offset_commit()?;
+        stream.offset_flush().await?;
     }
     Ok(())
 }

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -1,22 +1,11 @@
 use fluvio::consumer::{ConsumerConfigExtBuilder, OffsetManagementStrategy};
 use fluvio::{Fluvio, FluvioConfig, Offset};
-use fluvio::dataplane::record::ConsumerRecord;
 use fluvio_connector_package::config::{ConsumerPartitionConfig, OffsetConfig, OffsetStrategyConfig};
-use fluvio_sc_schema::errors::ErrorCode;
-use futures::StreamExt;
 use crate::{config::ConnectorConfig, Result};
 use crate::ensure_topic_exists;
 use crate::smartmodule::smartmodule_vec_from_config;
 
-pub trait ConsumerStream:
-    StreamExt<Item = std::result::Result<ConsumerRecord, ErrorCode>> + std::marker::Unpin
-{
-}
-
-impl<T: StreamExt<Item = std::result::Result<ConsumerRecord, ErrorCode>> + std::marker::Unpin>
-    ConsumerStream for T
-{
-}
+pub use fluvio::consumer::ConsumerStream;
 
 pub async fn consumer_stream_from_config(
     config: &ConnectorConfig,
@@ -78,7 +67,7 @@ pub async fn consumer_stream_from_config(
         builder.smartmodule(smartmodules);
     }
 
-    let stream = fluvio.consumer_with_config(builder.build()?).await?.boxed();
+    let stream = fluvio.consumer_with_config(builder.build()?).await?;
 
     Ok((fluvio, stream))
 }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.21.8"
+version = "0.21.9"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer/stream.rs
+++ b/crates/fluvio/src/consumer/stream.rs
@@ -13,7 +13,7 @@ use super::config::OffsetManagementStrategy;
 use super::{offset::OffsetLocalStore, StreamToServer};
 
 /// Extension of [`Stream`] trait with offset management capabilities.
-pub trait ConsumerStream: Stream {
+pub trait ConsumerStream: Stream<Item = Result<Record, ErrorCode>> + Unpin {
     /// Mark the offset of the last yelded record as committed. Depending on [`OffsetManagementStrategy`]
     /// it may require a subsequent `offset_flush()` call to take any effect.
     fn offset_commit(&mut self) -> Result<(), ErrorCode>;

--- a/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-multi-partition-consumer.bats
@@ -41,6 +41,9 @@ meta:
       count: 2
   consumer:
     partition: 1
+    id: $CONNECTOR_NAME
+    offset:
+      strategy: manual
 custom:
   api_key: api_key
   client_id: client_id
@@ -90,13 +93,16 @@ meta:
       count: 2
   consumer:
     partition: all
+    id: $CONNECTOR_NAME
+    offset:
+      strategy: manual
 custom:
   api_key: api_key
   client_id: client_id
 EOF
     # Test
     cd $CONNECTOR_DIR
-    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info
     assert_success
     assert_output --partial "Connector runs with process id"
 
@@ -135,6 +141,9 @@ meta:
     partition:
       count: 3
   consumer:
+    id: $CONNECTOR_NAME
+    offset:
+      strategy: manual
     partition:
       - 1
       - 2
@@ -144,7 +153,7 @@ custom:
 EOF
     # Test
     cd $CONNECTOR_DIR
-    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu  start --config $CONFIG_PATH --log-level info
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info
     assert_success
     assert_output --partial "Connector runs with process id"
 
@@ -166,12 +175,6 @@ EOF
 }
 
 @test "Consumer Offsets topic exist" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on fluvio cli stable version"
-    fi
-    if [ "$FLUVIO_CLUSTER_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on cluster stable version"
-    fi
     end_time=$((SECONDS + 65))
     while [ $SECONDS -lt $end_time ]; do
       SYSTEM_TOPIC_NAME="$($FLUVIO_BIN topic list --system -O json | jq '.[0].name' | tr -d '"')"
@@ -187,12 +190,6 @@ EOF
 }
 
 @test "Connector with managed consumer offsets" {
-    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on fluvio cli stable version"
-    fi
-    if [ "$FLUVIO_CLUSTER_RELEASE_CHANNEL" == "stable" ]; then
-        skip "don't run on cluster stable version"
-    fi
     # Prepare config
     TOPIC_NAME=$(random_string)
     CONSUMER_NAME=$(random_string)


### PR DESCRIPTION
Use the `ConsumerStream` trait with offset management capabilities in the common connectors dependencies.  