### PR TITLE
chore: relax correlation id constrain for fluvio socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-channel 1.9.0",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ fluvio-sc-schema = { version = "0.25.0", path = "crates/fluvio-sc-schema", defau
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-smartengine = {  version = "0.8.0", path = "crates/fluvio-smartengine", default-features = false }
 fluvio-smartmodule = { version = "0.8.0", path = "crates/fluvio-smartmodule", default-features = false }
-fluvio-socket = { version = "0.15.0", path = "crates/fluvio-socket", default-features = false }
+fluvio-socket = { version = "0.15.1", path = "crates/fluvio-socket", default-features = false }
 fluvio-spu-schema = { version = "0.17.0", path = "crates/fluvio-spu-schema", default-features  = false }
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-stream-dispatcher = { version = "0.13.2", path = "crates/fluvio-stream-dispatcher" }

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/multiplexing.rs
+++ b/crates/fluvio-socket/src/multiplexing.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::{SeqCst, Relaxed};
 use std::sync::atomic::AtomicI32;
 use std::time::Duration;
 use std::fmt;
@@ -119,7 +119,7 @@ impl MultiplexerSocket {
 
     /// get next available correlation to use
     fn next_correlation_id(&self) -> i32 {
-        self.correlation_id_counter.fetch_add(1, SeqCst)
+        self.correlation_id_counter.fetch_add(1, Relaxed)
     }
 
     /// create socket to perform request and response


### PR DESCRIPTION
since correlation id is access indirectly,  can relax ordering