### PR TITLE
chore: clean up not used dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,6 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "derive_builder",
- "thiserror",
 ]
 
 [[package]]
@@ -958,7 +957,6 @@ dependencies = [
  "serde",
  "sysinfo",
  "tempfile",
- "thiserror",
  "toml 0.8.15",
  "tracing",
 ]
@@ -2322,8 +2320,6 @@ dependencies = [
  "async-lock 3.4.0",
  "async-std",
  "async-trait",
- "base64 0.22.1",
- "bytes",
  "cfg-if",
  "chrono",
  "derive_builder",
@@ -2340,13 +2336,11 @@ dependencies = [
  "fluvio-stream-dispatcher",
  "fluvio-types",
  "fluvio_ws_stream_wasm",
- "futures-lite 2.3.0",
  "futures-util",
  "once_cell",
  "pin-project",
  "semver 1.0.23",
  "serde",
- "serde_json",
  "siphasher",
  "thiserror",
  "tokio",
@@ -2365,7 +2359,6 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-socket",
- "fluvio-types",
  "flv-tls-proxy",
  "futures-util",
  "serde",
@@ -2450,8 +2443,6 @@ dependencies = [
  "crossterm 0.27.0",
  "ctrlc",
  "current_platform",
- "dirs 5.0.1",
- "eyre",
  "flate2",
  "fluvio",
  "fluvio-auth",
@@ -2468,13 +2459,11 @@ dependencies = [
  "fluvio-sc-schema",
  "fluvio-smartengine",
  "fluvio-smartmodule",
- "fluvio-socket",
  "fluvio-spu-schema",
  "fluvio-types",
  "futures",
  "futures-util",
  "handlebars",
- "hex",
  "home",
  "humantime",
  "indicatif",
@@ -2487,13 +2476,10 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "sha2",
- "static_assertions",
- "sysinfo",
  "thiserror",
  "tokio",
  "tracing",
  "tui",
- "url",
  "which 6.0.1",
 ]
 
@@ -2508,7 +2494,6 @@ dependencies = [
  "comfy-table",
  "current_platform",
  "fluvio",
- "fluvio-future",
  "fluvio-package-index",
  "fluvio-protocol",
  "fluvio-sc-schema",
@@ -2560,7 +2545,6 @@ dependencies = [
  "fluvio-stream-dispatcher",
  "fluvio-types",
  "flv-util",
- "futures-channel",
  "futures-util",
  "include_dir",
  "indicatif",
@@ -2684,13 +2668,11 @@ name = "fluvio-controlplane-metadata"
 version = "0.29.1"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "bytesize",
  "derive_builder",
  "flate2",
- "fluvio-future",
  "fluvio-protocol",
  "fluvio-stream-model",
  "fluvio-types",
@@ -2708,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2716,7 +2698,6 @@ dependencies = [
  "comfy-table",
  "fluvio",
  "fluvio-package-index",
- "futures-lite 2.3.0",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -2825,7 +2806,6 @@ dependencies = [
  "pathdiff",
  "pem",
  "rand",
- "rand_core",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -2835,9 +2815,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "toml 0.8.15",
  "tracing",
- "tracing-subscriber",
  "ureq",
  "url",
  "wasmparser",
@@ -2915,8 +2893,6 @@ dependencies = [
  "semver 1.0.23",
  "serde_json",
  "thiserror",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2925,13 +2901,9 @@ version = "0.0.0"
 dependencies = [
  "adaptive_backoff",
  "anyhow",
- "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
- "base64 0.22.1",
- "cfg-if",
  "clap",
- "event-listener 5.3.1",
  "fluvio",
  "fluvio-auth",
  "fluvio-controlplane",
@@ -2945,19 +2917,15 @@ dependencies = [
  "fluvio-stream-model",
  "fluvio-types",
  "flv-tls-proxy",
- "flv-util",
  "futures-util",
  "k8-client",
  "mimalloc",
  "once_cell",
  "rand",
- "regex",
  "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
  "sysinfo",
- "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2972,7 +2940,6 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-socket",
  "fluvio-stream-model",
- "fluvio-types",
  "paste",
  "serde",
  "serde_json",
@@ -2993,13 +2960,12 @@ dependencies = [
  "fluvio-types",
  "futures-util",
  "portpicker",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3007,7 +2973,6 @@ dependencies = [
  "fluvio-future",
  "fluvio-protocol",
  "fluvio-smartmodule",
- "fluvio-types",
  "humantime-serde",
  "serde",
  "serde_json",
@@ -3042,9 +3007,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.9"
+version = "0.14.10"
 dependencies = [
- "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
@@ -3082,7 +3046,6 @@ dependencies = [
  "chrono",
  "clap",
  "derive_builder",
- "event-listener 5.3.1",
  "flate2",
  "fluvio",
  "fluvio-auth",
@@ -3103,16 +3066,13 @@ dependencies = [
  "flv-util",
  "futures-util",
  "mimalloc",
- "nix 0.29.0",
  "once_cell",
  "portpicker",
- "regex",
  "serde",
  "serde_json",
  "sysinfo",
  "thiserror",
  "tokio",
- "toml 0.8.15",
  "tracing",
 ]
 
@@ -3148,7 +3108,6 @@ dependencies = [
  "bytes",
  "clap",
  "derive_builder",
- "fluvio-compression",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-future",
@@ -3169,14 +3128,13 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
  "cfg-if",
- "event-listener 5.3.1",
  "fluvio-future",
  "fluvio-stream-model",
  "fluvio-types",
@@ -3187,7 +3145,6 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "tempfile",
- "thiserror",
  "tokio",
  "tracing",
 ]
@@ -3212,17 +3169,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
- "async-std",
- "async-trait",
- "bytes",
  "clap",
  "comfy-table",
  "crc",
- "crossbeam-channel",
  "fastrand 2.1.0",
  "fluvio",
  "fluvio-cli",
- "fluvio-cluster",
  "fluvio-command",
  "fluvio-controlplane-metadata",
  "fluvio-future",
@@ -3242,12 +3194,10 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
  "signal-hook",
  "sysinfo",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -3264,9 +3214,6 @@ dependencies = [
 name = "fluvio-test-derive"
 version = "0.0.0"
 dependencies = [
- "clap",
- "crossbeam-channel",
- "fluvio",
  "fluvio-future",
  "fluvio-test-util",
  "inflections",
@@ -3276,8 +3223,6 @@ dependencies = [
  "rand",
  "serde_json",
  "syn 2.0.71",
- "tokio",
- "tracing",
  "trybuild 1.0.42",
 ]
 
@@ -3287,28 +3232,21 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
  "clap",
  "comfy-table",
  "dyn-clone",
  "fluvio",
  "fluvio-cluster",
  "fluvio-command",
- "fluvio-controlplane-metadata",
  "fluvio-future",
  "fluvio-types",
- "futures-lite 2.3.0",
  "hdrhistogram",
  "humantime",
  "inventory",
  "once_cell",
- "proc-macro2",
- "quote",
  "semver 1.0.23",
  "serde",
- "serde_json",
  "syn 2.0.71",
- "tokio",
  "tracing",
  "uuid",
 ]
@@ -3340,7 +3278,6 @@ dependencies = [
  "fluvio-future",
  "fluvio-hub-util",
  "fs_extra",
- "hex",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -6891,7 +6828,6 @@ dependencies = [
  "cargo-builder",
  "cargo-generate",
  "clap",
- "current_platform",
  "dirs 5.0.1",
  "enum-display",
  "fluvio",
@@ -6900,13 +6836,10 @@ dependencies = [
  "fluvio-extension-common",
  "fluvio-future",
  "fluvio-hub-util",
- "fluvio-protocol",
- "fluvio-sc-schema",
  "fluvio-smartengine",
  "include_dir",
  "lib-cargo-crate",
  "tempfile",
- "tokio",
  "toml 0.8.15",
  "tracing",
 ]
@@ -7446,7 +7379,6 @@ dependencies = [
 name = "toml-diff"
 version = "0.0.0"
 dependencies = [
- "serde",
  "toml 0.8.15",
 ]
 

--- a/crates/cargo-builder/Cargo.toml
+++ b/crates/cargo-builder/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 
 [dependencies]
-thiserror = { workspace = true }
 anyhow = { workspace = true }
 derive_builder = { workspace = true }
 cargo_metadata = "0.18.0"

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -28,7 +28,6 @@ include_dir = { workspace = true }
 serde = { workspace = true,  features = ["derive"] }
 sysinfo = { workspace = true, default-features = false }
 tempfile = { workspace = true }
-thiserror = { workspace = true }
 toml = { workspace = true, features = ["parse", "display", "preserve_order"] }
 tracing = { workspace = true }
 

--- a/crates/fluvio-auth/Cargo.toml
+++ b/crates/fluvio-auth/Cargo.toml
@@ -27,6 +27,5 @@ fluvio-controlplane-metadata = { workspace = true  }
 fluvio-future = { workspace = true, features = ["net", "openssl_tls"] }
 fluvio-protocol = { workspace = true }
 fluvio-socket = { workspace = true }
-fluvio-types = { workspace = true  }
 flv-tls-proxy = { workspace = true }
 

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -47,7 +47,4 @@ fluvio-protocol = { workspace = true,  optional = true }
 fluvio-sc-schema = { path = "../fluvio-sc-schema", optional = true }
 fluvio-smartmodule = { path = "../fluvio-smartmodule", optional = true, default-features = false }
 fluvio-smartengine = { path = "../fluvio-smartengine", optional = true, features = ["transformation"] }
-fluvio-future = { workspace = true, features = ["tls"] }
 
-[dev-dependencies]
-fluvio-future = { workspace = true, features = ["fs", "io", "subscriber", "fixture"] }

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -43,11 +43,8 @@ anyhow = { workspace = true }
 bytesize = { workspace = true, features = ['serde'] }
 clap = { workspace = true, features = ["std", "derive", "string", "help", "usage", "env", "error-context"] }
 clap_complete = { workspace = true }
-dirs = { workspace = true }
 indicatif = { workspace = true }
-eyre = { workspace = true }
 sha2 = { workspace = true }
-hex = { workspace = true }
 home = { workspace = true }
 current_platform = { workspace = true }
 comfy-table = { workspace = true }
@@ -62,8 +59,6 @@ futures = { workspace = true }
 futures-util = { workspace = true, features = ["sink"] }
 humantime = { workspace = true }
 mimalloc = { workspace = true }
-static_assertions = { workspace = true }
-sysinfo = { workspace = true }
 serde_yaml = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -72,7 +67,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true,  features = ["macros"] }
 tracing = { workspace = true }
 which = { workspace = true }
-url = { workspace = true }
 
 # Fluvio dependencies
 k8-config = { workspace = true, optional = true }
@@ -82,7 +76,6 @@ fluvio-cluster = { path = "../fluvio-cluster", default-features = false, feature
 
 fluvio = { workspace = true }
 fluvio-auth = { workspace = true }
-fluvio-socket = { workspace = true }
 fluvio-command = { workspace = true  }
 fluvio-package-index = { workspace = true }
 fluvio-extension-common = { workspace = true,  features = ["target", "installation"] }

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -37,7 +37,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 futures-util = { workspace = true }
-futures-channel = { workspace = true, features = ["sink"] }
 tokio = { workspace = true, features = ["macros"] }
 once_cell = { workspace = true }
 which = {workspace = true }

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -17,8 +17,6 @@ use_serde = ["serde","semver/serde", "bytesize/serde", "humantime-serde", "serde
 k8 = ["use_serde", "fluvio-stream-model/k8"]
 
 [dependencies]
-async-trait = { workspace = true }
-
 thiserror = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
@@ -35,7 +33,6 @@ serde_yaml = { workspace = true, optional = true }
 derive_builder = { workspace = true }
 
 # External Fluvio dependencies
-fluvio-future = { workspace = true }
 flv-util = { workspace = true }
 
 fluvio-types = { workspace = true }
@@ -44,5 +41,4 @@ fluvio-protocol = { workspace = true, features = [ "record", "link", "api"] }
 
 
 [dev-dependencies]
-fluvio-future = { workspace = true, features = ["fixture"] }
 serde_json = { workspace = true }

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"
@@ -23,7 +23,6 @@ comfy-table = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
 serde_json ={ workspace = true }
 serde_yaml = { workspace = true }
-futures-lite = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -29,7 +29,6 @@ http = { workspace = true }
 mime = { workspace = true }
 pem = "3.0"
 rand = { workspace = true }
-rand_core = "0.6"
 sha2 = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features=["derive"] }
@@ -39,7 +38,6 @@ ssh-key = { version="0.6.1", features=[ "ed25519" ] }
 tar = { workspace = true }
 pathdiff = { version = "0.2.1", default-features = false }
 tempfile = { workspace = true }
-toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
@@ -54,6 +52,3 @@ fluvio-hub-protocol = { path = "../fluvio-hub-protocol" }
 fluvio-types = { workspace = true }
 fluvio-extension-common = { workspace = true,  optional = true }
 
-
-[dev-dependencies]
-tracing-subscriber = { workspace = true,  features = ["env-filter", "fmt"] }

--- a/crates/fluvio-run/Cargo.toml
+++ b/crates/fluvio-run/Cargo.toml
@@ -27,8 +27,6 @@ clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-
 semver = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 # regardless of TLS, sc and spu always use openssl_tls for now because we need cert API
 fluvio-future = { workspace = true, features = ["subscriber"] }

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -31,7 +31,6 @@ fluvio-controlplane-metadata = {  workspace = true, features = ["smartmodule", "
 fluvio-protocol = { workspace = true,  features = ["link"]}
 fluvio-socket = { workspace = true }
 fluvio-stream-model = { workspace = true, features = ["k8"] }
-fluvio-types = { workspace = true }
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["subscriber"] }

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -26,22 +26,15 @@ adaptive_backoff = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async-lock = { workspace = true }
-async-channel = { workspace = true }
-base64 = { workspace = true }
-cfg-if = { workspace = true }
 clap = { workspace = true,features = ["std", "derive", "env"]}
-event-listener = { workspace = true }
 futures-util = { workspace = true }
 mimalloc = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
-regex = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 sysinfo = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
 
@@ -71,5 +64,4 @@ flv-tls-proxy = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 fluvio-future = { workspace = true, features = ["fixture"] }
-flv-util = { workspace = true, features = ["fixture"] }
 fluvio-stream-model = { workspace = true, features = ["fixture"] }

--- a/crates/fluvio-service/Cargo.toml
+++ b/crates/fluvio-service/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 [dependencies]
 tracing = { workspace = true }
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
 anyhow = { workspace = true }
 
 # Fluvio dependencies

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-smartengine"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -37,5 +37,4 @@ fluvio-protocol = { workspace = true, features = [
 fluvio-smartmodule = { workspace = true, default-features = false }
 
 [dev-dependencies]
-fluvio-types = { workspace = true }
 fluvio-future = { workspace = true, default-features = false, features = ["task"] }

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.14.9"
+version = "0.14.10"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
@@ -29,7 +29,6 @@ tokio-util = { features = ["codec", "compat"], workspace = true }
 async-trait = { workspace = true }
 pin-project = { workspace = true }
 thiserror = { workspace = true }
-anyhow = { workspace = true }
 semver = { workspace = true }
 nix = { workspace = true, features = ["uio"]}
 

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -28,17 +28,13 @@ tracing = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"]}
 thiserror = { workspace = true }
-nix = { workspace = true, features = ["uio"]}
-toml = { workspace = true }
 futures-util = { workspace = true, features = ["sink"] }
 async-trait = { workspace = true }
 serde = { workspace = true,  features = ['derive'] }
 serde_json = { workspace = true }
-regex = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 async-channel = { workspace = true }
 async-lock = { workspace = true }
-event-listener = { workspace = true }
 async-io = { workspace = true }
 adaptive_backoff = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/fluvio-storage/Cargo.toml
+++ b/crates/fluvio-storage/Cargo.toml
@@ -17,7 +17,7 @@ required-features = ["cli", "fluvio-future/subscriber"]
 [features]
 default = ["iterators"]
 cli = ["clap"]
-iterators = ["fluvio-compression"]
+iterators = []
 fixture = []
 
 
@@ -52,7 +52,6 @@ fluvio-protocol = { workspace = true }
 fluvio-controlplane-metadata = { workspace = true  }
 fluvio-controlplane = { workspace = true }
 fluvio-spu-schema = { workspace = true, features = [ "file"] }
-fluvio-compression = { workspace = true, features = ["compress"], optional = true }
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture"] }

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2021"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"
@@ -21,13 +21,11 @@ async-trait = { workspace = true }
 async-lock = { workspace = true }
 async-channel = { workspace = true }
 cfg-if = { workspace = true }
-event-listener = { workspace = true }
 futures-util = { workspace = true, features = ["alloc"] }
 once_cell = { workspace = true }
 serde = { workspace = true,  features = ['derive'] }
 serde_json = { workspace = true, optional = true }
 serde_yaml = { workspace = true, optional = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/fluvio-test-derive/Cargo.toml
+++ b/crates/fluvio-test-derive/Cargo.toml
@@ -24,10 +24,5 @@ rand = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }
-fluvio = { workspace = true  }
-tokio = { workspace = true,  features = ["macros"] }
 fluvio-future = { workspace = true, features = ["task", "timer", "subscriber", "fixture"] }
-clap = { workspace = true,  features = ["std", "derive", "help", "usage", "error-context"] }
 inventory = { workspace = true }
-tracing = { workspace = true }
-crossbeam-channel = { workspace = true }

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -10,18 +10,12 @@ publish = false
 
 
 [dependencies]
-bytes = { workspace = true }
 tracing = { workspace = true }
-futures-lite = { workspace = true }
 clap = { workspace = true , features = ["std", "derive", "help", "usage", "error-context"] }
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
 syn = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 humantime = { workspace = true }
-quote =  { workspace = true }
-proc-macro2 = { workspace = true }
 inventory = { workspace = true }
 comfy-table = { workspace = true }
 once_cell = { workspace = true }
@@ -36,7 +30,6 @@ fluvio-types = { workspace = true }
 fluvio-future = { workspace = true, features = ["task", "timer", "subscriber", "fixture"] }
 fluvio-cluster = { path = "../fluvio-cluster" }
 fluvio-command = { workspace = true  }
-fluvio-controlplane-metadata = { workspace = true, features = ["k8"] }
 
 [lib]
 path = "lib.rs"

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -12,8 +12,6 @@ publish = false
 [dependencies]
 async-channel = { workspace = true }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
-bytes = { workspace = true }
 futures-lite = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true, features = ["std", "derive"] }
@@ -25,19 +23,15 @@ md-5 = "0.10"
 nix = { workspace = true, features = ["process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 inventory = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 comfy-table = { workspace = true }
 hdrhistogram = { workspace = true }
 crc = "3.0"
 fork = "0.2"
-crossbeam-channel = { workspace = true }
 sysinfo = { workspace = true }
 signal-hook = "0.3.13"
 indicatif = { workspace = true }
-async-std = { workspace = true, features = ["attributes"] }
-uuid = { workspace = true }
 
 tracing = { workspace = true }
 
@@ -52,7 +46,6 @@ fluvio-future = { workspace = true, features = [
     "fixture",
 ] }
 fluvio-command = { version = "0.2.0" }
-fluvio-cluster = { path = "../fluvio-cluster" }
 fluvio-cli = { path = "../fluvio-cli" }
 fluvio-controlplane-metadata = { workspace = true, features = ["k8"] }
 

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -22,7 +22,6 @@ comfy-table = { workspace = true }
 current_platform = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
-hex = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -29,16 +29,12 @@ async-channel = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
-base64 = { workspace = true }
-bytes = { workspace = true }
 cfg-if = { workspace = true }
 derive_builder = { workspace = true }
 event-listener = { workspace = true }
-futures-lite = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
-serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 thiserror = { workspace = true }
 semver = { workspace = true }

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -17,11 +17,9 @@ doc = false
 tracing = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
-current_platform = { workspace = true }
 dirs = { workspace = true }
 enum-display = { workspace = true }
 toml = { workspace = true }
-tokio = { workspace = true }
 cargo-generate = { workspace = true }
 include_dir = { workspace = true }
 tempfile = { workspace = true }
@@ -30,11 +28,9 @@ lib-cargo-crate = "0.2.1"
 
 fluvio = { path = "../fluvio", default-features = false }
 fluvio-hub-util = { path = "../fluvio-hub-util" }
-fluvio-protocol = { path = "../fluvio-protocol", features=["record","api"] }
 fluvio-future = { workspace = true, features = ["subscriber"]}
 fluvio-smartengine = { path = "../fluvio-smartengine", features = ["transformation"] }
 fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
 fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
-fluvio-sc-schema = { path = "../fluvio-sc-schema" }
 fluvio-cli-common = { path = "../fluvio-cli-common", features = ["file-records", "version-cmd", "serde", "smartmodule-test"] }
 cargo-builder = { path = "../cargo-builder"}

--- a/release-tools/check-crate-version/toml-diff/Cargo.toml
+++ b/release-tools/check-crate-version/toml-diff/Cargo.toml
@@ -11,5 +11,4 @@ license = "Apache-2.0"
 toml = { workspace = true, features = ["display"] }
 
 [dev-dependencies]
-serde = { workspace = true }
 toml = { workspace = true, features = ["display", "parse"] }

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cfg-if"
@@ -482,7 +482,6 @@ name = "fluvio-wasm-map-json"
 version = "0.0.0"
 dependencies = [
  "fluvio-smartmodule 0.7.4",
- "serde",
  "serde_json",
  "serde_yaml",
 ]

--- a/smartmodule/examples/map_json/Cargo.toml
+++ b/smartmodule/examples/map_json/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 crate-type = ['cdylib']
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.0"
 fluvio-smartmodule = { workspace = true }

--- a/smartmodule/regex-filter/Cargo.lock
+++ b/smartmodule/regex-filter/Cargo.lock
@@ -13,9 +13,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "content_inspector"
@@ -53,17 +59,19 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
+ "bytes",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.10.13"
+version = "0.11.0"
 dependencies = [
  "bytes",
+ "cfg-if",
  "content_inspector",
  "crc32c",
  "eyre",
@@ -89,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartmodule"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "eyre",
  "fluvio-protocol",
@@ -109,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "serde",
  "thiserror",


### PR DESCRIPTION
Using [cargo-machete](https://github.com/bnjbvr/cargo-machete) I notice some dependencies that we don't use.

I also added a CI step to check them in that PR: https://github.com/infinyon/fluvio/pull/4148/commits