### PR TITLE
first stab at overwriting

### DIFF
--- a/crates/fluvio-cluster/src/check/mod.rs
+++ b/crates/fluvio-cluster/src/check/mod.rs
@@ -823,13 +823,14 @@ impl ClusterChecker {
     }
 
     pub fn with_no_k8_checks(self, upgrade: bool) -> Self {
-        let checks = self.without_installed_local_cluster();
+        let mut checks = self.without_installed_local_cluster();
 
-        if upgrade {
-            checks
-        } else {
-            checks.with_clean_local_cluster()
+        // In a fresh install case (no upgrade) - we expect no cluster
+        if !upgrade {
+            checks = checks.with_clean_local_cluster()
         }
+
+        checks
     }
 
     pub fn without_installed_local_cluster(self) -> Self {

--- a/crates/fluvio-cluster/src/check/mod.rs
+++ b/crates/fluvio-cluster/src/check/mod.rs
@@ -822,9 +822,14 @@ impl ClusterChecker {
         self
     }
 
-    pub fn with_no_k8_checks(self) -> Self {
-        self.without_installed_local_cluster()
-            .with_clean_local_cluster()
+    pub fn with_no_k8_checks(self, upgrade: bool) -> Self {
+        let checks = self.without_installed_local_cluster();
+
+        if upgrade {
+            checks
+        } else {
+            checks.with_clean_local_cluster()
+        }
     }
 
     pub fn without_installed_local_cluster(self) -> Self {

--- a/crates/fluvio-cluster/src/cli/check.rs
+++ b/crates/fluvio-cluster/src/cli/check.rs
@@ -41,7 +41,7 @@ impl CheckOpt {
                     .with_check(SysChartCheck::new(sys_config, platform_version))
             }
             InstallationType::Local | InstallationType::ReadOnly => {
-                ClusterChecker::empty().with_no_k8_checks()
+                ClusterChecker::empty().with_no_k8_checks(false)
             }
             InstallationType::LocalK8 => ClusterChecker::empty().with_local_checks(),
             InstallationType::Cloud => {

--- a/crates/fluvio-cluster/src/cli/mod.rs
+++ b/crates/fluvio-cluster/src/cli/mod.rs
@@ -9,6 +9,7 @@ use tracing::debug;
 
 mod group;
 mod spu;
+mod options;
 mod start;
 mod resume;
 mod delete;
@@ -125,25 +126,12 @@ impl ClusterCmd {
                     }
                 };
 
-                start.process(platform_version, false).await?;
+                start.process(platform_version).await?;
             }
             Self::Resume(opt) => {
                 opt.process(platform_version).await?;
             }
-            Self::Upgrade(mut upgrade) => {
-                if let Ok(tag_strategy_value) = std::env::var(FLUVIO_IMAGE_TAG_STRATEGY) {
-                    let tag_strategy = ImageTagStrategy::from_str(&tag_strategy_value, true)
-                        .unwrap_or(ImageTagStrategy::Version);
-                    match tag_strategy {
-                        ImageTagStrategy::Version => {}
-                        ImageTagStrategy::VersionGit => {
-                            let image_version = format!("{}-{}", VERSION, env!("GIT_HASH"));
-                            upgrade.start.k8_config.image_version = Some(image_version);
-                        }
-                        ImageTagStrategy::Git => upgrade.start.develop = true,
-                    }
-                };
-
+            Self::Upgrade(upgrade) => {
                 upgrade.process(platform_version).await?;
             }
             Self::Delete(uninstall) => {

--- a/crates/fluvio-cluster/src/cli/options.rs
+++ b/crates/fluvio-cluster/src/cli/options.rs
@@ -1,4 +1,3 @@
-
 use std::path::PathBuf;
 use std::convert::TryFrom;
 
@@ -10,7 +9,6 @@ use crate::cli::ClusterCliError;
 use fluvio::config::{TlsPolicy, TlsPaths};
 use fluvio_controlplane_metadata::spg::{SpuConfig, StorageConfig};
 use fluvio_types::defaults::{TLS_SERVER_SECRET_NAME, TLS_CLIENT_SECRET_NAME};
-
 
 #[derive(Debug, Parser)]
 pub struct SpuCliConfig {

--- a/crates/fluvio-cluster/src/cli/resume.rs
+++ b/crates/fluvio-cluster/src/cli/resume.rs
@@ -76,7 +76,7 @@ impl LocalResume {
         }
         .with_context(|| "Unable to load configuration file for local cluster")?;
 
-        let installer = LocalInstaller::from_config(local_conf);
+        let installer = LocalInstaller::from_config(local_conf, false);
         _ = installer.install_only().await?;
         Ok(())
     }

--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -1,88 +1,118 @@
-use std::convert::TryInto;
-
 use anyhow::Result;
 use fluvio::config::TlsPolicy;
 use semver::Version;
 use tracing::debug;
 
-use crate::{ClusterInstaller, ClusterConfig};
+use crate::cli::options::ClusterConnectionOpts;
+use crate::{ClusterConfig, ClusterConfigBuilder, ClusterInstaller};
 use crate::cli::start::StartOpt;
 
-pub async fn process_k8(opt: StartOpt, platform_version: Version, upgrade: bool) -> Result<()> {
-    let (client, server): (TlsPolicy, TlsPolicy) = opt.tls.try_into()?;
+use super::K8Install;
 
+pub async fn process_k8(opt: StartOpt, platform_version: Version) -> Result<()> {
     let mut builder = ClusterConfig::builder(platform_version);
-
     if opt.develop {
         builder.development()?;
     }
-
+    
     builder
-        .namespace(opt.k8_config.namespace)
-        .chart_version(opt.k8_config.chart_version)
-        .group_name(opt.k8_config.group_name)
-        .spu_replicas(opt.spu)
-        .save_profile(!opt.skip_profile_creation)
-        .tls(client, server)
-        .tls_client_secret_name(opt.k8_config.tls_client_secret_name)
-        .tls_server_secret_name(opt.k8_config.tls_server_secret_name)
-        .chart_values(opt.k8_config.chart_values)
-        .hide_spinner(false)
-        .upgrade(upgrade)
-        .spu_config(opt.spu_config.as_spu_config())
-        .with_if(opt.skip_checks, |b| b.skip_checks(true))
-        .use_k8_port_forwarding(opt.k8_config.use_k8_port_forwarding)
-        .use_cluster_ip(opt.k8_config.use_cluster_ip);
-
-    if cfg!(target_os = "macos") {
-        builder.proxy_addr(opt.proxy_addr.unwrap_or_else(|| String::from("localhost")));
-    } else {
-        builder.proxy_addr(opt.proxy_addr);
-    }
-
-    if let Some(chart_location) = opt.k8_config.chart_location {
-        builder.local_chart(chart_location);
-    }
-
-    if let Some(registry) = opt.k8_config.registry {
-        builder.image_registry(registry);
-    }
-
-    if let Some(rust_log) = opt.rust_log {
-        builder.rust_log(rust_log);
-    }
-
-    if let Some(map) = opt.authorization_config_map {
-        builder.authorization_config_map(map);
-    }
-
-    if let Some(image_tag) = opt.k8_config.image_version {
-        builder.image_tag(image_tag.trim());
-    }
-
-    if let Some(service_type) = opt.service_type {
-        builder.service_type(service_type);
-    }
-
-    let config = builder.build()?;
-
-    debug!("cluster config: {:#?}", config);
-    let installer = ClusterInstaller::from_config(config)?;
-    if opt.setup {
-        setup_k8(&installer).await?;
-    } else {
-        start_k8(&installer).await?;
-    }
-
-    Ok(())
+        .append_connection_options(opt.connection_config)?
+        .append_k8s_options(opt.k8_config)
+        .append_spu_config(opt.spu, opt.spu_config)
+        .append_start_opt( !opt.skip_profile_creation, opt.skip_checks, opt.rust_log, opt.service_type)
+        .upgrade(false)
+        .build_and_start(opt.setup)
+        .await
 }
 
-pub async fn start_k8(installer: &ClusterInstaller) -> Result<()> {
+impl ClusterConfigBuilder {
+    fn append_start_opt(&mut self, 
+        save_profile: bool, 
+        skip_checks: bool,
+        rust_log: Option<String>,
+        service_type: Option<String>
+    ) -> &mut Self {
+        self
+            .save_profile(save_profile)
+            .hide_spinner(false)
+            .with_if(skip_checks, |b| b.skip_checks(true));
+
+        if let Some(rust_log) = rust_log {
+            self.rust_log(rust_log);
+        }
+
+        if let Some(service_type) = service_type {
+            self.service_type(service_type);
+        }
+
+        self
+    }
+
+    pub(crate) fn append_spu_config(&mut self, spu_replicas: u16, spu_config: super::SpuCliConfig) -> &mut Self {
+        self
+            .spu_replicas(spu_replicas)
+            .spu_config(spu_config.as_spu_config())
+    }
+
+    pub(crate) fn append_k8s_options(&mut self, k8_config: K8Install) -> &mut Self {
+        if let Some(chart_location) = k8_config.chart_location {
+            self.local_chart(chart_location);
+        }
+    
+        if let Some(registry) = k8_config.registry {
+            self.image_registry(registry);
+        }
+
+        if let Some(image_tag) = k8_config.image_version {
+            self.image_tag(image_tag.trim());
+        }
+
+        self
+            .namespace(k8_config.namespace)
+            .chart_version(k8_config.chart_version)
+            .group_name(k8_config.group_name)
+            .tls_client_secret_name(k8_config.tls_client_secret_name)
+            .tls_server_secret_name(k8_config.tls_server_secret_name)
+            .chart_values(k8_config.chart_values)
+            .use_k8_port_forwarding(k8_config.use_k8_port_forwarding)
+            .use_cluster_ip(k8_config.use_cluster_ip)
+    }
+
+    pub(crate) fn append_connection_options(&mut self, connection_config: ClusterConnectionOpts) -> Result<&mut Self> {
+        let (client, server): (TlsPolicy, TlsPolicy) = connection_config.tls.try_into()?;
+        self.tls(client, server);
+        if cfg!(target_os = "macos") {
+            self.proxy_addr(connection_config.proxy_addr.unwrap_or_else(|| String::from("localhost")));
+        } else {
+            self.proxy_addr(connection_config.proxy_addr);
+        }
+
+        if let Some(map) = connection_config.authorization_config_map {
+            self.authorization_config_map(map);
+        }
+    
+        Ok(self)
+    }
+
+    pub(crate) async fn build_and_start(&self, setup: bool) -> Result<()> {
+        let config = self.build()?;
+
+        debug!("cluster config: {:#?}", config);
+        let installer = ClusterInstaller::from_config(config)?;
+        if setup {
+            setup_k8(&installer).await
+        } else {
+            start_k8(&installer).await
+        }
+    }
+}
+
+async fn start_k8(installer: &ClusterInstaller) -> Result<()> {
     installer.install_fluvio().await?;
     Ok(())
 }
 
-pub async fn setup_k8(installer: &ClusterInstaller) -> Result<()> {
+async fn setup_k8(installer: &ClusterInstaller) -> Result<()> {
     installer.preflight_check(false).await?;
     Ok(())
 }

--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -14,25 +14,30 @@ pub async fn process_k8(opt: StartOpt, platform_version: Version) -> Result<()> 
     if opt.develop {
         builder.development()?;
     }
-    
+
     builder
         .append_connection_options(opt.connection_config)?
         .append_k8s_options(opt.k8_config)
         .append_spu_config(opt.spu, opt.spu_config)
-        .append_start_opt( !opt.skip_profile_creation, opt.skip_checks, opt.rust_log, opt.service_type)
+        .append_start_opt(
+            !opt.skip_profile_creation,
+            opt.skip_checks,
+            opt.rust_log,
+            opt.service_type,
+        )
         .build_and_start(opt.setup, false)
         .await
 }
 
 impl ClusterConfigBuilder {
-    fn append_start_opt(&mut self, 
-        save_profile: bool, 
+    fn append_start_opt(
+        &mut self,
+        save_profile: bool,
         skip_checks: bool,
         rust_log: Option<String>,
-        service_type: Option<String>
+        service_type: Option<String>,
     ) -> &mut Self {
-        self
-            .save_profile(save_profile)
+        self.save_profile(save_profile)
             .hide_spinner(false)
             .with_if(skip_checks, |b| b.skip_checks(true));
 
@@ -47,9 +52,12 @@ impl ClusterConfigBuilder {
         self
     }
 
-    pub(crate) fn append_spu_config(&mut self, spu_replicas: u16, spu_config: super::SpuCliConfig) -> &mut Self {
-        self
-            .spu_replicas(spu_replicas)
+    pub(crate) fn append_spu_config(
+        &mut self,
+        spu_replicas: u16,
+        spu_config: super::SpuCliConfig,
+    ) -> &mut Self {
+        self.spu_replicas(spu_replicas)
             .spu_config(spu_config.as_spu_config())
     }
 
@@ -57,7 +65,7 @@ impl ClusterConfigBuilder {
         if let Some(chart_location) = k8_config.chart_location {
             self.local_chart(chart_location);
         }
-    
+
         if let Some(registry) = k8_config.registry {
             self.image_registry(registry);
         }
@@ -66,8 +74,7 @@ impl ClusterConfigBuilder {
             self.image_tag(image_tag.trim());
         }
 
-        self
-            .namespace(k8_config.namespace)
+        self.namespace(k8_config.namespace)
             .chart_version(k8_config.chart_version)
             .group_name(k8_config.group_name)
             .tls_client_secret_name(k8_config.tls_client_secret_name)
@@ -77,11 +84,18 @@ impl ClusterConfigBuilder {
             .use_cluster_ip(k8_config.use_cluster_ip)
     }
 
-    pub(crate) fn append_connection_options(&mut self, connection_config: ClusterConnectionOpts) -> Result<&mut Self> {
+    pub(crate) fn append_connection_options(
+        &mut self,
+        connection_config: ClusterConnectionOpts,
+    ) -> Result<&mut Self> {
         let (client, server): (TlsPolicy, TlsPolicy) = connection_config.tls.try_into()?;
         self.tls(client, server);
         if cfg!(target_os = "macos") {
-            self.proxy_addr(connection_config.proxy_addr.unwrap_or_else(|| String::from("localhost")));
+            self.proxy_addr(
+                connection_config
+                    .proxy_addr
+                    .unwrap_or_else(|| String::from("localhost")),
+            );
         } else {
             self.proxy_addr(connection_config.proxy_addr);
         }
@@ -89,7 +103,7 @@ impl ClusterConfigBuilder {
         if let Some(map) = connection_config.authorization_config_map {
             self.authorization_config_map(map);
         }
-    
+
         Ok(self)
     }
 

--- a/crates/fluvio-cluster/src/cli/start/k8.rs
+++ b/crates/fluvio-cluster/src/cli/start/k8.rs
@@ -20,8 +20,7 @@ pub async fn process_k8(opt: StartOpt, platform_version: Version) -> Result<()> 
         .append_k8s_options(opt.k8_config)
         .append_spu_config(opt.spu, opt.spu_config)
         .append_start_opt( !opt.skip_profile_creation, opt.skip_checks, opt.rust_log, opt.service_type)
-        .upgrade(false)
-        .build_and_start(opt.setup)
+        .build_and_start(opt.setup, false)
         .await
 }
 
@@ -94,11 +93,11 @@ impl ClusterConfigBuilder {
         Ok(self)
     }
 
-    pub(crate) async fn build_and_start(&self, setup: bool) -> Result<()> {
+    pub(crate) async fn build_and_start(&self, setup: bool, upgrade: bool) -> Result<()> {
         let config = self.build()?;
 
         debug!("cluster config: {:#?}", config);
-        let installer = ClusterInstaller::from_config(config)?;
+        let installer = ClusterInstaller::from_config(config, upgrade)?;
         if setup {
             setup_k8(&installer).await
         } else {

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -6,7 +6,7 @@ use fluvio::config::TlsPolicy;
 
 use crate::{cli::options::{ClusterConnectionOpts, K8Install}, LocalConfig, LocalConfigBuilder, LocalInstaller};
 
-use super::StartOpt;
+use super::{IntallationTypeOpt, StartOpt};
 
 /// Attempts to either start a local Fluvio cluster or check (and fix) the preliminery preflight checks.
 /// Pass opt.setup = false, to only run the checks.
@@ -29,9 +29,10 @@ pub async fn process_local(opt: StartOpt, platform_version: Version/* , upgrade:
         .log_dir(opt.log_dir.deref())
         .spu_replicas(opt.spu)
         .hide_spinner(false)
-        .installation_type(opt.installation_type.get_or_default())
-        .read_only_config(opt.installation_type.read_only)
         .save_profile(!opt.skip_profile_creation)
+        .append_installation_type(opt.installation_type)
+        .append_k8s_config(opt.k8_config)
+        .append_connection_options(opt.connection_config)?
         .build_and_start(opt.setup, false).await
 }
 
@@ -51,6 +52,12 @@ impl LocalConfigBuilder {
         }
         
         Ok(self)
+    }
+
+    pub fn append_installation_type(&mut self, installation_type: IntallationTypeOpt) -> &mut Self {
+        self
+            .installation_type(installation_type.get_or_default())
+            .read_only_config(installation_type.read_only)
     }
 
     pub fn append_k8s_config(&mut self, k8_config: K8Install) -> &mut Self {

--- a/crates/fluvio-cluster/src/cli/start/local.rs
+++ b/crates/fluvio-cluster/src/cli/start/local.rs
@@ -4,13 +4,19 @@ use semver::Version;
 
 use fluvio::config::TlsPolicy;
 
-use crate::{cli::options::{ClusterConnectionOpts, K8Install}, LocalConfig, LocalConfigBuilder, LocalInstaller};
+use crate::{
+    cli::options::{ClusterConnectionOpts, K8Install},
+    LocalConfig, LocalConfigBuilder, LocalInstaller,
+};
 
 use super::{IntallationTypeOpt, StartOpt};
 
 /// Attempts to either start a local Fluvio cluster or check (and fix) the preliminery preflight checks.
 /// Pass opt.setup = false, to only run the checks.
-pub async fn process_local(opt: StartOpt, platform_version: Version/* , upgrade: bool*/) -> Result<()> {
+pub async fn process_local(
+    opt: StartOpt,
+    platform_version: Version, /* , upgrade: bool*/
+) -> Result<()> {
     let mut builder = LocalConfig::builder(platform_version);
 
     if let Some(data_dir) = opt.data_dir {
@@ -33,11 +39,15 @@ pub async fn process_local(opt: StartOpt, platform_version: Version/* , upgrade:
         .append_installation_type(opt.installation_type)
         .append_k8s_config(opt.k8_config)
         .append_connection_options(opt.connection_config)?
-        .build_and_start(opt.setup, false).await
+        .build_and_start(opt.setup, false)
+        .await
 }
 
 impl LocalConfigBuilder {
-    pub fn append_connection_options(&mut self, connection_config: ClusterConnectionOpts) -> Result<&mut Self>{
+    pub fn append_connection_options(
+        &mut self,
+        connection_config: ClusterConnectionOpts,
+    ) -> Result<&mut Self> {
         if connection_config.tls.tls {
             let (client, server): (TlsPolicy, TlsPolicy) = connection_config.tls.try_into()?;
             self.tls(client, server);
@@ -46,17 +56,16 @@ impl LocalConfigBuilder {
         if let Some(pub_addr) = connection_config.sc_pub_addr {
             self.sc_pub_addr(pub_addr);
         }
-    
+
         if let Some(priv_addr) = connection_config.sc_priv_addr {
             self.sc_priv_addr(priv_addr);
         }
-        
+
         Ok(self)
     }
 
     pub fn append_installation_type(&mut self, installation_type: IntallationTypeOpt) -> &mut Self {
-        self
-            .installation_type(installation_type.get_or_default())
+        self.installation_type(installation_type.get_or_default())
             .read_only_config(installation_type.read_only)
     }
 
@@ -64,7 +73,7 @@ impl LocalConfigBuilder {
         if let Some(chart_location) = k8_config.chart_location {
             self.local_chart(chart_location);
         }
-    
+
         self
     }
 

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -223,7 +223,7 @@ impl StartOpt {
         if self.sys_only {
             process_sys(&self, upgrade)?;
         } else if self.installation_type.is_local_group() {
-            process_local(self, platform_version).await?;
+            process_local(self, platform_version, upgrade).await?;
         } else {
             process_k8(self, platform_version, upgrade).await?;
         }

--- a/crates/fluvio-cluster/src/cli/start/mod.rs
+++ b/crates/fluvio-cluster/src/cli/start/mod.rs
@@ -91,11 +91,11 @@ pub struct StartOpt {
     /// Whether to skip pre-install checks, defaults to false
     #[arg(long)]
     pub skip_checks: bool,
-    
+
     /// Tries to setup necessary environment for cluster startup
     #[arg(long)]
     pub setup: bool,
-    
+
     /// Service Type
     #[arg(long)]
     pub service_type: Option<String>,
@@ -131,7 +131,10 @@ impl StartOpt {
         use crate::cli::start::k8::process_k8;
 
         if self.sys_only {
-            process_sys(&self, false /* TODO: I can't find a code-path where process_sys is called with upgrade=True */)?;
+            process_sys(
+                &self,
+                false, /* TODO: I can't find a code-path where process_sys is called with upgrade=True */
+            )?;
         } else if self.installation_type.is_local_group() {
             process_local(self, platform_version).await?;
         } else {

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 use fluvio_extension_common::installation::InstallationType;
 use semver::Version;
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use tracing::debug;
 
-use crate::{cli::shutdown::ShutdownOpt, cli::get_installation_type};
+use crate::cli::{get_installation_type, shutdown::ShutdownOpt};
 
 use super::start::StartOpt;
 

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -98,8 +98,7 @@ async fn process_k8(opt: UpgradeOpt, platform_version: Version, develop: bool) -
     
     builder
         .append_connection_options(opt.connection_config)?
-        .upgrade(true)
-        .build_and_start(false)
+        .build_and_start(false, true)
         .await
 }
 

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -1,38 +1,61 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use fluvio_channel::ImageTagStrategy;
+use fluvio_cli_common::FLUVIO_IMAGE_TAG_STRATEGY;
 use fluvio_extension_common::installation::InstallationType;
 use semver::Version;
 use anyhow::{bail, Result};
 use tracing::debug;
 
-use crate::cli::{get_installation_type, shutdown::ShutdownOpt};
+use crate::{
+    cli::{
+        get_installation_type, 
+        shutdown::ShutdownOpt,
+        options::{
+            ClusterConnectionOpts,
+            K8Install
+        },
+    }, 
+    ClusterConfig, 
+    LocalConfig
+};
 
-use super::start::StartOpt;
+use super::VERSION;
 
 #[derive(Debug, Parser)]
 pub struct UpgradeOpt {
     #[clap(flatten)]
-    pub start: StartOpt,
+    pub connection_config: ClusterConnectionOpts,
+
+    #[clap(flatten)]
+    pub k8_config: K8Install,
 }
 
 impl UpgradeOpt {
     pub async fn process(mut self, platform_version: Version) -> Result<()> {
         let (installation_type, config) = get_installation_type()?;
         debug!(?installation_type);
-        if let Some(requested) = self.start.installation_type.get() {
-            if installation_type != requested {
-                bail!("It is not allowed to change installation type during cluster upgrade. Current: {installation_type}, requested: {requested}");
-            }
-        } else {
-            self.start.installation_type.set(installation_type.clone());
-        }
+
+        // TODO: Overrider k8s image config
+        match get_image_override() {
+            ImageTag::Develop => {
+                // upgrade.start.develop = true
+            },
+            ImageTag::GitVersion(image_version) => {
+                self.k8_config.image_version = Some(image_version);
+            },
+            _ => {},
+        };
+
         match installation_type {
             InstallationType::K8 => {
-                self.start.process(platform_version, true).await?;
+                process_k8(self, platform_version, /* TODO: Why develop here is true? */ true).await?;
             }
+
             InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
                 ShutdownOpt.process().await?;
-                self.start.process(platform_version, true).await?;
+                process_local(self, platform_version).await?;
             }
+
             InstallationType::Cloud => {
                 let profile = config.config().current_profile_name().unwrap_or("none");
                 bail!("Fluvio cluster upgrade does not operate on cloud cluster \"{profile}\", use 'fluvio cloud ...' commands")
@@ -42,4 +65,47 @@ impl UpgradeOpt {
 
         Ok(())
     }
+}
+
+enum ImageTag {
+    Develop,
+    GitVersion(String),
+    Default
+}
+
+fn get_image_override() -> ImageTag {
+    if let Ok(tag_strategy_value) = std::env::var(FLUVIO_IMAGE_TAG_STRATEGY) {
+        let tag_strategy = ImageTagStrategy::from_str(&tag_strategy_value, true)
+            .unwrap_or(ImageTagStrategy::Version);
+        match tag_strategy {
+            ImageTagStrategy::Version => ImageTag::Default,
+            ImageTagStrategy::VersionGit => {
+                let image_version = format!("{}-{}", VERSION, env!("GIT_HASH"));
+                ImageTag::GitVersion(image_version)
+            },
+            ImageTagStrategy::Git => ImageTag::Develop,
+        }
+    } else  {
+        ImageTag::Default
+    }
+}
+
+async fn process_k8(opt: UpgradeOpt, platform_version: Version, develop: bool) -> Result<()> {
+    let mut builder = ClusterConfig::builder(platform_version);
+    if develop {
+        builder.development()?;
+    }
+    
+    builder
+        .append_connection_options(opt.connection_config)?
+        .upgrade(true)
+        .build_and_start(false)
+        .await
+}
+
+async fn process_local(opt: UpgradeOpt, platform_version: Version) -> Result<()> {
+    LocalConfig::builder(platform_version)
+        .append_connection_options(opt.connection_config)?
+        .build_and_start(false, true)
+        .await
 }

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -9,11 +9,12 @@ use tracing::debug;
 
 use crate::{
     cli::{
-        get_installation_type, options::{
-            ClusterConnectionOpts,
-            K8Install
-        }, shutdown::ShutdownOpt
-    }, start::local::LOCAL_CONFIG_PATH, ClusterConfig, LocalConfig
+        get_installation_type,
+        options::{ClusterConnectionOpts, K8Install},
+        shutdown::ShutdownOpt,
+    },
+    start::local::LOCAL_CONFIG_PATH,
+    ClusterConfig, LocalConfig,
 };
 
 use super::{ClusterCliError, VERSION};
@@ -37,13 +38,11 @@ impl UpgradeOpt {
 
         // Override the CLI options.
         match get_image_override() {
-            ImageTag::Develop => {
-                self.develop = true
-            },
+            ImageTag::Develop => self.develop = true,
             ImageTag::GitVersion(image_version) => {
                 self.k8_config.image_version = Some(image_version);
-            },
-            _ => {},
+            }
+            _ => {}
         };
 
         match installation_type {
@@ -70,7 +69,7 @@ impl UpgradeOpt {
 enum ImageTag {
     Develop,
     GitVersion(String),
-    Default
+    Default,
 }
 
 fn get_image_override() -> ImageTag {
@@ -82,10 +81,10 @@ fn get_image_override() -> ImageTag {
             ImageTagStrategy::VersionGit => {
                 let image_version = format!("{}-{}", VERSION, env!("GIT_HASH"));
                 ImageTag::GitVersion(image_version)
-            },
+            }
             ImageTagStrategy::Git => ImageTag::Develop,
         }
-    } else  {
+    } else {
         ImageTag::Default
     }
 }
@@ -95,21 +94,26 @@ async fn process_k8(opt: UpgradeOpt, platform_version: Version) -> Result<()> {
     if opt.develop {
         builder.development()?;
     }
-    
+
     builder
         .append_connection_options(opt.connection_config)?
         .build_and_start(false, true)
         .await
 }
 
-async fn process_local(opt: UpgradeOpt, platform_version: Version, installation_type: InstallationType) -> Result<()> {
+async fn process_local(
+    opt: UpgradeOpt,
+    platform_version: Version,
+    installation_type: InstallationType,
+) -> Result<()> {
     let config_path = LOCAL_CONFIG_PATH.as_ref().ok_or(ClusterCliError::Other(
         "Configuration file for local cluster not found from previous run".to_string(),
     ))?;
-    
+
     let config = LocalConfig::load_from(config_path)?;
-    
-    config.evolve()
+
+    config
+        .evolve()
         .platform_version(platform_version)
         .installation_type(installation_type)
         .append_k8s_config(opt.k8_config)

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -1376,7 +1376,7 @@ mod tests {
 
     #[test]
     fn test_build_config() {
-        let config: ClusterConfig =
+        let config =
             ClusterConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
                 .build()
                 .expect("should succeed with required config options");

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -592,7 +592,7 @@ impl ClusterInstaller {
             kube_client,
             pb_factory: ProgressBarFactory::new(config.hide_spinner),
             config,
-            upgrade
+            upgrade,
         })
     }
 
@@ -1377,10 +1377,9 @@ mod tests {
 
     #[test]
     fn test_build_config() {
-        let config =
-            ClusterConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
-                .build()
-                .expect("should succeed with required config options");
+        let config = ClusterConfig::builder(semver::Version::parse("0.7.0-alpha.1").unwrap())
+            .build()
+            .expect("should succeed with required config options");
         assert_eq!(
             config.platform_version,
             semver::Version::parse("0.7.0-alpha.1").unwrap()

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -390,7 +390,7 @@ impl LocalInstaller {
         Self {
             pb_factory: ProgressBarFactory::new(config.hide_spinner),
             config,
-            upgrade
+            upgrade,
         }
     }
 

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -223,12 +223,6 @@ impl LocalConfig {
             data_dir: self.data_dir.clone(),
         }
     }
-
-    pub fn overwrite_with(mut self, other: Self) -> Self {
-        // self.spu_replicas = other.spu_replicas; // How do we decide if we overwrite here?; as long as we don't, upgrade with smaller SPU will hang
-        self.rust_log = other.rust_log;
-        self
-    }
 }
 
 impl LocalConfigBuilder {

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -223,6 +223,30 @@ impl LocalConfig {
             data_dir: self.data_dir.clone(),
         }
     }
+
+    // Create a builder from the instance, so it could be used to create an evovled instance.
+    pub fn evolve(self) -> LocalConfigBuilder {
+        // This direct assignment style is used so the compiler can guarentee pairity between LocalConfig and the builder object
+        LocalConfigBuilder {
+            platform_version: Some(self.platform_version),
+            log_dir: Some(self.log_dir),
+            data_dir: Some(self.data_dir),
+            launcher: Some(self.launcher),
+            rust_log: Some(self.rust_log),
+            spu_replicas: Some(self.spu_replicas),
+            server_tls_policy: Some(self.server_tls_policy),
+            client_tls_policy: Some(self.client_tls_policy),
+            sc_pub_addr: Some(self.sc_pub_addr),
+            sc_priv_addr: Some(self.sc_priv_addr),
+            chart_version: Some(self.chart_version),
+            chart_location: Some(self.chart_location),
+            skip_checks: Some(self.skip_checks),
+            hide_spinner: Some(self.hide_spinner),
+            installation_type: Some(self.installation_type),
+            read_only_config: Some(self.read_only_config),
+            save_profile: Some(self.save_profile),
+        }
+    }
 }
 
 impl LocalConfigBuilder {

--- a/crates/fluvio-test-util/setup/environment/k8.rs
+++ b/crates/fluvio-test-util/setup/environment/k8.rs
@@ -62,8 +62,8 @@ impl EnvironmentDriver for K8EnvironmentDriver {
         }
 
         let config = builder.build().unwrap();
-        let installer =
-            ClusterInstaller::from_config(config, false).expect("Could not create ClusterInstaller");
+        let installer = ClusterInstaller::from_config(config, false)
+            .expect("Could not create ClusterInstaller");
         installer
             .install_fluvio()
             .await

--- a/crates/fluvio-test-util/setup/environment/k8.rs
+++ b/crates/fluvio-test-util/setup/environment/k8.rs
@@ -63,7 +63,7 @@ impl EnvironmentDriver for K8EnvironmentDriver {
 
         let config = builder.build().unwrap();
         let installer =
-            ClusterInstaller::from_config(config).expect("Could not create ClusterInstaller");
+            ClusterInstaller::from_config(config, false).expect("Could not create ClusterInstaller");
         installer
             .install_fluvio()
             .await

--- a/crates/fluvio-test-util/setup/environment/local.rs
+++ b/crates/fluvio-test-util/setup/environment/local.rs
@@ -66,7 +66,7 @@ impl EnvironmentDriver for LocalEnvDriver {
     }
 
     async fn start_cluster(&self) -> StartStatus {
-        let installer = LocalInstaller::from_config(self.config.clone());
+        let installer = LocalInstaller::from_config(self.config.clone(), false);
         installer
             .install()
             .await


### PR DESCRIPTION
Here is an example of a manufactured config file with older version is properly replaced after an upgrade command. 
Notice that I used replicas 3 on purpose to demonstrate how old values are not overwritten

```sh
$> fluvio cluster start --spu 3                                                                                                                                                                                                                                                                                                                                  

📝 Running pre-flight checks
    ✅ Local Fluvio is not installed
    ✅ Previous local fluvio installation not found
🎉 All checks passed!
✅ Local Cluster initialized
👤 Profile set
✅ SC Launched
🤖 Starting SPU: (3/3) \
✅ 3 SPU launched
🎯 Successfully installed Local Fluvio cluster

$> head -n 1 ~/.fluvio/local-config                                                                                                                                                                                                                                                                                                                              
platform_version = "0.11.9-dev"

$> sed -i.bak 's/platform_version = "\([^"]*\)"/platform_version = "0.0.0"/g' ~/.fluvio/local-config                                                                                                                                                                                                                                                             $> head -n 1 ~/.fluvio/local-config                                                                                                                                                                                                                                                                                                                              platform_version = "0.0.0"

$> fluvio cluster upgrade                                                                                                                                                                                                                                                                                                                                        Removed spu monitoring socket: /tmp/fluvio-spu.sock
Uninstalled fluvio local components
📝 Running pre-flight checks
    ✅ Local Fluvio is not installed
🎉 All checks passed!
✅ Local Cluster initialized
👤 Profile set
✅ SC Launched
🤖 Starting SPU: (3/3) \
✅ 3 SPU launched
🎯 Successfully installed Local Fluvio cluster
$> head -n 1 ~/.fluvio/local-config                                                                                                                                                                                                                                                                                                                              
platform_version = "0.11.9-dev"
```