### PR TITLE
chore: fix rules of clippy 1.78.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule-derive"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-model"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-rwlock",
  "async-std",

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -416,7 +416,7 @@ mod local_index {
                         Default::default()
                     }
                 };
-            index.path = index_path.to_owned();
+            index_path.clone_into(&mut index.path);
             Ok(index)
         }
 

--- a/crates/cdk/src/publish.rs
+++ b/crates/cdk/src/publish.rs
@@ -323,8 +323,8 @@ impl PackageMetaConnectorExt for PackageMeta {
         let package = &connector_metadata.package;
         packagename_validate(&package.name)?;
 
-        self.name = package.name.clone();
-        self.group = package.group.clone();
+        self.name.clone_from(&package.name);
+        self.group.clone_from(&package.group);
         self.version = package.version.to_string();
         self.description = package.description.clone().unwrap_or_default();
         self.visibility = from_connectorvis(&package.visibility);

--- a/crates/fluvio-benchmark/src/stats.rs
+++ b/crates/fluvio-benchmark/src/stats.rs
@@ -52,7 +52,7 @@ impl AllStats {
     /// configs
     pub fn merge(&mut self, other: &AllStats) {
         for (config, results) in other.iter() {
-            if self.0.get(config).is_none() {
+            if !self.0.contains_key(config) {
                 self.0.insert(config.clone(), results.clone());
             }
         }

--- a/crates/fluvio-cli/src/profile/sync/local.rs
+++ b/crates/fluvio-cli/src/profile/sync/local.rs
@@ -41,7 +41,7 @@ pub fn set_local_context(local_config: LocalOpt) -> Result<String> {
     // check if local cluster exists otherwise, create new one
     match config.cluster_mut(LOCAL_PROFILE) {
         Some(cluster) => {
-            cluster.endpoint = local_addr.clone();
+            cluster.endpoint.clone_from(&local_addr);
             cluster.tls = local_config.tls.try_into()?;
         }
         None => {

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -386,6 +386,7 @@ impl SystemInfo {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Serialize)]
 struct DiskInfo {
     name: String,

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Metadata definition for Fluvio control plane"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/spu/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/spu/spec.rs
@@ -112,7 +112,7 @@ impl SpuSpec {
 
     pub fn update(&mut self, other: &Self) {
         if self.rack != other.rack {
-            self.rack = other.rack.clone();
+            self.rack.clone_from(&other.rack);
         }
         if self.public_endpoint != other.public_endpoint {
             self.public_endpoint = other.public_endpoint.clone();

--- a/crates/fluvio-hub-protocol/src/package_meta.rs
+++ b/crates/fluvio-hub-protocol/src/package_meta.rs
@@ -139,8 +139,8 @@ impl PackageMeta {
 
         packagename_validate(&spk.name)?;
 
-        self.name = spk.name.clone();
-        self.group = spk.group.clone();
+        self.name.clone_from(&spk.name);
+        self.group.clone_from(&spk.group);
         self.version = spk.version.to_string();
         self.description = spk.description.clone().unwrap_or_default();
         self.visibility = PkgVisibility::from(&spk.visibility);

--- a/crates/fluvio-sc/src/k8/controllers/spu_service.rs
+++ b/crates/fluvio-sc/src/k8/controllers/spu_service.rs
@@ -203,7 +203,9 @@ impl SpuServiceController {
             .ctx()
             .create_child()
             .set_labels(vec![("fluvio.io/spu-name", spu_name)]);
-        ctx.item_mut().annotations = spu_k8_config.lb_service_annotations.clone();
+        ctx.item_mut()
+            .annotations
+            .clone_from(&spu_k8_config.lb_service_annotations);
 
         let obj = MetadataStoreObject::with_spec(svc_name.clone(), k8_service_spec.into())
             .with_context(ctx);

--- a/crates/fluvio-sc/src/services/public_api/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/list.rs
@@ -110,7 +110,7 @@ mod fetch {
     use crate::services::auth::AuthServiceContext;
 
     #[instrument(skip(filters, auth_ctx))]
-    pub async fn handle_fetch_request<AC: AuthContext, C: MetadataItem, S>(
+    pub async fn handle_fetch_request<AC, C: MetadataItem, S>(
         filters: ListFilters,
         auth_ctx: &AuthServiceContext<AC, C>,
         object_ctx: &StoreContext<S, C>,

--- a/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
+++ b/crates/fluvio-sc/src/services/public_api/smartmodule/list.rs
@@ -15,7 +15,7 @@ use fluvio_auth::{AuthContext, TypeAction};
 use fluvio_controlplane_metadata::extended::SpecExt;
 
 #[instrument(skip(filters, auth, object_ctx))]
-pub(crate) async fn fetch_smart_modules<AC: AuthContext, M>(
+pub(crate) async fn fetch_smart_modules<AC, M>(
     filters: Vec<ListFilter>,
     summary: bool,
     auth: &AC,

--- a/crates/fluvio-sc/src/stores/partition/store.rs
+++ b/crates/fluvio-sc/src/stores/partition/store.rs
@@ -32,6 +32,7 @@ pub type PartitionLocalStore<C> = LocalStore<PartitionSpec, C>;
 pub type DefaultPartitionMd = PartitionMetadata<String>;
 pub type DefaultPartitionStore = PartitionLocalStore<u32>;
 
+#[allow(dead_code)]
 pub(crate) trait PartitionMd<C: MetadataItem> {
     fn with_replicas(key: ReplicaKey, replicas: Vec<SpuId>) -> Self;
 
@@ -52,6 +53,7 @@ impl<C: MetadataItem> PartitionMd<C> for PartitionMetadata<C> {
     }
 }
 
+#[allow(dead_code)]
 #[async_trait]
 pub(crate) trait PartitionLocalStorePolicy<C>
 where

--- a/crates/fluvio-sc/src/stores/topic/store.rs
+++ b/crates/fluvio-sc/src/stores/topic/store.rs
@@ -153,7 +153,7 @@ mod test {
         topic1
             .status
             .set_replica_map(topic2.status.replica_map.clone());
-        topic1.status.reason = topic2.status.reason.clone();
+        topic1.status.reason.clone_from(&topic2.status.reason);
         topic1.status.resolution = topic2.status.resolution.clone();
 
         // topics should be identical

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
+++ b/crates/fluvio-smartengine/src/engine/wasmtime/instance.rs
@@ -201,11 +201,13 @@ pub(crate) trait SmartModuleTransform: Send + Sync {
     ) -> Result<SmartModuleOutput>;
 
     /// return name of transform, this is used for identifying transform and debugging
+    #[allow(dead_code)]
     fn name(&self) -> &str;
 }
 
 // In order turn to any, need following magic trick
 pub(crate) trait DowncastableTransform: SmartModuleTransform + Any {
+    #[allow(dead_code)]
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/crates/fluvio-smartmodule-derive/Cargo.toml
+++ b/crates/fluvio-smartmodule-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartmodule-derive"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartmodule-derive/src/ast.rs
+++ b/crates/fluvio-smartmodule-derive/src/ast.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use syn::meta::ParseNestedMeta;
 use syn::{ItemFn, Error as SynError, Result as SynResult, Signature};
 use syn::spanned::Spanned;
@@ -33,8 +34,8 @@ pub enum SmartModuleKind {
     FilterMap,
 }
 
-impl ToString for SmartModuleKind {
-    fn to_string(&self) -> String {
+impl Display for SmartModuleKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let string = match self {
             SmartModuleKind::Init => "init",
             SmartModuleKind::LookBack => "look_back",
@@ -45,7 +46,7 @@ impl ToString for SmartModuleKind {
             SmartModuleKind::FilterMap => "filter_map",
         };
 
-        string.to_string()
+        write!(f, "{}", string)
     }
 }
 

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/server/stream_fetch.rs
+++ b/crates/fluvio-spu-schema/src/server/stream_fetch.rs
@@ -112,7 +112,6 @@ where
     type Response = StreamFetchResponse<R>;
 }
 
-///
 #[derive(Debug, Default, Clone, Encoder, Decoder)]
 pub(crate) struct DerivedStreamInvocation {
     pub stream: String,

--- a/crates/fluvio-spu/src/control_plane/action.rs
+++ b/crates/fluvio-spu/src/control_plane/action.rs
@@ -1,7 +1,7 @@
 use fluvio_controlplane_metadata::partition::ReplicaKey;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum SupervisorCommand {
-    #[allow(dead_code)]
     ReplicaLeaderTerminated(ReplicaKey),
 }

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -65,7 +65,7 @@ impl TestConfig {
 
     pub fn leader_config(&self) -> SpuConfig {
         let mut config = SpuConfig::default();
-        config.log.base_dir = self.base_dir.clone();
+        config.log.base_dir.clone_from(&self.base_dir);
         config.id = self.base_id;
         config.private_endpoint = format!("{}:{}", HOST, self.base_port);
         config
@@ -74,7 +74,7 @@ impl TestConfig {
     pub fn follower_config(&self, follower_index: u16) -> SpuConfig {
         assert!(follower_index < self.followers);
         let mut config = SpuConfig::default();
-        config.log.base_dir = self.base_dir.clone();
+        config.log.base_dir.clone_from(&self.base_dir);
         config.replication.min_in_sync_replicas = self.in_sync_replica;
         config.id = self.follower_id(follower_index);
         config

--- a/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
+++ b/crates/fluvio-spu/src/services/public/tests/stream_fetch.rs
@@ -259,7 +259,7 @@ async fn adhoc_test<Fut, TestFn>(
 {
     let test_path = temp_dir().join(test_name);
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
     let wasm = zip(read_wasm_module(module_name));
@@ -282,7 +282,7 @@ async fn adhoc_chain_test<Fut, TestFn>(
 {
     let test_path = temp_dir().join(test_name);
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
     let mut smartmodules = Vec::with_capacity(modules.len());
@@ -310,7 +310,7 @@ async fn predefined_test<Fut, TestFn>(
 {
     let test_path = temp_dir().join(test_name);
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
     load_wasm_module(&ctx, module_name);
@@ -333,7 +333,7 @@ async fn predefined_chain_test<Fut, TestFn>(
 {
     let test_path = temp_dir().join(test_name);
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
     let mut smartmodules = Vec::with_capacity(modules.len());
@@ -2205,7 +2205,7 @@ async fn test_stream_fetch_filter_with_params(
 async fn test_stream_fetch_invalid_smartmodule_adhoc() {
     let test_path = temp_dir().join("test_stream_fetch_invalid_smartmodule_adhoc");
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
     let wasm = zip(include_bytes!("test_data/filter_missing_attribute.wasm").to_vec());
@@ -2222,7 +2222,7 @@ async fn test_stream_fetch_invalid_smartmodule_adhoc() {
 async fn test_stream_fetch_invalid_smartmodule_predefined() {
     let test_path = temp_dir().join("test_stream_fetch_invalid_smartmodule_predefined");
     let mut spu_config = SpuConfig::default();
-    spu_config.log.base_dir = test_path.clone();
+    spu_config.log.base_dir.clone_from(&test_path);
 
     let ctx = GlobalContext::new_shared_context(spu_config);
 

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2021"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-stream-dispatcher/src/metadata/k8.rs
+++ b/crates/fluvio-stream-dispatcher/src/metadata/k8.rs
@@ -140,7 +140,9 @@ impl<T: K8MetadataClient> MetadataClient<K8MetaItem> for T {
         };
 
         input_metadata.labels = ctx.item().get_labels();
-        input_metadata.annotations = ctx.item().annotations.clone();
+        input_metadata
+            .annotations
+            .clone_from(&ctx.item().annotations);
 
         trace!("converted metadata: {:#?}", input_metadata);
         let new_k8 = InputK8Obj::new(k8_spec, input_metadata);

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-model"
 edition = "2021"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-stream-model/src/epoch/dual_epoch_map.rs
+++ b/crates/fluvio-stream-model/src/epoch/dual_epoch_map.rs
@@ -268,10 +268,10 @@ where
 
     /// remove existing value
     /// if successful, remove are added to history
-    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<DualEpochCounter<V>>
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<DualEpochCounter<V>>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: ?Sized + Hash + Eq,
         V: Clone,
     {
         if let Some((_, mut old_value)) = self.values.remove_entry(k) {

--- a/crates/fluvio-stream-model/src/epoch/epoch_map.rs
+++ b/crates/fluvio-stream-model/src/epoch/epoch_map.rs
@@ -185,10 +185,10 @@ mod old_map {
 
         /// remove existing value
         /// if successful, remove are added to history
-        pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<EpochCounter<V>>
+        pub fn remove<Q>(&mut self, k: &Q) -> Option<EpochCounter<V>>
         where
             K: Borrow<Q>,
-            Q: Hash + Eq,
+            Q: ?Sized + Hash + Eq,
             V: Clone,
         {
             if let Some((_, mut old_value)) = self.map.remove_entry(k) {

--- a/crates/fluvio-stream-model/src/store/dual_store.rs
+++ b/crates/fluvio-stream-model/src/store/dual_store.rs
@@ -100,22 +100,19 @@ where
     }
 
     /// copy of the value
-    pub async fn value<K: ?Sized>(
-        &self,
-        key: &K,
-    ) -> Option<DualEpochCounter<MetadataStoreObject<S, C>>>
+    pub async fn value<K>(&self, key: &K) -> Option<DualEpochCounter<MetadataStoreObject<S, C>>>
     where
         S::IndexKey: Borrow<K>,
-        K: Eq + Hash,
+        K: ?Sized + Eq + Hash,
     {
         self.read().await.get(key).cloned()
     }
 
     /// copy spec
-    pub async fn spec<K: ?Sized>(&self, key: &K) -> Option<S>
+    pub async fn spec<K>(&self, key: &K) -> Option<S>
     where
         S::IndexKey: Borrow<K>,
-        K: Eq + Hash,
+        K: ?Sized + Eq + Hash,
     {
         self.read().await.get(key).map(|value| value.spec.clone())
     }
@@ -135,10 +132,10 @@ where
         }
     }
 
-    pub async fn contains_key<K: ?Sized>(&self, key: &K) -> bool
+    pub async fn contains_key<K>(&self, key: &K) -> bool
     where
         S::IndexKey: Borrow<K>,
-        K: Eq + Hash,
+        K: ?Sized + Eq + Hash,
     {
         self.read().await.contains_key(key)
     }

--- a/crates/fluvio-test-util/test_runner/test_driver/mod.rs
+++ b/crates/fluvio-test-util/test_runner/test_driver/mod.rs
@@ -134,7 +134,7 @@ impl TestDriver {
     pub async fn get_consumer_with_config(
         &self,
         config: ConsumerConfigExt,
-    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> + Unpin {
+    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> {
         let fluvio_client = self.create_client().await.expect("cant' create client");
         match fluvio_client.consumer_with_config(config).await {
             Ok(client) => {
@@ -152,7 +152,7 @@ impl TestDriver {
         topic: &str,
         partition: PartitionId,
         offset_start: Offset,
-    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> + Unpin {
+    ) -> impl ConsumerStream<Item = Result<Record, ErrorCode>> {
         let config = ConsumerConfigExtBuilder::default()
             .topic(topic)
             .partition(partition)

--- a/crates/fluvio-test/src/tests/consumer.rs
+++ b/crates/fluvio-test/src/tests/consumer.rs
@@ -112,11 +112,10 @@ impl TestOption for ConsumerTestOption {
     }
 }
 
-async fn consume_work<S: ?Sized>(stream: &mut S, consumer_id: u32, test_case: ConsumerTestCase)
+async fn consume_work<S>(stream: &mut S, consumer_id: u32, test_case: ConsumerTestCase)
 where
     //S: Stream<Item = Result<Record, FluvioError>> + std::marker::Unpin,
-    S: Stream<Item = Result<Record, ErrorCode>>,
-    S: Unpin,
+    S: ?Sized + Stream<Item = Result<Record, ErrorCode>> + Unpin,
 {
     let mut records_recvd = 0;
 

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -208,7 +208,7 @@ type = "local"
             }
         );
 
-        install.typ = "cloud".to_owned();
+        "cloud".clone_into(&mut install.typ);
 
         config
             .update_metadata_by_name("installation", install)

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -236,7 +236,7 @@ impl PartitionProducer {
 
         request.isolation = self.config.isolation;
         request.timeout = self.config.timeout;
-        request.smartmodules = self.config.smartmodules.clone();
+        request.smartmodules.clone_from(&self.config.smartmodules);
         request.topics.push(topic_request);
 
         let (response, _) = self.send_to_socket(spu_socket, request).await?;

--- a/crates/smartmodule-development-kit/src/publish.rs
+++ b/crates/smartmodule-development-kit/src/publish.rs
@@ -279,8 +279,8 @@ impl PackageMetaSmartModuleExt for PackageMeta {
 
         packagename_validate(&spk.name)?;
 
-        self.name = spk.name.clone();
-        self.group = spk.group.clone();
+        self.name.clone_from(&spk.name);
+        self.group.clone_from(&spk.group);
         self.version = spk.version.to_string();
         self.description = spk.description.clone().unwrap_or_default();
         self.visibility = PkgVisibility::from(&spk.visibility);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.78.0"


### PR DESCRIPTION
Fixing this clippy error:

```
error: direct implementation of `ToString`
  --> crates/fluvio-smartmodule-derive/src/ast.rs:36:1
   |
36 | / impl ToString for SmartModuleKind {
37 | |     fn to_string(&self) -> String {
38 | |         let string = match self {
39 | |             SmartModuleKind::Init => "init",
...  |
49 | |     }
50 | | }
   | |_^
   |
   = help: prefer implementing `Display` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_trait_impl
   = note: `-D clippy::to-string-trait-impl` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::to_string_trait_impl)]`
   ```