### PR TITLE
smdk(wasi): add build flags for println/panic enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/crates/cargo-builder/src/package.rs
+++ b/crates/cargo-builder/src/package.rs
@@ -121,6 +121,16 @@ impl PackageInfo {
         Ok(path)
     }
 
+    /// path to package's wasm32 target
+    pub fn target_wasm32_wasi_path(&self) -> anyhow::Result<PathBuf> {
+        let mut path = self.target_dir.clone();
+        path.push("wasm32-wasi");
+        path.push(&self.profile);
+        path.push(self.target_name()?.replace('-', "_"));
+        path.set_extension("wasm");
+        Ok(path)
+    }
+
     pub fn target_name(&self) -> anyhow::Result<&str> {
         self.package
             .targets

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -15,7 +15,7 @@ description = "The official Fluvio SmartEngine"
 engine = ["wasmtime"]
 wasi = ["wasmtime-wasi", "engine"]
 transformation = ["serde_json", "serde_yaml", "humantime-serde"]
-default = ["engine"]
+default = ["engine", "wasi"]
 
 
 [dependencies]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -32,7 +32,7 @@ fluvio = { path = "../fluvio", default-features = false }
 fluvio-hub-util = { path = "../fluvio-hub-util" }
 fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }
 fluvio-future = { workspace = true, features = ["subscriber"]}
-fluvio-smartengine = { path = "../fluvio-smartengine", features = ["transformation"] }
+fluvio-smartengine = { path = "../fluvio-smartengine", features = ["transformation", "wasi"] }
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
 fluvio-sc-schema = { path = "../fluvio-sc-schema" }

--- a/crates/smartmodule-development-kit/src/build.rs
+++ b/crates/smartmodule-development-kit/src/build.rs
@@ -8,8 +8,10 @@ use cargo_builder::package::PackageInfo;
 use cargo_builder::cargo::Cargo;
 
 use crate::cmd::PackageCmd;
+use crate::ENV_SMDK_WASI;
 
 pub(crate) const BUILD_TARGET: &str = "wasm32-unknown-unknown";
+pub(crate) const BUILD_TARGET_WASI: &str = "wasm32-wasi";
 
 /// Builds the SmartModule in the current working directory into a WASM file
 #[derive(Debug, Parser)]
@@ -20,6 +22,10 @@ pub struct BuildCmd {
     /// Extra arguments to be passed to cargo
     #[arg(raw = true)]
     extra_arguments: Vec<String>,
+
+    /// Build wasi target
+    #[arg(long, env = ENV_SMDK_WASI)]
+    wasi: bool,
 }
 
 impl BuildCmd {
@@ -27,11 +33,16 @@ impl BuildCmd {
         let opt = self.package.as_opt();
         let p = PackageInfo::from_options(&opt)?;
 
+        let build_target = if self.wasi {
+            BUILD_TARGET_WASI
+        } else {
+            BUILD_TARGET
+        };
         let cargo = Cargo::build()
             .profile(opt.release)
             .lib(true)
             .package(p.package_name())
-            .target(BUILD_TARGET)
+            .target(build_target)
             .extra_arguments(self.extra_arguments)
             .build()?;
 

--- a/crates/smartmodule-development-kit/src/load.rs
+++ b/crates/smartmodule-development-kit/src/load.rs
@@ -10,6 +10,7 @@ use fluvio_future::task::run_block_on;
 use cargo_builder::package::PackageInfo;
 
 use crate::cmd::PackageCmd;
+use crate::ENV_SMDK_WASI;
 
 pub const DEFAULT_META_LOCATION: &str = "SmartModule.toml";
 
@@ -37,6 +38,10 @@ pub struct LoadCmd {
     /// Skip SmartModule load to cluster
     #[arg(long)]
     dry_run: bool,
+
+    /// Build wasi target
+    #[arg(long, env = ENV_SMDK_WASI)]
+    wasi: bool,
 }
 impl LoadCmd {
     pub(crate) fn process(self) -> Result<()> {
@@ -64,7 +69,14 @@ impl LoadCmd {
         let sm_id = pkg_metadata.package.name.clone(); // pass anything, this should be overriden by SC
         let raw_bytes = match &self.wasm_file {
             Some(wasm_file) => crate::read_bytes_from_path(wasm_file)?,
-            None => crate::read_bytes_from_path(&package_info.target_wasm32_path()?)?,
+            None => {
+                let tgtpath = if self.wasi {
+                    package_info.target_wasm32_wasi_path()?
+                } else {
+                    package_info.target_wasm32_path()?
+                };
+                crate::read_bytes_from_path(&tgtpath)?
+            }
         };
 
         let spec = SmartModuleSpec {

--- a/crates/smartmodule-development-kit/src/main.rs
+++ b/crates/smartmodule-development-kit/src/main.rs
@@ -15,6 +15,8 @@ use tracing::debug;
 
 use cmd::SmdkCommand;
 
+pub const ENV_SMDK_WASI: &str = "SMDK_WASI";
+
 fn main() -> Result<()> {
     fluvio_future::subscriber::init_tracer(None);
 

--- a/crates/smartmodule-development-kit/src/test.rs
+++ b/crates/smartmodule-development-kit/src/test.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use fluvio_future::task::run_block_on;
 use fluvio_smartengine::{SmartModuleChainBuilder, SmartModuleConfig, Lookback};
 use crate::cmd::PackageCmd;
+use crate::ENV_SMDK_WASI;
 
 use fluvio_cli_common::smartmodule::{BaseTestCmd, WithChainBuilder};
 #[derive(Debug, Parser)]
@@ -18,6 +19,8 @@ pub struct TestCmd {
     package: PackageCmd,
     #[arg(long, group = "TestSmartModule")]
     wasm_file: Option<PathBuf>,
+    #[arg(long, env=ENV_SMDK_WASI)]
+    wasi: bool,
 }
 
 impl TestCmd {
@@ -32,7 +35,11 @@ impl TestCmd {
                     wasm_file
                 } else {
                     let package_info = PackageInfo::from_options(&self.package.as_opt())?;
-                    package_info.target_wasm32_path()?
+                    if self.wasi {
+                        package_info.target_wasm32_wasi_path()?
+                    } else {
+                        package_info.target_wasm32_path()?
+                    }
                 };
                 build_chain_ad_hoc(crate::read_bytes_from_path(&wasm_file)?, params, lookback)
             }))


### PR DESCRIPTION
smkd build/test/load accepts --wasi flags, or set
export SMDK_WASI=true
build build/test/load
