### PR TITLE
Fixes compilation error if openssl feature is deactivated but rustls activated

### DIFF
--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/config/tls.rs
+++ b/crates/fluvio/src/config/tls.rs
@@ -244,7 +244,7 @@ cfg_if::cfg_if! {
     }  else if #[cfg(feature = "rustls")] {
 
         impl TryFrom<TlsPolicy> for DomainConnector {
-            type Error = IoError;
+            type Error = anyhow::Error;
 
             fn try_from(config: TlsPolicy) -> Result<Self, Self::Error> {
 


### PR DESCRIPTION
Fixes: #4304

If openssl default feature is deactivated but rustls is active fluvio does not compile.
It complains about a missing `IoError` in `crates/fluvio/src/config/tls.rs:247`