### PR TITLE
feat: upgrade cluster for local

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install current stable Fluvio CLI and upgrade cluster
         run: |
           ~/.fvm/bin/fvm install stable
-          ~/.fluvio/bin/fluvio cluster upgrade
+          ~/.fluvio/bin/fluvio cluster upgrade --force
           ~/.fluvio/bin/fluvio version
 
       # TODO: Verify platform version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -991,7 +991,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: k8_upgrade_${{ matrix.run }}_log
+          name: local_upgrade_${{ matrix.run }}_log
           path: diagnostics*.gz
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,7 +881,7 @@ jobs:
           retention-days: 1
 
   k8_upgrade_test:
-    name: Upgrade cluster test on (${{ matrix.run }})
+    name: Upgrade K8S cluster test on (${{ matrix.run }})
     needs: build_image
     runs-on: ${{ matrix.os }}
     strategy:
@@ -931,6 +931,56 @@ jobs:
           date
           k3d image import -k /tmp/infinyon-fluvio.tar -c fluvio
           make FLUVIO_BIN=~/bin/fluvio upgrade-test
+
+      - name: Run diagnostics
+        if: ${{ !success() }}
+        timeout-minutes: 5
+        run: fluvio cluster diagnostics
+      - name: Upload logs
+        timeout-minutes: 5
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8_upgrade_${{ matrix.run }}_log
+          path: diagnostics*.gz
+          retention-days: 1
+
+  local_upgrade_test:
+    name: Upgrade local cluster test on (${{ matrix.run }})
+    needs: build_primary_binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+ #     fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust-target: [x86_64-unknown-linux-musl]
+        run: [r1]
+    steps:
+      - uses: actions/checkout@v4
+      # Download artifacts
+      - name: Download artifact - fluvio
+        uses: actions/download-artifact@v4
+        with:
+          name: fluvio-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Download artifact - fluvio-run
+        uses: actions/download-artifact@v4
+        with:
+          name: fluvio-run-${{ matrix.rust-target }}
+          path: ~/bin
+      - name: Mark executable
+        run: |
+          chmod +x ~/bin/fluvio-run
+          chmod +x ~/bin/fluvio && ~/bin/fluvio version
+          echo "${HOME}/bin" >> $GITHUB_PATH
+
+      - name: Run upgrade test with CI artifacts
+        timeout-minutes: 10
+        env:
+          TEST_DATA_BYTES: 10000
+        run: |
+          date
+          make FLUVIO_MODE=local FLUVIO_BIN=~/bin/fluvio upgrade-test
 
       - name: Run diagnostics
         if: ${{ !success() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-helm",
  "fluvio-sc-schema",
+ "fluvio-stream-dispatcher",
  "fluvio-types",
  "flv-util",
  "futures-channel",

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -78,6 +78,7 @@ fluvio-controlplane-metadata = { workspace = true,  features = ["k8",] }
 fluvio-sc-schema = { workspace = true  }
 fluvio-types = { workspace = true  }
 fluvio-channel = { workspace = true  }
+fluvio-stream-dispatcher = { workspace = true, features = ["k8", "local"]}
 dialoguer.workspace = true
 
 [dev-dependencies]

--- a/crates/fluvio-cluster/src/cli/shutdown.rs
+++ b/crates/fluvio-cluster/src/cli/shutdown.rs
@@ -94,7 +94,9 @@ impl ShutdownOpt {
                     "Removed spu monitoring socket: {SPU_MONITORING_UNIX_SOCKET}"
                 ));
             }
