### PR TITLE
feat: close producer when topic is deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
+ "async-std",
  "async-trait",
  "bytesize",
  "clap",

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -39,6 +39,7 @@ producer-file-io = ["fluvio-cli-common/file-records"]
 [dependencies]
 async-channel = { workspace = true }
 async-trait = { workspace = true }
+async-std = { workspace = true }
 anyhow = { workspace = true }
 bytesize = { workspace = true, features = ['serde'] }
 clap = { workspace = true, features = ["std", "derive", "string", "help", "usage", "env", "error-context"] }

--- a/crates/fluvio-cli/src/error.rs
+++ b/crates/fluvio-cli/src/error.rs
@@ -67,4 +67,6 @@ pub enum CliError {
     SmartModuleConfigBuilder(#[from] fluvio_smartengine::SmartModuleConfigBuilderError),
     #[error("Hub error: {0}")]
     HubError(String),
+    #[error("Topic \"{0}\" was deleted")]
+    TopicDeleted(String),
 }

--- a/tests/cli/fluvio_smoke_tests/produce-error.bats
+++ b/tests/cli/fluvio_smoke_tests/produce-error.bats
@@ -57,3 +57,23 @@ teardown_file() {
     run bash -c 'echo abcdefgh | timeout 15s "$FLUVIO_BIN" produce "$TOPIC_NAME_2" --compression lz4'
     assert_failure
 }
+
+# Delete topic should stop producer and return error
+@test "Delete topic while producing" {
+    if [ "$FLUVIO_CLI_RELEASE_CHANNEL" == "stable" ]; then
+        skip "don't run on fluvio cli stable version"
+    fi
+    if [ "$FLUVIO_CLUSTER_RELEASE_CHANNEL" == "stable" ]; then
+        skip "don't run on cluster stable version"
+    fi
+
+    run bash -c '/usr/bin/expect <<-EOF
+    spawn "$FLUVIO_BIN" produce "$TOPIC_NAME"
+    expect "> "
+    exec "$FLUVIO_BIN" topic delete "$TOPIC_NAME"
+    expect "Topic \"$TOPIC_NAME\" was deleted"
+    exit
+    EOF'
+    assert_success
+    assert_output --partial "Topic \"$TOPIC_NAME\" was deleted"
+}

--- a/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
+++ b/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
@@ -130,7 +130,7 @@ setup_file() {
 }
 
 @test "Home status at remote 1 should show the home cluster connected" {
-    sleep 15
+    sleep 30
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success
@@ -165,7 +165,7 @@ setup_file() {
 }
 
 @test "Home status at remote 2 should show the home cluster connected" {
-    sleep 15
+    sleep 30
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success


### PR DESCRIPTION
Related: https://github.com/infinyon/fluvio/issues/3836

We already close the consumer when the topic is deleted, now we will close the producer too.

Given:
```bash
fluvio produce my-topic   
```

When:
```bash
fluvio topic delete my-topic   
```

Then:
```bash
Topic "my-topic" was deleted
```