### PR TITLE
fix: shutdown of the cdk consumer

### DIFF
--- a/crates/cdk/src/deploy.rs
+++ b/crates/cdk/src/deploy.rs
@@ -359,7 +359,7 @@ mod local_index {
 
     use anyhow::{anyhow, Result};
     use fluvio_connector_deployer::DeploymentResult;
-    use sysinfo::Pid;
+    use sysinfo::{Pid, Signal};
     use tracing::debug;
 
     const LOCAL_INDEX_FILE_NAME: &str = "fluvio_cdk_deploy_index.toml";
@@ -515,7 +515,7 @@ mod local_index {
             } = entry;
 
             if let Some(process) = self.system.process(Pid::from_u32(*process_id)) {
-                process.kill();
+                process.kill_with(Signal::Term);
             }
 
             Ok(())

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["derive"]
 [dependencies]
 async-trait = { workspace = true }
 async-channel = { workspace = true }
-ctrlc = { workspace = true }
+ctrlc = { workspace = true, features = ["termination"]}
 anyhow = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true , features = ["sink"]}

--- a/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
@@ -45,7 +45,9 @@ meta:
     offset:
       strategy: auto
       start: beginning
-      flush: 10s
+      flush-period:
+        secs: 10
+        nanos: 0
 custom:
   api_key: api_key
   client_id: client_id


### PR DESCRIPTION
We're shutdown connectors with signal kill that couldn't be handled by the application.
I propose using `SIGTERM` that allows `ctrlc` package to handle with the graceful shutdown.



References:
- https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html