### PR TITLE
fix: use `Compression` as type and introduce `CompressionExt` with algorithms impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ version = "0.3.4"
 dependencies = [
  "bytes",
  "flate2",
+ "fluvio-types",
  "lz4_flex",
  "serde",
  "snap",
@@ -3186,6 +3187,7 @@ dependencies = [
  "bytes",
  "clap",
  "derive_builder",
+ "fluvio-compression",
  "fluvio-controlplane",
  "fluvio-controlplane-metadata",
  "fluvio-future",
@@ -3332,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "event-listener 5.3.1",
  "fluvio-future",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,6 @@ dependencies = [
  "anyhow",
  "bytesize",
  "bytesize-serde",
- "fluvio-compression",
  "fluvio-controlplane-metadata",
  "fluvio-smartengine",
  "fluvio-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-compression"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytes",
  "flate2",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.6.0"
+version = "0.5.1"
 dependencies = [
  "event-listener 5.3.1",
  "fluvio-future",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ fluvio-spu-schema = { version = "0.16.0", path = "crates/fluvio-spu-schema", def
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.13.2", path = "crates/fluvio-stream-dispatcher" }
 fluvio-stream-model = { version = "0.11.3", path = "crates/fluvio-stream-model", default-features = false }
-fluvio-types = { version = "0.5.0", path = "crates/fluvio-types", default-features = false }
+fluvio-types = { version = "0.6.0", path = "crates/fluvio-types", default-features = false }
 fluvio-kv-storage = { path = "crates/fluvio-kv-storage", default-features = false }
 
 # Used to make eyre faster on debug builds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ fluvio-controlplane-metadata = { version = "0.29.0", default-features = false, p
 fluvio-extension-common = { path = "crates/fluvio-extension-common", default-features = false }
 fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-package-index = { version = "0.7.6", path = "crates/fluvio-package-index", default-features = false }
-fluvio-protocol = { version = "0.11.0", path = "crates/fluvio-protocol" }
+fluvio-protocol = { version = "0.12.0", path = "crates/fluvio-protocol" }
 fluvio-sc-schema = { version = "0.24.0", path = "crates/fluvio-sc-schema", default-features = false }
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.8.0", path = "crates/fluvio-smartengine", default-features = false }
@@ -187,7 +187,7 @@ fluvio-spu-schema = { version = "0.16.0", path = "crates/fluvio-spu-schema", def
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.13.2", path = "crates/fluvio-stream-dispatcher" }
 fluvio-stream-model = { version = "0.11.3", path = "crates/fluvio-stream-model", default-features = false }
-fluvio-types = { version = "0.6.0", path = "crates/fluvio-types", default-features = false }
+fluvio-types = { version = "0.5.1", path = "crates/fluvio-types", default-features = false }
 fluvio-kv-storage = { path = "crates/fluvio-kv-storage", default-features = false }
 
 # Used to make eyre faster on debug builds

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-compression"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
@@ -10,7 +10,7 @@ repository = "https://github.com/infinyon/fluvio"
 description = "Fluvio Compression library"
 
 [features]
-default = ["compress"]
+default = ["compress", "types"]
 compress = [
     "gzip",
     "lz4",
@@ -21,6 +21,7 @@ gzip = ["dep:flate2"]
 lz4 = ["dep:lz4_flex"]
 snap = ["dep:snap"]
 zstd = ["dep:zstd"]
+types = []
 
 [dependencies]
 serde = { workspace = true,  features = ['derive'] }

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/infinyon/fluvio"
 description = "Fluvio Compression library"
 
 [features]
-default = ["compress", "types"]
+default = ["compress"]
 compress = [
     "gzip",
     "lz4",
@@ -21,7 +21,6 @@ gzip = ["dep:flate2"]
 lz4 = ["dep:lz4_flex"]
 snap = ["dep:snap"]
 zstd = ["dep:zstd"]
-types = []
 
 [dependencies]
 serde = { workspace = true,  features = ['derive'] }

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -28,6 +28,8 @@ serde = { workspace = true,  features = ['derive'] }
 thiserror = { workspace = true }
 bytes = { workspace = true }
 
+fluvio-types = { workspace = true }
+
 # Optional Dependencies
 flate2 = { workspace = true, optional = true }
 lz4_flex = { version = "0.11.1", default-features = false, features = ["safe-decode", "safe-encode", "frame"], optional = true }

--- a/crates/fluvio-compression/src/error.rs
+++ b/crates/fluvio-compression/src/error.rs
@@ -7,14 +7,16 @@ use bytes::BytesMut;
 #[cfg(feature = "compress")]
 use snap::write::{IntoInnerError, FrameEncoder};
 
+use fluvio_types::compression::CompressionParseError;
+
 #[derive(thiserror::Error, Debug)]
 pub enum CompressionError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error("Failed to parse compression type: {0}")]
+    ParseError(#[from] CompressionParseError),
     #[error("Unreachable error")]
     UnreachableError,
-    #[error("unknown compression format: {0}")]
-    UnknownCompressionFormat(String),
     #[error("error flushing Snap encoder: {0}")]
     #[cfg(feature = "compress")]
     SnapError(#[from] Box<IntoInnerError<FrameEncoder<Writer<BytesMut>>>>),

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -64,4 +64,3 @@ impl CompressionExt for Compression {
         }
     }
 }
-

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -27,13 +27,13 @@ use serde::{Serialize, Deserialize};
 pub enum Compression {
     #[default]
     None = 0,
-    #[cfg(any( feature = "types", feature = "gzip"))]
+    #[cfg(any(feature = "types", feature = "gzip"))]
     Gzip = 1,
-    #[cfg(any( feature = "types", feature = "snap"))]
+    #[cfg(any(feature = "types", feature = "snap"))]
     Snappy = 2,
-    #[cfg(any( feature = "types", feature = "lz4"))]
+    #[cfg(any(feature = "types", feature = "lz4"))]
     Lz4 = 3,
-    #[cfg(any( feature = "types", feature = "zstd"))]
+    #[cfg(any(feature = "types", feature = "zstd"))]
     Zstd = 4,
 }
 
@@ -42,13 +42,13 @@ impl TryFrom<i8> for Compression {
     fn try_from(v: i8) -> Result<Self, CompressionError> {
         match v {
             0 => Ok(Compression::None),
-            #[cfg(any( feature = "types", feature = "gzip"))]
+            #[cfg(any(feature = "types", feature = "gzip"))]
             1 => Ok(Compression::Gzip),
-            #[cfg(any( feature = "types", feature = "snap"))]
+            #[cfg(any(feature = "types", feature = "snap"))]
             2 => Ok(Compression::Snappy),
-            #[cfg(any( feature = "types", feature = "lz4"))]
+            #[cfg(any(feature = "types", feature = "lz4"))]
             3 => Ok(Compression::Lz4),
-            #[cfg(any( feature = "types", feature = "zstd"))]
+            #[cfg(any(feature = "types", feature = "zstd"))]
             4 => Ok(Compression::Zstd),
             _ => Err(CompressionError::UnknownCompressionFormat(format!(
                 "i8 representation: {v}"
@@ -63,13 +63,13 @@ impl FromStr for Compression {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "none" => Ok(Compression::None),
-            #[cfg(any( feature = "types", feature = "gzip"))]
+            #[cfg(any(feature = "types", feature = "gzip"))]
             "gzip" => Ok(Compression::Gzip),
-            #[cfg(any( feature = "types", feature = "snap"))]
+            #[cfg(any(feature = "types", feature = "snap"))]
             "snappy" => Ok(Compression::Snappy),
-            #[cfg(any( feature = "types", feature = "lz4"))]
+            #[cfg(any(feature = "types", feature = "lz4"))]
             "lz4" => Ok(Compression::Lz4),
-            #[cfg(any( feature = "types", feature = "zstd"))]
+            #[cfg(any(feature = "types", feature = "zstd"))]
             "zstd" => Ok(Compression::Zstd),
             _ => Err(CompressionError::UnknownCompressionFormat(s.into())),
         }
@@ -80,13 +80,13 @@ impl std::fmt::Display for Compression {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             Compression::None => write!(f, "none"),
-            #[cfg(any( feature = "types", feature = "gzip"))]
+            #[cfg(any(feature = "types", feature = "gzip"))]
             Compression::Gzip => write!(f, "gzip"),
-            #[cfg(any( feature = "types", feature = "snap"))]
+            #[cfg(any(feature = "types", feature = "snap"))]
             Compression::Snappy => write!(f, "snappy"),
-            #[cfg(any( feature = "types", feature = "lz4"))]
+            #[cfg(any(feature = "types", feature = "lz4"))]
             Compression::Lz4 => write!(f, "lz4"),
-            #[cfg(any( feature = "types", feature = "zstd"))]
+            #[cfg(any(feature = "types", feature = "zstd"))]
             Compression::Zstd => write!(f, "zstd"),
         }
     }

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -22,6 +22,7 @@ pub trait CompressionExt {
     fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError>;
 }
 
+#[cfg(feature = "compress")]
 impl CompressionExt for Compression {
     fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
         match *self {
@@ -64,49 +65,3 @@ impl CompressionExt for Compression {
     }
 }
 
-// impl Compression {
-//     /// Compress the given data, returning the compressed data
-//     #[cfg(feature = "compress")]
-//     pub fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
-//         match *self {
-//             Compression::None => Ok(Bytes::copy_from_slice(src)),
-//             #[cfg(feature = "gzip")]
-//             Compression::Gzip => gzip::compress(src),
-//             #[cfg(feature = "snap")]
-//             Compression::Snappy => snappy::compress(src),
-//             #[cfg(feature = "lz4")]
-//             Compression::Lz4 => lz4::compress(src),
-//             #[cfg(feature = "zstd")]
-//             Compression::Zstd => zstd::compress(src),
-//         }
-//     }
-
-//     /// Uncompresss the given data, returning the uncompressed data if any compression was applied, otherwise returns None
-//     #[allow(unused_variables)]
-//     #[cfg(feature = "compress")]
-//     pub fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError> {
-//         match *self {
-//             Compression::None => Ok(None),
-//             #[cfg(feature = "gzip")]
-//             Compression::Gzip => {
-//                 let output = gzip::uncompress(src)?;
-//                 Ok(Some(output))
-//             }
-//             #[cfg(feature = "snap")]
-//             Compression::Snappy => {
-//                 let output = snappy::uncompress(src)?;
-//                 Ok(Some(output))
-//             }
-//             #[cfg(feature = "lz4")]
-//             Compression::Lz4 => {
-//                 let output = lz4::uncompress(src)?;
-//                 Ok(Some(output))
-//             }
-//             #[cfg(feature = "zstd")]
-//             Compression::Zstd => {
-//                 let output = zstd::uncompress(src)?;
-//                 Ok(Some(output))
-//             }
-//         }
-//     }
-// }

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -27,13 +27,13 @@ use serde::{Serialize, Deserialize};
 pub enum Compression {
     #[default]
     None = 0,
-    #[cfg(feature = "gzip")]
+    #[cfg(any( feature = "types", feature = "gzip"))]
     Gzip = 1,
-    #[cfg(feature = "snap")]
+    #[cfg(any( feature = "types", feature = "snap"))]
     Snappy = 2,
-    #[cfg(feature = "lz4")]
+    #[cfg(any( feature = "types", feature = "lz4"))]
     Lz4 = 3,
-    #[cfg(feature = "zstd")]
+    #[cfg(any( feature = "types", feature = "zstd"))]
     Zstd = 4,
 }
 
@@ -42,13 +42,13 @@ impl TryFrom<i8> for Compression {
     fn try_from(v: i8) -> Result<Self, CompressionError> {
         match v {
             0 => Ok(Compression::None),
-            #[cfg(feature = "gzip")]
+            #[cfg(any( feature = "types", feature = "gzip"))]
             1 => Ok(Compression::Gzip),
-            #[cfg(feature = "snap")]
+            #[cfg(any( feature = "types", feature = "snap"))]
             2 => Ok(Compression::Snappy),
-            #[cfg(feature = "lz4")]
+            #[cfg(any( feature = "types", feature = "lz4"))]
             3 => Ok(Compression::Lz4),
-            #[cfg(feature = "zstd")]
+            #[cfg(any( feature = "types", feature = "zstd"))]
             4 => Ok(Compression::Zstd),
             _ => Err(CompressionError::UnknownCompressionFormat(format!(
                 "i8 representation: {v}"
@@ -63,13 +63,13 @@ impl FromStr for Compression {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "none" => Ok(Compression::None),
-            #[cfg(feature = "gzip")]
+            #[cfg(any( feature = "types", feature = "gzip"))]
             "gzip" => Ok(Compression::Gzip),
-            #[cfg(feature = "snap")]
+            #[cfg(any( feature = "types", feature = "snap"))]
             "snappy" => Ok(Compression::Snappy),
-            #[cfg(feature = "lz4")]
+            #[cfg(any( feature = "types", feature = "lz4"))]
             "lz4" => Ok(Compression::Lz4),
-            #[cfg(feature = "zstd")]
+            #[cfg(any( feature = "types", feature = "zstd"))]
             "zstd" => Ok(Compression::Zstd),
             _ => Err(CompressionError::UnknownCompressionFormat(s.into())),
         }
@@ -80,13 +80,13 @@ impl std::fmt::Display for Compression {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             Compression::None => write!(f, "none"),
-            #[cfg(feature = "gzip")]
+            #[cfg(any( feature = "types", feature = "gzip"))]
             Compression::Gzip => write!(f, "gzip"),
-            #[cfg(feature = "snap")]
+            #[cfg(any( feature = "types", feature = "snap"))]
             Compression::Snappy => write!(f, "snappy"),
-            #[cfg(feature = "lz4")]
+            #[cfg(any( feature = "types", feature = "lz4"))]
             Compression::Lz4 => write!(f, "lz4"),
-            #[cfg(feature = "zstd")]
+            #[cfg(any( feature = "types", feature = "zstd"))]
             Compression::Zstd => write!(f, "zstd"),
         }
     }
@@ -94,6 +94,7 @@ impl std::fmt::Display for Compression {
 
 impl Compression {
     /// Compress the given data, returning the compressed data
+    #[cfg(feature = "compress")]
     pub fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
         match *self {
             Compression::None => Ok(Bytes::copy_from_slice(src)),
@@ -110,6 +111,7 @@ impl Compression {
 
     /// Uncompresss the given data, returning the uncompressed data if any compression was applied, otherwise returns None
     #[allow(unused_variables)]
+    #[cfg(feature = "compress")]
     pub fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError> {
         match *self {
             Compression::None => Ok(None),

--- a/crates/fluvio-compression/src/lib.rs
+++ b/crates/fluvio-compression/src/lib.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 mod error;
 
 use bytes::Bytes;
@@ -17,85 +15,15 @@ mod lz4;
 mod zstd;
 
 pub use error::CompressionError;
-use serde::{Serialize, Deserialize};
+pub use fluvio_types::compression::{Compression, CompressionParseError};
 
-/// The compression algorithm used to compress and decompress records in fluvio batches
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
-#[serde(rename_all = "lowercase")]
-#[repr(i8)]
-#[derive(Default)]
-pub enum Compression {
-    #[default]
-    None = 0,
-    #[cfg(any(feature = "types", feature = "gzip"))]
-    Gzip = 1,
-    #[cfg(any(feature = "types", feature = "snap"))]
-    Snappy = 2,
-    #[cfg(any(feature = "types", feature = "lz4"))]
-    Lz4 = 3,
-    #[cfg(any(feature = "types", feature = "zstd"))]
-    Zstd = 4,
+pub trait CompressionExt {
+    fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError>;
+    fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError>;
 }
 
-impl TryFrom<i8> for Compression {
-    type Error = CompressionError;
-    fn try_from(v: i8) -> Result<Self, CompressionError> {
-        match v {
-            0 => Ok(Compression::None),
-            #[cfg(any(feature = "types", feature = "gzip"))]
-            1 => Ok(Compression::Gzip),
-            #[cfg(any(feature = "types", feature = "snap"))]
-            2 => Ok(Compression::Snappy),
-            #[cfg(any(feature = "types", feature = "lz4"))]
-            3 => Ok(Compression::Lz4),
-            #[cfg(any(feature = "types", feature = "zstd"))]
-            4 => Ok(Compression::Zstd),
-            _ => Err(CompressionError::UnknownCompressionFormat(format!(
-                "i8 representation: {v}"
-            ))),
-        }
-    }
-}
-
-impl FromStr for Compression {
-    type Err = CompressionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "none" => Ok(Compression::None),
-            #[cfg(any(feature = "types", feature = "gzip"))]
-            "gzip" => Ok(Compression::Gzip),
-            #[cfg(any(feature = "types", feature = "snap"))]
-            "snappy" => Ok(Compression::Snappy),
-            #[cfg(any(feature = "types", feature = "lz4"))]
-            "lz4" => Ok(Compression::Lz4),
-            #[cfg(any(feature = "types", feature = "zstd"))]
-            "zstd" => Ok(Compression::Zstd),
-            _ => Err(CompressionError::UnknownCompressionFormat(s.into())),
-        }
-    }
-}
-
-impl std::fmt::Display for Compression {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            Compression::None => write!(f, "none"),
-            #[cfg(any(feature = "types", feature = "gzip"))]
-            Compression::Gzip => write!(f, "gzip"),
-            #[cfg(any(feature = "types", feature = "snap"))]
-            Compression::Snappy => write!(f, "snappy"),
-            #[cfg(any(feature = "types", feature = "lz4"))]
-            Compression::Lz4 => write!(f, "lz4"),
-            #[cfg(any(feature = "types", feature = "zstd"))]
-            Compression::Zstd => write!(f, "zstd"),
-        }
-    }
-}
-
-impl Compression {
-    /// Compress the given data, returning the compressed data
-    #[cfg(feature = "compress")]
-    pub fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
+impl CompressionExt for Compression {
+    fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
         match *self {
             Compression::None => Ok(Bytes::copy_from_slice(src)),
             #[cfg(feature = "gzip")]
@@ -109,10 +37,7 @@ impl Compression {
         }
     }
 
-    /// Uncompresss the given data, returning the uncompressed data if any compression was applied, otherwise returns None
-    #[allow(unused_variables)]
-    #[cfg(feature = "compress")]
-    pub fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError> {
+    fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError> {
         match *self {
             Compression::None => Ok(None),
             #[cfg(feature = "gzip")]
@@ -138,3 +63,50 @@ impl Compression {
         }
     }
 }
+
+// impl Compression {
+//     /// Compress the given data, returning the compressed data
+//     #[cfg(feature = "compress")]
+//     pub fn compress(&self, src: &[u8]) -> Result<Bytes, CompressionError> {
+//         match *self {
+//             Compression::None => Ok(Bytes::copy_from_slice(src)),
+//             #[cfg(feature = "gzip")]
+//             Compression::Gzip => gzip::compress(src),
+//             #[cfg(feature = "snap")]
+//             Compression::Snappy => snappy::compress(src),
+//             #[cfg(feature = "lz4")]
+//             Compression::Lz4 => lz4::compress(src),
+//             #[cfg(feature = "zstd")]
+//             Compression::Zstd => zstd::compress(src),
+//         }
+//     }
+
+//     /// Uncompresss the given data, returning the uncompressed data if any compression was applied, otherwise returns None
+//     #[allow(unused_variables)]
+//     #[cfg(feature = "compress")]
+//     pub fn uncompress(&self, src: &[u8]) -> Result<Option<Vec<u8>>, CompressionError> {
+//         match *self {
+//             Compression::None => Ok(None),
+//             #[cfg(feature = "gzip")]
+//             Compression::Gzip => {
+//                 let output = gzip::uncompress(src)?;
+//                 Ok(Some(output))
+//             }
+//             #[cfg(feature = "snap")]
+//             Compression::Snappy => {
+//                 let output = snappy::uncompress(src)?;
+//                 Ok(Some(output))
+//             }
+//             #[cfg(feature = "lz4")]
+//             Compression::Lz4 => {
+//                 let output = lz4::uncompress(src)?;
+//                 Ok(Some(output))
+//             }
+//             #[cfg(feature = "zstd")]
+//             Compression::Zstd => {
+//                 let output = zstd::uncompress(src)?;
+//                 Ok(Some(output))
+//             }
+//         }
+//     }
+// }

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -28,7 +28,7 @@ fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata/", defa
 fluvio-smartengine = { path = "../fluvio-smartengine", default-features = false, features = [
     "transformation",
 ] }
-fluvio-compression = { path = "../fluvio-compression", default-features = false }
+fluvio-compression = { path = "../fluvio-compression", default-features = false, features = ["types"] }
 fluvio-types = { path = "../fluvio-types" }
 bytesize-serde = "0.2.1"
 

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -28,7 +28,7 @@ fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata/", defa
 fluvio-smartengine = { path = "../fluvio-smartengine", default-features = false, features = [
     "transformation",
 ] }
-fluvio-compression = { path = "../fluvio-compression" }
+fluvio-compression = { path = "../fluvio-compression", default-features = false }
 fluvio-types = { path = "../fluvio-types" }
 bytesize-serde = "0.2.1"
 

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -28,7 +28,6 @@ fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata/", defa
 fluvio-smartengine = { path = "../fluvio-smartengine", default-features = false, features = [
     "transformation",
 ] }
-fluvio-compression = { path = "../fluvio-compression", default-features = false, features = ["types"] }
 fluvio-types = { path = "../fluvio-types" }
 bytesize-serde = "0.2.1"
 

--- a/crates/fluvio-connector-package/src/config/mod.rs
+++ b/crates/fluvio-connector-package/src/config/mod.rs
@@ -15,8 +15,8 @@ pub use bytesize::ByteSize;
 
 pub use fluvio_controlplane_metadata::topic::config as topic_config;
 pub use fluvio_smartengine::transformation::TransformationStep;
-pub use fluvio_compression::Compression;
 pub use fluvio_types::PartitionId;
+pub use fluvio_types::compression::Compression;
 
 use crate::metadata::Direction;
 

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"
@@ -61,7 +61,7 @@ tracing = { workspace = true }
 fluvio-protocol-derive = { version = "0.5.0", path = "../fluvio-protocol-derive", optional = true }
 fluvio-future = { workspace = true, optional = true }
 flv-util = { workspace = true,  optional = true }
-fluvio-compression = { path = "../fluvio-compression", version = "0.3.0", default-features = false, optional = true }
+fluvio-compression = { path = "../fluvio-compression", version = "0.3.0", default-features = false, features = ["compress"], optional = true }
 fluvio-types = { workspace = true,  optional = true }
 
 [dev-dependencies]

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/record/batch.rs
+++ b/crates/fluvio-protocol/src/record/batch.rs
@@ -6,8 +6,7 @@ use fluvio_types::PartitionId;
 use tracing::trace;
 
 use fluvio_types::Timestamp;
-use fluvio_compression::Compression;
-use fluvio_compression::CompressionError;
+use fluvio_compression::{Compression, CompressionExt, CompressionError};
 
 use crate::bytes::Buf;
 use crate::bytes::BufMut;
@@ -461,7 +460,7 @@ pub struct BatchHeader {
 impl BatchHeader {
     fn get_compression(&self) -> Result<Compression, CompressionError> {
         let compression_bits = self.attributes & ATTR_COMPRESSION_CODEC_MASK;
-        Compression::try_from(compression_bits as i8)
+        Compression::try_from(compression_bits as i8).map_err(CompressionError::from)
     }
 
     pub fn set_compression(&mut self, compression: Compression) {

--- a/crates/fluvio-spu/src/smartengine/produce_batch.rs
+++ b/crates/fluvio-spu/src/smartengine/produce_batch.rs
@@ -1,7 +1,7 @@
 use std::io::{Error as IoError, ErrorKind};
 
 use fluvio_protocol::record::{Batch, RawRecords, Offset};
-use fluvio_compression::{Compression, CompressionError};
+use fluvio_compression::{Compression, CompressionExt, CompressionError};
 
 use super::batch::SmartModuleInputBatch;
 

--- a/crates/fluvio-storage/Cargo.toml
+++ b/crates/fluvio-storage/Cargo.toml
@@ -52,6 +52,7 @@ fluvio-protocol = { workspace = true }
 fluvio-controlplane-metadata = { workspace = true  }
 fluvio-controlplane = { workspace = true }
 fluvio-spu-schema = { workspace = true, features = [ "file"] }
+fluvio-compression = { workspace = true }
 
 [dev-dependencies]
 fluvio-future = { workspace = true, features = ["fixture"] }

--- a/crates/fluvio-storage/src/iterators.rs
+++ b/crates/fluvio-storage/src/iterators.rs
@@ -5,9 +5,9 @@ use std::io::{Error as IoError, ErrorKind, Cursor};
 
 use nix::sys::uio::pread;
 
+use fluvio_compression::CompressionExt;
 use fluvio_protocol::types::Timestamp;
 use fluvio_protocol::{Decoder, Version};
-
 use fluvio_protocol::record::{Batch, Offset, BATCH_FILE_HEADER_SIZE, BATCH_HEADER_SIZE, Record};
 use fluvio_future::file_slice::AsyncFileSlice;
 

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.6.0"
+version = "0.5.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -14,7 +14,7 @@ events = ["event-listener"]
 event-listener = { workspace = true,  optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 toml = { workspace = true, features = ["display", "preserve_order", "parse"] }
 
 [dev-dependencies]

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-types"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2021"
 description = "Fluvio common types and objects"

--- a/crates/fluvio-types/src/compression.rs
+++ b/crates/fluvio-types/src/compression.rs
@@ -1,0 +1,79 @@
+use std::str::FromStr;
+
+use serde::{Serialize, Deserialize};
+
+#[derive(thiserror::Error, Debug)]
+pub enum CompressionParseError {
+    #[error("unknown compression format: {0}")]
+    UnknownCompressionFormat(String),
+}
+
+pub const COMPRESSION_CODE_NONE: i8 = 0;
+pub const COMPRESSION_CODE_GZIP: i8 = 1;
+pub const COMPRESSION_CODE_SNAPPY: i8 = 2;
+pub const COMPRESSION_CODE_LZ4: i8 = 3;
+pub const COMPRESSION_CODE_ZSTD: i8 = 4;
+
+pub const COMPRESSION_NONE: &str = "none";
+pub const COMPRESSION_GZIP: &str = "gzip";
+pub const COMPRESSION_SNAPPY: &str = "snappy";
+pub const COMPRESSION_LZ4: &str = "lz4";
+pub const COMPRESSION_ZSTD: &str = "zstd";
+
+/// The compression algorithm used to compress and decompress records in fluvio batches
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "lowercase")]
+#[repr(i8)]
+#[derive(Default)]
+pub enum Compression {
+    #[default]
+    None = COMPRESSION_CODE_NONE,
+    Gzip = COMPRESSION_CODE_GZIP,
+    Snappy = COMPRESSION_CODE_SNAPPY,
+    Lz4 = COMPRESSION_CODE_LZ4,
+    Zstd = COMPRESSION_CODE_ZSTD,
+}
+
+impl TryFrom<i8> for Compression {
+    type Error = CompressionParseError;
+
+    fn try_from(v: i8) -> Result<Self, CompressionParseError> {
+        match v {
+            COMPRESSION_CODE_NONE => Ok(Compression::None),
+            COMPRESSION_CODE_GZIP => Ok(Compression::Gzip),
+            COMPRESSION_CODE_SNAPPY => Ok(Compression::Snappy),
+            COMPRESSION_CODE_LZ4 => Ok(Compression::Lz4),
+            COMPRESSION_CODE_ZSTD => Ok(Compression::Zstd),
+            _ => Err(CompressionParseError::UnknownCompressionFormat(format!(
+                "i8 representation: {v}"
+            ))),
+        }
+    }
+}
+
+impl FromStr for Compression {
+    type Err = CompressionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            COMPRESSION_NONE => Ok(Compression::None),
+            COMPRESSION_GZIP => Ok(Compression::Gzip),
+            COMPRESSION_SNAPPY => Ok(Compression::Snappy),
+            COMPRESSION_LZ4 => Ok(Compression::Lz4),
+            COMPRESSION_ZSTD => Ok(Compression::Zstd),
+            _ => Err(CompressionParseError::UnknownCompressionFormat(s.into())),
+        }
+    }
+}
+
+impl std::fmt::Display for Compression {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Compression::None => write!(f, "{}", COMPRESSION_NONE),
+            Compression::Gzip => write!(f, "{}", COMPRESSION_GZIP),
+            Compression::Snappy => write!(f, "{}", COMPRESSION_SNAPPY),
+            Compression::Lz4 => write!(f, "{}", COMPRESSION_LZ4),
+            Compression::Zstd => write!(f, "{}", COMPRESSION_ZSTD),
+        }
+    }
+}

--- a/crates/fluvio-types/src/lib.rs
+++ b/crates/fluvio-types/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+pub mod compression;
 pub mod defaults;
 pub mod macros;
 pub mod partition;

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -3,13 +3,12 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use derive_builder::Builder;
+use serde::{Serialize, Deserialize};
 
+use fluvio_compression::Compression;
 use fluvio_future::retry::{ExponentialBackoff, FibonacciBackoff, FixedDelay};
 use fluvio_spu_schema::Isolation;
 use fluvio_spu_schema::server::smartmodule::SmartModuleInvocation;
-
-use fluvio_compression::Compression;
-use serde::{Serialize, Deserialize};
 
 use crate::producer::partitioning::{Partitioner, SiphashRoundRobinPartitioner};
 


### PR DESCRIPTION
Disables compression for Connector Package as its using types for conn meta and not
compression algorithms themselves.

Fluvio Compression will now use `compress` and `types` features by default, but if you need only types for use cases like configurations, then you can turn off default features and use `types` feature only instead.