### PR TITLE
chore: fix how check if a package is uploaded

### DIFF
--- a/release-tools/publish-crates.sh
+++ b/release-tools/publish-crates.sh
@@ -18,7 +18,7 @@ function check_if_crate_uploaded() {
     local CRATE=$1;
 
     # Check for whether the crate was already uploaded to determine if we're good to move forward
-    tail -1 "$CARGO_OUTPUT_TMP" | grep "already uploaded" > /dev/null
+    tail -1 "$CARGO_OUTPUT_TMP" | grep "already exists" > /dev/null
 
     # If exit code from `grep` is 0
     if [[ ${PIPESTATUS[1]} != 0 ]];


### PR DESCRIPTION
Seems that Cargo is checking if the dependency is already uploaded before calling cargo.io.

And returning a different error that we were not expecting.

https://github.com/rust-lang/cargo/commit/6ede1e2b276eaf93618765a08bd3ec2f0f44d955


https://github.com/infinyon/fluvio/actions/runs/12332023979/attempts/1