### PR TITLE
feat(fvm): `fvm self update` support

### DIFF
--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -35,7 +35,7 @@ toml = { workspace = true }
 url = { workspace = true }
 
 # Workspace Crates
-fluvio-future = { workspace = true, features = ["subscriber"] }
+fluvio-future = { workspace = true, features = ["http-client", "subscriber"] }
 fluvio-hub-util = { workspace = true }
 
 [dev-dependencies]

--- a/crates/fluvio-version-manager/src/command/itself/install.rs
+++ b/crates/fluvio-version-manager/src/command/itself/install.rs
@@ -1,10 +1,11 @@
 use std::env::current_exe;
-use std::fs::{copy, write, create_dir_all};
+use std::fs::{copy, create_dir_all, write};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
 
+use crate::common::executable::remove_fvm_binary_if_exists;
 use crate::common::notify::Notify;
 use crate::common::settings::Settings;
 use crate::common::workdir::{fvm_bin_path, fvm_workdir_path, fvm_versions_path};
@@ -78,6 +79,8 @@ impl SelfInstallOpt {
             // from the binary itself and not from the installer script.
             return Err(anyhow::anyhow!("FVM is already installed"));
         }
+
+        remove_fvm_binary_if_exists()?;
 
         // Copies "this" binary to the FVM binary directory
         copy(current_binary_path.clone(), fvm_binary_path.clone()).map_err(|e| {

--- a/crates/fluvio-version-manager/src/command/itself/update.rs
+++ b/crates/fluvio-version-manager/src/command/itself/update.rs
@@ -1,15 +1,71 @@
-use anyhow::Result;
-use clap::Parser;
+use std::env::var;
 
-use crate::common::notify::Notify;
+use anyhow::{bail, Result};
+use clap::Parser;
+use colored::Colorize;
+use semver::Version;
+
+use fluvio_future::http_client::{Client, ResponseExt};
+
+use crate::{
+    common::{notify::Notify, update_manager::UpdateManager},
+    VERSION,
+};
+
+/// Environment variable to store the version of FVM to fetch
+const FVM_UPDATE_VERSION: &str = "FVM_UPDATE_VERSION";
+
+/// Default URL used to fetch the `stable` channel tag
+const FVM_STABLE_CHANNEL_URL: &str =
+    "https://packages.fluvio.io/v1/packages/fluvio/fvm/tags/stable";
 
 #[derive(Clone, Debug, Parser)]
 pub struct SelfUpdateOpt;
 
+// https://packages.fluvio.io/v1/packages/fluvio/fvm/0.11.0/aarch64-apple-darwin/fvm
 impl SelfUpdateOpt {
     pub async fn process(&self, notify: Notify) -> Result<()> {
-        notify.info("To update fvm, please run:");
-        notify.info("curl -fsS https://hub.infinyon.cloud/install/install.sh | bash");
+        let update_manager = UpdateManager::new(&notify);
+        let next_version = self.resolve_version().await?;
+
+        if next_version.to_string() != VERSION {
+            notify.info(format!(
+                "Updating FVM from {} to {}",
+                VERSION.red(),
+                next_version.to_string().green(),
+            ));
+            update_manager.update(&next_version).await?;
+            return Ok(());
+        }
+
+        notify.info("Already up-to-date");
         Ok(())
+    }
+
+    /// Determines the version of FVM to fetch taking into account
+    /// the environment variable `FVM_VERSION` and the `stable` channel
+    async fn resolve_version(&self) -> Result<Version> {
+        if let Ok(version) = var(FVM_UPDATE_VERSION) {
+            return Ok(Version::parse(&version)?);
+        }
+
+        self.fetch_stable_tag().await
+    }
+
+    /// Fetches the `stable` channel tag from the Fluvio Version Manager
+    async fn fetch_stable_tag(&self) -> Result<Version> {
+        let client = Client::new();
+        let request = client.get(FVM_STABLE_CHANNEL_URL)?;
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            let version = response.body_string().await?;
+            let version = Version::parse(&version)?;
+
+            return Ok(version);
+        }
+
+        tracing::error!(status=%response.status(), "Unable to retrieve stable tag for FVM");
+        bail!("Failed to reach server when checking for updates")
     }
 }

--- a/crates/fluvio-version-manager/src/common/executable.rs
+++ b/crates/fluvio-version-manager/src/common/executable.rs
@@ -1,11 +1,8 @@
 //! Executable file utilities.
 
 use std::fs::remove_file;
-use std::{fs::File, io::copy};
-use std::path::PathBuf;
 
 use anyhow::Result;
-use sha2::{Digest, Sha256};
 
 use super::workdir::fvm_bin_path;
 
@@ -18,18 +15,6 @@ pub fn remove_fvm_binary_if_exists() -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Generates Sha256 checksum for a given file
-pub fn sha256_digest(path: &PathBuf) -> Result<String> {
-    let mut hasher = Sha256::new();
-    let mut file = File::open(path)?;
-
-    copy(&mut file, &mut hasher)?;
-
-    let hash_bytes = hasher.finalize();
-
-    Ok(hex::encode(hash_bytes))
 }
 
 /// Sets the executable mode for the specified file in Unix systems.

--- a/crates/fluvio-version-manager/src/common/executable.rs
+++ b/crates/fluvio-version-manager/src/common/executable.rs
@@ -1,0 +1,91 @@
+//! Executable file utilities.
+
+use std::fs::remove_file;
+use std::{fs::File, io::copy};
+use std::path::PathBuf;
+
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+
+use super::workdir::fvm_bin_path;
+
+/// Removes FVM Binary if present in the FVM home directory
+pub fn remove_fvm_binary_if_exists() -> Result<()> {
+    let fvm_binary_path = fvm_bin_path()?;
+
+    if fvm_binary_path.exists() {
+        remove_file(fvm_binary_path)?;
+    }
+
+    Ok(())
+}
+
+/// Generates Sha256 checksum for a given file
+pub fn sha256_digest(path: &PathBuf) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut file = File::open(path)?;
+
+    copy(&mut file, &mut hasher)?;
+
+    let hash_bytes = hasher.finalize();
+
+    Ok(hex::encode(hash_bytes))
+}
+
+/// Sets the executable mode for the specified file in Unix systems.
+/// This is no-op in non-Unix systems.
+#[cfg(unix)]
+pub fn set_executable_mode(path: &std::path::PathBuf) -> anyhow::Result<()> {
+    use std::{fs::File, os::unix::fs::PermissionsExt};
+
+    const EXECUTABLE_MODE: u32 = 0o700;
+
+    // Add u+rwx mode to the existing file permissions, leaving others unchanged
+    let file = File::open(path)?;
+    let mut permissions = file.metadata()?.permissions();
+    let mut mode = permissions.mode();
+
+    mode |= EXECUTABLE_MODE;
+    permissions.set_mode(mode);
+    file.set_permissions(permissions)?;
+
+    Ok(())
+}
+
+/// Setting binary executable mode is a no-op in non-Unix systems.
+#[cfg(not(unix))]
+pub fn set_executable_mode(path: &PathBuf) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn sets_unix_execution_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmpdir = TempDir::new().unwrap();
+        let path = tmpdir.path().join("test");
+        let file = File::create(&path).unwrap();
+        let meta = file.metadata().unwrap();
+        let perm = meta.permissions();
+        let is_executable = perm.mode() & 0o111 != 0;
+
+        assert!(!is_executable, "should not be executable");
+
+        set_executable_mode(&path).unwrap();
+
+        let file = File::open(&path).unwrap();
+        let meta = file.metadata().unwrap();
+        let perm = meta.permissions();
+        let is_executable = perm.mode() & 0o111 != 0;
+
+        assert!(is_executable, "should be executable");
+    }
+}

