### PR TITLE
feat: add sc opts to cluster start

### DIFF
--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -13,6 +13,11 @@ use super::StartOpt;
 /// Pass opt.setup = false, to only run the checks.
 pub async fn process_local(opt: StartOpt, platform_version: Version) -> Result<()> {
     let mut builder = LocalConfig::builder(platform_version);
+
+    if let Some(data_dir) = opt.data_dir {
+        builder.data_dir(data_dir);
+    }
+
     builder
         .log_dir(opt.log_dir.deref())
         .spu_replicas(opt.spu)
@@ -38,6 +43,16 @@ pub async fn process_local(opt: StartOpt, platform_version: Version) -> Result<(
     builder.installation_type(opt.installation_type.get_or_default());
 
     builder.read_only_config(opt.installation_type.read_only);
+
+    builder.save_profile(!opt.skip_profile_creation);
+
+    if let Some(pub_addr) = opt.sc_pub_addr {
+        builder.sc_pub_addr(pub_addr);
+    }
+
+    if let Some(priv_addr) = opt.sc_priv_addr {
+        builder.sc_priv_addr(priv_addr);
+    }
 
     let config = builder.build()?;
     let installer = LocalInstaller::from_config(config);

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -141,6 +141,18 @@ pub struct StartOpt {
     #[arg(long)]
     pub skip_profile_creation: bool,
 
+    /// SC public address
+    #[arg(long)]
+    pub sc_pub_addr: Option<String>,
+
+    /// SC private address
+    #[arg(long)]
+    pub sc_priv_addr: Option<String>,
+
+    /// data dir
+    #[arg(long)]
+    pub data_dir: Option<PathBuf>,
+
     /// number of SPU
     #[arg(long, default_value = "1")]
     pub spu: u16,

--- a/crates/fluvio-cluster/src/runtime/local/sc.rs
+++ b/crates/fluvio-cluster/src/runtime/local/sc.rs
@@ -18,6 +18,8 @@ pub struct ScProcess {
     pub tls_policy: TlsPolicy,
     pub rust_log: String,
     pub mode: ScMode,
+    pub public_address: String,
+    pub private_address: Option<String>,
 }
 
 #[derive(Debug)]
@@ -53,6 +55,12 @@ impl ScProcess {
                 binary.arg("--k8");
             }
         };
+
+        binary.arg("--bind-public").arg(&self.public_address);
+
+        if let Some(address) = &self.private_address {
+            binary.arg("--bind-private").arg(address);
+        }
 
         if let TlsPolicy::Verified(tls) = &self.tls_policy {
             self.set_server_tls(&mut binary, tls, 9005)?;

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -41,7 +41,7 @@ const DEFAULT_RUST_LOG: &str = "info";
 const DEFAULT_SPU_REPLICAS: u16 = 1;
 const DEFAULT_TLS_POLICY: TlsPolicy = TlsPolicy::Disabled;
 const LOCAL_SC_ADDRESS: &str = "127.0.0.1:9003";
-const LOCAL_SC_PORT: u16 = 9003;
+const LOCAL_SC_PORT: &str = "9003";
 
 static DEFAULT_RUNNER_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| std::env::current_exe().ok());
 
@@ -129,6 +129,10 @@ pub struct LocalConfig {
     /// The TLS policy for the client
     #[builder(private, default = "DEFAULT_TLS_POLICY")]
     client_tls_policy: TlsPolicy,
+    #[builder(default = "LOCAL_SC_ADDRESS.to_string()")]
+    sc_pub_addr: String,
+    #[builder(setter(into), default)]
+    sc_priv_addr: Option<String>,
     /// The version of the Fluvio system chart to install
     ///
     /// This is the only required field that does not have a default value.
@@ -177,6 +181,9 @@ pub struct LocalConfig {
 
     #[builder(default)]
     read_only_config: Option<PathBuf>,
+
+    #[builder(default = "false")]
+    save_profile: bool,
 }
 
 impl LocalConfig {
@@ -455,12 +462,18 @@ impl LocalInstaller {
         pb.finish_and_clear();
         drop(pb);
 
-        self.set_profile()?;
+        if self.config.save_profile {
+            self.set_profile()?;
+        }
 
         let pb = self.pb_factory.create()?;
-        // set host name and port for SC (this should mirror K8)
-        let (address, port) = (LOCAL_SC_ADDRESS.to_owned(), LOCAL_SC_PORT);
-        let fluvio = self.launch_sc(&address, port, &pb).await?;
+        let fluvio = self
+            .launch_sc(
+                self.config.sc_pub_addr.clone(),
+                self.config.sc_priv_addr.clone(),
+                &pb,
+            )
+            .await?;
         pb.println(InstallProgressMessage::ScLaunched.msg());
         pb.finish_and_clear();
 
@@ -483,14 +496,30 @@ impl LocalInstaller {
 
         self.save_config_file();
 
-        Ok(StartStatus { address, port })
+        let port: u16 = self
+            .config
+            .sc_pub_addr
+            .split(':')
+            .last()
+            .unwrap_or(LOCAL_SC_PORT)
+            .parse()?;
+
+        Ok(StartStatus {
+            address: self.config.sc_pub_addr.clone(),
+            port,
+        })
     }
 
     /// Launches an SC on the local machine
     ///
     /// Returns the address of the SC if successful
     #[instrument(skip(self))]
-    async fn launch_sc(&self, host_name: &str, port: u16, pb: &ProgressRenderer) -> Result<Fluvio> {
+    async fn launch_sc(
+        &self,
+        public_address: String,
+        private_address: Option<String>,
+        pb: &ProgressRenderer,
+    ) -> Result<Fluvio> {
         use super::common::try_connect_to_sc;
 
         pb.set_message(InstallProgressMessage::LaunchingSC.msg());
@@ -517,6 +546,8 @@ impl LocalInstaller {
             tls_policy: self.config.server_tls_policy.clone(),
             rust_log: self.config.rust_log.clone(),
             mode,
+            private_address,
+            public_address: public_address.clone(),
         };
 
         sc_process.start()?;
@@ -526,7 +557,7 @@ impl LocalInstaller {
 
         // construct config to connect to SC
         let cluster_config =
-            FluvioConfig::new(LOCAL_SC_ADDRESS).with_tls(self.config.client_tls_policy.clone());
+            FluvioConfig::new(public_address).with_tls(self.config.client_tls_policy.clone());
 
         try_connect_to_sc(&cluster_config, &self.config.platform_version, pb)
             .await
@@ -537,12 +568,15 @@ impl LocalInstaller {
     #[instrument(skip(self))]
     fn set_profile(&self) -> Result<()> {
         let pb = self.pb_factory.create()?;
-        pb.set_message(format!("Creating Local Profile to: {LOCAL_SC_ADDRESS}"));
+        pb.set_message(format!(
+            "Creating Local Profile to: {}",
+            self.config.sc_pub_addr
+        ));
 
         let mut config_file = ConfigFile::load_default_or_new()?;
         config_file.add_or_replace_profile(
             LOCAL_PROFILE,
-            LOCAL_SC_ADDRESS,
+            &self.config.sc_pub_addr,
             &self.config.client_tls_policy,
         )?;
         let config = config_file.mut_config().current_cluster_mut()?;


### PR DESCRIPTION
This PR allows runs two local clusters in the same environment.

Added in this PR: 

- Option to change data_dir
- Option to change public and private SC addresses
- Option --skip-profile-creation for local cluster, now allows creating a profile manually before.

## how to test
```bash
flvd cluster start

flvd profile add user1 127.0.0.1:9103 local 
flvd cluster start --skip-profile-creation --skip-checks --spu 0 --sc-pub-addr 127.0.0.1:9103 --sc-priv-addr 0.0.0.0:9104 --data-dir ~/.fluvio_2 
flvd cluster spu register --id 6001 -p 0.0.0.0:9020 -v 0.0.0.0:9021
flvd run spu -i 6001 -p 0.0.0.0:9020 -v 0.0.0.0:9021 --sc-addr localhost:9104 --log-base-dir ~/.fluvio_2/data 
```

## fluvio cluster delete

The actual implementation for deleting a cluster on local mode is deleting all executables with `fluvio` as name. I propose creating an issue to handle it by profile.
