### PR TITLE
feat(hub): provide `wasm32-unknown-unknown` support for `hub-util`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,12 +2800,14 @@ dependencies = [
  "fluvio-future",
  "fluvio-hub-protocol",
  "fluvio-types",
+ "getrandom",
  "hex",
  "http 1.1.0",
  "mime",
  "pathdiff",
  "pem",
  "rand",
+ "reqwest 0.12.5",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3600,8 +3602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ futures = { version = "0.3.1" }
 futures-channel = "0.3"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.6", default-features = false }
+getrandom = "0.2.15"
 handlebars = "5.1.2"
 hdrhistogram = "7.0"
 hex = "0.4"
@@ -120,6 +121,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 rand = "0.8.5"
 regex = "1.7"
+reqwest = "0.12"
 semver = "1.0.13"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0.60"

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -45,10 +45,16 @@ wasmparser = { workspace = true }
 current_platform = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 comfy-table = { workspace = true, optional = true }
-ureq = { workspace = true }
 
 fluvio-future = { workspace = true, features = ["fixture", "task", "tls"] }
 fluvio-hub-protocol = { path = "../fluvio-hub-protocol" }
 fluvio-types = { workspace = true }
 fluvio-extension-common = { workspace = true,  optional = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+http = { workspace = true, features = ["std"] }
+getrandom = { workspace = true, features = ["js"] }
+reqwest = { workspace = true, features = ["json"] }

--- a/crates/fluvio-hub-util/src/fvm/api/download.rs
+++ b/crates/fluvio-hub-util/src/fvm/api/download.rs
@@ -43,6 +43,12 @@ pub trait Download {
 
 #[async_trait]
 impl Download for Artifact {
+    #[cfg(target_arch = "wasm32")]
+    async fn download(&self, target_dir: PathBuf) -> Result<PathBuf> {
+        unimplemented!("The download support is not implemented for wasm32 architecture");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     #[instrument(skip(self, target_dir))]
     async fn download(&self, target_dir: PathBuf) -> Result<PathBuf> {
         tracing::info!(

--- a/crates/fluvio-hub-util/src/fvm/api/download.rs
+++ b/crates/fluvio-hub-util/src/fvm/api/download.rs
@@ -43,12 +43,6 @@ pub trait Download {
 
 #[async_trait]
 impl Download for Artifact {
-    #[cfg(target_arch = "wasm32")]
-    async fn download(&self, target_dir: PathBuf) -> Result<PathBuf> {
-        unimplemented!("The download support is not implemented for wasm32 architecture");
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     #[instrument(skip(self, target_dir))]
     async fn download(&self, target_dir: PathBuf) -> Result<PathBuf> {
         tracing::info!(

--- a/crates/fluvio-hub-util/src/htclient.rs
+++ b/crates/fluvio-hub-util/src/htclient.rs
@@ -3,8 +3,10 @@ pub use http::StatusCode;
 pub use http::{Request, Response};
 
 use anyhow::{anyhow, Result};
-use ureq::OrAnyStatus;
 use serde::de::DeserializeOwned;
+
+#[cfg(not(target_arch = "wasm32"))]
+use ureq::OrAnyStatus;
 
 pub async fn get_auth_json<J: serde::de::DeserializeOwned>(
     url: &str,
@@ -27,6 +29,7 @@ pub async fn get_auth_json<J: serde::de::DeserializeOwned>(
 }
 
 /// for simple get requests
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn get(uri: impl AsRef<str>) -> Result<Response<Vec<u8>>> {
     use std::io::Read;
 
@@ -51,6 +54,45 @@ pub async fn get(uri: impl AsRef<str>) -> Result<Response<Vec<u8>>> {
     Ok(response)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub async fn get(uri: impl AsRef<str>) -> Result<Response<Vec<u8>>> {
+    let request = reqwest::Client::new().get(uri.as_ref());
+    let response = request.send().await?;
+    let status = response.status();
+    let bytes = response.bytes().await?;
+    let bytes = bytes.to_vec();
+    let response = Response::builder().status(status).body(bytes)?;
+
+    Ok(response)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn send<T>(request: Request<T>) -> Result<Response<Vec<u8>>>
+where
+    T: Into<Vec<u8>> + std::fmt::Debug,
+{
+    use url::Url;
+
+    let (parts, body) = request.into_parts();
+    let method = parts.method.to_owned();
+    let url = Url::parse(&parts.uri.to_string())?;
+    let client = reqwest::Client::new();
+    let body: Vec<u8> = body.into();
+    let response = client
+        .request(method.into(), url)
+        .headers(parts.headers)
+        .body(body)
+        .send()
+        .await?;
+    let status = response.status();
+    let bytes = response.bytes().await?;
+    let bytes = bytes.to_vec();
+    let response = Response::builder().status(status).body(bytes)?;
+
+    Ok(response)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn send<T>(request: Request<T>) -> Result<Response<Vec<u8>>>
 where
     T: Into<Vec<u8>> + std::fmt::Debug,

--- a/crates/fluvio-hub-util/src/htclient.rs
+++ b/crates/fluvio-hub-util/src/htclient.rs
@@ -69,21 +69,23 @@ pub async fn get(uri: impl AsRef<str>) -> Result<Response<Vec<u8>>> {
 #[cfg(target_arch = "wasm32")]
 pub async fn send<T>(request: Request<T>) -> Result<Response<Vec<u8>>>
 where
-    T: Into<Vec<u8>> + std::fmt::Debug, reqwest::Request: TryFrom<http::Request<T>>,
+    T: Into<Vec<u8>> + std::fmt::Debug,
+    reqwest::Request: TryFrom<http::Request<T>>,
 {
     let client = reqwest::Client::new();
-    let reqwest_req = reqwest::Request::try_from(request).map_err(|_| {
-        anyhow::anyhow!("Failed to build Request on conversion.")
-    })?;
-    let response = client.execute(reqwest_req).await.map_err(|err| {
-        anyhow::anyhow!("Failed to execute request: {:?}", err)
-    })?;
+    let reqwest_req = reqwest::Request::try_from(request)
+        .map_err(|_| anyhow::anyhow!("Failed to build Request on conversion."))?;
+    let response = client
+        .execute(reqwest_req)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to execute request: {:?}", err))?;
     let status = response.status();
     let bytes = response.bytes().await?;
     let bytes = bytes.to_vec();
-    let response = Response::builder().status(status).body(bytes).map_err(|_| {
-        anyhow::anyhow!("Failed to build Response on conversion.")
-    })?;
+    let response = Response::builder()
+        .status(status)
+        .body(bytes)
+        .map_err(|_| anyhow::anyhow!("Failed to build Response on conversion."))?;
 
     Ok(response)
 }

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -1,26 +1,41 @@
 use std::path::{Path, PathBuf};
 
+#[cfg(not(target_arch = "wasm32"))]
 use anyhow::anyhow;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tracing::info;
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 use http::StatusCode;
-use tracing::{debug, info};
+use tracing::debug;
 
+#[cfg(not(target_arch = "wasm32"))]
 use fluvio_future::task::run_block_on;
+
+#[cfg(not(target_arch = "wasm32"))]
+use fluvio_hub_protocol::infinyon_tok::read_infinyon_token_rem;
+
 use fluvio_hub_protocol::{Result, HubError};
 use fluvio_hub_protocol::infinyon_tok::read_infinyon_token;
-use fluvio_hub_protocol::infinyon_tok::read_infinyon_token_rem;
 use fluvio_hub_protocol::constants::{HUB_API_ACT, HUB_API_HUBID, HUB_REMOTE, CLI_CONFIG_HUB};
 use fluvio_types::defaults::CLI_CONFIG_PATH;
 
-use crate::keymgmt::Keypair;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::htclient;
+
+use crate::keymgmt::Keypair;
 use crate::htclient::ResponseExt;
+
+#[cfg(not(target_arch = "wasm32"))]
+const ACCESS_FILE_DEF: &str = "default"; // default profile name
+
+#[cfg(not(target_arch = "wasm32"))]
+const DEFAULT_CLOUD_REMOTE: &str = "https://infinyon.cloud";
 
 // in .fluvio/hub/hcurrent
 const ACCESS_FILE_PTR: &str = "hcurrent";
-const ACCESS_FILE_DEF: &str = "default"; // default profile name
-const DEFAULT_CLOUD_REMOTE: &str = "https://infinyon.cloud";
 
 pub const ACTION_LIST: &str = "list";
 pub const ACTION_LIST_WITH_META: &str = "lwm";
@@ -50,6 +65,7 @@ impl HubAccess {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn default_load(remote: &Option<String>) -> Result<Self> {
         let cfgpath = default_cfg_path()?;
         let profileopt = std::env::var(FLUVIO_HUB_PROFILE_ENV).ok();
@@ -188,6 +204,7 @@ impl HubAccess {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn load_path<P: AsRef<Path>>(
         base_path: P,
         profile_in: Option<String>,
@@ -307,11 +324,13 @@ pub fn default_cfg_path() -> Result<PathBuf> {
     Ok(hub_cfg_path)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Deserialize)]
 struct ReplyHubref {
     hub_remote: String,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn get_hubref() -> Option<String> {
     let Ok((_, fcremote)) = read_infinyon_token_rem() else {
         return None;

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -72,6 +72,11 @@ impl HubAccess {
         HubAccess::load_path(cfgpath, profileopt, remote)
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn default_load(_remote: &Option<String>) -> Result<Self> {
+        unimplemented!("Support for `HubAccess::default_load` is not available for `wasm32`");
+    }
+
     pub async fn create_hubid(&self, hubid: &str) -> Result<()> {
         let action_token = self.get_action_auth(ACTION_CREATE_HUBID).await?;
         let msg = MsgHubIdReq {

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -74,7 +74,9 @@ impl HubAccess {
 
     #[cfg(target_arch = "wasm32")]
     pub fn default_load(_remote: &Option<String>) -> Result<Self> {
-        unimplemented!("Support for `HubAccess::default_load` is not available for `wasm32`");
+        Err(HubError::General(String::from(
+            "Support for `HubAccess::default_load` is not available for `wasm32`",
+        )))
     }
 
     pub async fn create_hubid(&self, hubid: &str) -> Result<()> {

--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -164,7 +164,7 @@ impl HubAccess {
         let msg_action_token = serde_json::to_string(&mat)
             .map_err(|_e| HubError::HubAccess("Failed access setup".to_string()))?;
 
-        let mut builder = http::Request::get(&api_url);
+        let mut builder = http::Request::post(&api_url);
         if !authn_token.is_empty() {
             builder = builder.header("Authorization", &authn_token);
         }

--- a/crates/fluvio-hub-util/src/lib.rs
+++ b/crates/fluvio-hub-util/src/lib.rs
@@ -8,6 +8,8 @@ pub mod cmd;
 
 pub mod htclient;
 pub mod keymgmt;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod fvm;
 
 use const_format::concatcp;


### PR DESCRIPTION
Provides `fluvio-hub-util` support for target `wasm32-unknown-unknown`.
Using the feature `wasm` certain `HubAccess` utilities wont be available.