### PR TITLE
perf improvement: implement async write for hw checkpoint

### DIFF
--- a/crates/fluvio-storage/src/bin/cli.rs
+++ b/crates/fluvio-storage/src/bin/cli.rs
@@ -275,7 +275,7 @@ impl Hw {
             let mut commit_checkpoint =
                 CheckPoint::create(Arc::new(config.into()), HW_CHECKPOINT_FILE_NAME, offset)
                     .await?;
-            commit_checkpoint.write(offset).await?;
+            commit_checkpoint.write(offset);
             sleep(std::time::Duration::from_secs(1)).await;
             println!("hw: {offset} written to checkpoint");
             return Ok(());

--- a/crates/fluvio-storage/src/checkpoint.rs
+++ b/crates/fluvio-storage/src/checkpoint.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use std::io::Cursor;
 use std::io::Error as IoError;
 use std::io::ErrorKind;
@@ -6,14 +5,19 @@ use std::io::SeekFrom;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::Result;
 use bytes::Buf;
-use bytes::BufMut;
+use fluvio_protocol::record::Offset;
+use fluvio_types::event::offsets::OffsetChangeListener;
+use fluvio_types::event::offsets::OffsetPublisher;
+use fluvio_types::event::StickyEvent;
 use futures_lite::io::AsyncReadExt;
 use futures_lite::io::AsyncWriteExt;
 use futures_lite::io::AsyncSeekExt;
+use tokio::select;
 use tracing::debug;
+use tracing::error;
 use tracing::info;
-use tracing::trace;
 
 use fluvio_future::fs::File;
 use fluvio_future::fs::metadata;
@@ -27,26 +31,6 @@ pub trait ReadToBuf: Sized {
     fn read_from<B>(buf: &mut B) -> Self
     where
         B: Buf;
-
-    fn write_to<B>(&mut self, buf: &mut B)
-    where
-        B: BufMut;
-}
-
-impl ReadToBuf for u64 {
-    fn read_from<B>(buf: &mut B) -> Self
-    where
-        B: Buf,
-    {
-        buf.get_u64()
-    }
-
-    fn write_to<B>(&mut self, buf: &mut B)
-    where
-        B: BufMut,
-    {
-        buf.put_u64(*self);
-    }
 }
 
 impl ReadToBuf for i64 {
@@ -56,32 +40,22 @@ impl ReadToBuf for i64 {
     {
         buf.get_i64()
     }
-
-    fn write_to<B>(&mut self, buf: &mut B)
-    where
-        B: BufMut,
-    {
-        buf.put_i64(*self);
-    }
 }
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct CheckPoint<T> {
+pub struct CheckPoint {
     option: Arc<SharedReplicaConfig>,
-    offset: T,
+    offset: Arc<OffsetPublisher>,
+    flush: Arc<StickyEvent>,
     path: PathBuf,
-    file: File,
 }
 
-impl<T> CheckPoint<T>
-where
-    T: Display + ReadToBuf + Clone + Sized + 'static,
-{
+impl CheckPoint {
     pub async fn create(
         option: Arc<SharedReplicaConfig>,
         name: &str,
-        initial_offset: T,
+        initial_offset: Offset,
     ) -> Result<Self, IoError> {
         let checkpoint_path = option.base_dir.join(name);
 
@@ -89,14 +63,25 @@ where
             Ok(_) => {
                 info!("checkpoint {:#?} exists, reading", checkpoint_path);
                 let file = util::open_read_write(&checkpoint_path).await?;
-                let mut checkpoint = CheckPoint {
-                    option: option.clone(),
-                    file,
-                    path: checkpoint_path,
-                    offset: initial_offset.clone(),
+                let mut lazy_writer = LazyWriter::new(file);
+                let old_offset = match lazy_writer.read().await {
+                    Ok(offset) => {
+                        info!(offset = %offset,"checkpoint old offset read");
+                        offset
+                    }
+                    Err(err) => {
+                        error!("error reading checkpoint: {}, resetting", err);
+                        0
+                    }
                 };
-                checkpoint.read().await?;
-                Ok(checkpoint)
+                let offset = OffsetPublisher::shared(old_offset);
+                let flush = lazy_writer.spawn_writer(offset.change_listener());
+                Ok(CheckPoint {
+                    option: option.clone(),
+                    path: checkpoint_path,
+                    offset,
+                    flush,
+                })
             }
             Err(_) => {
                 info!(
@@ -104,37 +89,103 @@ where
                     checkpoint_path.display()
                 );
                 let file = util::open_read_write(&checkpoint_path).await?;
-                trace!("file created: {:#?}", checkpoint_path);
-                let mut checkpoint = CheckPoint {
+                info!("checkfile created: {:#?}", checkpoint_path);
+                let lazy_writer = LazyWriter::new(file);
+                let offset = OffsetPublisher::shared(initial_offset);
+                let flush = lazy_writer.spawn_writer(offset.change_listener());
+                Ok(CheckPoint {
                     option: option.clone(),
-                    file,
-                    offset: initial_offset.clone(),
                     path: checkpoint_path,
-                };
-                checkpoint.write(initial_offset.clone()).await?;
-                Ok(checkpoint)
+                    flush,
+                    offset,
+                })
             }
         }
     }
 
-    pub fn get_offset(&self) -> &T {
-        &self.offset
+    pub fn get_offset(&self) -> Offset {
+        self.offset.current_value()
     }
 
     /// return last modified time
     pub async fn get_last_modified(&self) -> Result<std::time::SystemTime, IoError> {
-        let metadata = self.file.metadata().await?;
+        let file = util::open_read_write(&self.path).await?;
+        let metadata = file.metadata().await?;
         metadata.modified()
     }
 
-    /// read contents of the
-    async fn read(&mut self) -> Result<(), IoError> {
+    pub async fn write(&mut self, pos: Offset) -> Result<(), IoError> {
+        debug!(%pos,"Update checkpoint");
+        self.offset.update(pos);
+
+        Ok(())
+    }
+}
+
+impl Drop for CheckPoint {
+    fn drop(&mut self) {
+        info!("dropping checkpoint");
+        self.flush.notify();
+    }
+}
+
+/// write in lazy
+#[derive(Debug)]
+struct LazyWriter {
+    file: File,
+    offset: Offset,
+}
+
+impl LazyWriter {
+    fn new(file: File) -> Self {
+        Self { file, offset: 0 }
+    }
+
+    fn spawn_writer(self, listener: OffsetChangeListener) -> Arc<StickyEvent> {
+        let flush_event = StickyEvent::shared();
+        let loop_flush = flush_event.clone();
+        fluvio_future::task::spawn(async move {
+            if let Err(err) = self.write_loop(listener, loop_flush).await {
+                error!("error writing checkpoint: {}", err);
+            }
+        });
+        flush_event
+    }
+
+    async fn write_loop(
+        mut self,
+        mut listener: OffsetChangeListener,
+        flush: Arc<StickyEvent>,
+    ) -> Result<()> {
+        info!("starting checkpoint writer loop");
+        loop {
+            select! {
+                _ = flush.listen() => {
+                    info!("flushing checkpoint");
+                    self.flush().await?;
+                    break;
+                },
+                offset = listener.listen() => {
+                    if offset == self.offset {
+                        debug!(offset, "no change in offset, skipping");
+                    } else {
+                        debug!(offset, "writing checkpoint");
+                        let buf = offset.to_be_bytes();
+                        self.file.seek(SeekFrom::Start(0)).await?;
+                        self.file.write_all(&buf).await?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// get offset from file
+    async fn read(&mut self) -> Result<Offset, IoError> {
         self.file.seek(SeekFrom::Start(0)).await?;
         let mut contents = Vec::new();
-        self.file
-            .read_to_end(&mut contents)
-            .await
-            .expect("reading to end");
+        self.file.read_to_end(&mut contents).await?;
 
         if contents.len() != 8 {
             return Err(IoError::new(
@@ -148,23 +199,13 @@ where
 
         let mut buf = Cursor::new(contents);
         self.offset = ReadToBuf::read_from(&mut buf);
-        info!(offset = %self.offset,"checkpoint offset read");
-        Ok(())
+        info!(offset = self.offset, "checkpoint read");
+        Ok(self.offset)
     }
 
-    pub(crate) async fn write(&mut self, pos: T) -> Result<(), IoError> {
-        debug!(%pos,"Update checkpoint");
-        self.file.seek(SeekFrom::Start(0)).await?;
-        let mut contents = Vec::new();
-        self.offset = pos;
-        self.offset.write_to(&mut contents);
-        self.file.write_all(&contents).await?;
+    async fn flush(&mut self) -> Result<(), IoError> {
+        self.file.sync_all().await?;
         Ok(())
-    }
-
-    #[cfg(test)]
-    async fn sync_all(&mut self) -> Result<(), IoError> {
-        self.file.sync_all().await
     }
 }
 
@@ -173,10 +214,27 @@ mod tests {
 
     use std::env::temp_dir;
 
+    use fluvio_future::timer::sleep;
     use flv_util::fixture::ensure_clean_file;
 
     use crate::config::ReplicaConfig;
     use super::CheckPoint;
+
+    use super::*;
+
+    #[fluvio_future::test]
+    async fn lister_test() {
+        let publisher = OffsetPublisher::shared(10);
+        let mut listener = publisher.change_listener();
+        assert!(listener.listen().await == 10);
+
+        publisher.update(21);
+        assert!(listener.listen().await == 21);
+
+        publisher.update(30);
+        publisher.update(40);
+        assert!(listener.listen().await == 40);
+    }
 
     #[fluvio_future::test]
     async fn checkpoint_test() {
@@ -189,22 +247,19 @@ mod tests {
         }
         .shared();
 
-        let mut ck: CheckPoint<u64> = CheckPoint::create(option.clone(), "test.chk", 0)
+        let mut ck = CheckPoint::create(option.clone(), "test.chk", 0)
             .await
             .expect("create");
-        ck.read().await.expect("do initial read");
-        assert_eq!(*ck.get_offset(), 0);
+        assert_eq!(ck.get_offset(), 0);
         ck.write(10).await.expect("first write");
         ck.write(40).await.expect("2nd write");
-        ck.sync_all().await.expect("sync");
-
         drop(ck);
+        sleep(std::time::Duration::from_millis(200)).await;
 
-        let mut ck2: CheckPoint<u64> = CheckPoint::create(option, "test.chk", 0)
+        let mut ck2 = CheckPoint::create(option, "test.chk", 0)
             .await
             .expect("restore");
-        ck2.read().await.expect("read");
-        assert_eq!(*ck2.get_offset(), 40);
+        assert_eq!(ck2.get_offset(), 40);
         ck2.write(20)
             .await
             .expect("write aft er reading should work");

--- a/crates/fluvio-storage/src/checkpoint.rs
+++ b/crates/fluvio-storage/src/checkpoint.rs
@@ -114,11 +114,9 @@ impl CheckPoint {
         metadata.modified()
     }
 
-    pub async fn write(&mut self, pos: Offset) -> Result<(), IoError> {
+    pub fn write(&mut self, pos: Offset) {
         debug!(%pos,"Update checkpoint");
         self.offset.update(pos);
-
-        Ok(())
     }
 }
 
@@ -251,8 +249,8 @@ mod tests {
             .await
             .expect("create");
         assert_eq!(ck.get_offset(), 0);
-        ck.write(10).await.expect("first write");
-        ck.write(40).await.expect("2nd write");
+        ck.write(10);
+        ck.write(40);
         drop(ck);
         sleep(std::time::Duration::from_millis(200)).await;
 
@@ -260,8 +258,6 @@ mod tests {
             .await
             .expect("restore");
         assert_eq!(ck2.get_offset(), 40);
-        ck2.write(20)
-            .await
-            .expect("write aft er reading should work");
+        ck2.write(20);
     }
 }

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -179,7 +179,7 @@ impl ReplicaStorage for FileReplica {
                 old_offset,
                 offset
             );
-            self.commit_checkpoint.write(offset).await?;
+            self.commit_checkpoint.write(offset);
             Ok(true)
         }
     }
@@ -270,7 +270,7 @@ impl FileReplica {
                 hw,
                 leo, "high watermark is greater than log end offset, resetting to leo"
             );
-            commit_checkpoint.write(leo).await?;
+            commit_checkpoint.write(leo);
         }
 
         let size = Arc::new(ReplicaSize::default());

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -37,7 +37,7 @@ pub struct FileReplica {
     option: Arc<SharedReplicaConfig>,
     active_segment: MutableSegment,
     prev_segments: Arc<SharedSegments>,
-    commit_checkpoint: CheckPoint<Offset>,
+    commit_checkpoint: CheckPoint,
     cleaner: Arc<Cleaner>,
     size: Arc<ReplicaSize>,
 }
@@ -74,7 +74,7 @@ impl ReplicaStorage for FileReplica {
 
     #[inline(always)]
     fn get_hw(&self) -> Offset {
-        *self.commit_checkpoint.get_offset()
+        self.commit_checkpoint.get_offset()
     }
 
     /// offset mark that beginning of uncommitted
@@ -255,7 +255,7 @@ impl FileReplica {
 
         let last_base_offset = active_segment.get_base_offset();
 
-        let mut commit_checkpoint: CheckPoint<Offset> = CheckPoint::create(
+        let mut commit_checkpoint = CheckPoint::create(
             shared_config.clone(),
             HW_CHECKPOINT_FILE_NAME,
             last_base_offset,
@@ -263,7 +263,7 @@ impl FileReplica {
         .await?;
 
         // ensure checkpoint is valid
-        let hw = *commit_checkpoint.get_offset();
+        let hw = commit_checkpoint.get_offset();
         let leo = active_segment.get_end_offset();
         if hw > leo {
             info!(


### PR DESCRIPTION
Since HW write doesn't need to be sync with file, we can separate into  asynchronous task.

Writer task is spawned to write to file which doesn't block checkpoint update.