### PR TITLE
feat: export mirror file with tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "eyre",
  "flate2",
  "fluvio",
+ "fluvio-auth",
  "fluvio-channel",
  "fluvio-cli-common",
  "fluvio-cluster",

--- a/crates/fluvio-auth/src/x509/authenticator.rs
+++ b/crates/fluvio-auth/src/x509/authenticator.rs
@@ -96,7 +96,7 @@ impl X509Authenticator {
         Ok(principal)
     }
 
-    fn principal_from_raw_certificate(certificate_bytes: &[u8]) -> Result<String, IoError> {
+    pub fn principal_from_raw_certificate(certificate_bytes: &[u8]) -> Result<String, IoError> {
         parse_x509_certificate(certificate_bytes)
             .map_err(|err| IoError::new(IoErrorKind::InvalidData, err))
             .and_then(|(_, parsed_cert)| Self::common_name_from_parsed_certificate(parsed_cert))

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -84,6 +84,7 @@ k8-types = { workspace = true , features = ["core"] }
 fluvio-cluster = { path = "../fluvio-cluster", default-features = false, features = ["cli"], optional = true }
 
 fluvio = { workspace = true }
+fluvio-auth = { workspace = true }
 fluvio-socket = { workspace = true }
 fluvio-command = { workspace = true  }
 fluvio-package-index = { workspace = true }

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane-metadata"
 edition = "2021"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Metadata definition for Fluvio control plane"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/src/mirror/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirror/spec.rs
@@ -76,7 +76,7 @@ pub struct Home {
     pub remote_id: String,
     pub public_endpoint: String,
     #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub tls: Option<ClientTls>,
+    pub client_tls: Option<ClientTls>,
 }
 
 #[derive(Clone, PartialEq, Eq, Default, Encoder, Decoder)]

--- a/crates/fluvio-controlplane-metadata/src/mirror/spec.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirror/spec.rs
@@ -75,4 +75,25 @@ pub struct Home {
     pub id: String,
     pub remote_id: String,
     pub public_endpoint: String,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub tls: Option<ClientTls>,
+}
+
+#[derive(Clone, PartialEq, Eq, Default, Encoder, Decoder)]
+#[cfg_attr(
+    feature = "use_serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct ClientTls {
+    pub domain: String,
+    pub ca_cert: String,
+    pub client_cert: String,
+    pub client_key: String,
+}
+
+impl std::fmt::Debug for ClientTls {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ClientTls: {{ domain: {} }}", self.domain)
+    }
 }

--- a/crates/fluvio-spu/src/mirroring/test/fixture.rs
+++ b/crates/fluvio-spu/src/mirroring/test/fixture.rs
@@ -200,7 +200,7 @@ impl ReplicaConfig {
                     id: self.home_cluster.clone(),
                     remote_id: self.home_cluster.clone(),
                     public_endpoint: self.home_port.clone(),
-                    tls: None,
+                    client_tls: None,
                 }),
             },
         }]);

--- a/crates/fluvio-spu/src/mirroring/test/fixture.rs
+++ b/crates/fluvio-spu/src/mirroring/test/fixture.rs
@@ -200,6 +200,7 @@ impl ReplicaConfig {
                     id: self.home_cluster.clone(),
                     remote_id: self.home_cluster.clone(),
                     public_endpoint: self.home_port.clone(),
+                    tls: None,
                 }),
             },
         }]);

--- a/k8-util/helm/fluvio-sys/Chart.yaml
+++ b/k8-util/helm/fluvio-sys/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fluvio-sys
 description: A Helm chart for Fluvio
 type: application
-version: 0.9.16
+version: 0.9.17

--- a/k8-util/helm/fluvio-sys/templates/crd_mirror.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_mirror.yaml
@@ -46,6 +46,17 @@ spec:
                           type: string
                         publicEndpoint:
                           type: string
+                        tls:
+                          type: object
+                          properties:
+                            domain:
+                              type: string
+                            caCert:
+                              type: string
+                            clientCert:
+                              type: string
+                            clientKey:
+                              type: string
                 keyPair:
                   type: object
                   required: ["privateKey", "publicKey"]

--- a/k8-util/helm/fluvio-sys/templates/crd_mirror.yaml
+++ b/k8-util/helm/fluvio-sys/templates/crd_mirror.yaml
@@ -46,7 +46,7 @@ spec:
                           type: string
                         publicEndpoint:
                           type: string
-                        tls:
+                        clientTls:
                           type: object
                           properties:
                             domain:

--- a/tests/cli/mirroring_smoke_tests/export.bats
+++ b/tests/cli/mirroring_smoke_tests/export.bats
@@ -28,23 +28,30 @@ setup_file() {
     assert_success
 }
 
-@test "Can't register an remote cluster with the same name" {
-    run timeout 15s "$FLUVIO_BIN" remote register "$REMOTE_NAME"
+@test "Export remote" {
+    run timeout 15s "$FLUVIO_BIN" remote export "$REMOTE_NAME" --file remote.json
+    assert_output ""
+    assert_success
 
-    assert_output "remote cluster \"$REMOTE_NAME\" already exists"
-    assert_failure
+    run jq -r .home.id remote.json 
+    assert_output "home"
+    assert_success
+
+    run jq -r .home.remoteId remote.json 
+    assert_output "$REMOTE_NAME"
+    assert_success
+
+    run jq -r .home.publicEndpoint remote.json 
+    assert_output "127.0.0.1:9003"
+    assert_success
 }
 
 @test "Can unregister an remote cluster" {
-    run timeout 15s "$FLUVIO_BIN" remote unregister "$REMOTE_NAME"
+    run rm -f remote.json
 
+
+    run timeout 15s "$FLUVIO_BIN" remote unregister "$REMOTE_NAME"
     assert_output "remote cluster \"$REMOTE_NAME\" was unregistered"
     assert_success
 }
 
-@test "Can't unregister an remote cluster that doesn't exist" {
-    run timeout 15s "$FLUVIO_BIN" remote unregister "$REMOTE_NAME"
-
-    assert_output "remote cluster \"$REMOTE_NAME\" not found"
-    assert_failure
-}


### PR DESCRIPTION
Example: 
```
fluvio remote register user1 
fluvio remote export user1 --file user1.json --key ~/workspace/infinyon/fluvio/tls/certs/client-user1.key --cert ~/workspace/infinyon/fluvio/tls/certs/client-user1.crt
```