### PR TITLE
fix: enable tracing subscribe again

### DIFF
--- a/crates/fluvio-run/src/bin/main.rs
+++ b/crates/fluvio-run/src/bin/main.rs
@@ -4,6 +4,8 @@ use fluvio_run::RunCmd;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cmd: RunCmd = RunCmd::parse();
 
+    fluvio_future::subscriber::init_tracer(None);
+
     cmd.process()?;
     Ok(())
 }


### PR DESCRIPTION
I think that had a refactoring removing not used features flags, but I noticed that it was removed a block of code enabling tracing subscribe when `telemetry` feature was disabled.

I noticed this because only prints were working, all the tracings functions stopped working.

Related: https://github.com/infinyon/fluvio/pull/4118.

