### PR TITLE
feat: add fluvio producer callback

### DIFF
--- a/crates/fluvio-benchmark/src/producer_benchmark.rs
+++ b/crates/fluvio-benchmark/src/producer_benchmark.rs
@@ -57,8 +57,12 @@ impl ProducerBenchmark {
         for producer_id in 0..config.num_producers {
             let (event_sender, event_receiver) = unbounded();
             println!("starting up producer {}", producer_id);
-            let stat_collector =
-                StatCollector::create(end_sender.clone(), stat_sender.clone(), event_receiver);
+            let stat_collector = StatCollector::create(
+                config.num_records,
+                end_sender.clone(),
+                stat_sender.clone(),
+                event_receiver,
+            );
             let (tx_control, rx_control) = unbounded();
             let worker =
                 ProducerWorker::new(producer_id, config.clone(), stat_collector, event_sender)

--- a/crates/fluvio-benchmark/src/producer_benchmark.rs
+++ b/crates/fluvio-benchmark/src/producer_benchmark.rs
@@ -60,7 +60,6 @@ impl ProducerBenchmark {
             let stat_collector =
                 StatCollector::create(end_sender.clone(), stat_sender.clone(), event_receiver);
             let (tx_control, rx_control) = unbounded();
-            //sleep(Duration::from_secs(1)).await;
             let worker =
                 ProducerWorker::new(producer_id, config.clone(), stat_collector, event_sender)
                     .await?;

--- a/crates/fluvio-benchmark/src/producer_benchmark.rs
+++ b/crates/fluvio-benchmark/src/producer_benchmark.rs
@@ -80,9 +80,11 @@ impl ProducerBenchmark {
                     if let Ok(stat) = stat_rx {
                         let human_readable_bytes = ByteSize(stat.bytes_per_sec).to_string();
                         println!(
-                            "{} records sent, {} records/sec: ({}/sec), {:.2}ms avg latency, {:.2}ms max latency",
+                            //TODO: fix inteval latency
+                            //"{} records sent, {} records/sec: ({}/sec), {:.2}ms avg latency, {:.2}ms max latency",
+                            "{} records sent, {} records/sec: ({}/sec)",
                              stat.record_send, stat.records_per_sec, human_readable_bytes,
-                                utils::nanos_to_ms_pritable(stat.latency_avg), utils::nanos_to_ms_pritable(stat.latency_max)
+                            //utils::nanos_to_ms_pritable(stat.latency_avg), utils::nanos_to_ms_pritable(stat.latency_max)
                         );
                     }
                 }

--- a/crates/fluvio-benchmark/src/producer_benchmark.rs
+++ b/crates/fluvio-benchmark/src/producer_benchmark.rs
@@ -51,18 +51,19 @@ impl ProducerBenchmark {
         let mut workers_jh = Vec::new();
 
         let (stat_sender, stat_receiver) = unbounded();
-        let (latency_sender, latency_receiver) = unbounded();
+        let (end_sender, end_receiver) = unbounded();
+
         // Set up producers
         for producer_id in 0..config.num_producers {
+            let (event_sender, event_receiver) = unbounded();
             println!("starting up producer {}", producer_id);
-            let stat_collector = StatCollector::create(
-                config.batch_size.as_u64(),
-                config.num_records,
-                latency_sender.clone(),
-                stat_sender.clone(),
-            );
+            let stat_collector =
+                StatCollector::create(end_sender.clone(), stat_sender.clone(), event_receiver);
             let (tx_control, rx_control) = unbounded();
-            let worker = ProducerWorker::new(producer_id, config.clone(), stat_collector).await?;
+            //sleep(Duration::from_secs(1)).await;
+            let worker =
+                ProducerWorker::new(producer_id, config.clone(), stat_collector, event_sender)
+                    .await?;
             let jh = spawn(timeout(
                 config.worker_timeout,
                 ProducerDriver::main_loop(rx_control, worker),
@@ -76,35 +77,38 @@ impl ProducerBenchmark {
 
         loop {
             select! {
-                hist = latency_receiver.recv() => {
-                    if let Ok(hist) = hist {
-                        let mut latency_yaml = String::new();
-                        latency_yaml.push_str(&format!("{:.2}ms avg latency, {:.2}ms max latency",
-                            utils::nanos_to_ms_pritable(hist.mean() as u64),
-                            utils::nanos_to_ms_pritable(hist.value_at_quantile(1.0))));
-                        for percentile in [0.5, 0.95, 0.99] {
-                            latency_yaml.push_str(&format!(
-                                ", {:.2}ms p{percentile:4.2}",
-                                utils::nanos_to_ms_pritable(hist.value_at_quantile(percentile)),
-                            ));
-                        }
-                        println!("{}", latency_yaml);
-                    }
-                    break;
-                }
                 stat_rx = stat_receiver.recv() => {
                     if let Ok(stat) = stat_rx {
-                        // lantecy_receiver is finishing the benchmark now
-                        //if stat.end {
-                        //    break;
-                        //}
-                        let human_readable_bytes = ByteSize(stat.bytes_per_sec as u64).to_string();
+                        let human_readable_bytes = ByteSize(stat.bytes_per_sec).to_string();
                         println!(
                             "{} records sent, {} records/sec: ({}/sec), {:.2}ms avg latency, {:.2}ms max latency",
-                             stat.total_records_send, stat.records_per_sec, human_readable_bytes,
+                             stat.record_send, stat.records_per_sec, human_readable_bytes,
                                 utils::nanos_to_ms_pritable(stat.latency_avg), utils::nanos_to_ms_pritable(stat.latency_max)
                         );
                     }
+                }
+                end = end_receiver.recv() => {
+                    if let Ok(end) = end {
+                        let mut latency_yaml = String::new();
+                        latency_yaml.push_str(&format!("{:.2}ms avg latency, {:.2}ms max latency",
+                            utils::nanos_to_ms_pritable(end.histogram.mean() as u64),
+                            utils::nanos_to_ms_pritable(end.histogram.value_at_quantile(1.0))));
+                        for percentile in [0.5, 0.95, 0.99] {
+                            latency_yaml.push_str(&format!(
+                                ", {:.2}ms p{percentile:4.2}",
+                                utils::nanos_to_ms_pritable(end.histogram.value_at_quantile(percentile)),
+                            ));
+                        }
+                        println!();
+                        println!("{}", latency_yaml);
+
+                        let human_readable_bytes = ByteSize(end.bytes_per_sec).to_string();
+                        println!(
+                            "{} total records sent, {} records/sec: ({}/sec) ",
+                             end.total_records, end.records_per_sec, human_readable_bytes
+                        );
+                    }
+                    break;
                 }
             }
         }

--- a/crates/fluvio-benchmark/src/producer_worker.rs
+++ b/crates/fluvio-benchmark/src/producer_worker.rs
@@ -30,7 +30,7 @@ impl BenchmarkProducerCallback {
     }
 }
 
-impl ProducerCallback<ProduceCompletionEvent> for BenchmarkProducerCallback {
+impl ProducerCallback for BenchmarkProducerCallback {
     fn finished(&self, event: ProduceCompletionEvent) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async {
             self.event_sender.send(event).await?;
@@ -52,7 +52,7 @@ impl ProducerWorker {
         event_sender: Sender<ProduceCompletionEvent>,
     ) -> Result<Self> {
         let fluvio = Fluvio::connect().await?;
-        let callback: SharedProducerCallback<ProduceCompletionEvent> =
+        let callback: SharedProducerCallback =
             Arc::new(BenchmarkProducerCallback::new(event_sender));
 
         let fluvio_config = TopicProducerConfigBuilder::default()

--- a/crates/fluvio-benchmark/src/stats_collector.rs
+++ b/crates/fluvio-benchmark/src/stats_collector.rs
@@ -1,162 +1,207 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    f64,
+    sync::{atomic::AtomicU64, Arc},
+    time::{Duration, Instant},
+};
 
-use async_channel::Sender;
-use fluvio::ProduceOutput;
-use fluvio_future::{sync::Mutex, task::spawn};
+use async_channel::{Receiver, Sender};
+use fluvio::ProduceCompletionEvent;
+use fluvio_future::{sync::Mutex, task::spawn, timer::sleep};
 use hdrhistogram::Histogram;
 
-#[derive(Debug)]
 pub(crate) struct ProducerStat {
-    record_send: u64,
-    record_bytes: u64,
-    start_time: Instant,
-    output_tx: Sender<(ProduceOutput, Instant)>,
-    histogram: Arc<Mutex<Histogram<u64>>>,
+    stats: Arc<AtomicStats>,
+    start_time: Arc<Mutex<Option<Instant>>>,
+}
+
+pub struct AtomicStats {
+    record_send: AtomicU64,
+    record_bytes: AtomicU64,
+}
+
+pub struct Stats {
+    pub record_send: u64,
+    pub record_bytes: u64,
+    pub records_per_sec: u64,
+    pub bytes_per_sec: u64,
+    pub latency_avg: u64,
+    pub latency_max: u64,
+}
+
+pub struct EndProducerStat {
+    pub histogram: Histogram<u64>,
+    pub total_records: u64,
+    pub records_per_sec: u64,
+    pub bytes_per_sec: u64,
 }
 
 impl ProducerStat {
-    pub(crate) fn new(num_records: u64, latency_sender: Sender<Histogram<u64>>) -> Self {
-        let (output_tx, rx) = async_channel::unbounded::<(ProduceOutput, Instant)>();
-        let histogram = Arc::new(Mutex::new(hdrhistogram::Histogram::<u64>::new(2).unwrap()));
+    pub(crate) fn new(
+        end_sender: Sender<EndProducerStat>,
+        stats_sender: Sender<Stats>,
+        event_receiver: Receiver<ProduceCompletionEvent>,
+    ) -> Self {
+        let start_time = Arc::new(Mutex::new(None));
+        let stats = Arc::new(AtomicStats {
+            record_send: AtomicU64::new(0),
+            record_bytes: AtomicU64::new(0),
+        });
 
-        ProducerStat::track_latency(num_records, latency_sender, rx, histogram.clone());
+        let histogram = Arc::new(Mutex::new(hdrhistogram::Histogram::<u64>::new(3).unwrap()));
+
+        ProducerStat::track_latency(
+            end_sender,
+            histogram.clone(),
+            event_receiver,
+            stats.clone(),
+            Arc::clone(&start_time),
+        );
+
+        ProducerStat::send_stats(histogram.clone(), stats_sender, stats.clone())
+            .expect("send stats");
 
         Self {
-            record_send: 0,
-            record_bytes: 0,
-            start_time: Instant::now(),
-            output_tx,
-            histogram,
+            stats: stats.clone(),
+            start_time,
         }
+    }
+
+    fn send_stats(
+        histogram: Arc<Mutex<Histogram<u64>>>,
+        stats_sender: Sender<Stats>,
+        stats: Arc<AtomicStats>,
+    ) -> Result<(), std::io::Error> {
+        spawn(async move {
+            loop {
+                let stats_sender = stats_sender.clone();
+                let stats = Arc::clone(&stats);
+                let old_record_send = stats.record_send.load(std::sync::atomic::Ordering::Relaxed);
+                let old_record_bytes = stats
+                    .record_bytes
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                sleep(Duration::from_secs(1)).await;
+                let new_record_send = stats.record_send.load(std::sync::atomic::Ordering::Relaxed);
+                let new_record_bytes = stats
+                    .record_bytes
+                    .load(std::sync::atomic::Ordering::Relaxed);
+
+                if new_record_send == old_record_send {
+                    continue;
+                }
+
+                let records_delta = new_record_send - old_record_send;
+                let bytes_delta = new_record_bytes - old_record_bytes;
+
+                let records_per_sec = records_delta;
+                let bytes_per_sec = bytes_delta / 1000;
+
+                let hist = histogram.lock().await;
+                let latency_avg = hist.mean() as u64;
+                let latency_max = hist.value_at_quantile(1.0);
+
+                stats_sender
+                    .send(Stats {
+                        record_send: records_delta,
+                        record_bytes: bytes_delta,
+                        records_per_sec,
+                        bytes_per_sec,
+                        latency_avg,
+                        latency_max,
+                    })
+                    .await
+                    .expect("send stats");
+            }
+        });
+        Ok(())
     }
 
     fn track_latency(
-        num_records: u64,
-        latency_sender: Sender<Histogram<u64>>,
-        rx: async_channel::Receiver<(ProduceOutput, Instant)>,
+        end_sender: Sender<EndProducerStat>,
         histogram: Arc<Mutex<Histogram<u64>>>,
+        event_receiver: Receiver<ProduceCompletionEvent>,
+        stats: Arc<AtomicStats>,
+        start_time: Arc<Mutex<Option<Instant>>>,
     ) {
         spawn(async move {
-            while let Ok((send_out, time)) = rx.recv().await {
-                let hist = histogram.clone();
-                let latency_sender = latency_sender.clone();
-                //spawn(async move {
-                match send_out.wait().await {
-                    Ok(_) => {
-                        let duration = time.elapsed();
+            let hist = histogram.clone();
+            while let Ok(event) = event_receiver.recv().await {
+                match event.metadata.base_offset().await {
+                    Ok(_base_offset) => {
+                        let elapsed = event.created_at.elapsed();
                         let mut hist = hist.lock().await;
-                        hist.record(duration.as_nanos() as u64).expect("record");
-
-                        if hist.len() >= num_records {
-                            latency_sender.send(hist.clone()).await.expect("send");
-                        }
+                        hist.record(elapsed.as_nanos() as u64).expect("record");
                     }
                     Err(err) => {
-                        println!("error sending record: {}", err);
-                        return;
+                        println!("received err: {:?}", err);
                     }
                 }
-                //});
             }
+
+            // send end
+            let hist = hist.lock().await;
+            let start_time = start_time.lock().await.expect("start time");
+            let elapsed = start_time.elapsed();
+
+            let elapsed_seconds = elapsed.as_millis() as f64 / 1000.0;
+            let records_per_sec = (stats.record_send.load(std::sync::atomic::Ordering::Relaxed)
+                as f64
+                / elapsed_seconds)
+                .round() as u64;
+            let bytes_per_sec = (stats
+                .record_bytes
+                .load(std::sync::atomic::Ordering::Relaxed) as f64
+                / elapsed_seconds)
+                .round() as u64;
+
+            let end = EndProducerStat {
+                histogram: hist.clone(),
+                total_records: stats.record_send.load(std::sync::atomic::Ordering::Relaxed),
+                records_per_sec,
+                bytes_per_sec,
+            };
+            end_sender.send(end).await.expect("send end");
         });
     }
 
-    pub(crate) fn calcuate(&mut self) -> Stat {
-        let elapse = self.start_time.elapsed().as_millis();
-        let records_per_sec = ((self.record_send as f64 / elapse as f64) * 1000.0).round();
-        let bytes_per_sec = (self.record_bytes as f64 / elapse as f64) * 1000.0;
-
-        let hist = self.histogram.lock_blocking();
-        let latency_avg = hist.mean() as u64;
-        let latency_max = hist.value_at_quantile(1.0);
-
-        Stat {
-            records_per_sec,
-            bytes_per_sec,
-            _total_bytes_send: self.record_bytes,
-            total_records_send: self.record_send,
-            latency_avg,
-            latency_max,
-            _end: false,
-        }
+    pub(crate) fn add_record(&mut self, bytes: u64) {
+        self.stats
+            .record_send
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.stats
+            .record_bytes
+            .fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
     }
 
-    pub(crate) fn set_current_time(&mut self) {
-        self.start_time = Instant::now();
+    pub(crate) async fn set_current_time(&mut self) {
+        self.start_time.lock().await.replace(Instant::now());
     }
-
-    pub(crate) fn send_out(&mut self, out: (ProduceOutput, Instant)) {
-        self.output_tx.try_send(out).expect("send out");
-    }
-}
-
-pub(crate) struct Stat {
-    pub records_per_sec: f64,
-    pub bytes_per_sec: f64,
-    pub _total_bytes_send: u64,
-    pub total_records_send: u64,
-    pub latency_avg: u64,
-    pub latency_max: u64,
-    pub _end: bool,
 }
 
 pub(crate) struct StatCollector {
     current: ProducerStat,
-    batch_size: u64,     // number of records before we calculate stats
-    current_record: u64, // how many records we have sent in current cycle
-    sender: Sender<Stat>,
+    current_record: u64,
 }
 
 impl StatCollector {
     pub(crate) fn create(
-        batch_size: u64,
-        num_records: u64,
-        latency_sender: Sender<Histogram<u64>>,
-        sender: Sender<Stat>,
+        end_sender: Sender<EndProducerStat>,
+        stat_sender: Sender<Stats>,
+        event_receiver: Receiver<ProduceCompletionEvent>,
     ) -> Self {
         Self {
-            current: ProducerStat::new(num_records, latency_sender),
-            batch_size,
+            current: ProducerStat::new(end_sender, stat_sender, event_receiver),
             current_record: 0,
-            sender,
         }
     }
 
-    pub(crate) fn start(&mut self) {
+    pub(crate) async fn start(&mut self) {
         if self.current_record == 0 {
-            self.current.set_current_time();
+            self.current.set_current_time().await;
         }
-    }
-
-    pub(crate) fn send_out(&mut self, out: (ProduceOutput, Instant)) {
-        self.current.send_out(out);
     }
 
     pub(crate) async fn add_record(&mut self, bytes: u64) {
-        self.current.record_send += 1;
-        self.current.record_bytes += bytes;
+        self.current.add_record(bytes);
         self.current_record += 1;
-
-        if self.current_record >= self.batch_size {
-            let stat = self.current.calcuate();
-            self.current_record = 0;
-            self.current.record_bytes = 0;
-            self.current.record_send = 0;
-            self.sender.try_send(stat).expect("send stats");
-        }
-    }
-
-    pub(crate) fn finish(&mut self) {
-        let end_record = Stat {
-            records_per_sec: 0.0,
-            bytes_per_sec: 0.0,
-            _total_bytes_send: 0,
-            total_records_send: 0,
-            latency_avg: 0,
-            latency_max: 0,
-            _end: true,
-        };
-
-        self.sender.try_send(end_record).expect("send end stats");
     }
 }

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -19,10 +19,10 @@ pub mod spu;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{
-    ProducerCallback, SharedProducerCallback, ProduceCompletionEvent, TopicProducerConfigBuilder,
-    TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey, ProduceOutput,
-    FutureRecordMetadata, RecordMetadata, DeliverySemantic, RetryPolicy, RetryStrategy,
-    Partitioner, PartitionerConfig, ProducerError,
+    ProducerCallback, SharedProducerCallback, ProduceCompletionBatchEvent,
+    TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey,
+    ProduceOutput, FutureRecordMetadata, RecordMetadata, DeliverySemantic, RetryPolicy,
+    RetryStrategy, Partitioner, PartitionerConfig, ProducerError,
 };
 #[cfg(feature = "smartengine")]
 pub use producer::{SmartModuleChainBuilder, SmartModuleConfig, SmartModuleInitialData};

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -19,9 +19,10 @@ pub mod spu;
 pub use error::FluvioError;
 pub use config::FluvioConfig;
 pub use producer::{
-    TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey,
-    ProduceOutput, FutureRecordMetadata, RecordMetadata, DeliverySemantic, RetryPolicy,
-    RetryStrategy, Partitioner, PartitionerConfig, ProducerError,
+    ProducerCallback, SharedProducerCallback, ProduceCompletionEvent, TopicProducerConfigBuilder,
+    TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey, ProduceOutput,
+    FutureRecordMetadata, RecordMetadata, DeliverySemantic, RetryPolicy, RetryStrategy,
+    Partitioner, PartitionerConfig, ProducerError,
 };
 #[cfg(feature = "smartengine")]
 pub use producer::{SmartModuleChainBuilder, SmartModuleConfig, SmartModuleInitialData};

--- a/crates/fluvio/src/producer/accumulator.rs
+++ b/crates/fluvio/src/producer/accumulator.rs
@@ -223,9 +223,9 @@ pub struct ProduceCompletionEvent {
     pub metadata: Arc<BatchMetadata>,
 }
 
-pub type SharedProducerCallback<T> = Arc<dyn ProducerCallback<T> + Send + Sync>;
-pub trait ProducerCallback<T> {
-    fn finished(&self, item: T) -> BoxFuture<'_, anyhow::Result<()>>;
+pub type SharedProducerCallback = Arc<dyn ProducerCallback + Send + Sync>;
+pub trait ProducerCallback {
+    fn finished(&self, item: ProduceCompletionEvent) -> BoxFuture<'_, anyhow::Result<()>>;
 }
 
 pub(crate) struct PushRecord {

--- a/crates/fluvio/src/producer/accumulator.rs
+++ b/crates/fluvio/src/producer/accumulator.rs
@@ -218,14 +218,18 @@ impl RecordAccumulator {
     }
 }
 
-pub struct ProduceCompletionEvent {
+#[derive(Debug)]
+pub struct ProduceCompletionBatchEvent {
+    pub topic: String,
+    pub bytes_size: u64,
+    pub records_len: u64,
+    pub partition: PartitionId,
     pub created_at: Instant,
-    pub metadata: Arc<BatchMetadata>,
 }
 
 pub type SharedProducerCallback = Arc<dyn ProducerCallback + Send + Sync>;
 pub trait ProducerCallback {
-    fn finished(&self, item: ProduceCompletionEvent) -> BoxFuture<'_, anyhow::Result<()>>;
+    fn finished(&self, item: ProduceCompletionBatchEvent) -> BoxFuture<'_, anyhow::Result<()>>;
 }
 
 pub(crate) struct PushRecord {
@@ -332,8 +336,7 @@ type ProduceResponseFuture = Shared<BoxFuture<'static, Arc<Result<ProduceRespons
 
 /// A Future that resolves to pair `base_offset` and `error_code`, which effectively come from
 /// [`PartitionProduceResponse`].
-#[derive(Debug, Clone)]
-pub struct ProducePartitionResponseFuture {
+pub(crate) struct ProducePartitionResponseFuture {
     inner: Either<(ProduceResponseFuture, usize), Option<(Offset, ErrorCode)>>,
 }
 

--- a/crates/fluvio/src/producer/accumulator.rs
+++ b/crates/fluvio/src/producer/accumulator.rs
@@ -220,11 +220,11 @@ impl RecordAccumulator {
 
 #[derive(Debug)]
 pub struct ProduceCompletionBatchEvent {
-    pub topic: String,
     pub bytes_size: u64,
     pub records_len: u64,
     pub partition: PartitionId,
     pub created_at: Instant,
+    pub elapsed: Duration,
 }
 
 pub type SharedProducerCallback = Arc<dyn ProducerCallback + Send + Sync>;

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -16,7 +16,6 @@ use crate::producer::partitioning::{Partitioner, SiphashRoundRobinPartitioner};
 
 use super::accumulator::SharedProducerCallback;
 use super::partitioning::SpecificPartitioner;
-use super::ProduceCompletionEvent;
 
 const DEFAULT_LINGER_MS: u64 = 0;
 const DEFAULT_TIMEOUT_MS: u64 = 1500;
@@ -122,7 +121,7 @@ pub struct TopicProducerConfig {
     pub(crate) smartmodules: Vec<SmartModuleInvocation>,
 
     #[builder(setter(into, strip_option), default)]
-    pub(crate) callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
+    pub(crate) callback: Option<SharedProducerCallback>,
 }
 
 impl TopicProducerConfigBuilder {

--- a/crates/fluvio/src/producer/config.rs
+++ b/crates/fluvio/src/producer/config.rs
@@ -14,7 +14,9 @@ use serde::{Serialize, Deserialize};
 
 use crate::producer::partitioning::{Partitioner, SiphashRoundRobinPartitioner};
 
+use super::accumulator::SharedProducerCallback;
 use super::partitioning::SpecificPartitioner;
+use super::ProduceCompletionEvent;
 
 const DEFAULT_LINGER_MS: u64 = 0;
 const DEFAULT_TIMEOUT_MS: u64 = 1500;
@@ -70,7 +72,7 @@ impl fmt::Debug for Box<dyn Partitioner + Send + Sync> {
 /// Create this struct with [`TopicProducerConfigBuilder`].
 ///
 /// Create a producer with a custom config with [`crate::Fluvio::topic_producer_with_config()`].
-#[derive(Debug, Builder)]
+#[derive(Builder)]
 #[builder(pattern = "owned")]
 pub struct TopicProducerConfig {
     /// Maximum amount of bytes accumulated by the records before sending the batch.
@@ -118,6 +120,9 @@ pub struct TopicProducerConfig {
 
     #[builder(default)]
     pub(crate) smartmodules: Vec<SmartModuleInvocation>,
+
+    #[builder(setter(into, strip_option), default)]
+    pub(crate) callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
 }
 
 impl TopicProducerConfigBuilder {
@@ -177,6 +182,7 @@ impl Default for TopicProducerConfig {
             isolation: default_isolation(),
             delivery_semantic: default_delivery(),
             smartmodules: vec![],
+            callback: None,
         }
     }
 }

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -47,7 +47,7 @@ use self::accumulator::BatchHandler;
 use self::accumulator::BatchesDeque;
 pub use self::accumulator::SharedProducerCallback;
 pub use self::accumulator::ProducerCallback;
-pub use self::accumulator::ProduceCompletionEvent;
+pub use self::accumulator::ProduceCompletionBatchEvent;
 pub use self::config::{
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducerConfigBuilderError,
     DeliverySemantic, RetryPolicy, RetryStrategy,

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -78,7 +78,7 @@ where
     batches_deque: Arc<BatchesDeque>,
     batch_events: Arc<BatchEvents>,
     client_metric: Arc<ClientMetrics>,
-    callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
+    callback: Option<SharedProducerCallback>,
 }
 
 impl ProducerPool {
@@ -88,7 +88,7 @@ impl ProducerPool {
         spu_pool: Arc<S>,
         batches: Arc<HashMap<PartitionId, BatchHandler>>,
         client_metric: Arc<ClientMetrics>,
-        callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
+        callback: Option<SharedProducerCallback>,
     ) -> Self
     where
         S: SpuPool + Send + Sync + 'static,

--- a/crates/fluvio/src/producer/mod.rs
+++ b/crates/fluvio/src/producer/mod.rs
@@ -45,6 +45,9 @@ pub use crate::producer::partitioning::{Partitioner, PartitionerConfig};
 use self::accumulator::BatchEvents;
 use self::accumulator::BatchHandler;
 use self::accumulator::BatchesDeque;
+pub use self::accumulator::SharedProducerCallback;
+pub use self::accumulator::ProducerCallback;
+pub use self::accumulator::ProduceCompletionEvent;
 pub use self::config::{
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducerConfigBuilderError,
     DeliverySemantic, RetryPolicy, RetryStrategy,
@@ -75,6 +78,7 @@ where
     batches_deque: Arc<BatchesDeque>,
     batch_events: Arc<BatchEvents>,
     client_metric: Arc<ClientMetrics>,
+    callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
 }
 
 impl ProducerPool {
@@ -84,6 +88,7 @@ impl ProducerPool {
         spu_pool: Arc<S>,
         batches: Arc<HashMap<PartitionId, BatchHandler>>,
         client_metric: Arc<ClientMetrics>,
+        callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
     ) -> Self
     where
         S: SpuPool + Send + Sync + 'static,
@@ -103,6 +108,7 @@ impl ProducerPool {
                 batches_deque: batch_list.clone(),
                 batch_events: batch_events.clone(),
                 client_metric: client_metric.clone(),
+                callback: callback.clone(),
             };
 
             PartitionProducer::start(
@@ -271,6 +277,7 @@ where
             batches_deque: BatchesDeque::shared(),
             batch_events: BatchEvents::shared(),
             client_metric: self.metrics.clone(),
+            callback: self.config.callback.clone(),
         };
 
         let _ = producer_pool
@@ -433,6 +440,7 @@ where
             spu_pool.clone(),
             Arc::new(record_accumulator.batches().await),
             metrics.clone(),
+            config.callback.clone(),
         );
 
         Ok(Self {

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -34,7 +34,7 @@ where
     batch_events: Arc<BatchEvents>,
     last_error: Arc<RwLock<Option<ProducerError>>>,
     metrics: Arc<ClientMetrics>,
-    callback: Option<SharedProducerCallback<ProduceCompletionEvent>>,
+    callback: Option<SharedProducerCallback>,
 }
 
 impl<S> PartitionProducer<S>

--- a/crates/fluvio/src/producer/partition_producer.rs
+++ b/crates/fluvio/src/producer/partition_producer.rs
@@ -220,12 +220,13 @@ where
 
             if self.callback.is_some() {
                 let created_at = metadata.created_at;
+                let elapsed = created_at.elapsed();
                 let event = ProduceCompletionBatchEvent {
                     created_at,
-                    topic: self.replica.topic.clone(),
                     partition: self.replica.partition,
                     bytes_size,
                     records_len,
+                    elapsed,
                 };
 
                 events_to_callback.push(event);

--- a/crates/fluvio/src/producer/record.rs
+++ b/crates/fluvio/src/producer/record.rs
@@ -35,7 +35,7 @@ impl RecordMetadata {
 }
 
 /// Possible states of a batch in the accumulator
-pub enum BatchMetadataState {
+pub(crate) enum BatchMetadataState {
     /// The batch is buffered and ready to be sent to the SPU
     Buffered(Receiver<ProducePartitionResponseFuture>),
     /// The batch was sent to the SPU. Base offset is known
@@ -59,7 +59,7 @@ impl BatchMetadata {
 
     /// Wait for the base offset of the batch. This is the offset of the first
     /// record in the batch and it is known once the batch is sent to the server.
-    pub async fn base_offset(&self) -> Result<Offset> {
+    pub(crate) async fn base_offset(&self) -> Result<Offset> {
         let mut state = self.state.write().await;
         match &*state {
             BatchMetadataState::Buffered(receiver) => {

--- a/crates/fluvio/src/producer/record.rs
+++ b/crates/fluvio/src/producer/record.rs
@@ -44,9 +44,9 @@ pub(crate) enum BatchMetadataState {
     Failed(ProducerError),
 }
 
-pub struct BatchMetadata {
-    pub state: RwLock<BatchMetadataState>,
-    pub created_at: Instant,
+pub(crate) struct BatchMetadata {
+    state: RwLock<BatchMetadataState>,
+    pub(crate) created_at: Instant,
 }
 
 impl BatchMetadata {


### PR DESCRIPTION
This PR adds a callback option for the producer.

Also prints total bytes and total records per sec at the end:
```
> fluvio bench producer --batch-size 16kib --num-records 300000
27244 records sent, 27244 records/sec: (138.9 KB/sec), 1.34ms avg latency, 3.69ms max latency
37800 records sent, 37800 records/sec: (192.8 KB/sec), 1.41ms avg latency, 10.63ms max latency
42028 records sent, 42028 records/sec: (214.3 KB/sec), 1.38ms avg latency, 10.63ms max latency
41552 records sent, 41552 records/sec: (211.9 KB/sec), 1.36ms avg latency, 10.63ms max latency
40138 records sent, 40138 records/sec: (204.7 KB/sec), 1.37ms avg latency, 12.28ms max latency
40868 records sent, 40868 records/sec: (208.4 KB/sec), 1.37ms avg latency, 12.28ms max latency
40488 records sent, 40488 records/sec: (206.5 KB/sec), 1.37ms avg latency, 12.28ms max latency

1.36ms avg latency, 12.28ms max latency, 1.27ms p0.50, 1.70ms p0.95, 2.54ms p0.99
300000 total records sent, 40689 records/sec: (207.5 MB/sec) 
Benchmark completed
```