-            Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                debug!("SPU monitoring socket not found: {SPU_MONITORING_UNIX_SOCKET}");
+            }
             Err(err) => {
                 pb.println(format!(
                     "SPU monitoring socket  {SPU_MONITORING_UNIX_SOCKET}, can't be removed: {err}"

--- a/crates/fluvio-cluster/src/cli/shutdown.rs
+++ b/crates/fluvio-cluster/src/cli/shutdown.rs
@@ -94,6 +94,7 @@ impl ShutdownOpt {
                     "Removed spu monitoring socket: {SPU_MONITORING_UNIX_SOCKET}"
                 ));
             }
+            Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => {
                 pb.println(format!(
                     "SPU monitoring socket  {SPU_MONITORING_UNIX_SOCKET}, can't be removed: {err}"

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -1,13 +1,24 @@
 use clap::Parser;
+use color_eyre::owo_colors::OwoColorize;
+use colored::Colorize;
 use fluvio_extension_common::installation::InstallationType;
+use fluvio_sc_schema::{
+    mirror::MirrorSpec, partition::PartitionSpec, smartmodule::SmartModuleSpec, spg::SpuGroupSpec,
+    spu::SpuSpec, store::NameSpace, tableformat::TableFormatSpec, topic::TopicSpec,
+};
+use fluvio_stream_dispatcher::metadata::{local::LocalMetadataStorage, MetadataClient};
 use fluvio_types::config_file::SaveLoadConfig;
 use semver::Version;
 use anyhow::{anyhow, Result, bail};
 use tracing::debug;
 
 use crate::{
-    cli::{get_installation_type, shutdown::ShutdownOpt},
-    start::local::{DEFAULT_RUNNER_PATH, LOCAL_CONFIG_PATH},
+    cli::{get_installation_type, shutdown::ShutdownOpt, ClusterCliError},
+    progress::ProgressBarFactory,
+    render::ProgressRenderer,
+    start::local::{
+        DEFAULT_DATA_DIR, DEFAULT_METADATA_SUB_DIR, DEFAULT_RUNNER_PATH, LOCAL_CONFIG_PATH,
+    },
     LocalConfig,
 };
 
@@ -53,8 +64,22 @@ impl UpgradeOpt {
                 self.start.process(platform_version, true).await?;
             }
             InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
+                let pb_factory = ProgressBarFactory::new(false);
+
+                let pb = match pb_factory.create() {
+                    Ok(pb) => pb,
+                    Err(_) => {
+                        return Err(ClusterCliError::Other(
+                            "Failed to create progress bar".to_string(),
+                        )
+                        .into())
+                    }
+                };
                 ShutdownOpt.process().await?;
-                self.upgrade_local_cluster(platform_version)?;
+                if let Err(err) = self.upgrade_local_cluster(&pb, platform_version).await {
+                    pb.println(format!("💔 {}", err.to_string().red()));
+                }
+                pb.finish_and_clear();
             }
             InstallationType::Cloud => {
                 let profile = config.config().current_profile_name().unwrap_or("none");
@@ -66,27 +91,77 @@ impl UpgradeOpt {
         Ok(())
     }
 
-    fn upgrade_local_cluster(&self, platform_version: Version) -> Result<()> {
-        let path = LOCAL_CONFIG_PATH
+    async fn upgrade_local_cluster(
+        &self,
+        pb: &ProgressRenderer,
+        platform_version: Version,
+    ) -> Result<()> {
+        let local_config_path = LOCAL_CONFIG_PATH
             .as_ref()
             .ok_or(anyhow!("Local config path not set"))?;
 
-        let mut local_config = LocalConfig::load_from(path)
+        let data_path = DEFAULT_DATA_DIR
+            .as_ref()
+            .ok_or(anyhow!("Data path not set"))?;
+
+        let metadata_path = data_path.join(DEFAULT_METADATA_SUB_DIR);
+        let client = LocalMetadataStorage::new(metadata_path);
+
+        check_all_metadata(pb, &client)
+            .await
+            .map_err(|err| anyhow!("Failed to check metadata: {err}"))?;
+
+        let mut local_config = LocalConfig::load_from(local_config_path)
             .map_err(|err| anyhow!("Failed to load local config: {err}"))?
             .evolve();
+
+        pb.println(format!(
+            "🚀 {}",
+            format!("Upgrading Local Fluvio cluster to {}", platform_version).bold(),
+        ));
 
         let config = local_config
             .platform_version(platform_version.clone())
             .launcher(DEFAULT_RUNNER_PATH.clone())
             .build()?;
 
-        config.save_to(path)?;
+        config.save_to(local_config_path)?;
 
-        println!(
-            "Successfully upgraded Local Fluvio cluster to {}",
-            platform_version,
-        );
-        println!("To start the cluster again, run: fluvio cluster resume");
+        pb.println(format!(
+            "🎉 {}",
+            format!(
+                "Successfully upgraded Local Fluvio cluster to {}",
+                platform_version
+            )
+            .bold(),
+        ));
+
+        pb.println(format!(
+            "Run: {} to start the cluster again",
+            "fluvio cluster resume".bold()
+        ));
         Ok(())
     }
+}
+
+async fn check_all_metadata(pb: &ProgressRenderer, client: &LocalMetadataStorage) -> Result<()> {
+    pb.println(format!("📝 {}", "Checking All Metadatas".bold()));
+    let _ = client.retrieve_items::<TopicSpec>(&NameSpace::All).await?;
+    let _ = client
+        .retrieve_items::<PartitionSpec>(&NameSpace::All)
+        .await?;
+    let _ = client.retrieve_items::<SpuSpec>(&NameSpace::All).await?;
+    client
+        .retrieve_items::<SmartModuleSpec>(&NameSpace::All)
+        .await?;
+    let _ = client
+        .retrieve_items::<SpuGroupSpec>(&NameSpace::All)
+        .await?;
+    let _ = client
+        .retrieve_items::<TableFormatSpec>(&NameSpace::All)
+        .await?;
+    let _ = client.retrieve_items::<MirrorSpec>(&NameSpace::All).await?;
+
+    pb.println(format!("✅ {}", "Checked All Metadata".bold()));
+    Ok(())
 }

--- a/crates/fluvio-cluster/src/cli/upgrade.rs
+++ b/crates/fluvio-cluster/src/cli/upgrade.rs
@@ -15,6 +15,9 @@ use super::start::StartOpt;
 
 #[derive(Debug, Parser)]
 pub struct UpgradeOpt {
+    /// Force upgrade without confirmation
+    #[clap(short, long)]
+    pub force: bool,
     #[clap(flatten)]
     pub start: StartOpt,
 }
@@ -30,32 +33,28 @@ impl UpgradeOpt {
         } else {
             self.start.installation_type.set(installation_type.clone());
         }
+
+        if !self.force {
+            let prompt = dialoguer::Confirm::new()
+                .with_prompt(format!(
+                    "Upgrade Local Fluvio cluster to version {}?",
+                    platform_version
+                ))
+                .interact()?;
+
+            if !prompt {
+                println!("Upgrade cancelled");
+                return Ok(());
+            }
+        }
+
         match installation_type {
             InstallationType::K8 => {
                 self.start.process(platform_version, true).await?;
             }
             InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
                 ShutdownOpt.process().await?;
-
-                let path = LOCAL_CONFIG_PATH
-                    .as_ref()
-                    .ok_or(anyhow!("Local config path not set"))?;
-
-                let mut local_config = LocalConfig::load_from(path)
-                    .map_err(|err| anyhow!("Failed to load local config: {err}"))?
-                    .evolve();
-
-                let config = local_config
-                    .platform_version(platform_version.clone())
-                    .launcher(DEFAULT_RUNNER_PATH.clone())
-                    .build()?;
-
-                config.save_to(path)?;
-
-                println!(
-                    "Successfully upgraded Local Fluvio cluster to {}",
-                    platform_version,
-                );
+                self.upgrade_local_cluster(platform_version)?;
             }
             InstallationType::Cloud => {
                 let profile = config.config().current_profile_name().unwrap_or("none");
@@ -64,6 +63,30 @@ impl UpgradeOpt {
             other => bail!("upgrade command is not supported for {other} installation type"),
         };
 
+        Ok(())
+    }
+
+    fn upgrade_local_cluster(&self, platform_version: Version) -> Result<()> {
+        let path = LOCAL_CONFIG_PATH
+            .as_ref()
+            .ok_or(anyhow!("Local config path not set"))?;
+
+        let mut local_config = LocalConfig::load_from(path)
+            .map_err(|err| anyhow!("Failed to load local config: {err}"))?
+            .evolve();
+
+        let config = local_config
+            .platform_version(platform_version.clone())
+            .launcher(DEFAULT_RUNNER_PATH.clone())
+            .build()?;
+
+        config.save_to(path)?;
+
+        println!(
+            "Successfully upgraded Local Fluvio cluster to {}",
+            platform_version,
+        );
+        println!("To start the cluster again, run: fluvio cluster resume");
         Ok(())
     }
 }

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -43,7 +43,7 @@ const DEFAULT_TLS_POLICY: TlsPolicy = TlsPolicy::Disabled;
 const LOCAL_SC_ADDRESS: &str = "127.0.0.1:9003";
 const LOCAL_SC_PORT: &str = "9003";
 
-static DEFAULT_RUNNER_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| std::env::current_exe().ok());
+pub static DEFAULT_RUNNER_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| std::env::current_exe().ok());
 
 /// Describes how to install Fluvio locally
 #[derive(Builder, Debug, Clone, Serialize, Deserialize)]
@@ -221,6 +221,30 @@ impl LocalConfig {
             launcher: self.launcher.clone(),
             tls_policy: self.server_tls_policy.clone(),
             data_dir: self.data_dir.clone(),
+        }
+    }
+
+    // Create a builder from the instance, so it could be used to create an evovled instance.
+    pub fn evolve(self) -> LocalConfigBuilder {
+        // This direct assignment style is used so the compiler can guarentee pairity between LocalConfig and the builder object
+        LocalConfigBuilder {
+            platform_version: Some(self.platform_version),
+            log_dir: Some(self.log_dir),
+            data_dir: Some(self.data_dir),
+            launcher: Some(self.launcher),
+            rust_log: Some(self.rust_log),
+            spu_replicas: Some(self.spu_replicas),
+            server_tls_policy: Some(self.server_tls_policy),
+            client_tls_policy: Some(self.client_tls_policy),
+            sc_pub_addr: Some(self.sc_pub_addr),
+            sc_priv_addr: Some(self.sc_priv_addr),
+            chart_version: Some(self.chart_version),
+            chart_location: Some(self.chart_location),
+            skip_checks: Some(self.skip_checks),
+            hide_spinner: Some(self.hide_spinner),
+            installation_type: Some(self.installation_type),
+            read_only_config: Some(self.read_only_config),
+            save_profile: Some(self.save_profile),
         }
     }
 }

