### PR TITLE
chore: remove unneeded encoding mark for api protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bytes",
  "derive_builder",

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu-schema"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"

--- a/crates/fluvio-spu-schema/src/server/api.rs
+++ b/crates/fluvio-spu-schema/src/server/api.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use tracing::trace;
 
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Decoder;
 use fluvio_protocol::api::ApiMessage;
 use fluvio_protocol::api::api_decode;
 use fluvio_protocol::api::RequestHeader;
@@ -29,30 +29,18 @@ use super::mirror::StartMirrorRequest;
 
 #[allow(clippy::large_enum_variant)]
 /// Request to Spu Server
-#[derive(Debug, Encoder)]
+#[derive(Debug)]
 pub enum SpuServerRequest {
-    /// list of versions supported
-    #[fluvio(tag = 0)]
     ApiVersionsRequest(RequestMessage<ApiVersionsRequest>),
 
-    // Kafka compatible requests
-    #[fluvio(tag = 1)]
     ProduceRequest(RequestMessage<DefaultProduceRequest>),
-    #[fluvio(tag = 2)]
     FileFetchRequest(RequestMessage<FileFetchRequest>),
-    #[fluvio(tag = 3)]
     FetchOffsetsRequest(RequestMessage<FetchOffsetsRequest>),
-    #[fluvio(tag = 4)]
     FileStreamFetchRequest(RequestMessage<FileStreamFetchRequest>),
-    #[fluvio(tag = 5)]
     UpdateOffsetsRequest(RequestMessage<UpdateOffsetsRequest>),
-    #[fluvio(tag = 6)]
     UpdateConsumerOffsetRequest(RequestMessage<UpdateConsumerOffsetRequest>),
-    #[fluvio(tag = 7)]
     DeleteConsumerOffsetRequest(RequestMessage<DeleteConsumerOffsetRequest>),
-    #[fluvio(tag = 8)]
     FetchConsumerOffsetsRequest(RequestMessage<FetchConsumerOffsetsRequest>),
-    #[fluvio(tag = 9)]
     StartMirrorRequest(RequestMessage<StartMirrorRequest>),
 }
 

--- a/crates/fluvio-spu/src/mirroring/home/home_api.rs
+++ b/crates/fluvio-spu/src/mirroring/home/home_api.rs
@@ -4,16 +4,15 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Decoder;
 use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::MirrorHomeApiEnum;
 use super::update_offsets::UpdateHomeOffsetRequest;
 
 /// Requests from home to remote
-#[derive(Debug, Encoder)]
+#[derive(Debug)]
 pub enum HomeMirrorRequest {
-    #[fluvio(tag = 0)]
     UpdateHomeOffset(RequestMessage<UpdateHomeOffsetRequest>),
 }
 

--- a/crates/fluvio-spu/src/mirroring/remote/remote_api.rs
+++ b/crates/fluvio-spu/src/mirroring/remote/remote_api.rs
@@ -4,18 +4,15 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Decoder;
 use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::MirrorRemoteApiEnum;
 use super::sync::DefaultPartitionSyncRequest;
 
-#[derive(Debug, Encoder)]
+#[derive(Debug)]
 pub enum RemoteMirrorRequest {
-    #[fluvio(tag = 0)]
     SyncRecords(RequestMessage<DefaultPartitionSyncRequest>),
-    //   #[fluvio(tag = 1)]
-    //   RejectedOffsetRequest(RequestMessage<RejectOffsetRequest>),
 }
 
 impl Default for RemoteMirrorRequest {

--- a/crates/fluvio-spu/src/replication/follower/peer_api.rs
+++ b/crates/fluvio-spu/src/replication/follower/peer_api.rs
@@ -4,18 +4,16 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Decoder;
 use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::api_key::FollowerPeerApiEnum;
 use super::sync::DefaultSyncRequest;
 use super::reject_request::RejectOffsetRequest;
 
-#[derive(Debug, Encoder)]
+#[derive(Debug)]
 pub enum FollowerPeerRequest {
-    #[fluvio(tag = 0)]
     SyncRecords(RequestMessage<DefaultSyncRequest>),
-    #[fluvio(tag = 1)]
     RejectedOffsetRequest(RequestMessage<RejectOffsetRequest>),
 }
 

--- a/crates/fluvio-spu/src/replication/leader/connection.rs
+++ b/crates/fluvio-spu/src/replication/leader/connection.rs
@@ -9,10 +9,7 @@ use fluvio_socket::{FluvioSink, SocketError, FluvioStream};
 use fluvio_protocol::api::RequestMessage;
 use fluvio_types::SpuId;
 
-use crate::{
-    core::DefaultSharedGlobalContext,
-    replication::follower::sync::FileSyncRequest,
-};
+use crate::{core::DefaultSharedGlobalContext, replication::follower::sync::FileSyncRequest};
 
 use super::LeaderPeerApiEnum;
 use super::LeaderPeerRequest;

--- a/crates/fluvio-spu/src/replication/leader/connection.rs
+++ b/crates/fluvio-spu/src/replication/leader/connection.rs
@@ -11,7 +11,7 @@ use fluvio_types::SpuId;
 
 use crate::{
     core::DefaultSharedGlobalContext,
-    replication::follower::sync::{FileSyncRequest},
+    replication::follower::sync::FileSyncRequest,
 };
 
 use super::LeaderPeerApiEnum;

--- a/crates/fluvio-spu/src/replication/leader/peer_api.rs
+++ b/crates/fluvio-spu/src/replication/leader/peer_api.rs
@@ -4,15 +4,14 @@ use std::convert::TryInto;
 use tracing::trace;
 
 use fluvio_protocol::bytes::Buf;
-use fluvio_protocol::{Encoder, Decoder};
+use fluvio_protocol::Decoder;
 use fluvio_protocol::api::{RequestMessage, ApiMessage, RequestHeader};
 
 use super::LeaderPeerApiEnum;
 use super::UpdateOffsetRequest;
 
-#[derive(Debug, Encoder)]
+#[derive(Debug)]
 pub enum LeaderPeerRequest {
-    #[fluvio(tag = 0)]
     UpdateOffsets(RequestMessage<UpdateOffsetRequest>),
 }
 


### PR DESCRIPTION
The enum encoding of API was not needed since each api is encoded directly.  Enum is used only for decoding only