### PR TITLE
fix: update sysinfo and fix fd leak on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,7 +4261,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -7057,15 +7057,14 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "windows",
 ]
 
@@ -8350,11 +8349,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -8363,6 +8362,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ sha2 = { version = "0.10" }
 siphasher = "1.0.0"
 static_assertions = "1.1.0"
 syn = "2.0"
-sysinfo = { version = "0.30.13", default-features = false }
+sysinfo = { version = "0.31.4", default-features = false, features = ["system"] }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.4.0"
 thiserror = "1.0.30"

--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -472,8 +472,9 @@ mod local_index {
             table.load_preset(comfy_table::presets::NOTHING);
             table.set_header(LIST_TABLE_HEADERS);
 
+            sysinfo::set_open_files_limit(0);
             let mut system = sysinfo::System::new();
-            system.refresh_processes();
+            system.refresh_processes(sysinfo::ProcessesToUpdate::All);
             for connector in self.entries {
                 let status = self.operator.status(&connector)?;
                 let Entry::Local {
@@ -524,7 +525,7 @@ mod local_index {
     impl Default for LocalProcesses {
         fn default() -> Self {
             let mut system: sysinfo::System = Default::default();
-            system.refresh_processes();
+            system.refresh_processes(sysinfo::ProcessesToUpdate::All);
             Self { system }
         }
     }

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -58,7 +58,7 @@ duct = { workspace = true, optional = true }
 comfy-table = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 tar = { workspace = true ,  optional = true }
-sysinfo = { workspace = true, default-features = false }
+sysinfo = { workspace = true, default-features = false, features = ["system", "network", "disk"] }
 
 
 # External Fluvio dependencies

--- a/crates/fluvio-cluster/src/check/mod.rs
+++ b/crates/fluvio-cluster/src/check/mod.rs
@@ -686,10 +686,11 @@ struct LocalClusterCheck;
 #[async_trait]
 impl ClusterCheck for LocalClusterCheck {
     async fn perform_check(&self, _pb: &ProgressRenderer) -> CheckResult {
+        sysinfo::set_open_files_limit(0);
         let mut sys = System::new();
-        sys.refresh_processes(); // Only load what we need.
+        sys.refresh_processes(sysinfo::ProcessesToUpdate::All); // Only load what we need.
         let proc_count = sys
-            .processes_by_exact_name("fluvio-run")
+            .processes_by_exact_name("fluvio-run".as_ref())
             .map(|x| println!("       found existing fluvio-run process. pid: {}", x.pid()))
             .count();
         if proc_count > 0 {

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -262,6 +262,7 @@ impl DiagnosticsOpt {
             Ok(())
         };
 
+        sysinfo::set_open_files_limit(0);
         let mut sys = System::new_all();
         let mut net = Networks::new();
 
@@ -452,13 +453,17 @@ impl ProcessInfo {
         let mut processes = Vec::new();
 
         for (pid, process) in sys.processes() {
-            if process.name().contains("fluvio") {
-                processes.push(ProcessInfo {
-                    pid: pid.as_u32(),
-                    name: process.name().to_string(),
-                    disk_usage: format!("{:?}", process.disk_usage()),
-                    cmd: format!("{:?}", process.cmd()),
-                });
+            let process_name = process.name().to_str();
+
+            if let Some(process_name) = process_name {
+                if process_name.contains("fluvio") {
+                    processes.push(ProcessInfo {
+                        pid: pid.as_u32(),
+                        name: process_name.to_string(),
+                        disk_usage: format!("{:?}", process.disk_usage()),
+                        cmd: format!("{:?}", process.cmd()),
+                    });
+                }
             }
         }
 

--- a/crates/fluvio-cluster/src/cli/diagnostics.rs
+++ b/crates/fluvio-cluster/src/cli/diagnostics.rs
@@ -17,6 +17,8 @@ use crate::cli::ClusterCliError;
 use crate::cli::start::default_log_directory;
 use crate::start::local::{DEFAULT_DATA_DIR as DEFAULT_LOCAL_DIR, DEFAULT_METADATA_SUB_DIR};
 
+const FLUVIO_PROCESS_NAME: &str = "fluvio";
+
 #[derive(Parser, Debug)]
 pub struct DiagnosticsOpt {
     #[arg(long)]
@@ -155,7 +157,7 @@ impl DiagnosticsOpt {
         // Filter for only Fluvio pods
         let pods = pods
             .split(' ')
-            .filter(|pod| pod.contains("fluvio"))
+            .filter(|pod| pod.contains(FLUVIO_PROCESS_NAME))
             .collect::<Vec<_>>();
 
         for &pod in &pods {
@@ -196,7 +198,7 @@ impl DiagnosticsOpt {
         // Filter for only Fluvio services
         let objects = objects
             .split(' ')
-            .filter(|obj| !filter_fluvio || obj.contains("fluvio"))
+            .filter(|obj| !filter_fluvio || obj.contains(FLUVIO_PROCESS_NAME))
             .map(|name| name.trim())
             .collect::<Vec<_>>();
 
@@ -456,7 +458,7 @@ impl ProcessInfo {
             let process_name = process.name().to_str();
 
             if let Some(process_name) = process_name {
-                if process_name.contains("fluvio") {
+                if process_name.contains(FLUVIO_PROCESS_NAME) {
                     processes.push(ProcessInfo {
                         pid: pid.as_u32(),
                         name: process_name.to_string(),

--- a/crates/fluvio-cluster/src/cli/shutdown.rs
+++ b/crates/fluvio-cluster/src/cli/shutdown.rs
@@ -1,16 +1,14 @@
-use std::ffi::OsString;
-use std::fs::remove_file;
 use std::process::Command;
 
 use anyhow::bail;
 use anyhow::Result;
 use clap::Parser;
 use tracing::debug;
-use sysinfo::System;
 
 use fluvio_types::defaults::SPU_MONITORING_UNIX_SOCKET;
 use fluvio_command::CommandExt;
 
+use crate::process;
 use crate::render::ProgressRenderer;
 use crate::cli::ClusterCliError;
 use crate::progress::ProgressBarFactory;
@@ -36,7 +34,7 @@ impl ShutdownOpt {
 
         match installation_type {
             InstallationType::Local | InstallationType::LocalK8 | InstallationType::ReadOnly => {
-                Self::kill_local_processes(&installation_type, &pb).await?;
+                Self::shutdown_local(&installation_type, &pb).await?;
             }
             InstallationType::Cloud => {
                 let profile = config.config().current_profile_name().unwrap_or("none");
@@ -50,67 +48,23 @@ impl ShutdownOpt {
         Ok(())
     }
 
-    async fn kill_local_processes(
+    async fn shutdown_local(
         installation_type: &InstallationType,
         pb: &ProgressRenderer,
     ) -> Result<()> {
-        pb.set_message("Uninstalling fluvio local components");
-
-        let kill_proc = |name: &str, command_args: Option<&[String]>| {
-            sysinfo::set_open_files_limit(0);
-            let mut sys = System::new();
-            sys.refresh_processes(sysinfo::ProcessesToUpdate::All); // Only load what we need.
-            for process in sys.processes_by_exact_name(name.as_ref()) {
-                if let Some(cmd_args) = command_args {
-                    let proc_cmds = process.cmd();
-                    if cmd_args.len() > proc_cmds.len() {
-                        continue; // Ignore procs with less command_args than the target.
-                    }
-                    if cmd_args
-                        .iter()
-                        .map(OsString::from)
-                        .collect::<Vec<_>>()
-                        .iter()
-                        .ne(proc_cmds[..cmd_args.len()].iter())
-                    {
-                        continue; // Ignore procs which don't match.
-                    }
-                }
-                if !process.kill() {
-                    // This will fail if called on a proc running as root, so only log failure.
-                    debug!(
-                        "Sysinto process.kill() returned false. pid: {}, name: {}: user: {:?}",
-                        process.pid(),
-                        process.name().to_str().unwrap_or("unknown"),
-                        process.user_id(),
-                    );
-                }
-            }
-        };
-        kill_proc("fluvio", Some(&["cluster".into(), "run".into()]));
-        kill_proc("fluvio", Some(&["run".into()]));
-        kill_proc("fluvio-run", None);
+        process::kill_local_processes(pb).await?;
 
         if let InstallationType::LocalK8 = installation_type {
             let _ = Self::remove_custom_objects("spus", true);
         }
 
         // remove monitoring socket
-        match remove_file(SPU_MONITORING_UNIX_SOCKET) {
-            Ok(_) => {
-                pb.println(format!(
-                    "Removed spu monitoring socket: {SPU_MONITORING_UNIX_SOCKET}"
-                ));
-            }
-            Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
-                debug!("SPU monitoring socket not found: {SPU_MONITORING_UNIX_SOCKET}");
-            }
-            Err(err) => {
-                pb.println(format!(
-                    "SPU monitoring socket  {SPU_MONITORING_UNIX_SOCKET}, can't be removed: {err}"
-                ));
-            }
-        }
+        process::delete_fs(
+            Some(SPU_MONITORING_UNIX_SOCKET),
+            "SPU monitoring socket",
+            true,
+            Some(pb),
+        );
 
         pb.println("Uninstalled fluvio local components");
         pb.finish_and_clear();

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::Path;
 use std::process::Command;
 use std::fs::{remove_dir_all, remove_file};
@@ -149,16 +150,23 @@ impl ClusterUninstaller {
         pb.set_message("Uninstalling fluvio local components");
 
         let kill_proc = |name: &str, command_args: Option<&[String]>| {
+            sysinfo::set_open_files_limit(0);
             let mut sys = System::new();
-            sys.refresh_processes(); // Only load what we need.
-            for process in sys.processes_by_exact_name(name) {
+            sys.refresh_processes(sysinfo::ProcessesToUpdate::All); // Only load what we need.
+            for process in sys.processes_by_exact_name(name.as_ref()) {
                 if let Some(cmd_args) = command_args {
                     // First command is the executable so cut that out.
-                    let proc_cmds = &process.cmd();
+                    let proc_cmds = process.cmd();
                     if cmd_args.len() > proc_cmds.len() {
                         continue; // Ignore procs with less command_args than the target.
                     }
-                    if cmd_args.iter().ne(proc_cmds[..cmd_args.len()].iter()) {
+                    if cmd_args
+                        .iter()
+                        .map(OsString::from)
+                        .collect::<Vec<_>>()
+                        .iter()
+                        .ne(proc_cmds[..cmd_args.len()].iter())
+                    {
                         continue; // Ignore procs which don't match.
                     }
                 }
@@ -167,7 +175,7 @@ impl ClusterUninstaller {
                     debug!(
                         "Sysinto process.kill() returned false. pid: {}, name: {}: user: {:?}",
                         process.pid(),
-                        process.name(),
+                        process.name().to_str().unwrap_or("unknown"),
                         process.user_id(),
                     );
                 }

--- a/crates/fluvio-cluster/src/delete.rs
+++ b/crates/fluvio-cluster/src/delete.rs
@@ -1,23 +1,17 @@
-use std::ffi::OsString;
-use std::path::Path;
 use std::process::Command;
-use std::fs::{remove_dir_all, remove_file};
 
 use derive_builder::Builder;
 use k8_client::meta_client::MetadataClient;
 use tracing::{info, warn, debug, instrument};
-use sysinfo::System;
 
 use fluvio_command::CommandExt;
-use fluvio_types::defaults::SPU_MONITORING_UNIX_SOCKET;
 
 use crate::helm::HelmClient;
 use crate::charts::{APP_CHART_NAME, SYS_CHART_NAME};
 use crate::progress::ProgressBarFactory;
 use crate::render::ProgressRenderer;
-use crate::DEFAULT_NAMESPACE;
+use crate::{process, DEFAULT_NAMESPACE};
 use crate::error::UninstallError;
-use crate::start::local::{DEFAULT_DATA_DIR, LOCAL_CONFIG_PATH};
 use anyhow::Result;
 
 /// Uninstalls different flavors of fluvio
@@ -147,97 +141,17 @@ impl ClusterUninstaller {
 
     async fn uninstall_local(&self) -> Result<()> {
         let pb = self.pb_factory.create()?;
-        pb.set_message("Uninstalling fluvio local components");
-
-        let kill_proc = |name: &str, command_args: Option<&[String]>| {
-            sysinfo::set_open_files_limit(0);
-            let mut sys = System::new();
-            sys.refresh_processes(sysinfo::ProcessesToUpdate::All); // Only load what we need.
-            for process in sys.processes_by_exact_name(name.as_ref()) {
-                if let Some(cmd_args) = command_args {
-                    // First command is the executable so cut that out.
-                    let proc_cmds = process.cmd();
-                    if cmd_args.len() > proc_cmds.len() {
-                        continue; // Ignore procs with less command_args than the target.
-                    }
-                    if cmd_args
-                        .iter()
-                        .map(OsString::from)
-                        .collect::<Vec<_>>()
-                        .iter()
-                        .ne(proc_cmds[..cmd_args.len()].iter())
-                    {
-                        continue; // Ignore procs which don't match.
-                    }
-                }
-                if !process.kill() {
-                    // This will fail if called on a proc running as root, so only log failure.
-                    debug!(
-                        "Sysinto process.kill() returned false. pid: {}, name: {}: user: {:?}",
-                        process.pid(),
-                        process.name().to_str().unwrap_or("unknown"),
-                        process.user_id(),
-                    );
-                }
-            }
-        };
-        kill_proc("fluvio", Some(&["cluster".into(), "run".into()]));
-        kill_proc("fluvio", Some(&["run".into()]));
-        kill_proc("fluvio-run", None);
-
-        fn delete_fs<T: AsRef<Path>>(
-            path: Option<T>,
-            tag: &'static str,
-            is_file: bool,
-            pb: Option<&ProgressRenderer>,
-        ) {
-            match path {
-                Some(path) => {
-                    let path_ref = path.as_ref();
-                    match if is_file {
-                        remove_file(path_ref)
-                    } else {
-                        remove_dir_all(path_ref)
-                    } {
-                        Ok(_) => {
-                            debug!("Removed {}: {}", tag, path_ref.display());
-                            if let Some(pb) = pb {
-                                pb.println(format!("Removed {}", tag))
-                            }
-                        }
-                        Err(err) => {
-                            warn!("{} can't be removed: {}", tag, err);
-                            if let Some(pb) = pb {
-                                pb.println(format!("{tag}, can't be removed: {err}"))
-                            }
-                        }
-                    }
-                }
-                None => {
-                    warn!("Unable to find {}, cannot remove", tag);
-                }
-            }
-        }
+        process::kill_local_processes(&pb).await?;
 
         // delete fluvio file
         debug!("Removing fluvio directory");
-        delete_fs(DEFAULT_DATA_DIR.as_ref(), "data dir", false, None);
+        process::delete_data_dir();
 
         // delete local cluster config file
-        delete_fs(
-            LOCAL_CONFIG_PATH.as_ref(),
-            "local cluster config",
-            true,
-            None,
-        );
+        process::delete_local_config();
 
         // remove monitoring socket
-        delete_fs(
-            Some(SPU_MONITORING_UNIX_SOCKET),
-            "SPU monitoring socket",
-            true,
-            Some(&pb),
-        );
+        process::delete_spu_socket();
 
         pb.println("Uninstalled fluvio local components");
         pb.finish_and_clear();

--- a/crates/fluvio-cluster/src/lib.rs
+++ b/crates/fluvio-cluster/src/lib.rs
@@ -34,6 +34,7 @@ mod delete;
 mod error;
 mod progress;
 pub mod runtime;
+mod process;
 
 /// extensions
 #[cfg(feature = "cli")]

--- a/crates/fluvio-cluster/src/process/mod.rs
+++ b/crates/fluvio-cluster/src/process/mod.rs
@@ -1,0 +1,112 @@
+use std::ffi::OsString;
+use std::fs::{remove_dir_all, remove_file};
+use std::path::Path;
+
+use fluvio_types::defaults::SPU_MONITORING_UNIX_SOCKET;
+use sysinfo::System;
+use anyhow::Result;
+
+use tracing::{debug, warn};
+
+use crate::render::ProgressRenderer;
+use crate::start::local::{DEFAULT_DATA_DIR, LOCAL_CONFIG_PATH};
+
+pub async fn kill_local_processes(pb: &ProgressRenderer) -> Result<()> {
+    pb.set_message("Uninstalling fluvio local components");
+
+    let kill_proc = |name: &str, command_args: Option<&[String]>| {
+        sysinfo::set_open_files_limit(0);
+        let mut sys = System::new();
+        sys.refresh_processes(sysinfo::ProcessesToUpdate::All); // Only load what we need.
+        for process in sys.processes_by_exact_name(name.as_ref()) {
+            if let Some(cmd_args) = command_args {
+                let proc_cmds = process.cmd();
+                if cmd_args.len() > proc_cmds.len() {
+                    continue; // Ignore procs with less command_args than the target.
+                }
+                if cmd_args
+                    .iter()
+                    .map(OsString::from)
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .ne(proc_cmds[..cmd_args.len()].iter())
+                {
+                    continue; // Ignore procs which don't match.
+                }
+            }
+            if !process.kill() {
+                // This will fail if called on a proc running as root, so only log failure.
+                debug!(
+                    "Sysinto process.kill() returned false. pid: {}, name: {}: user: {:?}",
+                    process.pid(),
+                    process.name().to_str().unwrap_or("unknown"),
+                    process.user_id(),
+                );
+            }
+        }
+    };
+    kill_proc("fluvio", Some(&["cluster".into(), "run".into()]));
+    kill_proc("fluvio", Some(&["run".into()]));
+    kill_proc("fluvio-run", None);
+
+    Ok(())
+}
+
+pub fn delete_fs<T: AsRef<Path>>(
+    path: Option<T>,
+    tag: &'static str,
+    is_file: bool,
+    pb: Option<&ProgressRenderer>,
+) {
+    match path {
+        Some(path) => {
+            let path_ref = path.as_ref();
+            match if is_file {
+                remove_file(path_ref)
+            } else {
+                remove_dir_all(path_ref)
+            } {
+                Ok(_) => {
+                    debug!("Removed {}: {}", tag, path_ref.display());
+                    if let Some(pb) = pb {
+                        pb.println(format!("Removed {}", tag))
+                    }
+                }
+                Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                    debug!("{} not found: {}", tag, path_ref.display());
+                }
+                Err(err) => {
+                    warn!("{} can't be removed: {}", tag, err);
+                    if let Some(pb) = pb {
+                        pb.println(format!("{tag}, can't be removed: {err}"))
+                    }
+                }
+            }
+        }
+        None => {
+            warn!("Unable to find {}, cannot remove", tag);
+        }
+    }
+}
+
+pub fn delete_spu_socket() {
+    delete_fs(
+        Some(SPU_MONITORING_UNIX_SOCKET),
+        "SPU monitoring socket",
+        true,
+        None,
+    );
+}
+
+pub fn delete_local_config() {
+    delete_fs(
+        LOCAL_CONFIG_PATH.as_ref(),
+        "local cluster config",
+        true,
+        None,
+    );
+}
+
+pub fn delete_data_dir() {
+    delete_fs(DEFAULT_DATA_DIR.as_ref(), "data dir", false, None);
+}

--- a/crates/fluvio-sc/src/start.rs
+++ b/crates/fluvio-sc/src/start.rs
@@ -70,6 +70,7 @@ pub fn main_loop(opt: ScOpt) {
 fn inspect_system() {
     use sysinfo::System;
 
+    sysinfo::set_open_files_limit(0);
     let mut sys = System::new_all();
     sys.refresh_all();
     info!(version = crate::VERSION, "Platform");

--- a/crates/fluvio-spu/src/start.rs
+++ b/crates/fluvio-spu/src/start.rs
@@ -31,6 +31,7 @@ pub fn main_loop(opt: SpuOpt) {
 
     println!("starting spu server (id:{})", spu_config.id);
 
+    sysinfo::set_open_files_limit(0);
     let mut sys = System::new_all();
     sys.refresh_all();
     info!(version = crate::VERSION, "Platform");


### PR DESCRIPTION
Update sysinfo to 0.31.4 and fix file descriptor leak on Linux. 
`sysinfo` leaks file descriptors on Linux if the limit is not set.



Spu Before:

```
▷ ls /proc/570230/fd/ | wc -l
1114
```

Spu After:
```
▷ ls /proc/574099/fd/ | wc -l
19
```

