### PR TITLE
fix: record too large error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.24.4"
+version = "0.24.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/producer/memory_batch.rs
+++ b/crates/fluvio/src/producer/memory_batch.rs
@@ -60,8 +60,8 @@ impl MemoryBatch {
         if actual_batch_size > self.write_limit {
             self.is_full = true;
             return Err(ProducerError::RecordTooLarge(
-                record_size,
                 actual_batch_size,
+                self.write_limit,
             ));
         }
 


### PR DESCRIPTION


Got this error testing max_request_size on python client: 

```
mymodule.PyFluvioError: record size (17 bytes), exceeded maximum request size (17 bytes)
```

Should be

```
mymodule.PyFluvioError: record size (17 bytes), exceeded maximum request size ("max_request_size" bytes)
```