### PR TITLE
feat(cli): use `std::io::IsTerminal` over `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,17 +519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auth-git2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,7 +2310,6 @@ dependencies = [
  "async-channel 1.9.0",
  "async-net",
  "async-trait",
- "atty",
  "bytesize",
  "clap",
  "clap_complete",
@@ -3930,15 +3918,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -4245,7 +4224,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4268,7 +4247,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
@@ -5085,7 +5064,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ async-net = { version = "1.7.0", default-features = false  }
 async-rwlock = "1.3.0"
 async-std = { version = "1.8.0", default-features = false }
 async-trait = { version = "0.1.41", default-features = false }
-atty = { version = "0.2.14" }
 base64 = "0.22.0"
 bytes = "1.1.0"
 bytesize = "1.1.0"

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -21,7 +21,6 @@ doc = false
 [features]
 default = ["consumer", "k8s", "producer-file-io"]
 consumer = [
-    "atty",
     "ctrlc",
     "content_inspector",
     "fluvio-types",
@@ -53,7 +52,6 @@ hex = { workspace = true }
 home = { workspace = true }
 current_platform = { workspace = true }
 comfy-table = { workspace = true }
-atty = { workspace = true, optional = true }
 ctrlc = { workspace = true, optional = true }
 colored = { workspace = true }
 handlebars = { workspace = true }

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -9,6 +9,7 @@ mod table_format;
 mod record_format;
 
 use table_format::TableModel;
+
 pub use cmd::ConsumeOpt;
 
 mod cmd {
@@ -16,7 +17,7 @@ mod cmd {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{UNIX_EPOCH, Duration};
     use std::{io::Error as IoError, path::PathBuf};
-    use std::io::{self, ErrorKind, Stdout};
+    use std::io::{self, ErrorKind, IsTerminal, Stdout};
     use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::sync::Arc;
@@ -708,7 +709,8 @@ mod cmd {
 
         fn print_status(&self) {
             use colored::*;
-            if !atty::is(atty::Stream::Stdout) {
+
+            if !std::io::stdout().is_terminal() {
                 return;
             }
 

--- a/crates/fluvio-cli/src/client/produce/mod.rs
+++ b/crates/fluvio-cli/src/client/produce/mod.rs
@@ -563,7 +563,9 @@ mod cmd {
 
         #[cfg(feature = "producer-file-io")]
         fn interactive_mode(&self) -> bool {
-            self.file.is_none() && atty::is(atty::Stream::Stdin)
+            use std::io::IsTerminal;
+
+            self.file.is_none() && std::io::stdin().is_terminal()
         }
 
         #[cfg(not(feature = "producer-file-io"))]


### PR DESCRIPTION
Uses `std::io::IsTerminal` over `atty` to detect tty environments in Fluvio CLI.