### PR TITLE
fix: link_parent more realible and delete topic partitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/crates/fluvio-sc/src/controllers/topics/policy.rs
+++ b/crates/fluvio-sc/src/controllers/topics/policy.rs
@@ -222,7 +222,7 @@ impl<C: MetadataItem> TopicNextState<C> {
                     if next_state.resolution == TopicResolution::Provisioned {
                         debug!("creating new partitions");
                         next_state.partitions =
-                            topic.partitions_from_replicas(scheduler.partitions()).await;
+                            topic.create_new_partitions(scheduler.partitions()).await;
                     }
                     next_state
                 }
@@ -239,7 +239,7 @@ impl<C: MetadataItem> TopicNextState<C> {
                             .await;
                     if next_state.resolution == TopicResolution::Provisioned {
                         next_state.partitions =
-                            topic.partitions_from_replicas(scheduler.partitions()).await;
+                            topic.create_new_partitions(scheduler.partitions()).await;
                     }
                     next_state
                 }
@@ -251,7 +251,7 @@ impl<C: MetadataItem> TopicNextState<C> {
                     let mut next_state = TopicNextState::same_next_state(topic);
                     if next_state.resolution == TopicResolution::Provisioned {
                         next_state.partitions =
-                            topic.partitions_from_replicas(scheduler.partitions()).await;
+                            topic.create_new_partitions(scheduler.partitions()).await;
                     }
                     next_state
                 }
@@ -335,7 +335,7 @@ impl<C: MetadataItem> TopicNextState<C> {
                     if next_state.resolution == TopicResolution::Provisioned {
                         debug!("creating new partitions");
                         next_state.partitions =
-                            topic.partitions_from_replicas(scheduler.partitions()).await;
+                            topic.create_new_partitions(scheduler.partitions()).await;
                     }
                     next_state
                 }

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-stream-dispatcher"
 edition = "2021"
-version = "0.13.5"
+version = "0.13.6"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"
 repository = "https://github.com/infinyon/fluvio"


### PR DESCRIPTION
The fix of https://github.com/infinyon/fluvio/pull/4094 was a wrong fix to have sure that all partitions are childrens of its Topic.

I reverted this PR, and I made the `link_parent` and `unlink_parent` more reliable.
Because they were being called correct, but `link_parent` it was using stale objects.

Now they are getting the parent from the store to have sure to not lose data.


How to test:

```
fluvio topic create data
fluvio topic add-partition data
fluvio topic add-partition data
fluvio topic add-partition data
fluvio topic add-partition data
fluvio topic add-partition data
fluvio topic delete data
fluvio partition list
```

Must output no results.

This should also fix logs like these after each 5min (SC_RECONCILIATION_INTERVAL_SEC):

```bash
 sc        | 2024-10-25T21:16:09.364724Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 11, proposed: 10
sc        | 2024-10-25T21:16:09.366955Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 5, proposed: 4
sc        | 2024-10-25T21:16:09.370491Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 14, proposed: 13
sc        | 2024-10-25T21:16:09.378256Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 8, proposed: 7
sc        | 2024-10-25T21:16:09.379879Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 8, proposed: 7
sc        | 2024-10-25T21:16:09.381140Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 6, proposed: 5
sc        | 2024-10-25T21:16:09.382941Z ERROR MetadataDispatcher{spec="Partition" namespace="default"}:process_ws_action: fluvio_stream_dispatcher::dispatcher::metadata: error: Partition, applying attempt to update by stale value: current version: 12, proposed: 11
```