### PR TITLE
fix: use `Connector` over `SmartConnector` to match docs

### DIFF
--- a/crates/cdk/src/generate.rs
+++ b/crates/cdk/src/generate.rs
@@ -17,7 +17,7 @@ use enum_display::EnumDisplay;
 static CONNECTOR_TEMPLATE: Dir<'static> =
     include_dir!("$CARGO_MANIFEST_DIR/../../connector/cargo_template");
 
-/// Generate new SmartConnector project
+/// Generate new Connector project
 #[derive(Debug, Parser)]
 pub struct GenerateCmd {
     /// Connector Name
@@ -31,7 +31,7 @@ pub struct GenerateCmd {
     #[arg(long, value_name = "DESCRIPTION")]
     conn_description: Option<String>,
 
-    /// Local path to generate the SmartConnector project.
+    /// Local path to generate the Connector project.
     /// Default to directory with project name, created in current directory
     #[arg(long, env = "CDK_DESTINATION", value_name = "PATH")]
     destination: Option<PathBuf>,

--- a/crates/fluvio-connector-derive/Cargo.toml
+++ b/crates/fluvio-connector-derive/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"
-description = "Fluvio SmartConnector procedural macro"
+description = "Fluvio Connector procedural macro"
 
 [lib]
 proc-macro = true

--- a/crates/fluvio-hub-util/src/cmd/download.rs
+++ b/crates/fluvio-hub-util/src/cmd/download.rs
@@ -11,11 +11,11 @@ use crate::{cli_pkgname_to_filename, cli_conn_pkgname_to_url, get_package};
 
 use super::get_hub_access;
 
-/// Download SmartConnector to the local folder
+/// Download Connector to the local folder
 #[derive(Debug, Parser)]
 #[command(arg_required_else_help = true)]
 pub struct ConnectorHubDownloadOpts {
-    /// SmartConnector name: e.g. infinyon/http-sink@vX.Y.Z
+    /// Connector name: e.g. infinyon/http-sink@vX.Y.Z
     #[arg(value_name = "name", required = true)]
     package_name: String,
 

--- a/crates/fluvio-hub-util/src/cmd/list.rs
+++ b/crates/fluvio-hub-util/src/cmd/list.rs
@@ -10,7 +10,7 @@ use crate::HUB_API_CONN_LIST;
 
 use super::get_pkg_list;
 
-/// List all available SmartConnectors
+/// List all available Connectors
 #[derive(Debug, Parser)]
 pub struct ConnectorHubListOpts {
     #[clap(flatten)]


### PR DESCRIPTION
Updates references to `SmartConnector` to be `Connector` instead as referred in our docs.

<img width="1492" src="https://github.com/user-attachments/assets/26fa48f0-d52e-43fb-8eeb-07d1aad56de7">
