### PR TITLE
fix: shutdown of the cdk consumer by future not stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
+ "tokio",
  "tracing",
  "trybuild 1.0.97",
 ]
@@ -2726,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3194,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -1,6 +1,8 @@
 mod sink;
 
-use fluvio_connector_common::{connector, Result, consumer::ConsumerStream, Sink, secret::SecretString};
+use fluvio_connector_common::{
+    connector, consumer::ConsumerStream, secret::SecretString, LocalBoxSink, Result, Sink,
+};
 use futures::{SinkExt, StreamExt};
 use sink::TestSink;
 
@@ -8,12 +10,52 @@ use sink::TestSink;
 async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<()> {
     let sink = TestSink::new(&config)?;
     let mut sink = sink.connect(None).await?;
-    while let Some(item) = stream.next().await {
-        let str = String::from_utf8(item?.as_ref().to_vec())?;
-        sink.send(str).await?;
-        stream.offset_commit()?;
-        stream.offset_flush().await?;
+
+    if config.test_stream_lifetime {
+        // This test case ensures the stream is properly dropped, even when it is in a state
+        // that would otherwise prevent it from being dropped.
+        // The challenge here is that the stream could remain "stuck" in such a state,
+        // holding resources indefinitely.
+        //
+        // The solution is to explicitly shut down the future managing the stream before it
+        // gets into this problematic state. Previously, we used a `TakeUntil` wrapper to
+        // stop the stream. However, this approach failed when the stream entered a state
+        // that blocked it from being dropped correctly.
+        //
+        // Here, we simulate such a scenario using an infinite loop to test the robustness
+        // of the stream's lifetime management.
+        loop {
+            while let Some(item) = stream.next().await {
+                process_item(
+                    String::from_utf8(item?.as_ref().to_vec())?,
+                    &mut sink,
+                    &mut stream,
+                )
+                .await?;
+            }
+        }
     }
+
+    while let Some(item) = stream.next().await {
+        process_item(
+            String::from_utf8(item?.as_ref().to_vec())?,
+            &mut sink,
+            &mut stream,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn process_item(
+    str: String,
+    sink: &mut LocalBoxSink<String>,
+    stream: &mut impl ConsumerStream,
+) -> Result<()> {
+    sink.send(str).await?;
+    stream.offset_commit()?;
+    stream.offset_flush().await?;
     Ok(())
 }
 
@@ -21,4 +63,6 @@ async fn start(config: CustomConfig, mut stream: impl ConsumerStream) -> Result<
 struct CustomConfig {
     api_key: SecretString,
     client_id: String,
+    #[serde(default)]
+    test_stream_lifetime: bool,
 }

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true,  features = ["derive", "rc"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 fluvio = { workspace = true, features = ["smartengine"] }
 fluvio-future = { workspace = true, features = ["subscriber"] }

--- a/crates/fluvio-connector-common/src/lib.rs
+++ b/crates/fluvio-connector-common/src/lib.rs
@@ -20,6 +20,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 pub mod future {
     pub use fluvio_future::task::run_block_on;
+    pub use tokio::select;
     pub use fluvio_future::subscriber::init_logger;
     pub use fluvio_future::retry;
 }

--- a/crates/fluvio-connector-common/ui-test/ui/config_use_reserved_name_fluvio.stderr
+++ b/crates/fluvio-connector-common/ui-test/ui/config_use_reserved_name_fluvio.stderr
@@ -33,22 +33,15 @@ note: function defined here
   |          ^^^^^^^^                       ------------
   = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
- --> ui-test/ui/config_use_reserved_name_fluvio.rs:3:20
-  |
-3 | #[connector(source)]
-  | -------------------^
-  | |                  |
-  | |                  cannot use the `?` operator in an async block that returns `()`
-  | this function should return `Result` or `Option` to accept `?`
-  |
-  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
-  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
+error[E0308]: mismatched types
  --> ui-test/ui/config_use_reserved_name_fluvio.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  | ^^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected `()`, found `Result<_, _>`
+  | this expression has type `()`
   |
-  = help: the trait `Try` is not implemented for `()`
+  = note: expected unit type `()`
+                  found enum `Result<_, _>`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/fluvio-connector-common/ui-test/ui/config_use_reserved_name_transforms.stderr
+++ b/crates/fluvio-connector-common/ui-test/ui/config_use_reserved_name_transforms.stderr
@@ -33,22 +33,15 @@ note: function defined here
   |          ^^^^^^^^                       ------------
   = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
- --> ui-test/ui/config_use_reserved_name_transforms.rs:3:20
-  |
-3 | #[connector(source)]
-  | -------------------^
-  | |                  |
-  | |                  cannot use the `?` operator in an async block that returns `()`
-  | this function should return `Result` or `Option` to accept `?`
-  |
-  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
-  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
+error[E0308]: mismatched types
  --> ui-test/ui/config_use_reserved_name_transforms.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  | ^^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected `()`, found `Result<_, _>`
+  | this expression has type `()`
   |
-  = help: the trait `Try` is not implemented for `()`
+  = note: expected unit type `()`
+                  found enum `Result<_, _>`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/fluvio-connector-common/ui-test/ui/struct_without_config.stderr
+++ b/crates/fluvio-connector-common/ui-test/ui/struct_without_config.stderr
@@ -33,22 +33,15 @@ note: function defined here
   |          ^^^^^^^^                       ------------
   = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
- --> ui-test/ui/struct_without_config.rs:3:20
-  |
-3 | #[connector(source)]
-  | -------------------^
-  | |                  |
-  | |                  cannot use the `?` operator in an async block that returns `()`
-  | this function should return `Result` or `Option` to accept `?`
-  |
-  = help: the trait `FromResidual<Result<Infallible, anyhow::Error>>` is not implemented for `()`
-  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the `?` operator can only be applied to values that implement `Try`
+error[E0308]: mismatched types
  --> ui-test/ui/struct_without_config.rs:3:1
   |
 3 | #[connector(source)]
-  | ^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
+  | ^^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected `()`, found `Result<_, _>`
+  | this expression has type `()`
   |
-  = help: the trait `Try` is not implemented for `()`
+  = note: expected unit type `()`
+                  found enum `Result<_, _>`
+  = note: this error originates in the attribute macro `connector` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/fluvio-connector-derive/src/generator.rs
+++ b/crates/fluvio-connector-derive/src/generator.rs
@@ -35,7 +35,7 @@ fn generate_source(func: &ConnectorFn) -> TokenStream {
                         match user_fn_result {
                             Ok(_) => ::fluvio_connector_common::tracing::info!("Connector arrived at end of stream"),
                             Err(e) => {
-                                ::fluvio_connector_common::tracing::error!(%e, "Connector failed");
+                                ::fluvio_connector_common::tracing::error!(%e, "Error encountered producing records in source connector");
                                 return Err(e.into());
                             },
                         }
@@ -78,7 +78,7 @@ fn generate_sink(func: &ConnectorFn) -> TokenStream {
                         match user_fn_result {
                             Ok(_) => ::fluvio_connector_common::tracing::info!("Connector arrived at end of stream"),
                             Err(e) => {
-                                ::fluvio_connector_common::tracing::error!(%e, "Connector failed");
+                                ::fluvio_connector_common::tracing::error!(%e, "Error encountered processing records in sink connector");
                                 return Err(e.into());
                             },
                         }

--- a/crates/fluvio-connector-derive/src/generator.rs
+++ b/crates/fluvio-connector-derive/src/generator.rs
@@ -20,6 +20,7 @@ fn generate_source(func: &ConnectorFn) -> TokenStream {
 
         fn main() -> ::fluvio_connector_common::Result<()> {
             #init_and_parse_config
+            let stop_signal = ::fluvio_connector_common::consumer::init_ctrlc()?;
 
             ::fluvio_connector_common::future::run_block_on(async {
                 let (fluvio, producer) = ::fluvio_connector_common::producer::producer_from_config(&common_config).await?;
@@ -27,7 +28,23 @@ fn generate_source(func: &ConnectorFn) -> TokenStream {
                 let metrics = ::std::sync::Arc::new(::fluvio_connector_common::monitoring::ConnectorMetrics::new(fluvio.metrics()));
                 ::fluvio_connector_common::monitoring::init_monitoring(metrics);
 
-                #user_fn(user_config, producer).await
+                ::fluvio_connector_common::future::select! {
+                    user_fn_result = async {
+                        #user_fn(user_config, producer).await
+                    } => {
+                        match user_fn_result {
+                            Ok(_) => ::fluvio_connector_common::tracing::info!("Connector arrived at end of stream"),
+                            Err(e) => {
+                                ::fluvio_connector_common::tracing::error!(%e, "Connector failed");
+                                return Err(e.into());
+                            },
+                        }
+                    },
+                    _ = stop_signal.recv() => {
+                        ::fluvio_connector_common::tracing::info!("Stop signal received, shutting down connector.");
+                    },
+                };
+                Ok(()) as ::fluvio_connector_common::Result<()>
             })?;
 
             Ok(())
@@ -45,17 +62,32 @@ fn generate_sink(func: &ConnectorFn) -> TokenStream {
     quote! {
 
         fn main() -> ::fluvio_connector_common::Result<()> {
-            let stop_signal = ::fluvio_connector_common::consumer::init_ctrlc()?;
             #init_and_parse_config
+            let stop_signal = ::fluvio_connector_common::consumer::init_ctrlc()?;
 
             ::fluvio_connector_common::future::run_block_on(async {
-                let (fluvio, stream) = ::fluvio_connector_common::consumer::consumer_stream_from_config(&common_config).await?;
+                let (fluvio, mut stream) = ::fluvio_connector_common::consumer::consumer_stream_from_config(&common_config).await?;
 
                 let metrics = ::std::sync::Arc::new(::fluvio_connector_common::monitoring::ConnectorMetrics::new(fluvio.metrics()));
                 ::fluvio_connector_common::monitoring::init_monitoring(metrics);
 
-                let mut stream = stream.take_until(stop_signal.recv());
-                #user_fn(user_config, stream).await
+                ::fluvio_connector_common::future::select! {
+                    user_fn_result = async {
+                        #user_fn(user_config, stream).await
+                    } => {
+                        match user_fn_result {
+                            Ok(_) => ::fluvio_connector_common::tracing::info!("Connector arrived at end of stream"),
+                            Err(e) => {
+                                ::fluvio_connector_common::tracing::error!(%e, "Connector failed");
+                                return Err(e.into());
+                            },
+                        }
+                    },
+                    _ = stop_signal.recv() => {
+                        ::fluvio_connector_common::tracing::info!("Stop signal received, shutting down connector.");
+                    },
+                };
+                Ok(()) as ::fluvio_connector_common::Result<()>
             })?;
 
             Ok(())

--- a/crates/fluvio/src/consumer/offset.rs
+++ b/crates/fluvio/src/consumer/offset.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::AtomicI64;
+use std::{
+    fmt::{Display, Formatter},
+    sync::atomic::AtomicI64,
+};
 
 use async_channel::{Sender, bounded};
 use anyhow::Result;
@@ -86,6 +89,18 @@ impl OffsetLocalStore {
 
     fn set_flushed(&self, val: i64) {
         self.flushed.store(val, DEFAULT_ORDERING)
+    }
+}
+
+impl Display for OffsetLocalStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OffsetLocalStore {{ seen: {}, comitted: {}, flushed: {} }}",
+            self.seen.load(DEFAULT_ORDERING),
+            self.comitted.load(DEFAULT_ORDERING),
+            self.flushed.load(DEFAULT_ORDERING)
+        )
     }
 }
 

--- a/crates/fluvio/src/consumer/stream.rs
+++ b/crates/fluvio/src/consumer/stream.rs
@@ -7,7 +7,7 @@ use fluvio_protocol::{link::ErrorCode, record::ConsumerRecord as Record};
 use futures_util::stream::select_all;
 use futures_util::{future::try_join_all, ready, Future, FutureExt};
 use futures_util::Stream;
-use tracing::{debug, warn};
+use tracing::{info, warn};
 
 use super::config::OffsetManagementStrategy;
 use super::{offset::OffsetLocalStore, StreamToServer};
@@ -242,7 +242,7 @@ impl Drop for OffsetManagement {
             if let Err(err) = offset_store.try_flush() {
                 warn!("flush on drop failed: {err:?}");
             }
-            debug!("offsets flushed on drop");
+            info!("offsets flushed on drop, with: {}", offset_store);
         }
     }
 }

--- a/crates/fluvio/src/consumer/stream.rs
+++ b/crates/fluvio/src/consumer/stream.rs
@@ -7,7 +7,7 @@ use fluvio_protocol::{link::ErrorCode, record::ConsumerRecord as Record};
 use futures_util::stream::select_all;
 use futures_util::{future::try_join_all, ready, Future, FutureExt};
 use futures_util::Stream;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::config::OffsetManagementStrategy;
 use super::{offset::OffsetLocalStore, StreamToServer};
@@ -242,6 +242,7 @@ impl Drop for OffsetManagement {
             if let Err(err) = offset_store.try_flush() {
                 warn!("flush on drop failed: {err:?}");
             }
+            debug!("offsets flushed on drop");
         }
     }
 }

--- a/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
+++ b/tests/cli/cdk_smoke_tests/cdk-graceful-shutdown.bats
@@ -51,6 +51,7 @@ meta:
 custom:
   api_key: api_key
   client_id: client_id
+  prevent_dropped_stream: true
 EOF
     # Test
     cd $CONNECTOR_DIR


### PR DESCRIPTION
Related: https://github.com/infinyon/fluvio/pull/4273

This PR fixes an issue where streams could fail to drop in certain states, leading to resource leaks. The solution ensures the future managing the stream is explicitly shut down, resolving the problem.

Changes:

- Replaced the unreliable `TakeUntil` wrapper with explicit stream management logic.
- Uses the same E2E test of https://github.com/infinyon/fluvio/pull/4273, but with a custom config to replicate these problematic states