--- a/crates/fluvio-controlplane-metadata/src/mirror/status.rs
+++ b/crates/fluvio-controlplane-metadata/src/mirror/status.rs
@@ -9,7 +9,9 @@ use fluvio_protocol::{Encoder, Decoder};
 )]
 pub struct MirrorStatus {
     pub connection_status: ConnectionStatus,
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub pairing_sc: MirrorPairStatus,
+    #[cfg_attr(feature = "use_serde", serde(default))]
     pub pairing_spu: MirrorPairStatus,
     pub connection_stat: ConnectionStat,
 }

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -149,7 +149,7 @@ function validate_upgrade_cluster_to_prerelease() {
         echo "Target Version ${TARGET_VERSION}"
 
         FLUVIO_IMAGE_TAG_STRATEGY=version-git \
-        $FLUVIO_BIN_ABS_PATH cluster upgrade
+        $FLUVIO_BIN_ABS_PATH cluster upgrade --force
         echo "Wait for SPU to be upgraded. sleeping 1 minute"
 
     else
@@ -159,7 +159,7 @@ function validate_upgrade_cluster_to_prerelease() {
         # This should use the binary that the Makefile set
 
         echo "Using Fluvio binary located @ ${FLUVIO_BIN_ABS_PATH}"
-        $FLUVIO_BIN_ABS_PATH cluster upgrade --develop
+        $FLUVIO_BIN_ABS_PATH cluster upgrade --force --develop
     fi
     popd
 

--- a/tests/upgrade-test.sh
+++ b/tests/upgrade-test.sh
@@ -35,6 +35,7 @@ readonly PRERELEASE_TOPIC=${PRERELEASE_TOPIC:-prerelease}
 readonly USE_LATEST=${USE_LATEST:-}
 readonly FLUVIO_BIN=$(${READLINK} -f ${FLUVIO_BIN:-"$(which fluvio)"})
 readonly FVM_BIN=$(${READLINK} -f ${FVM_BIN:-"~/.fvm/bin/fvm"})
+readonly FLUVIO_MODE=${FLUVIO_MODE:-"k8"}
 
 # Change to this script's directory 
 pushd "$(dirname "$(${READLINK} -f "$0")")" > /dev/null
@@ -75,7 +76,12 @@ function validate_cluster_stable() {
     ~/.fvm/bin/fvm switch stable
 
     echo "Installing stable fluvio cluster"
-    $STABLE_FLUVIO cluster start --k8
+    if [[ "$FLUVIO_MODE" == "local" ]]; then
+	$STABLE_FLUVIO cluster start --local
+    else
+	$STABLE_FLUVIO cluster start --k8
+    fi
+
     ci_check;
 
     # Baseline: CLI version and platform version are expected to be the same
@@ -90,6 +96,9 @@ function validate_cluster_stable() {
     $STABLE_FLUVIO topic create ${STABLE_TOPIC} 
     # $STABLE_FLUVIO topic create ${STABLE_TOPIC}-delete 
     ci_check;
+
+    echo "Create mirror"
+    $STABLE_FLUVIO remote register stable-remote
 
     # Validate consume on topic before produce
     # https://github.com/infinyon/fluvio/issues/1819
@@ -161,7 +170,13 @@ function validate_upgrade_cluster_to_prerelease() {
         echo "Using Fluvio binary located @ ${FLUVIO_BIN_ABS_PATH}"
         $FLUVIO_BIN_ABS_PATH cluster upgrade --force --develop
     fi
+    if [[ "$FLUVIO_MODE" == "local" ]]; then
+	echo "Resuming local cluster"
+	sleep 5
+	$FLUVIO_BIN_ABS_PATH cluster resume
+    fi
     popd
+
 
     # Validate that the development version output matches the expected version from installer output
     $FLUVIO_BIN_ABS_PATH version


### PR DESCRIPTION
Related:
- https://github.com/infinyon/fluvio/issues/962
- https://github.com/infinyon/fluvio/issues/4136
- https://github.com/infinyon/fluvio/issues/4137

Before:

```
▷ flvd cluster upgrade
SPU monitoring socket  /tmp/fluvio-spu.sock, can't be removed: No such file or directory (os error 2)
Uninstalled fluvio local components
📝 Running pre-flight checks
    ✅ Local Fluvio is not installed
    ❌ Check Clean Fluvio Local Installation failed Local Fluvio cluster wasn't deleted. Use 'resume' to resume created cluster or 'delete' before starting a new one
💔 Some pre-flight check failed!
Preflight check failed
```

After

```
Upgrade Local Fluvio cluster to version 0.11.12-dev-1? yes
Uninstalled fluvio local components
📝 Checking All Metadatas
✅ Checked All Metadata
🚀 Upgrading Local Fluvio cluster to 0.11.12-dev-1
🎉 Successfully upgraded Local Fluvio cluster to 0.11.12-dev-1
Run: fluvio cluster resume to start the cluster again, 
```

Failure case:

```
Upgrade Local Fluvio cluster to version 0.11.12-dev-1? yes                                                                                                         
📝 Checking All Metadatas
💔 Failed to check metadata: loading metadata 'Mirror' from /Users/frai/.fluvio/data/metadata/Mirror/mac.yaml
```


New CI got one bug (fixed in the last commit):

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/76fe13e3-0093-4bbe-bc57-19b8788e219b">