### PR TITLE
feat: update mirror status when find errors on spu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1310,9 +1310,9 @@ jobs:
         timeout-minutes: 10
         run: | 
           fluvio profile add local2 ${REMOTE_2_SC_PUB_ADDR} local
-          fluvio cluster start --skip-profile-creation --skip-checks --spu 0 --sc-pub-addr ${REMOTE_2_SC_PUB_ADDR} --sc-priv-addr ${REMOTE_2_SC_PRIV_ADDR} --data-dir ${REMOTE_2_SC_PRIV_ADDR}
+          fluvio cluster start --skip-profile-creation --skip-checks --spu 0 --sc-pub-addr ${REMOTE_2_SC_PUB_ADDR} --sc-priv-addr ${REMOTE_2_SC_PRIV_ADDR} --data-dir ${REMOTE_2_BASE_DIR}
           fluvio cluster spu register --id ${REMOTE_2_SPU_ID} -p ${REMOTE_2_SPU_PUB_ADDR} -v ${REMOTE_2_SPU_PRIV_ADDR}
-          fluvio run spu -i ${REMOTE_2_SPU_ID} -p ${REMOTE_2_SPU_PUB_ADDR} -v ${REMOTE_2_SPU_PRIV_ADDR} --sc-addr ${REMOTE_2_SC_PRIV_ADDR} --log-base-dir ${REMOTE_2_SC_PRIV_ADDR}/data &
+          fluvio run spu -i ${REMOTE_2_SPU_ID} -p ${REMOTE_2_SPU_PUB_ADDR} -v ${REMOTE_2_SPU_PRIV_ADDR} --sc-addr ${REMOTE_2_SC_PRIV_ADDR} --log-base-dir ${REMOTE_2_BASE_DIR}/data &
 
       - name: Start home cluster in k8
         timeout-minutes: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
 name = "fluvio-sc"
 version = "0.0.0"
 dependencies = [
+ "adaptive_backoff",
  "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "fluvio-controlplane-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytes",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ k8-diff = { version = "0.1.2" }
 trybuild = { branch = "check_option", git = "https://github.com/infinyon/trybuild" }
 
 # Internal fluvio dependencies
-fluvio = { version = "0.23.0", path = "crates/fluvio" }
+fluvio = { version = "0.23.2", path = "crates/fluvio" }
 fluvio-auth = { path = "crates/fluvio-auth" }
 fluvio-channel = { path = "crates/fluvio-channel" }
 fluvio-cli-common = { path = "crates/fluvio-cli-common"}
@@ -180,7 +180,7 @@ fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.8.0", path = "crates/fluvio-smartengine", default-features = false }
 fluvio-smartmodule = { version = "0.7.4", path = "crates/fluvio-smartmodule", default-features = false }
 fluvio-socket = { version = "0.14.9", path = "crates/fluvio-socket", default-features = false }
-fluvio-spu-schema = { version = "0.15.0", path = "crates/fluvio-spu-schema", default-features  = false }
+fluvio-spu-schema = { version = "0.16.0", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.13.2", path = "crates/fluvio-stream-dispatcher" }
 fluvio-stream-model = { version = "0.11.3", path = "crates/fluvio-stream-model", default-features = false }

--- a/crates/fluvio-cli/src/client/home/status.rs
+++ b/crates/fluvio-cli/src/client/home/status.rs
@@ -7,6 +7,8 @@ use fluvio_extension_common::target::ClusterTarget;
 use fluvio_extension_common::{OutputFormat, Terminal};
 use fluvio_sc_schema::mirror::{MirrorSpec, MirrorType};
 
+use self::output::HomeStatusRow;
+
 use super::get_admin;
 
 #[derive(Debug, Parser)]
@@ -14,6 +16,7 @@ pub struct StatusOpt {
     #[clap(flatten)]
     output: OutputFormat,
 }
+
 impl StatusOpt {
     pub async fn execute<T: Terminal>(
         self,
@@ -24,17 +27,19 @@ impl StatusOpt {
         let list = admin.all::<MirrorSpec>().await?;
         let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
 
-        let outlist: Vec<(String, String, String, String)> = list
+        let outlist: Vec<HomeStatusRow> = list
             .into_iter()
             .filter_map(|item| {
                 match item.spec.mirror_type {
                     MirrorType::Home(home) => {
-                        Some((
-                            home.id.to_string(),        // Source ID
-                            home.public_endpoint,       // Route
-                            item.status.to_string(),    // Status
-                            item.status.last_seen(now), // Last-Seen
-                        ))
+                        Some(HomeStatusRow {
+                            home: home.id.to_string(),                       // Source ID
+                            route: home.public_endpoint,                     // Route
+                            sc_status: item.status.pairing_sc.to_string(),   // SC Status
+                            spu_status: item.status.pairing_spu.to_string(), // SPU Status
+                            last_seen: item.status.last_seen(now),           // Last-Seen
+                            errors: item.status.pair_errors(),               // Errors
+                        })
                     }
                     _ => None,
                 }
@@ -51,7 +56,6 @@ mod output {
     //!
     use comfy_table::{Cell, Row};
     use comfy_table::CellAlignment;
-    use tracing::debug;
     use serde::Serialize;
     use anyhow::Result;
 
@@ -60,10 +64,18 @@ mod output {
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
-    type ListVec = Vec<(String, String, String, String)>;
+    #[derive(Serialize)]
+    pub struct HomeStatusRow {
+        pub home: String,
+        pub route: String,
+        pub sc_status: String,
+        pub spu_status: String,
+        pub last_seen: String,
+        pub errors: String,
+    }
 
     #[derive(Serialize)]
-    struct TableList(ListVec);
+    struct TableList(Vec<HomeStatusRow>);
 
     // -----------------------------------
     // Format Output
@@ -71,11 +83,9 @@ mod output {
 
     pub fn format<O: Terminal>(
         out: std::sync::Arc<O>,
-        listvec: ListVec,
+        listvec: Vec<HomeStatusRow>,
         output_type: OutputType,
     ) -> Result<()> {
-        debug!("listvec: {:#?}", listvec);
-
         if !listvec.is_empty() {
             let rlist = TableList(listvec);
             out.render_list(&rlist, output_type)?;
@@ -92,7 +102,17 @@ mod output {
     impl TableOutputHandler for TableList {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["HOME", "ROUTE", "STATUS", "LAST SEEN"])
+            Row::from(
+                [
+                    "HOME",
+                    "ROUTE",
+                    "SC STATUS",
+                    "SPU STATUS",
+                    "LAST SEEN",
+                    "ERRORS",
+                ]
+                .iter(),
+            )
         }
 
         /// return errors in string format
@@ -106,10 +126,12 @@ mod output {
                 .iter()
                 .map(|e| {
                     Row::from([
-                        Cell::new(&e.0).set_alignment(CellAlignment::Left),
-                        Cell::new(&e.1).set_alignment(CellAlignment::Left),
-                        Cell::new(&e.2).set_alignment(CellAlignment::Left),
-                        Cell::new(&e.3).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.home).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.route).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.sc_status).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.spu_status).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.last_seen).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.errors).set_alignment(CellAlignment::Left),
                     ])
                 })
                 .collect()

--- a/crates/fluvio-cli/src/client/home/status.rs
+++ b/crates/fluvio-cli/src/client/home/status.rs
@@ -1,13 +1,13 @@
-pub use std::sync::Arc;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::Result;
 use clap::Parser;
+use serde::Serialize;
+
 use fluvio_extension_common::target::ClusterTarget;
 use fluvio_extension_common::{OutputFormat, Terminal};
 use fluvio_sc_schema::mirror::{MirrorSpec, MirrorType};
-
-use self::output::HomeStatusRow;
 
 use super::get_admin;
 
@@ -49,6 +49,16 @@ impl StatusOpt {
     }
 }
 
+#[derive(Serialize)]
+struct HomeStatusRow {
+    home: String,
+    route: String,
+    sc_status: String,
+    spu_status: String,
+    last_seen: String,
+    errors: String,
+}
+
 mod output {
 
     //!
@@ -64,15 +74,7 @@ mod output {
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
-    #[derive(Serialize)]
-    pub struct HomeStatusRow {
-        pub home: String,
-        pub route: String,
-        pub sc_status: String,
-        pub spu_status: String,
-        pub last_seen: String,
-        pub errors: String,
-    }
+    use super::HomeStatusRow;
 
     #[derive(Serialize)]
     struct TableList(Vec<HomeStatusRow>);

--- a/crates/fluvio-cli/src/client/remote/list.rs
+++ b/crates/fluvio-cli/src/client/remote/list.rs
@@ -1,13 +1,13 @@
-pub use std::sync::Arc;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::Result;
 use clap::Parser;
+use serde::Serialize;
+
 use fluvio_extension_common::target::ClusterTarget;
 use fluvio_extension_common::{OutputFormat, Terminal};
 use fluvio_sc_schema::mirror::{MirrorSpec, MirrorType};
-
-use self::output::RemoteStatusRow;
 
 use super::get_admin;
 
@@ -16,6 +16,7 @@ pub struct ListOpt {
     #[clap(flatten)]
     output: OutputFormat,
 }
+
 impl ListOpt {
     pub async fn execute<T: Terminal>(
         self,
@@ -46,6 +47,15 @@ impl ListOpt {
     }
 }
 
+#[derive(Serialize)]
+struct RemoteStatusRow {
+    remote: String,
+    sc_status: String,
+    spu_status: String,
+    last_seen: String,
+    errors: String,
+}
+
 mod output {
 
     //!
@@ -61,14 +71,7 @@ mod output {
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
-    #[derive(Serialize)]
-    pub struct RemoteStatusRow {
-        pub remote: String,
-        pub sc_status: String,
-        pub spu_status: String,
-        pub last_seen: String,
-        pub errors: String,
-    }
+    use super::RemoteStatusRow;
 
     #[derive(Serialize)]
     struct TableList(Vec<RemoteStatusRow>);

--- a/crates/fluvio-cli/src/client/remote/list.rs
+++ b/crates/fluvio-cli/src/client/remote/list.rs
@@ -7,6 +7,8 @@ use fluvio_extension_common::target::ClusterTarget;
 use fluvio_extension_common::{OutputFormat, Terminal};
 use fluvio_sc_schema::mirror::{MirrorSpec, MirrorType};
 
+use self::output::RemoteStatusRow;
+
 use super::get_admin;
 
 #[derive(Debug, Parser)]
@@ -24,13 +26,18 @@ impl ListOpt {
         let list = admin.all::<MirrorSpec>().await?;
         let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
 
-        let outlist: Vec<(String, String, String)> = list
+        let outlist: Vec<RemoteStatusRow> = list
             .into_iter()
             .filter_map(|item| match item.spec.mirror_type {
                 MirrorType::Remote(r) => {
                     let status = item.status.clone();
-                    let last_seen = item.status.last_seen(now);
-                    Some((r.id, status.to_string(), last_seen))
+                    Some(RemoteStatusRow {
+                        remote: r.id,
+                        sc_status: status.pairing_sc.to_string(),
+                        spu_status: status.pairing_spu.to_string(),
+                        last_seen: item.status.last_seen(now),
+                        errors: status.pair_errors(),
+                    })
                 }
                 _ => None,
             })
@@ -46,7 +53,6 @@ mod output {
     //!
     use comfy_table::{Cell, Row};
     use comfy_table::CellAlignment;
-    use tracing::debug;
     use serde::Serialize;
     use anyhow::Result;
 
@@ -55,10 +61,17 @@ mod output {
     use fluvio_extension_common::output::TableOutputHandler;
     use fluvio_extension_common::t_println;
 
-    type ListVec = Vec<(String, String, String)>;
+    #[derive(Serialize)]
+    pub struct RemoteStatusRow {
+        pub remote: String,
+        pub sc_status: String,
+        pub spu_status: String,
+        pub last_seen: String,
+        pub errors: String,
+    }
 
     #[derive(Serialize)]
-    struct TableList(ListVec);
+    struct TableList(Vec<RemoteStatusRow>);
 
     // -----------------------------------
     // Format Output
@@ -66,11 +79,9 @@ mod output {
 
     pub fn format<O: Terminal>(
         out: std::sync::Arc<O>,
-        listvec: ListVec,
+        listvec: Vec<RemoteStatusRow>,
         output_type: OutputType,
     ) -> Result<()> {
-        debug!("listvec: {:#?}", listvec);
-
         if !listvec.is_empty() {
             let rlist = TableList(listvec);
             out.render_list(&rlist, output_type)?;
@@ -87,7 +98,7 @@ mod output {
     impl TableOutputHandler for TableList {
         /// table header implementation
         fn header(&self) -> Row {
-            Row::from(["REMOTE", "STATUS", "LAST SEEN"])
+            Row::from(["REMOTE", "SC STATUS", "SPU STATUS", "LAST SEEN", "ERRORS"])
         }
 
         /// return errors in string format
@@ -101,9 +112,11 @@ mod output {
                 .iter()
                 .map(|e| {
                     Row::from([
-                        Cell::new(&e.0).set_alignment(CellAlignment::Left),
-                        Cell::new(&e.1).set_alignment(CellAlignment::Left),
-                        Cell::new(&e.2).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.remote).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.sc_status).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.spu_status).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.last_seen).set_alignment(CellAlignment::Left),
+                        Cell::new(&e.errors).set_alignment(CellAlignment::Left),
                     ])
                 })
                 .collect()

--- a/crates/fluvio-controlplane-metadata/src/mirror/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirror/status.rs
@@ -47,13 +47,13 @@ impl MirrorStatus {
         self.connection_stat = other.connection_stat;
     }
 
-    pub fn pair_errors(&self) -> String {
-        match (self.pairing_sc.clone(), self.pairing_spu.clone()) {
-            (MirrorPairStatus::Failed(sc_err), MirrorPairStatus::Failed(spu_err)) => {
+    pub fn pair_errors(self) -> String {
+        match (self.pairing_sc, self.pairing_spu) {
+            (MirrorPairStatus::DetailFailure(sc_err), MirrorPairStatus::DetailFailure(spu_err)) => {
                 format!("SC: {} - SPU: {}", sc_err, spu_err)
             }
-            (MirrorPairStatus::Failed(sc_err), _) => sc_err,
-            (_, MirrorPairStatus::Failed(spu_err)) => spu_err,
+            (MirrorPairStatus::DetailFailure(sc_err), _) => sc_err,
+            (_, MirrorPairStatus::DetailFailure(spu_err)) => spu_err,
             _ => "-".to_string(),
         }
     }
@@ -68,11 +68,13 @@ pub enum MirrorPairStatus {
     #[fluvio(tag = 1)]
     Succesful,
     #[fluvio(tag = 2)]
-    Failed(String),
+    Failed,
     #[fluvio(tag = 3)]
     Disabled,
     #[fluvio(tag = 4)]
     Unauthorized,
+    #[fluvio(tag = 5)]
+    DetailFailure(String),
 }
 
 #[derive(Encoder, Decoder, Debug, Clone, Eq, PartialEq, Default)]
@@ -128,9 +130,10 @@ impl std::fmt::Display for MirrorPairStatus {
         let status = match self {
             MirrorPairStatus::Succesful => "Connected",
             MirrorPairStatus::Disabled => "Disabled",
-            MirrorPairStatus::Failed(_) => "Failed", // the msg is showed with pair_errors
+            MirrorPairStatus::Failed => "Failed",
             MirrorPairStatus::Waiting => "Waiting",
             MirrorPairStatus::Unauthorized => "Unauthorized",
+            MirrorPairStatus::DetailFailure(_) => "Failed", // the msg is showed with pair_errors
         };
         write!(f, "{}", status)
     }

--- a/crates/fluvio-controlplane-metadata/src/mirror/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirror/status.rs
@@ -73,7 +73,7 @@ pub enum MirrorPairStatus {
     Disabled,
     #[fluvio(tag = 4)]
     Unauthorized,
-    #[fluvio(tag = 5)]
+    #[fluvio(tag = 5, min_version = 17)]
     DetailFailure(String),
 }
 

--- a/crates/fluvio-controlplane/src/sc_api/api.rs
+++ b/crates/fluvio-controlplane/src/sc_api/api.rs
@@ -9,6 +9,8 @@ use fluvio_protocol::bytes::Buf;
 use fluvio_protocol::derive::Encoder;
 use fluvio_protocol::derive::Decoder;
 
+use crate::sc_api::update_mirror::UpdateMirrorStatRequest;
+
 use super::register_spu::RegisterSpuRequest;
 use super::update_lrs::UpdateLrsRequest;
 use super::remove::ReplicaRemovedRequest;
@@ -24,6 +26,7 @@ pub enum InternalScKey {
     RegisterSpu = 2000,
     UpdateLrs = 2001,
     ReplicaRemoved = 2002,
+    UpdateMirror = 2003,
 }
 
 /// Request made to Spu from Sc
@@ -35,6 +38,8 @@ pub enum InternalScRequest {
     UpdateLrsRequest(RequestMessage<UpdateLrsRequest>),
     #[fluvio(tag = 2)]
     ReplicaRemovedRequest(RequestMessage<ReplicaRemovedRequest>),
+    #[fluvio(tag = 3)]
+    UpdateMirrorStatRequest(RequestMessage<UpdateMirrorStatRequest>),
 }
 
 impl Default for InternalScRequest {
@@ -61,6 +66,9 @@ impl ApiMessage for InternalScRequest {
             }
             InternalScKey::ReplicaRemoved => {
                 api_decode!(InternalScRequest, ReplicaRemovedRequest, src, header)
+            }
+            InternalScKey::UpdateMirror => {
+                api_decode!(InternalScRequest, UpdateMirrorStatRequest, src, header)
             }
         }
     }

--- a/crates/fluvio-controlplane/src/sc_api/mod.rs
+++ b/crates/fluvio-controlplane/src/sc_api/mod.rs
@@ -2,3 +2,4 @@ pub mod api;
 pub mod register_spu;
 pub mod remove;
 pub mod update_lrs;
+pub mod update_mirror;

--- a/crates/fluvio-controlplane/src/sc_api/update_mirror.rs
+++ b/crates/fluvio-controlplane/src/sc_api/update_mirror.rs
@@ -1,0 +1,77 @@
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use fluvio_controlplane_metadata::mirror::MirrorStatus;
+use fluvio_protocol::api::Request;
+use fluvio_protocol::Decoder;
+use fluvio_protocol::Encoder;
+
+use super::api::InternalScKey;
+
+/// Live Mirror Status
+#[derive(Decoder, Encoder, Debug, Default, Clone)]
+pub struct UpdateMirrorStatRequest {
+    stats: Vec<MirrorStatRequest>,
+}
+
+impl UpdateMirrorStatRequest {
+    pub fn new(stats: Vec<MirrorStatRequest>) -> Self {
+        Self { stats }
+    }
+
+    /// make into vec of requests
+    pub fn into_stats(self) -> Vec<MirrorStatRequest> {
+        self.stats
+    }
+}
+
+impl fmt::Display for UpdateMirrorStatRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "mirror updates {}", self.stats.len())
+    }
+}
+
+impl Request for UpdateMirrorStatRequest {
+    const API_KEY: u16 = InternalScKey::UpdateMirror as u16;
+    type Response = UpdateMirrorResponse;
+}
+
+#[derive(Decoder, Encoder, Default, Debug)]
+pub struct UpdateMirrorResponse {}
+
+/// Request to update replica status
+#[derive(Decoder, Encoder, Debug, Default, Clone)]
+pub struct MirrorStatRequest {
+    pub mirror_id: String,
+    pub status: MirrorStatus,
+}
+
+impl PartialEq for MirrorStatRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.mirror_id == other.mirror_id
+    }
+}
+
+impl Eq for MirrorStatRequest {}
+
+// we only care about id for hashing
+impl Hash for MirrorStatRequest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.mirror_id.hash(state);
+    }
+}
+
+impl fmt::Display for MirrorStatRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MirrorUpdate {}", self.mirror_id)
+    }
+}
+
+impl MirrorStatRequest {
+    pub fn new(id: String, status: MirrorStatus) -> Self {
+        Self {
+            mirror_id: id,
+            status,
+        }
+    }
+}

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc-schema"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"

--- a/crates/fluvio-sc-schema/src/objects/mod.rs
+++ b/crates/fluvio-sc-schema/src/objects/mod.rs
@@ -15,7 +15,7 @@ pub use list::*;
 pub use watch::*;
 pub use metadata::*;
 
-pub(crate) const COMMON_VERSION: i16 = 16; // from now, we use a single version for all objects
+pub(crate) const COMMON_VERSION: i16 = 17; // from now, we use a single version for all objects
 pub(crate) const DYN_OBJ: i16 = 11; // version indicate dynamic object
 
 #[cfg(test)]

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -22,6 +22,7 @@ required-features = []
 default = []
 
 [dependencies]
+adaptive_backoff = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async-lock = { workspace = true }

--- a/crates/fluvio-sc/src/controllers/mirroring/controller.rs
+++ b/crates/fluvio-sc/src/controllers/mirroring/controller.rs
@@ -1,9 +1,10 @@
 use std::time::{Duration, SystemTime};
+
 use tracing::{debug, error, info, instrument};
 use anyhow::{anyhow, Result};
 
 use fluvio::config::TlsPolicy;
-use fluvio_socket::{ClientConfig, MultiplexerSocket, StreamSocket};
+use fluvio_socket::{AsyncResponse, ClientConfig, MultiplexerSocket, StreamSocket};
 use futures_util::StreamExt;
 use fluvio_future::{net::DomainConnector, task::spawn, timer::sleep};
 use fluvio_sc_schema::{
@@ -20,7 +21,7 @@ use fluvio_controlplane_metadata::mirroring::{
 
 use crate::core::SharedContext;
 
-const MIRRORING_CONTROLLER_INTERVAL: u64 = 5;
+const MIRRORING_CONTROLLER_INTERVAL: u64 = 1;
 const MIRRORING_CONTROLLER_RETRY_INTERVAL: u64 = 10;
 
 // This is the main controller for the mirroring feature.
@@ -43,14 +44,15 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
 
     #[instrument(skip(self), name = "MirroringControllerLoop")]
     async fn dispatch_loop(self) {
-        info!("started");
         loop {
             if let Err(err) = self.inner_loop().await {
                 error!("error with inner loop: {:#?}", err);
-                debug!(
-                    "sleeping {} seconds try again",
-                    MIRRORING_CONTROLLER_RETRY_INTERVAL
-                );
+                if let Err(err) = self
+                    .update_status(MirrorPairStatus::Failed(err.to_string()))
+                    .await
+                {
+                    error!("error updating status: {:#?}", err);
+                }
                 sleep(Duration::from_secs(MIRRORING_CONTROLLER_RETRY_INTERVAL)).await;
             }
         }
@@ -58,82 +60,13 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
 
     #[instrument(skip(self))]
     async fn inner_loop(&self) -> Result<()> {
-        debug!("initializing listeners");
-
         loop {
-            let home_mirrors = self
-                .mirrors
-                .store()
-                .read()
-                .await
-                .values()
-                .filter_map(|r| match r.spec().mirror_type.clone() {
-                    MirrorType::Home(h) => Some(h),
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
-
-            if let Some(home) = home_mirrors.first() {
-                //send to home cluster the connect request
-                let tlspolicy = option_tlspolicy(home);
-
-                // handling tls
-                let home_config = if let Some(tlspolicy) = &tlspolicy {
-                    match DomainConnector::try_from(tlspolicy.clone()) {
-                        Ok(connector) => {
-                            ClientConfig::new(home.public_endpoint.clone(), connector, false)
-                        }
-                        Err(err) => {
-                            error!(
-                                "error establishing tls with leader at: <{}> err: {}",
-                                home.public_endpoint.clone(),
-                                err
-                            );
-                            let now = SystemTime::now()
-                                .duration_since(SystemTime::UNIX_EPOCH)?
-                                .as_millis();
-                            let status = MirrorStatus::new(
-                                MirrorPairStatus::Failed,
-                                ConnectionStatus::Online,
-                                now as u64,
-                            );
-                            self.mirrors.update_status(home.id.clone(), status).await?;
-                            return Err(err);
-                        }
-                    }
-                } else {
-                    ClientConfig::with_addr(home.public_endpoint.clone())
-                };
-
-                let versioned_socket = home_config.connect().await?;
-                let (socket, config, versions) = versioned_socket.split();
-                info!("connecting to home: {}", home.public_endpoint);
-
-                let request = MirrorConnect {
-                    remote_id: home.remote_id.clone(),
-                };
-                debug!("sending connect request: {:#?}", request);
-
-                let mut stream_socket =
-                    StreamSocket::new(config, MultiplexerSocket::shared(socket), versions.clone());
-
-                let version = versions
-                    .lookup_version::<ObjectMirroringRequest>()
-                    .ok_or(anyhow!("no version found for mirroring request"))?;
-
-                let req = ObjectMirroringRequest::try_encode_from(
-                    MirroringRemoteClusterRequest { request },
-                    version,
-                )?;
-
-                let mut stream = stream_socket
-                    .create_stream_with_version(req, version)
-                    .await?;
+            if let Some((home, _)) = self.get_mirror_home_cluster().await {
+                debug!("initializing listeners");
+                let home_config = self.build_home_client(&home).await?;
+                let mut stream = self.request_stream(&home, home_config).await?;
 
                 while let Some(response) = stream.next().await {
-                    let now = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)?
-                        .as_millis();
                     match response {
                         Ok(response) => {
                             debug!("received response: {:#?}", response);
@@ -147,25 +80,14 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
                                 .await?;
 
                             for topic in response.topics.iter() {
-                                self.sync_topic(home, topic).await?;
+                                self.sync_topic(&home, topic).await?;
                             }
 
-                            let status = MirrorStatus::new(
-                                MirrorPairStatus::Succesful,
-                                ConnectionStatus::Online,
-                                now as u64,
-                            );
-                            self.mirrors.update_status(home.id.clone(), status).await?;
+                            debug!("synced topics from home");
+                            self.update_status(MirrorPairStatus::Succesful).await?;
                         }
                         Err(err) => {
-                            debug!("received error: {:#?}", err);
-                            let status = MirrorStatus::new(
-                                MirrorPairStatus::Failed,
-                                ConnectionStatus::Online,
-                                now as u64,
-                            );
-                            self.mirrors.update_status(home.id.clone(), status).await?;
-
+                            error!("received error: {:#?}", err);
                             return Err(err.into());
                         }
                     }
@@ -173,11 +95,80 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
             }
 
             debug!(
-                "sleeping {} seconds before next iteration",
+                "sleeping {}s before next iteration",
                 MIRRORING_CONTROLLER_INTERVAL
             );
             sleep(Duration::from_secs(MIRRORING_CONTROLLER_INTERVAL)).await;
         }
+    }
+
+    async fn request_stream(
+        &self,
+        home: &Home,
+        home_config: ClientConfig,
+    ) -> Result<AsyncResponse<ObjectMirroringRequest>> {
+        let versioned_socket = home_config.connect().await?;
+        let (socket, config, versions) = versioned_socket.split();
+        info!(endpoint = home.public_endpoint, "connection to home");
+
+        let request = MirrorConnect {
+            remote_id: home.remote_id.clone(),
+        };
+        debug!(request = ?request, "sending connect request");
+
+        let mut stream_socket =
+            StreamSocket::new(config, MultiplexerSocket::shared(socket), versions.clone());
+
+        let version = versions
+            .lookup_version::<ObjectMirroringRequest>()
+            .ok_or(anyhow!("no version found for mirroring request"))?;
+
+        let req = ObjectMirroringRequest::try_encode_from(
+            MirroringRemoteClusterRequest { request },
+            version,
+        )?;
+
+        let stream = stream_socket
+            .create_stream_with_version(req, version)
+            .await?;
+
+        Ok(stream)
+    }
+
+    // Build the home client
+    async fn build_home_client(&self, home: &Home) -> Result<ClientConfig> {
+        let tlspolicy = option_tlspolicy(home);
+
+        // handling tls
+        if let Some(tlspolicy) = tlspolicy {
+            match DomainConnector::try_from(tlspolicy.clone()) {
+                Ok(connector) => Ok(ClientConfig::new(
+                    home.public_endpoint.clone(),
+                    connector,
+                    false,
+                )),
+                Err(err) => {
+                    error!(
+                        "error establishing tls with leader at: <{}> err: {}",
+                        home.public_endpoint.clone(),
+                        err
+                    );
+                    Err(err)
+                }
+            }
+        } else {
+            Ok(ClientConfig::with_addr(home.public_endpoint.clone()))
+        }
+    }
+
+    // Get the mirror home
+    async fn get_mirror_home_cluster(&self) -> Option<(Home, MirrorStatus)> {
+        self.mirrors.store().read().await.values().find_map(|r| {
+            match r.spec().mirror_type.clone() {
+                MirrorType::Home(h) => Some((h, r.status.clone())),
+                _ => None,
+            }
+        })
     }
 
     // Delete topics that are not in the response
@@ -264,6 +255,22 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
             .create_spec(topic.key.clone(), remote_topic)
             .await?;
 
+        Ok(())
+    }
+
+    // Update the status of the mirror
+    async fn update_status(&self, pair_status: MirrorPairStatus) -> Result<()> {
+        let (home, status) = self
+            .get_mirror_home_cluster()
+            .await
+            .ok_or(anyhow!("no home cluster found"))?;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_millis();
+        let new_status = MirrorStatus::new(pair_status, ConnectionStatus::Online, now as u64);
+        let mut status = status.clone();
+        status.merge_from_sc(new_status);
+        self.mirrors.update_status(home.id.clone(), status).await?;
         Ok(())
     }
 }

--- a/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
+++ b/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
@@ -107,7 +107,7 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
                 let remote = self.get_remote_mirror().await;
                 if let Ok((_, status)) = remote {
                     if let Err(err) = self
-                        .update_status(MirrorPairStatus::Failed(err.to_string()), status)
+                        .update_status(MirrorPairStatus::DetailFailure(err.to_string()), status)
                         .await
                     {
                         error!("error updating status: {}", err);
@@ -118,11 +118,11 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
 
             select! {
                 _ = self.end_event.listen() => {
-                    debug!("connection has been terminated");
+                    info!("connection has been terminated");
                     let remote = self.get_remote_mirror().await;
                     if let Ok((_, status)) = remote {
                         if let Err(err) = self
-                            .update_status(MirrorPairStatus::Failed("connection closed".to_owned()), status)
+                            .update_status(MirrorPairStatus::DetailFailure("connection closed".to_owned()), status)
                             .await
                         {
                             error!("error updating status: {}", err);

--- a/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
+++ b/crates/fluvio-sc/src/services/public_api/mirroring/connect.rs
@@ -2,7 +2,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, warn};
 use anyhow::{Result, anyhow};
 
 use fluvio_auth::{AuthContext, InstanceAction};
@@ -14,7 +14,7 @@ use fluvio_future::{task::spawn, timer::sleep};
 use fluvio_protocol::api::{RequestHeader, ResponseMessage};
 use fluvio_sc_schema::{
     core::MetadataItem,
-    mirror::{ConnectionStatus, MirrorPairStatus, MirrorStatus, MirrorType},
+    mirror::{ConnectionStatus, MirrorPairStatus, MirrorSpec, MirrorStatus, MirrorType},
     spu::SpuSpec,
     store::ChangeListener,
     topic::{MirrorConfig, ReplicaSpec, TopicSpec},
@@ -59,38 +59,37 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
     async fn dispatch_loop(mut self) {
         use tokio::select;
 
-        // authorization check
-        if let Ok(authorized) = self
-            .auth_ctx
-            .auth
-            .allow_instance_action(
-                ObjectType::Mirror,
-                InstanceAction::Update,
-                &self.req.remote_id,
-            )
-            .await
-        {
-            if !authorized {
-                warn!("identity mismatch for remote_id: {}", self.req.remote_id);
-                return;
+        if let Ok((_, status)) = self.get_remote_mirror().await {
+            // authorization check
+            if let Ok(authorized) = self
+                .auth_ctx
+                .auth
+                .allow_instance_action(
+                    ObjectType::Mirror,
+                    InstanceAction::Update,
+                    &self.req.remote_id,
+                )
+                .await
+            {
+                if !authorized {
+                    if let Err(err) = self
+                        .update_status(MirrorPairStatus::Unauthorized, status)
+                        .await
+                    {
+                        error!("error updating status: {}", err);
+                    }
+                    warn!("identity mismatch for remote_id: {}", self.req.remote_id);
+                    return;
+                }
             }
+        } else {
+            // check if remote cluster exists
+            error!("remote cluster not found: {}", self.req.remote_id);
+            return;
         }
 
         let ctx = self.auth_ctx.global_ctx.clone();
 
-        // check if remote cluster exists
-        let mirrors = ctx.mirrors().store().value(&self.req.remote_id).await;
-        let remote = mirrors
-            .iter()
-            .find(|mirror| match &mirror.spec.mirror_type {
-                MirrorType::Remote(r) => r.id == self.req.remote_id,
-                _ => false,
-            });
-
-        if remote.is_none() {
-            warn!("remote cluster not found: {}", self.req.remote_id);
-            return;
-        }
         info!(
             name = self.req.remote_id,
             "received mirroring connect request"
@@ -100,19 +99,35 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
         let mut spus_listerner = ctx.spus().change_listener();
 
         loop {
-            if self
+            if let Err(err) = self
                 .sync_and_send_topics(&mut topics_listener, &mut spus_listerner)
                 .await
-                .is_err()
             {
-                self.end_event.notify();
+                error!("error syncing topics: {}", err);
+                let remote = self.get_remote_mirror().await;
+                if let Ok((_, status)) = remote {
+                    if let Err(err) = self
+                        .update_status(MirrorPairStatus::Failed(err.to_string()), status)
+                        .await
+                    {
+                        error!("error updating status: {}", err);
+                    }
+                }
                 break;
             }
 
-            trace!("{}: waiting for changes", self.req.remote_id);
             select! {
                 _ = self.end_event.listen() => {
                     debug!("connection has been terminated");
+                    let remote = self.get_remote_mirror().await;
+                    if let Ok((_, status)) = remote {
+                        if let Err(err) = self
+                            .update_status(MirrorPairStatus::Failed("connection closed".to_owned()), status)
+                            .await
+                        {
+                            error!("error updating status: {}", err);
+                        }
+                    }
                     break;
                 },
 
@@ -131,7 +146,28 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
         }
     }
 
-    #[instrument(skip(self, topics_listener))]
+    async fn get_remote_mirror(&self) -> Result<(MirrorSpec, MirrorStatus)> {
+        let ctx = self.auth_ctx.global_ctx.clone();
+        let mirrors = ctx.mirrors().store().value(&self.req.remote_id).await;
+        let remote = mirrors
+            .iter()
+            .find(|mirror| match &mirror.spec.mirror_type {
+                MirrorType::Remote(r) => r.id == (self.req.remote_id),
+                _ => false,
+            });
+
+        if let Some(remote) = remote {
+            return Ok((
+                remote.inner().spec().clone(),
+                remote.inner().status().clone(),
+            ));
+        }
+
+        warn!("remote cluster not found: {}", self.req.remote_id);
+        Err(anyhow!("remote cluster not found: {}", self.req.remote_id))
+    }
+
+    #[instrument(skip(self))]
     async fn sync_and_send_topics(
         &mut self,
         topics_listener: &mut ChangeListener<TopicSpec, C>,
@@ -189,12 +225,8 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
 
         match ctx.mirrors().store().value(&self.req.remote_id).await {
             Some(remote) => {
-                let now = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis();
-
                 let remote_name = remote.spec().to_string();
+                let status = remote.inner().status().clone();
                 let response = MirroringStatusResponse::new_ok(&remote_name, mirror_topics);
                 let resp_msg = ResponseMessage::from_header(&self.header, response);
 
@@ -204,40 +236,41 @@ impl<AC: AuthContext, C: MetadataItem> RemoteFetchingFromHomeController<AC, C> {
                     .send_response(&resp_msg, self.header.api_version())
                     .await
                 {
-                    let status = MirrorStatus::new(
-                        MirrorPairStatus::Failed,
-                        ConnectionStatus::Online,
-                        now as u64,
-                    );
-
-                    ctx.mirrors()
-                        .update_status(remote.key.clone(), status)
-                        .await?;
-                    error!(
-                        "error mirroring sending {}, correlation_id: {}, err: {}",
-                        self.req.remote_id,
-                        self.header.correlation_id(),
-                        err
-                    );
                     return Err(anyhow!("error sending response, err: {}", err));
                 }
 
                 // update status
-                let status = MirrorStatus::new(
-                    MirrorPairStatus::Succesful,
-                    ConnectionStatus::Online,
-                    now as u64,
-                );
-                ctx.mirrors()
-                    .update_status(remote.key.clone(), status)
+                self.update_status(MirrorPairStatus::Succesful, status)
                     .await?;
 
                 return Ok(());
             }
             None => {
-                error!("remote cluster not found: {}", self.req.remote_id);
                 return Err(anyhow!("remote cluster not found: {}", self.req.remote_id));
             }
         }
+    }
+
+    async fn update_status(
+        &self,
+        pair_status: MirrorPairStatus,
+        status: MirrorStatus,
+    ) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_millis();
+
+        let new_status =
+            MirrorStatus::new(pair_status.clone(), ConnectionStatus::Online, now as u64);
+        let mut status = status.clone();
+        status.merge_from_sc(new_status);
+
+        self.auth_ctx
+            .global_ctx
+            .mirrors()
+            .update_status(self.req.remote_id.clone(), status)
+            .await?;
+
+        Ok(())
     }
 }

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/server/mirror.rs
+++ b/crates/fluvio-spu-schema/src/server/mirror.rs
@@ -11,7 +11,6 @@ use super::SpuServerApiKey;
 pub struct StartMirrorRequest {
     pub remote_replica: String,
     pub remote_cluster_id: String,
-    pub access_key: String,
 }
 
 impl Request for StartMirrorRequest {

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -22,7 +22,7 @@ use fluvio_storage::FileReplica;
 
 use crate::core::SharedGlobalContext;
 
-use super::message_sink::SharedStatusUpdate;
+use super::message_sink::SharedLrsStatusUpdate;
 use super::SharedMirrorStatusUpdate;
 
 // keep track of various internal state of dispatcher
@@ -39,7 +39,7 @@ struct DispatcherCounter {
 /// including registering and reconnect
 pub struct ScDispatcher<S> {
     ctx: SharedGlobalContext<S>,
-    status_update: SharedStatusUpdate,
+    status_update: SharedLrsStatusUpdate,
     mirror_status_update: SharedMirrorStatusUpdate,
     counter: DispatcherCounter,
 }

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use fluvio_controlplane::sc_api::update_mirror::UpdateMirrorStatRequest;
 use fluvio_controlplane::spu_api::update_mirror::UpdateMirrorRequest;
 use tracing::{info, trace, error, debug, warn, instrument};
 use tokio::select;
@@ -22,6 +23,7 @@ use fluvio_storage::FileReplica;
 use crate::core::SharedGlobalContext;
 
 use super::message_sink::SharedStatusUpdate;
+use super::SharedMirrorStatusUpdate;
 
 // keep track of various internal state of dispatcher
 #[derive(Default)]
@@ -30,6 +32,7 @@ struct DispatcherCounter {
     pub spu_changes: u64,     // spu changes received from sc
     pub reconnect: u64,       // number of reconnect to sc
     pub smartmodule: u64,     // number of sm updates from sc
+    pub mirror: u64,          // number of mirror updates from sc
 }
 
 /// Controller for handling connection to SC
@@ -37,6 +40,7 @@ struct DispatcherCounter {
 pub struct ScDispatcher<S> {
     ctx: SharedGlobalContext<S>,
     status_update: SharedStatusUpdate,
+    mirror_status_update: SharedMirrorStatusUpdate,
     counter: DispatcherCounter,
 }
 
@@ -44,6 +48,7 @@ impl ScDispatcher<FileReplica> {
     pub fn new(ctx: SharedGlobalContext<FileReplica>) -> Self {
         Self {
             status_update: ctx.status_update_owned(),
+            mirror_status_update: ctx.mirror_status_update_owned(),
             ctx,
             counter: DispatcherCounter::default(),
         }
@@ -131,6 +136,7 @@ impl ScDispatcher<FileReplica> {
 
                 _ = status_timer.next() =>  {
                     self.send_status_back_to_sc(&mut sink).await?;
+                    self.send_mirror_status_back_to_sc(&mut sink).await?;
                 },
 
                 sc_request = api_stream.next() => {
@@ -155,6 +161,7 @@ impl ScDispatcher<FileReplica> {
                             }
                         },
                         Some(Ok(InternalSpuRequest::UpdateMirrorRequest(request))) => {
+                            self.counter.mirror += 1;
                             if let Err(err) = self.handle_update_mirror_request(request).await {
                                 error!(%err, "error handling update mirror request", );
                                 break;
@@ -191,6 +198,23 @@ impl ScDispatcher<FileReplica> {
         }
         let message = RequestMessage::new_request(UpdateLrsRequest::new(requests));
 
+        sc_sink
+            .send_request(&message)
+            .await
+            .map_err(|err| anyhow!("error sending status back to sc: {}", err))
+    }
+
+    /// send mirror status back to sc, if there is error return false
+    #[instrument(skip(self))]
+    async fn send_mirror_status_back_to_sc(&mut self, sc_sink: &mut FluvioSink) -> Result<()> {
+        let requests = self.mirror_status_update.remove_all().await;
+
+        if requests.is_empty() {
+            return Ok(());
+        }
+
+        trace!(requests = ?requests, "sending mirror status back to sc");
+        let message = RequestMessage::new_request(UpdateMirrorStatRequest::new(requests));
         sc_sink
             .send_request(&message)
             .await

--- a/crates/fluvio-spu/src/control_plane/dispatcher.rs
+++ b/crates/fluvio-spu/src/control_plane/dispatcher.rs
@@ -135,7 +135,7 @@ impl ScDispatcher<FileReplica> {
             select! {
 
                 _ = status_timer.next() =>  {
-                    self.send_status_back_to_sc(&mut sink).await?;
+                    self.send_lrs_status_back_to_sc(&mut sink).await?;
                     self.send_mirror_status_back_to_sc(&mut sink).await?;
                 },
 
@@ -188,7 +188,7 @@ impl ScDispatcher<FileReplica> {
 
     /// send status back to sc, if there is error return false
     #[instrument(skip(self))]
-    async fn send_status_back_to_sc(&mut self, sc_sink: &mut FluvioSink) -> Result<()> {
+    async fn send_lrs_status_back_to_sc(&mut self, sc_sink: &mut FluvioSink) -> Result<()> {
         let requests = self.status_update.remove_all().await;
 
         if requests.is_empty() {

--- a/crates/fluvio-spu/src/control_plane/message_sink.rs
+++ b/crates/fluvio-spu/src/control_plane/message_sink.rs
@@ -1,29 +1,52 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::SystemTime;
 
+use anyhow::Result;
 use async_lock::Mutex;
 use fluvio_controlplane::sc_api::update_lrs::LrsRequest;
+use fluvio_controlplane::sc_api::update_mirror::MirrorStatRequest;
+use fluvio_controlplane_metadata::mirror::{MirrorPairStatus, MirrorStatus};
 
 pub type SharedStatusUpdate = Arc<StatusMessageSink>;
+pub type SharedMirrorStatusUpdate = Arc<StatusMirrorMessageSink>;
 
 /// channel used to send message to sc
 #[derive(Debug)]
-pub struct StatusMessageSink(Mutex<HashSet<LrsRequest>>);
+pub struct MessageSink<R>(Mutex<HashSet<R>>);
 
-impl StatusMessageSink {
+pub type StatusMessageSink = MessageSink<LrsRequest>;
+pub type StatusMirrorMessageSink = MessageSink<MirrorStatRequest>;
+
+impl<R> MessageSink<R>
+where
+    R: Eq + std::hash::Hash + Clone,
+{
     pub fn shared() -> Arc<Self> {
         Arc::new(Self(Mutex::new(HashSet::new())))
     }
 
     /// send lrs request sc
     /// newer entry will overwrite previous if it has not been cleared
-    pub async fn send(&self, request: LrsRequest) {
+    pub async fn send(&self, request: R) {
         let mut lock = self.0.lock().await;
         lock.replace(request);
     }
 
-    pub async fn remove_all(&self) -> Vec<LrsRequest> {
+    pub async fn remove_all(&self) -> Vec<R> {
         let mut lock = self.0.lock().await;
         lock.drain().collect()
+    }
+}
+
+impl StatusMirrorMessageSink {
+    pub async fn send_status(&self, id: String, pair_status: MirrorPairStatus) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_millis();
+
+        let status = MirrorStatus::new_by_spu(pair_status, now as u64);
+        self.send(MirrorStatRequest::new(id, status)).await;
+        Ok(())
     }
 }

--- a/crates/fluvio-spu/src/control_plane/message_sink.rs
+++ b/crates/fluvio-spu/src/control_plane/message_sink.rs
@@ -8,14 +8,14 @@ use fluvio_controlplane::sc_api::update_lrs::LrsRequest;
 use fluvio_controlplane::sc_api::update_mirror::MirrorStatRequest;
 use fluvio_controlplane_metadata::mirror::{MirrorPairStatus, MirrorStatus};
 
-pub type SharedStatusUpdate = Arc<StatusMessageSink>;
+pub type SharedLrsStatusUpdate = Arc<StatusLrsMessageSink>;
 pub type SharedMirrorStatusUpdate = Arc<StatusMirrorMessageSink>;
 
 /// channel used to send message to sc
 #[derive(Debug)]
 pub struct MessageSink<R>(Mutex<HashSet<R>>);
 
-pub type StatusMessageSink = MessageSink<LrsRequest>;
+pub type StatusLrsMessageSink = MessageSink<LrsRequest>;
 pub type StatusMirrorMessageSink = MessageSink<MirrorStatRequest>;
 
 impl<R> MessageSink<R>

--- a/crates/fluvio-spu/src/core/global_context.rs
+++ b/crates/fluvio-spu/src/core/global_context.rs
@@ -12,6 +12,8 @@ use fluvio_types::SpuId;
 use fluvio_storage::ReplicaStorage;
 
 use crate::config::SpuConfig;
+use crate::control_plane::SharedMirrorStatusUpdate;
+use crate::control_plane::StatusMirrorMessageSink;
 use crate::kv::consumer::SharedConsumerOffsetStorages;
 use crate::replication::follower::FollowersState;
 use crate::replication::follower::SharedFollowersState;
@@ -45,6 +47,7 @@ pub struct GlobalContext<S> {
     followers_state: SharedFollowersState<S>,
     spu_followers: SharedSpuUpdates,
     status_update: SharedStatusUpdate,
+    mirror_status_update: SharedMirrorStatusUpdate,
     sm_engine: SmartEngine,
     leaders: Arc<LeaderConnections>,
     mirrors: SharedMirrorLocalStore,
@@ -78,6 +81,7 @@ where
             followers_state: FollowersState::new_shared(),
             spu_followers: FollowerNotifier::shared(),
             status_update: StatusMessageSink::shared(),
+            mirror_status_update: StatusMirrorMessageSink::shared(),
             sm_engine: SmartEngine::new(),
             leaders: LeaderConnections::shared(spus, replicas),
             mirrors: MirrorLocalStore::new_shared(),
@@ -111,7 +115,6 @@ where
         &self.mirrors
     }
 
-    #[allow(dead_code)]
     pub fn mirrors_localstore_owned(&self) -> SharedMirrorLocalStore {
         self.mirrors.clone()
     }
@@ -147,6 +150,15 @@ where
 
     pub fn status_update_owned(&self) -> SharedStatusUpdate {
         self.status_update.clone()
+    }
+
+    #[allow(unused)]
+    pub fn mirror_status_update(&self) -> &StatusMirrorMessageSink {
+        &self.mirror_status_update
+    }
+
+    pub fn mirror_status_update_owned(&self) -> SharedMirrorStatusUpdate {
+        self.mirror_status_update.clone()
     }
 
     /// notify all follower handlers with SPU changes

--- a/crates/fluvio-spu/src/kv/consumer.rs
+++ b/crates/fluvio-spu/src/kv/consumer.rs
@@ -200,7 +200,7 @@ mod tests {
 
     use crate::{
         config::ReplicationConfig, storage::SharableReplicaStorage,
-        control_plane::StatusMessageSink,
+        control_plane::StatusLrsMessageSink,
     };
 
     use super::*;
@@ -257,7 +257,7 @@ mod tests {
         let replica_id = ReplicaKey::new("topic", PartitionId::default());
         let replication_config = ReplicationConfig::default();
         let replica = Replica::new(replica_id.clone(), 5000, vec![5000]);
-        let status_update = StatusMessageSink::shared();
+        let status_update = StatusLrsMessageSink::shared();
 
         let storage = SharableReplicaStorage::create(replica_id, config)
             .await

--- a/crates/fluvio-spu/src/mirroring/home/connection.rs
+++ b/crates/fluvio-spu/src/mirroring/home/connection.rs
@@ -137,7 +137,7 @@ impl MirrorHomeHandler {
                 if let Err(err) = mirror_status_update
                     .send_status(
                         remote_cluster_id.clone(),
-                        MirrorPairStatus::Failed(err.to_string()),
+                        MirrorPairStatus::DetailFailure(err.to_string()),
                     )
                     .await
                 {
@@ -194,7 +194,7 @@ impl MirrorHomeHandler {
                          }
 
                     } else {
-                        self.update_status(MirrorPairStatus::Failed("closed connection".to_owned())).await?;
+                        self.update_status(MirrorPairStatus::DetailFailure("closed connection".to_owned())).await?;
                         debug!("leader socket has terminated");
                         break;
                     }

--- a/crates/fluvio-spu/src/mirroring/remote/controller.rs
+++ b/crates/fluvio-spu/src/mirroring/remote/controller.rs
@@ -4,7 +4,7 @@ use std::{
         atomic::{AtomicI64, AtomicU64, Ordering},
         Arc,
     },
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 
 use tokio::select;
@@ -15,10 +15,9 @@ use adaptive_backoff::prelude::{
 };
 
 use fluvio::config::TlsPolicy;
-use fluvio_controlplane::sc_api::update_mirror::MirrorStatRequest;
 use futures_util::StreamExt;
 use fluvio_controlplane_metadata::{
-    mirror::{Home, MirrorPairStatus, MirrorStatus, MirrorType},
+    mirror::{Home, MirrorPairStatus, MirrorType},
     partition::RemotePartitionConfig,
 };
 use fluvio_storage::{ReplicaStorage, FileReplica};

--- a/crates/fluvio-spu/src/replication/leader/kv.rs
+++ b/crates/fluvio-spu/src/replication/leader/kv.rs
@@ -157,7 +157,7 @@ mod tests {
     use futures_util::StreamExt;
 
     use crate::{
-        config::ReplicationConfig, control_plane::StatusMessageSink,
+        config::ReplicationConfig, control_plane::StatusLrsMessageSink,
         storage::SharableReplicaStorage,
     };
 
@@ -340,7 +340,7 @@ mod tests {
         let replica_id = ReplicaKey::new("topic", PartitionId::default());
         let replication_config = ReplicationConfig::default();
         let replica = Replica::new(replica_id.clone(), 5000, vec![5000]);
-        let status_update = StatusMessageSink::shared();
+        let status_update = StatusLrsMessageSink::shared();
 
         let storage = SharableReplicaStorage::create(replica_id, config)
             .await

--- a/crates/fluvio-spu/src/replication/leader/leaders_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/leaders_state.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use fluvio_controlplane_metadata::partition::{PartitionMirrorConfig, ReplicaKey};
 use fluvio_storage::{FileReplica, ReplicaStorage};
 
-use crate::{control_plane::SharedStatusUpdate, core::GlobalContext};
+use crate::{control_plane::SharedLrsStatusUpdate, core::GlobalContext};
 use crate::config::ReplicationConfig;
 use crate::replication::follower::FollowerReplicaState;
 
@@ -109,7 +109,7 @@ impl ReplicaLeadersState<FileReplica> {
         &self,
         ctx: &GlobalContext<FileReplica>,
         replica: Replica,
-        status_update: SharedStatusUpdate,
+        status_update: SharedLrsStatusUpdate,
     ) -> Result<LeaderReplicaState<FileReplica>> {
         let replica_id = replica.id.clone();
 
@@ -148,7 +148,7 @@ impl ReplicaLeadersState<FileReplica> {
         config: ReplicationConfig,
         follower: FollowerReplicaState<FileReplica>,
         replica: Replica,
-        status_update: SharedStatusUpdate,
+        status_update: SharedLrsStatusUpdate,
         ctx: &GlobalContext<FileReplica>,
     ) -> Result<LeaderReplicaState<FileReplica>> {
         let replica_id = replica.id.clone();

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
+++ b/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
@@ -122,14 +122,24 @@ setup_file() {
 }
 
 @test "Can connect to the home cluster from remote 1" {
+    sleep 2
     run timeout 15s "$FLUVIO_BIN" home connect --file remote.json
 
     assert_output "connecting with \"$HOME_NAME\" cluster"
     assert_success
 }
 
+@test "Home status at remote 1 should show the home cluster connected" {
+    sleep 15
+    run timeout 15s "$FLUVIO_BIN" home status
+
+    assert_success
+    assert_line --partial --index 1 "Connected  Connected"
+    assert [ ${#lines[@]} -eq 2 ]
+}
+
 @test "Can produce message to mirror topic from remote 1" {
-    sleep 5
+    sleep 2
     run bash -c 'echo 1 | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
     assert_success
     run bash -c 'echo a | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
@@ -147,14 +157,24 @@ setup_file() {
 }
 
 @test "Can connect to the home cluster from remote 2" {
+    sleep 2
     run timeout 15s "$FLUVIO_BIN" home connect --file remote2.json
 
     assert_output "connecting with \"$HOME_NAME\" cluster"
     assert_success
 }
 
+@test "Home status at remote 2 should show the home cluster connected" {
+    sleep 15
+    run timeout 15s "$FLUVIO_BIN" home status
+
+    assert_success
+    assert_line --partial --index 1 "Connected  Connected"
+    assert [ ${#lines[@]} -eq 2 ]
+}
+
 @test "Can produce message to mirror topic" {
-    sleep 5
+    sleep 2
     run bash -c 'echo 9 | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
     assert_success
     run bash -c 'echo z | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME"'
@@ -176,6 +196,16 @@ setup_file() {
     run timeout 15s "$FLUVIO_BIN" profile switch "$HOME_PROFILE"
     assert_output ""
     assert_success
+}
+
+@test "Remote list should show the remote clusters connected" {
+    sleep 2
+    run timeout 15s "$FLUVIO_BIN" remote list
+
+    assert_success
+    assert_line --partial --index 1 "Connected  Connected"
+    assert_line --partial --index 2 "Connected  Connected"
+    assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "Can consume message from mirror topic produced from remote 1 by partition or remote" {


### PR DESCRIPTION
This PR aims to improve the feedback of the SPU-to-SPU connection on mirroring. Also improving the feedback of the failures showing errors.

# Changes
- Add two new columns (SPU STATUS and ERRORS) for `fluvio remote list` and `fluvio home status` commands
- Mirror Failed Status Enum now stores an error.
- New private SC API to receive the status from SPU
- A dispatcher on SC to apply these new status

# Error column

The new error column will show the error from SPU or SC or both. 
When both will be "SC:ERROR SPU:ERROR".
When none will be "-".

# Outputs
<img width="936" alt="image" src="https://github.com/user-attachments/assets/e6802047-50ee-4627-a97f-f1a849a254c0">
<img width="630" alt="Screenshot 2024-07-31 at 00 06 58" src="https://github.com/user-attachments/assets/74bf511f-a3b6-49ab-b086-e3afbf08a30e">
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/bfaf795e-d9ae-4799-bde0-b55bd5d1aacd">
<img width="1590" alt="image" src="https://github.com/user-attachments/assets/d2b24528-c0a7-4411-b8c4-40df7a2be15a">
<img width="1568" alt="image" src="https://github.com/user-attachments/assets/748e8156-b688-4bb9-92c5-6773cfbe1823">


Related:
- https://github.com/infinyon/fluvio/issues/4102
