### PR TITLE
feat: add graceful shutdown for consume connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,9 @@ name = "fluvio-connector-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-channel 1.9.0",
  "async-trait",
+ "ctrlc",
  "fluvio",
  "fluvio-connector-derive",
  "fluvio-connector-package",

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -18,6 +18,8 @@ required-features = ["derive"]
 
 [dependencies]
 async-trait = { workspace = true }
+async-channel = { workspace = true }
+ctrlc = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true , features = ["sink"]}

--- a/crates/fluvio-connector-derive/src/generator.rs
+++ b/crates/fluvio-connector-derive/src/generator.rs
@@ -45,6 +45,7 @@ fn generate_sink(func: &ConnectorFn) -> TokenStream {
     quote! {
 
         fn main() -> ::fluvio_connector_common::Result<()> {
+            let stop_signal = ::fluvio_connector_common::consumer::init_ctrlc()?;
             #init_and_parse_config
 
             ::fluvio_connector_common::future::run_block_on(async {
@@ -53,6 +54,7 @@ fn generate_sink(func: &ConnectorFn) -> TokenStream {
                 let metrics = ::std::sync::Arc::new(::fluvio_connector_common::monitoring::ConnectorMetrics::new(fluvio.metrics()));
                 ::fluvio_connector_common::monitoring::init_monitoring(metrics);
 
+                let mut stream = stream.take_until(stop_signal.recv());
                 #user_fn(user_config, stream).await
             })?;
 

--- a/crates/fluvio/src/consumer/stream.rs
+++ b/crates/fluvio/src/consumer/stream.rs
@@ -109,6 +109,19 @@ impl<T: Stream<Item = Result<Record, ErrorCode>> + Unpin> Stream
     }
 }
 
+impl<T> ConsumerStream for futures_util::stream::TakeUntil<T, async_channel::Recv<'_, ()>>
+where
+    T: ConsumerStream,
+{
+    fn offset_commit(&mut self) -> Result<(), ErrorCode> {
+        self.get_mut().offset_commit()
+    }
+
+    fn offset_flush(&mut self) -> impl Future<Output = Result<(), ErrorCode>> + Send {
+        self.get_mut().offset_flush()
+    }
+}
+
 impl<T: Stream<Item = Result<Record, ErrorCode>> + Unpin> ConsumerStream
     for SinglePartitionConsumerStream<T>
 {

--- a/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+TEST_HELPER_DIR="$BATS_TEST_DIRNAME/../test_helper"
+export TEST_HELPER_DIR
+
+load "$TEST_HELPER_DIR"/tools_check.bash
+load "$TEST_HELPER_DIR"/fluvio_dev.bash
+load "$TEST_HELPER_DIR"/bats-support/load.bash
+load "$TEST_HELPER_DIR"/bats-assert/load.bash
+
+setup_file() {
+    PROJECT_NAME_PREFIX="$(random_string)"
+    export PROJECT_NAME_PREFIX
+    TEST_DIR="$(mktemp -d -t cdk-graceful-test.XXXXX)"
+    export TEST_DIR
+
+    CONNECTOR_DIR="$(pwd)/connector/sink-test-connector"
+    export CONNECTOR_DIR
+}
+
+@test "Graceful shutdown on connector with managed consumer offsets" {
+    # Prepare config
+    TOPIC_NAME=$(random_string)
+    debug_msg "Topic name: $TOPIC_NAME"
+    CONNECTOR_NAME="my-$TOPIC_NAME"
+    debug_msg "Connector name: $CONNECTOR_NAME"
+    export LOG_PATH="$CONNECTOR_DIR/$CONNECTOR_NAME.log"
+    debug_msg "Log path: $LOG_PATH"
+
+    CONFIG_PATH="$TEST_DIR/$TOPIC_NAME.yaml"
+    cat <<EOF >$CONFIG_PATH
+apiVersion: 0.2.0
+meta:
+  version: 0.1.0
+  name: $CONNECTOR_NAME
+  type: test-sink
+  topic:
+    meta:
+      name: $TOPIC_NAME
+    partition:
+      count: 1
+  consumer:
+    partition: all
+    id: $CONNECTOR_NAME
+    offset:
+      strategy: auto
+      start: beginning
+      flush: 10s
+custom:
+  api_key: api_key
+  client_id: client_id
+EOF
+    # Test
+    cd $CONNECTOR_DIR
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info 3>&-
+    assert_success
+    assert_output --partial "Connector runs with process id"
+
+    wait_for_line_in_file "successfully created" $LOG_PATH 5
+    wait_for_line_in_file "monitoring started" $LOG_PATH 5
+
+    echo 1:1 | "$FLUVIO_BIN" produce $TOPIC_NAME --key-separator ":"
+    sleep 2
+    echo 2:2 | "$FLUVIO_BIN" produce $TOPIC_NAME --key-separator ":"
+    sleep 2
+
+    wait_for_line_in_file "Received record: 1" $LOG_PATH 5
+    wait_for_line_in_file "Received record: 2" $LOG_PATH 5
+
+    run $CDK_BIN deploy shutdown --name $CONNECTOR_NAME 3>&-
+    assert_success
+
+    echo 3:3 | "$FLUVIO_BIN" produce $TOPIC_NAME --key-separator ":"
+    echo 4:4 | "$FLUVIO_BIN" produce $TOPIC_NAME --key-separator ":"
+
+    run $CDK_BIN deploy --target x86_64-unknown-linux-gnu start --config $CONFIG_PATH --log-level info 3>&-
+    assert_success
+    assert_output --partial "Connector runs with process id"
+    wait_for_line_in_file "Received record: 3" $LOG_PATH 5
+    assert_success
+    wait_for_line_in_file "Received record: 4" $LOG_PATH 5
+
+    run cat $LOG_PATH
+    refute_output --partial 'Received record: 1'
+    refute_output --partial 'Received record: 2'
+}
+


### PR DESCRIPTION
When a consumer connector disconnects it is not dropping the offset management, then it was losing some record in the offset storage.


I added a graceful shutdown similar to what we have in `fluvio-cli`.