### PR TITLE
chore: update bytes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,9 +682,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytesize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ async-rwlock = "1.3.0"
 async-std = { version = "1.8.0", default-features = false }
 async-trait = { version = "0.1.41", default-features = false }
 base64 = "0.22.0"
-bytes = "1.1.0"
+bytes = "1.6.0"
 bytesize = "1.1.0"
 cargo_toml = "0.17.1"
 cargo-generate = { version = "0.21", default-features = false }


### PR DESCRIPTION
Updates `bytes` crate in order to allow newer k8-client versions.