### PR TITLE
4099 produce config debug

### DIFF
--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -53,7 +53,7 @@ fn default_delivery() -> DeliverySemantic {
 
 // This is needed only to bypass the partitioner property when debugging
 impl fmt::Debug for Box<dyn Partitioner + Send + Sync> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Ok(())
     }
 }

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -51,11 +51,18 @@ fn default_delivery() -> DeliverySemantic {
     DeliverySemantic::default()
 }
 
+// This is needed only for bypass the partitioner property when debugging
+impl fmt::Debug for Box<dyn Partitioner + Send + Sync> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
 /// Options used to adjust the behavior of the Producer.
 /// Create this struct with [`TopicProducerConfigBuilder`].
 ///
 /// Create a producer with a custom config with [`crate::Fluvio::topic_producer_with_config()`].
-#[derive(Builder)]
+#[derive(Debug, Builder)]
 #[builder(pattern = "owned")]
 pub struct TopicProducerConfig {
     /// Maximum amount of bytes accumulated by the records before sending the batch.
@@ -100,6 +107,40 @@ pub struct TopicProducerConfig {
 
     #[builder(default)]
     pub(crate) smartmodules: Vec<SmartModuleInvocation>,
+}
+
+impl TopicProducerConfig {
+    pub fn linger(&self) -> Duration {
+        self.linger
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    pub fn batch_queue_size(&self) -> usize {
+        self.batch_queue_size
+    }
+
+    pub fn compression(&self) -> Option<Compression> {
+        self.compression
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    pub fn isolation(&self) -> Isolation {
+        self.isolation
+    }
+
+    pub fn delivery_semantic(&self) -> DeliverySemantic {
+        self.delivery_semantic
+    }
+
+    pub fn smartmodules(&self) -> &Vec<SmartModuleInvocation> {
+        &self.smartmodules
+    }
 }
 
 impl Default for TopicProducerConfig {

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -51,7 +51,7 @@ fn default_delivery() -> DeliverySemantic {
     DeliverySemantic::default()
 }
 
-// This is needed only for bypass the partitioner property when debugging
+// This is needed only to bypass the partitioner property when debugging
 impl fmt::Debug for Box<dyn Partitioner + Send + Sync> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Ok(())

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -440,6 +440,14 @@ where
         })
     }
 
+    pub fn topic(&self) -> &str {
+        &self.inner.topic
+    }
+
+    pub fn config(&self) -> &TopicProducerConfig {
+        &self.inner.config
+    }
+
     /// Send all the queued records in the producer batches.
     ///
     /// # Example


### PR DESCRIPTION
to fix #4099  ,  I did:

1. Create accessor fn for the properties on TopicProducerConfig;
2. Derive Debug;
3. Ignore debug for Box<dyn Partitioner + Send + Sync>;
4. Expose topic and config on TopicProducer;

It is unclear (at least for me :D) if these "non-functional" changes must be unit-tested in some fashion. I am more than happy to implement the needed tests.

![flujvio](https://github.com/user-attachments/assets/cdb6cfb3-45cd-4ece-9e0b-5cd013e3c652)


Thank you