### PR TITLE
chore: decrease exponential timeout of mirroring

### DIFF
--- a/crates/fluvio-sc/src/controllers/mirroring/controller.rs
+++ b/crates/fluvio-sc/src/controllers/mirroring/controller.rs
@@ -284,8 +284,9 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
 
 fn create_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::default()
-        .min(Duration::from_millis(100))
-        .max(Duration::from_secs(5))
+        .factor(1.1)
+        .min(Duration::from_secs(1))
+        .max(Duration::from_secs(30))
         .build()
         .unwrap()
 }

--- a/crates/fluvio-sc/src/controllers/mirroring/controller.rs
+++ b/crates/fluvio-sc/src/controllers/mirroring/controller.rs
@@ -284,8 +284,8 @@ impl<C: MetadataItem> RemoteMirrorController<C> {
 
 fn create_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::default()
-        .min(Duration::from_secs(1))
-        .max(Duration::from_secs(30))
+        .min(Duration::from_millis(100))
+        .max(Duration::from_secs(5))
         .build()
         .unwrap()
 }

--- a/crates/fluvio-spu/src/mirroring/remote/controller.rs
+++ b/crates/fluvio-spu/src/mirroring/remote/controller.rs
@@ -509,8 +509,9 @@ where
 
 fn create_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::default()
-        .min(Duration::from_millis(100))
-        .max(Duration::from_secs(5))
+        .factor(1.1)
+        .min(Duration::from_secs(1))
+        .max(Duration::from_secs(30))
         .build()
         .unwrap()
 }

--- a/crates/fluvio-spu/src/mirroring/remote/controller.rs
+++ b/crates/fluvio-spu/src/mirroring/remote/controller.rs
@@ -509,8 +509,8 @@ where
 
 fn create_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::default()
-        .min(Duration::from_secs(1))
-        .max(Duration::from_secs(30))
+        .min(Duration::from_millis(100))
+        .max(Duration::from_secs(5))
         .build()
         .unwrap()
 }

--- a/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
+++ b/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
@@ -130,7 +130,7 @@ setup_file() {
 }
 
 @test "Home status at remote 1 should show the home cluster connected" {
-    sleep 15
+    sleep 30
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success
@@ -165,7 +165,7 @@ setup_file() {
 }
 
 @test "Home status at remote 2 should show the home cluster connected" {
-    sleep 15
+    sleep 30
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success

--- a/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
+++ b/tests/cli/mirroring_smoke_tests/e2e/fluvio-core.bats
@@ -130,7 +130,7 @@ setup_file() {
 }
 
 @test "Home status at remote 1 should show the home cluster connected" {
-    sleep 30
+    sleep 60
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success
@@ -165,7 +165,7 @@ setup_file() {
 }
 
 @test "Home status at remote 2 should show the home cluster connected" {
-    sleep 30
+    sleep 60
     run timeout 15s "$FLUVIO_BIN" home status
 
     assert_success


### PR DESCRIPTION
That should improve to not sleeping a lot at first seconds trying to connect. 
Also helping our mirroring tests be more reliable.