### PR TITLE
fix: use info as default log level for cdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,7 +2680,9 @@ name = "fluvio-connector-deployer"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "clap",
  "derive_builder",
+ "enum-display",
  "fluvio-connector-package",
  "tracing",
 ]

--- a/crates/fluvio-connector-deployer/Cargo.toml
+++ b/crates/fluvio-connector-deployer/Cargo.toml
@@ -12,6 +12,8 @@ description = "Deployer Fluvio Connector"
 [dependencies]
 tracing = { workspace = true }
 anyhow = { workspace = true }
+clap = { workspace = true, features = ["std", "derive", "help", "usage", "error-context", "env", "wrap_help", "suggestions"], default-features = false }
 derive_builder = { workspace = true }
+enum-display = { workspace = true }
 
 fluvio-connector-package = { workspace = true  }

--- a/crates/fluvio-connector-deployer/src/lib.rs
+++ b/crates/fluvio-connector-deployer/src/lib.rs
@@ -7,8 +7,6 @@ use derive_builder::Builder;
 
 use fluvio_connector_package::metadata::ConnectorMetadata;
 
-const DEFAULT_LOG_LEVEL: &str = "info";
-
 pub use local::LogLevel;
 
 #[derive(Clone)]
@@ -30,7 +28,7 @@ pub struct Deployment {
     pub config: PathBuf,     // Configuration to pass along,
     pub pkg: ConnectorMetadata, // Connector pkg definition
     pub deployment_type: DeploymentType, // deployment type
-    #[builder(default = "DEFAULT_LOG_LEVEL.to_string()")]
+    #[builder(default)]
     pub log_level: LogLevel, // log level
 }
 

--- a/crates/fluvio-connector-deployer/src/local.rs
+++ b/crates/fluvio-connector-deployer/src/local.rs
@@ -3,11 +3,23 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
+use clap::ValueEnum;
+use enum_display::EnumDisplay;
 use tracing::debug;
 
 use crate::Deployment;
 
-pub type LogLevel = String;
+#[derive(ValueEnum, Debug, Clone, PartialEq, Eq, Default, EnumDisplay)]
+#[clap(rename_all = "kebab-case")]
+#[enum_display(case = "Kebab")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
 
 pub(crate) fn deploy_local<P: AsRef<Path>>(
     deployment: &Deployment,
@@ -29,7 +41,7 @@ pub(crate) fn deploy_local<P: AsRef<Path>>(
     debug!("running executable: {}", &executable.to_string_lossy());
     let mut cmd = Command::new(executable);
 
-    cmd.env("RUST_LOG", &deployment.log_level);
+    cmd.env("RUST_LOG", deployment.log_level.to_string());
     cmd.stdin(Stdio::null());
     cmd.stdout(stdout);
     cmd.stderr(stderr);


### PR DESCRIPTION
Related: https://github.com/infinyon/fluvio/issues/4287


```
cdk deploy start -h                                                                                                               
Start new deployment for the given connector config

Usage: cdk deploy start [OPTIONS] --config <PATH>

Options:
  -c, --config <PATH>          Path to configuration file in YAML format
  -s, --secrets <PATH>         Path to file with secrets. Secrets are 'key=value' pairs separated by the new line character. Optional
      --ipkg <PATH>            Deploy from local package file
      --log-level <LOG_LEVEL>  Log level for the connector process [default: info] [possible values: trace, debug, info, warn, error]
  -h, --help                   Print help
```