### PR TITLE
chore: bump fluvio-socket to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.11"
+version = "0.15.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-lock 3.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,11 +182,11 @@ fluvio-sc-schema = { version = "0.25.0", path = "crates/fluvio-sc-schema", defau
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.8.0", path = "crates/fluvio-smartengine", default-features = false }
 fluvio-smartmodule = { version = "0.8.0", path = "crates/fluvio-smartmodule", default-features = false }
-fluvio-socket = { version = "0.14.9", path = "crates/fluvio-socket", default-features = false }
+fluvio-socket = { version = "0.15.0", path = "crates/fluvio-socket", default-features = false }
 fluvio-spu-schema = { version = "0.17.0", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.13.2", path = "crates/fluvio-stream-dispatcher" }
-fluvio-stream-model = { version = "0.11.3", path = "crates/fluvio-stream-model", default-features = false }
+fluvio-stream-model = { version = "0.11.4", path = "crates/fluvio-stream-model", default-features = false }
 fluvio-types = { version = "0.5.0", path = "crates/fluvio-types", default-features = false }
 fluvio-kv-storage = { path = "crates/fluvio-kv-storage", default-features = false }
 

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.14.11"
+version = "0.15.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"


### PR DESCRIPTION
We need bump fluvio-socket as fluvio-protocol was updated, to release a new version to fix the release of fluvio-sc-schema v0.25.0.
https://github.com/infinyon/fluvio/actions/runs/11849569173/job/33023036556