### PR TITLE
chore: update Rust `1.81`

### DIFF
--- a/crates/fluvio-cluster/src/cli/delete.rs
+++ b/crates/fluvio-cluster/src/cli/delete.rs
@@ -37,7 +37,7 @@ impl DeleteOpt {
         };
 
         if !self.force {
-            let mut user_input: String = Input::with_theme(&ColorfulTheme::default()).with_prompt(&format!(
+            let mut user_input: String = Input::with_theme(&ColorfulTheme::default()).with_prompt(format!(
                 "WARNING: You are about to delete {cluster}/{endpoint}. This operation is irreversible \
                 and the data stored in your cluster will be permanently lost. \
                 \nPlease type the cluster name to confirm: {cluster} <enter> (to confirm) / or CTRL-C (to cancel)",

--- a/crates/fluvio-version-manager/src/command/itself/uninstall.rs
+++ b/crates/fluvio-version-manager/src/command/itself/uninstall.rs
@@ -23,7 +23,7 @@ impl SelfUninstallOpt {
         if workdir_path.exists() {
             if self.yes
                 || Confirm::with_theme(&ColorfulTheme::default())
-                    .with_prompt(&format!(
+                    .with_prompt(format!(
                         "Are you sure you want to uninstall FVM from {}?",
                         workdir_path.display()
                     ))

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -480,13 +480,12 @@ where
 
                 let server_sender_clone2 = server_sender_clone.clone();
                 let update_stream = StreamExt::map(stream, move |item| {
-                    item.map(|response| {
+                    item.inspect(|response| {
                         if let Some(last_offset) = response.partition.next_offset_for_fetch() {
                             debug!(last_offset, stream_id, "received last offset from spu");
                             let _ = server_sender_clone
                                 .try_send(StreamToServer::UpdateOffset(last_offset));
                         }
-                        response
                     })
                     .map_err(|e| {
                         error!(?e, "error in stream");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"


### PR DESCRIPTION
Updates Rust to version `1.81`.