### PR TITLE
feat(cli): graceful period for stream interruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ name = "fluvio-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-channel 1.9.0",
  "async-net",
  "async-trait",
  "atty",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -38,7 +38,7 @@ smartengine = ["fluvio-smartengine/default"]
 producer-file-io = ["fluvio-cli-common/file-records"]
 
 [dependencies]
-
+async-channel = { workspace = true }
 async-net = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Added graceful shutdown for the `consume` CLI operation.

Fixes #3963 