### PR TITLE
perf: improve index flush

### DIFF
--- a/crates/fluvio-storage/src/mut_index.rs
+++ b/crates/fluvio-storage/src/mut_index.rs
@@ -26,7 +26,7 @@ pub const EXTENSION: &str = "index";
 /// Index file for offset
 /// Each entry in index consist of pair of (relative_offset, file_position)
 pub struct MutLogIndex {
-    mmap: MemoryMappedMutFile,
+    _mmap: MemoryMappedMutFile,
     file: File,
     base_offset: Offset,         // base offset of segment
     accumulated_batch_len: Size, // accumulated batches len
@@ -76,7 +76,7 @@ impl MutLogIndex {
 
         Ok(MutLogIndex {
             max_index_interval,
-            mmap: m_file,
+            _mmap: m_file,
             file,
             first_empty_slot: 0,
             accumulated_batch_len: 0,
@@ -112,7 +112,7 @@ impl MutLogIndex {
         let max_index_interval = option.index_max_interval_bytes.get_consistent();
 
         let mut index = MutLogIndex {
-            mmap: m_file,
+            _mmap: m_file,
             max_index_interval,
             file,
             first_empty_slot: 0,
@@ -213,7 +213,6 @@ impl MutLogIndex {
             let slot_index = self.first_empty_slot as usize;
             debug!(slot_index, offset_delta, file_position, "add new entry at");
             self[slot_index] = (offset_delta.to_be(), file_position.to_be());
-            self.mmap.flush_ft().await?;
             self.accumulated_batch_len = 0;
             self.first_empty_slot += 1;
         } else {


### PR DESCRIPTION
Bottleneck which is flush on index, with that remove, here is perf number:
On mac:
```
50428 records sent, 63914 records/sec: (321.0 MB/sec), 0.48ms avg latency, 4.16ms max latency
66976 records sent, 65625 records/sec: (329.6 MB/sec), 0.46ms avg latency, 5.51ms max latency
63532 records sent, 64875 records/sec: (325.8 MB/sec), 0.48ms avg latency, 6.23ms max latency

0.48ms avg latency, 6.23ms max latency, 0.46ms p0.50, 0.55ms p0.95, 0.97ms p0.99
200000 total records sent, 64516 records/sec: (324.0 MB/sec) 
Benchmark completed
```

on EC2 using C7 (4 cores/8G of memory):
```
10752 records sent, 29059 records/sec: (145.9 MB/sec), 1.00ms avg latency, 1.81ms max latency
29008 records sent, 29022 records/sec: (145.8 MB/sec), 1.01ms avg latency, 1.22ms max latency
29036 records sent, 29028 records/sec: (145.8 MB/sec), 1.01ms avg latency, 1.27ms max latency
29148 records sent, 29055 records/sec: (145.9 MB/sec), 1.01ms avg latency, 1.33ms max latency
29176 records sent, 29083 records/sec: (146.1 MB/sec), 1.00ms avg latency, 1.20ms max latency
29092 records sent, 29084 records/sec: (146.1 MB/sec), 1.01ms avg latency, 1.74ms max latency
29260 records sent, 29112 records/sec: (146.2 MB/sec), 1.00ms avg latency, 1.65ms max latency
```

1.01ms avg latency, 1.81ms max latency, 1.01ms p0.50, 1.09ms p0.95, 1.14ms p0.99
200000 total records sent, 29121 records/sec: (146.3 MB/sec) 
Benchmark completed
Compared with Kafka:
On mac:

```
$> bin/kafka-producer-perf-test.sh --producer-props bootstrap.servers=localhost:9092 --topic test4 --throughput  -1 --num-records 200000 --record-size 5120
200000 records sent, 49862.877088 records/sec (243.47 MB/sec), 111.90 ms avg latency, 198.00 ms max latency, 111 ms 50th, 151 ms 95th, 172 ms 99th, 190 ms 99.9th.
```

On linux:

```
~/kafka_2.13-3.9.0$ bin/kafka-producer-perf-test.sh --producer-props bootstrap.servers=localhost:9092 --topic test4 --throughput  -1 --num-records 200000 --record-size 5120
76384 records sent, 15276.8 records/sec (74.59 MB/sec), 359.0 ms avg latency, 650.0 ms max latency.
200000 records sent, 23582.124749 records/sec (115.15 MB/sec), 244.14 ms avg latency, 650.00 ms max latency, 177 ms 50th, 545 ms 95th, 608 ms 99th, 644 ms 99.9th.
```