### PR TITLE
feat(fvm): override installed binaries target

### DIFF
--- a/crates/fluvio-version-manager/src/command/install.rs
+++ b/crates/fluvio-version-manager/src/command/install.rs
@@ -20,6 +20,9 @@ use crate::common::workdir::fvm_versions_path;
 /// The `install` command is responsible of installing the desired Package Set
 #[derive(Debug, Parser)]
 pub struct InstallOpt {
+    /// Binaries architecture triple to use
+    #[arg(long, env = "FVM_BINARY_ARCH_TRIPLE", default_value = TARGET)]
+    target: String,
     /// Registry used to fetch Fluvio Versions
     #[arg(long, env = "INFINYON_HUB_REMOTE", default_value = HUB_REMOTE)]
     registry: Url,
@@ -38,7 +41,9 @@ impl InstallOpt {
         }
 
         let client = Client::new(self.registry.as_str())?;
-        let pkgset = client.fetch_package_set(&self.version, TARGET).await?;
+        let pkgset = client
+            .fetch_package_set(&self.version, &self.target)
+            .await?;
 
         VersionInstaller::new(self.version.to_owned(), pkgset, notify)
             .install()

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -1024,7 +1024,7 @@ setup_file() {
 
     # Attempts to install unsupported target triple
     run bash -c '$FVM_BIN install 0.11.12 --target aarch64-unknown-linux-gnu'
-    assert_line --index 0 "Error: PackageSet "0.11.12" is not available for architecture: \"aarch64-unknown-linux-gnu\""
+    assert_line --index 0 "Error: PackageSet \"0.11.12\" is not available for architecture: \"aarch64-unknown-linux-gnu\""
     assert_success
 
     # Removes FVM

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -1012,3 +1012,24 @@ setup_file() {
     rm -rf $FLUVIO_HOME_DIR
     assert_success
 }
+
+@test "Supports Binary Target Overriding" {
+    run bash -c '$FVM_BIN self install'
+    assert_success
+
+    # Sets `fvm` in the PATH using the "env" file included in the installation
+    source ~/.fvm/env
+
+    # Attempts to install unsupported target triple
+    run bash -c '$FVM_BIN install 0.11.12 --target aarch64-unknown-linux-gnu'
+    assert_line --index 0 "Error: PackageSet "0.11.12" is not available for architecture: \"aarch64-unknown-linux-gnu\""
+    assert_success
+
+    # Removes FVM
+    run bash -c '$FVM_BIN self uninstall --yes'
+    assert_success
+
+    # Removes Fluvio
+    rm -rf $FLUVIO_HOME_DIR
+    assert_success
+}

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -1025,7 +1025,7 @@ setup_file() {
     # Attempts to install unsupported target triple
     run bash -c '$FVM_BIN install 0.11.12 --target aarch64-unknown-linux-gnu'
     assert_line --index 0 "Error: PackageSet \"0.11.12\" is not available for architecture: \"aarch64-unknown-linux-gnu\""
-    assert_success
+    assert_failure
 
     # Removes FVM
     run bash -c '$FVM_BIN self uninstall --yes'

--- a/tests/cli/fvm_smoke_tests/fvm_basic.bats
+++ b/tests/cli/fvm_smoke_tests/fvm_basic.bats
@@ -16,6 +16,8 @@ setup_file() {
     export INFINYON_HUB_REMOTE
     debug_msg "Using Hub Registry URL: $INFINYON_HUB_REMOTE"
 
+    export INFINYON_CI_CONTEXT="ci"
+
     # Retrieves the latest stable version from the GitHub API and removes the
     # `v` prefix from the tag name.
     STABLE_VERSION=$(curl "https://api.github.com/repos/infinyon/fluvio/releases/latest" | jq -r .tag_name | cut -c2-)


### PR DESCRIPTION
Provides support to override the target triple used when fetching binaries from package registry.

## Demo

`fvm install` now accepts the `--target` option which takes a [Rust Target Triple](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools) thats used to replace the default target which is host's OS target.

Alternately a user could specify `FVM_BINARY_ARCH_TRIPLE` environment variable, used for the same purpose. This is useful for CI environments.

![help](https://github.com/user-attachments/assets/0c0dcc45-7bd8-4a63-badb-6e16b2647138)

If the target triple is not available, FVM will notify the user before performing any further tasks.

```bash
fvm install latest --target aarch64-unknown-linux-gnu
Error: PackageSet "latest" is not available for architecture: "aarch64-unknown-linux-gnu"
```

![bad-target](https://github.com/user-attachments/assets/44736c13-943c-4948-9d66-3d5d04402ead)
