### PR TITLE
chore: solve bin fluvio conflicts in setup_fluvio_cluster

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -241,21 +241,10 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.2.1
+          bats-version: 1.11.0
       - name: CLI ${{ matrix.cli_version }} x Cluster ${{ matrix.cluster_version }}
         run: |
           make CLI_VERSION=${{ matrix.cli_version }} CLUSTER_VERSION=${{ matrix.cluster_version }} cli-platform-cross-version-test
-      - name: Run diagnostics
-        if: ${{ !success() }}
-        timeout-minutes: 5
-        run: fluvio cluster diagnostics
-      - name: Upload diagnostics
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        if: ${{ !success() }}
-        with:
-          name: cli-platform-cross-version-test
-          path: diagnostics*.gz
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         if: ${{ !success() }}

--- a/tests/cli/cli-backward-compatibility.bash
+++ b/tests/cli/cli-backward-compatibility.bash
@@ -30,7 +30,7 @@ for version in $versions; do
     # Install old version of the CLI
     curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=$version bash
     # Run the tests
-    CLI_VERSION=$version SKIP_SETUP=true CI=false make cli-platform-cross-version-test
+    CLI_VERSION=$version SKIP_SETUP=true make cli-platform-cross-version-test
 
     # Check if we have reached the version we want to stop at
     if [[ $version == $BACKWARD_SINCE_VERSION ]]; then

--- a/tests/cli/test_helper/fluvio_dev.bash
+++ b/tests/cli/test_helper/fluvio_dev.bash
@@ -51,15 +51,17 @@ function random_string() {
 # Give version as arg to control what version you download and install
 function setup_fluvio_cluster() {
     CLUSTER_VERSION=${1:-latest}
+    # not using $FLUVIO_BIN to not conflict with the env var set in the makefile
+    NEW_FLUVIO_BIN=$HOME/.fvm/versions/$CLUSTER_VERSION/fluvio
 
     echo "# Installing cluster @ VERSION: $CLUSTER_VERSION" >&3
-    curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=$CLUSTER_VERSION bash
+    curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=$CLUSTER_VERSION bash >&3
     echo "# Starting cluster @ VERSION: $CLUSTER_VERSION" >&3
 
     if [ "$CLUSTER_VERSION" = "latest" ]; then
-        $FLUVIO_BIN cluster start --image-version latest
+        $NEW_FLUVIO_BIN cluster start --image-version latest
     else
-        $FLUVIO_BIN cluster start
+        $NEW_FLUVIO_BIN cluster start
     fi
 }
 
@@ -72,6 +74,6 @@ function setup_fluvio_cluster() {
 function setup_fluvio_cli() {
     CLI_VERSION=${1:-latest}
     echo "Installing CLI @ VERSION: $CLI_VERSION" >&3
-    curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=$CLI_VERSION bash
+    curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | VERSION=$CLI_VERSION bash >&3
     $HOME/.fvm/versions/$CLI_VERSION/fluvio version >&3
 }


### PR DESCRIPTION
Related: https://github.com/infinyon/fluvio/pull/4258


On my last Pull Request (https://github.com/infinyon/fluvio/pull/4258) I forgot to solve bin fluvio conflicts in setup_fluvio_cluster.


Also, I updated Bats version to catch the error and I tested directly on pull request this time in another commit:

<img width="385" alt="image" src="https://github.com/user-attachments/assets/82e79487-c802-4a54-855a-f215b92b9d1e">

https://github.com/infinyon/fluvio/actions/runs/11847565015/job/33017495561?pr=4260