### PR TITLE
chore: wrap offset_flush return in pin<box<_>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",


### PR DESCRIPTION
I need that changes to be able to store dynamic `ConsumerStream` in a struct for https://github.com/infinyon/fluvio-client-python/pull/541

Remembering that we can't use generics with pyo3 structures.