--- a/crates/fluvio-version-manager/src/common/executable.rs
+++ b/crates/fluvio-version-manager/src/common/executable.rs
@@ -39,7 +39,7 @@ pub fn set_executable_mode(path: &std::path::PathBuf) -> anyhow::Result<()> {
 
 /// Setting binary executable mode is a no-op in non-Unix systems.
 #[cfg(not(unix))]
-pub fn set_executable_mode(path: &PathBuf) -> anyhow::Result<()> {
+pub fn set_executable_mode(path: &std::path::PathBuf) -> anyhow::Result<()> {
     Ok(())
 }
 

--- a/crates/fluvio-version-manager/src/common/mod.rs
+++ b/crates/fluvio-version-manager/src/common/mod.rs
@@ -1,6 +1,8 @@
+pub mod executable;
 pub mod manifest;
 pub mod notify;
 pub mod settings;
+pub mod update_manager;
 pub mod version_directory;
 pub mod version_installer;
 pub mod workdir;

--- a/crates/fluvio-version-manager/src/common/notify.rs
+++ b/crates/fluvio-version-manager/src/common/notify.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 
+#[derive(Copy, Clone, Debug)]
 pub struct Notify {
     /// Whether to suppress all output
     quiet: bool,

--- a/crates/fluvio-version-manager/src/common/update_manager.rs
+++ b/crates/fluvio-version-manager/src/common/update_manager.rs
@@ -1,0 +1,125 @@
+use std::fs::File;
+use std::io::{copy, Cursor};
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use semver::Version;
+use tempfile::TempDir;
+
+use fluvio_future::http_client::{Client, ResponseExt};
+
+use crate::common::executable::{remove_fvm_binary_if_exists, set_executable_mode};
+
+use super::executable::sha256_digest;
+use super::notify::Notify;
+use super::workdir::fvm_bin_path;
+use super::TARGET;
+
+/// Updates Manager for the Fluvio Version Manager
+pub struct UpdateManager {
+    client: Client,
+    notify: Notify,
+}
+
+impl UpdateManager {
+    pub fn new(notify: &Notify) -> Self {
+        Self {
+            client: Client::new(),
+            notify: notify.to_owned(),
+        }
+    }
+
+    async fn fetch_checksum_for_version(&self, version: &Version) -> Result<String> {
+        let checksum_url = format!(
+            "https://packages.fluvio.io/v1/packages/fluvio/fvm/{}/{}/fvm.sha256",
+            version, TARGET
+        );
+        let request = self.client.get(&checksum_url)?;
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            let checksum = response.body_string().await?;
+            return Ok(checksum);
+        }
+
+        bail!(
+            "Failed to fetch checksum for fvm@{} from {}",
+            version,
+            checksum_url
+        );
+    }
+
+    pub async fn update(&self, version: &Version) -> Result<()> {
+        self.notify.info(format!("Downloading fvm@{}", version));
+        let (_tmp_dir, new_fvm_bin) = self.download(version).await?;
+
+        self.notify.info(format!("Installing fvm@{}", version));
+        self.install(&new_fvm_bin).await?;
+        self.notify
+            .done(format!("Installed fvm@{} with success", version));
+
+        Ok(())
+    }
+
+    /// Downloads Fluvio Version Manager binary into a temporary directory
+    async fn download(&self, version: &Version) -> Result<(TempDir, PathBuf)> {
+        let tmp_dir = TempDir::new()?;
+        let download_url = format!(
+            "https://packages.fluvio.io/v1/packages/fluvio/fvm/{}/{}/fvm",
+            version, TARGET
+        );
+        let request = self.client.get(&download_url)?;
+
+        tracing::info!(download_url, "Downloading FVM");
+
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            let out_path = tmp_dir.path().join("fvm");
+            let mut file = File::create(&out_path)?;
+            let bytes = response.bytes().await?;
+            let mut buf = Cursor::new(&bytes);
+
+            copy(&mut buf, &mut file)?;
+            self.checksum(version, &out_path).await?;
+            set_executable_mode(&out_path)?;
+
+            return Ok((tmp_dir, out_path));
+        }
+
+        bail!("Failed to download fvm@{} from {}", version, download_url);
+    }
+
+    /// Verifies downloaded FVM binary checksums against the upstream checksums
+    async fn checksum(&self, version: &Version, path: &PathBuf) -> Result<()> {
+        let local_file_shasum = sha256_digest(path)?;
+        let upstream_shasum = self.fetch_checksum_for_version(version).await?;
+
+        if local_file_shasum != upstream_shasum {
+            bail!(
+                "Checksum mismatch for fvm@{}: local={}, upstream={}",
+                version,
+                local_file_shasum,
+                upstream_shasum
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn install(&self, new_fvm_bin: &PathBuf) -> Result<()> {
+        let old_fvm_bin = fvm_bin_path()?;
+
+        if !new_fvm_bin.exists() {
+            tracing::warn!(?new_fvm_bin, "New fvm binary not found. Aborting update.");
+            bail!("Failed to update FVM due to missing binary");
+        }
+
+        remove_fvm_binary_if_exists()?;
+
+        tracing::warn!(src=?new_fvm_bin, dst=?old_fvm_bin , "Copying new fvm binary");
+        std::fs::copy(new_fvm_bin, &old_fvm_bin)?;
+
+        Ok(())
+    }
+}

--- a/crates/fluvio-version-manager/src/common/update_manager.rs
+++ b/crates/fluvio-version-manager/src/common/update_manager.rs
@@ -7,10 +7,10 @@ use semver::Version;
 use tempfile::TempDir;
 
 use fluvio_future::http_client::{Client, ResponseExt};
+use fluvio_hub_util::sha256_digest;
 
 use crate::common::executable::{remove_fvm_binary_if_exists, set_executable_mode};
 
-use super::executable::sha256_digest;
 use super::notify::Notify;
 use super::workdir::fvm_bin_path;
 use super::TARGET;

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -27,6 +27,24 @@ setup_file() {
     export FLUVIO_CLOUD_STABLE_VERSION
     debug_msg "Fluvio Cloud Stable Version: $FLUVIO_CLOUD_STABLE_VERSION"
 
+    # Fetches current FVM Stable Version
+    FVM_VERSION_STABLE=$(curl "https://packages.fluvio.io/v1/packages/fluvio/fvm/tags/stable")
+    export FVM_VERSION_STABLE
+    debug_msg "FVM Stable Version: $FVM_VERSION_STABLE"
+
+    # Fetches current FVM Stable Version Sha256
+    FVM_VERSION_STABLE_SHA256=$(curl "https://packages.fluvio.io/v1/packages/fluvio/fvm/$FVM_VERSION_STABLE/x86_64-unknown-linux-musl/fvm.sha256")
+    export FVM_VERSION_STABLE_SHA256
+    debug_msg "FVM Stable Version Sha256: $FVM_VERSION_STABLE_SHA256"
+
+    FVM_UPDATE_CUSTOM_VERSION="0.11.0"
+    export FVM_UPDATE_CUSTOM_VERSION
+    debug_msg "FVM Update Custom Version: $FVM_UPDATE_CUSTOM_VERSION"
+
+    FVM_UPDATE_CUSTOM_VERSION_SHA256=$(curl "https://packages.fluvio.io/v1/packages/fluvio/fvm/$FVM_UPDATE_CUSTOM_VERSION/x86_64-unknown-linux-musl/fvm.sha256")
+    export FVM_UPDATE_CUSTOM_VERSION_SHA256
+    debug_msg "FVM Update Custom Version Sha256: $FVM_UPDATE_CUSTOM_VERSION_SHA256"
+
     # The directory where FVM files live
     FVM_HOME_DIR="$HOME/.fvm"
     export FVM_HOME_DIR
@@ -902,6 +920,85 @@ setup_file() {
 
     # Removes FVM
     run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Updates FVM" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Checks installed version
+    run bash -c 'fvm version'
+    assert_line --index 0 "fvm CLI: $VERSION_FILE"
+    assert_success
+
+    # Store this file Sha256 Checksum
+    export CURR_FVM_BIN_CHECKSUM=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+    # Store FVM_BIN file Sha256 Checksum
+    export FVM_BIN_CHECKSUM=$(sha256sum "$FVM_BIN" | awk '{ print $1 }')
+
+    # Ensure the installed FVM matches test binary FVM
+    [[ "$CURR_FVM_BIN_CHECKSUM" == "$FVM_BIN_CHECKSUM" ]]
+    assert_success
+
+    # Updates FVM
+    run bash -c 'fvm self update'
+    assert_line --index 0 "info: Updating FVM from $VERSION_FILE to $FVM_VERSION_STABLE"
+    assert_line --index 1 "info: Downloading fvm@$FVM_VERSION_STABLE"
+    assert_line --index 2 "info: Installing fvm@$FVM_VERSION_STABLE"
+    assert_line --index 3 "done: Installed fvm@$FVM_VERSION_STABLE with success"
+    assert_success
+
+    # Store FVM Binary Sha256 Checksum
+    export NEXT_FVM_BIN_CHECKSUM=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+    # Ensure the checksums matches upstream FVM checksum for this architecture
+    run bash -c "[[ "$FVM_VERSION_STABLE_SHA256" == "$NEXT_FVM_BIN_CHECKSUM" ]]"
+    assert_success
+
+    # Removes FVM
+    run bash -c 'fvm self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}
+
+@test "Installs Custom FVM Version on FVM Update" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Checks installed version
+    run bash -c '$FVM_BIN version'
+    assert_line --index 0 "fvm CLI: $VERSION_FILE"
+    assert_success
+
+    # Updates FVM using FVM as of Fluvio 0.11.0
+    run bash -c "FVM_UPDATE_VERSION=$FVM_UPDATE_CUSTOM_VERSION $FVM_BIN self update"
+    assert_line --index 0 "info: Updating FVM from $VERSION_FILE to $FVM_UPDATE_CUSTOM_VERSION"
+    assert_success
+
+    # Store FVM Binary Sha256 Checksum
+    export NEXT_FVM_BIN_CHECKSUM=$(sha256sum "$FVM_HOME_DIR/bin/fvm" | awk '{ print $1 }')
+
+    # Ensure the checksums matches upstream FVM checksum for this architecture
+    run bash -c "[[ "$FVM_UPDATE_CUSTOM_VERSION_SHA256" == "$NEXT_FVM_BIN_CHECKSUM" ]]"
+    assert_success
+
+    # Removes FVM
+    run bash -c '$FVM_BIN self uninstall --yes'
     assert_success
 
     # Removes Fluvio


### PR DESCRIPTION
Provides support to update FVM with `fvm self update`.

Current behavior doesn't check for "greater" versions, but instead just checks if versions
are different. By default `stable` fvm channel is checked.

In order to overwrite the version to update of FVM an environment variable
`FVM_UPDATE_VERSION` can be used to provide the tag to be used at the moment of fetching
the FVM version.

## Demo

https://github.com/infinyon/fluvio/assets/34756077/bcc6f226-5ee3-433e-922a-95dc9778d371

