### PR TITLE
feat: consumer stream should be able to reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
 name = "fluvio"
 version = "0.26.0"
 dependencies = [
+ "adaptive_backoff",
  "anyhow",
  "async-channel 1.9.0",
  "async-lock",
@@ -2884,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ k8-diff = { version = "0.1.2" }
 trybuild = { branch = "check_option", git = "https://github.com/infinyon/trybuild" }
 
 # Internal fluvio dependencies
-fluvio = { version = "0.25.0", path = "crates/fluvio" }
+fluvio = { version = "0.26.0", path = "crates/fluvio" }
 fluvio-auth = { path = "crates/fluvio-auth" }
 fluvio-benchmark = { path = "crates/fluvio-benchmark" }
 fluvio-channel = { path = "crates/fluvio-channel" }

--- a/connector/sink-test-connector/src/main.rs
+++ b/connector/sink-test-connector/src/main.rs
@@ -54,7 +54,7 @@ async fn process_item(
     stream: &mut impl ConsumerStream,
 ) -> Result<()> {
     sink.send(str).await?;
-    stream.offset_commit()?;
+    stream.offset_commit().await?;
     stream.offset_flush().await?;
     Ok(())
 }

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -490,6 +490,10 @@ mod cmd {
                                         continue;
                                     }
                                     */
+                                    Err(ErrorCode::MaxRetryReached) => {
+                                        eprintln!("Max limit of retry connection reached");
+                                        break;
+                                    }
                                     Err(other) => return Err(other.into()),
                                 };
 

--- a/crates/fluvio-cli/src/client/consume/mod.rs
+++ b/crates/fluvio-cli/src/client/consume/mod.rs
@@ -403,7 +403,7 @@ mod cmd {
             }
 
             if self.consumer.is_some() {
-                stream.get_mut().offset_commit()?;
+                stream.get_mut().offset_commit().await?;
                 stream.get_mut().offset_flush().await?;
             }
 

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/link/error_code.rs
+++ b/crates/fluvio-protocol/src/link/error_code.rs
@@ -125,9 +125,6 @@ pub enum ErrorCode {
     #[fluvio(tag = 3005)]
     #[error("max retry attempts reached")]
     MaxRetryReached,
-    #[fluvio(tag = 3006)]
-    #[error("max commit duration reached")]
-    MaxCommitDuration,
 
     // Managed Connector Errors
     #[fluvio(tag = 5000)]

--- a/crates/fluvio-protocol/src/link/error_code.rs
+++ b/crates/fluvio-protocol/src/link/error_code.rs
@@ -126,8 +126,8 @@ pub enum ErrorCode {
     #[error("max retry attempts reached")]
     MaxRetryReached,
     #[fluvio(tag = 3006)]
-    #[error("no current stream")]
-    NoCurrentStream,
+    #[error("max commit duration reached")]
+    MaxCommitDuration,
 
     // Managed Connector Errors
     #[fluvio(tag = 5000)]

--- a/crates/fluvio-protocol/src/link/error_code.rs
+++ b/crates/fluvio-protocol/src/link/error_code.rs
@@ -122,6 +122,12 @@ pub enum ErrorCode {
     #[fluvio(tag = 3004)]
     #[error("the offset management is disabled for the stream")]
     OffsetManagementDisabled,
+    #[fluvio(tag = 3005)]
+    #[error("max retry attempts reached")]
+    MaxRetryReached,
+    #[fluvio(tag = 3006)]
+    #[error("no current stream")]
+    NoCurrentStream,
 
     // Managed Connector Errors
     #[fluvio(tag = 5000)]

--- a/crates/fluvio-test/src/tests/consumer_offsets/mod.rs
+++ b/crates/fluvio-test/src/tests/consumer_offsets/mod.rs
@@ -109,7 +109,7 @@ async fn test_strategy_none(client: &Fluvio, topic: &str, partitions: usize) -> 
     for _ in 0..RECORDS_COUNT {
         ensure_read(&mut stream, &mut counts).await?;
     }
-    ensure!(stream.offset_commit().is_err());
+    ensure!(stream.offset_commit().await.is_err());
     ensure!(stream.offset_flush().await.is_err());
     Ok(())
 }
@@ -125,7 +125,7 @@ async fn test_strategy_manual(client: &Fluvio, topic: &str, partitions: usize) -
         for _ in chunk {
             ensure_read(&mut stream, &mut counts).await?;
         }
-        stream.offset_commit()?;
+        stream.offset_commit().await?;
         stream.offset_flush().await?;
     }
     // no more records for this consumer

--- a/crates/fluvio-test/src/tests/reconnection/mod.rs
+++ b/crates/fluvio-test/src/tests/reconnection/mod.rs
@@ -1,17 +1,17 @@
 use std::time::Duration;
 
 use futures_lite::stream::StreamExt;
+use clap::Parser;
 
 use fluvio::{Offset, RecordKey};
 use fluvio_controlplane_metadata::partition::PartitionSpec;
 use fluvio_future::timer::sleep;
-use clap::Parser;
-
 use fluvio_test_derive::fluvio_test;
 use fluvio_test_case_derive::MyTestCase;
+use fluvio_test_util::{test_meta::environment::EnvDetail, test_runner::test_driver::TestDriver};
 
 // time to wait for ac
-const ACK_WAIT: u64 = 20;
+const ACK_WAIT: u64 = 5;
 
 #[derive(Debug, Clone, Parser, Default, Eq, PartialEq, MyTestCase)]
 #[command(name = "Fluvio reconnection Test")]
@@ -19,53 +19,35 @@ pub struct ReconnectionTestOption {}
 
 #[fluvio_test(topic = "reconnection", async)]
 pub async fn reconnection(mut test_driver: TestDriver, mut test_case: TestCase) {
+    reconnect_producer(&test_driver, &test_case).await;
+
+    reconnect_consumer(&test_driver, &test_case).await;
+}
+
+async fn reconnect_producer(test_driver: &TestDriver, test_case: &TestCase) {
     println!("Starting reconnection test");
 
-    // first a create simple message
     let topic_name = test_case.environment.base_topic_name();
     let producer = test_driver.create_producer(&topic_name).await;
     println!("sending first record");
 
     producer
-        .send(RecordKey::NULL, "msg1")
+        .send(RecordKey::NULL, "msg1_producer")
         .await
         .expect("sending");
 
     producer.flush().await.expect("flushing");
 
-    let admin = test_driver.client().admin().await;
-
-    let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
-
-    let test_topic = &partitions[0];
-    let leader = test_topic.spec.leader;
-    println!("spu id is: {leader}");
-
-    let cluster_manager = test_driver
-        .get_cluster()
-        .expect("cluster")
-        .env_driver()
-        .create_cluster_manager();
-
-    println!("terminating spu: {}", &leader);
-
-    cluster_manager.terminate_spu(leader).expect("terminate");
-
+    let leader = get_leader(test_driver).await;
+    terminate_spu(test_driver, leader).await;
     sleep(Duration::from_secs(ACK_WAIT)).await;
-
-    println!("starting spu again: {}", &leader);
-
-    let leader_spu = cluster_manager.create_spu_absolute(leader as u16);
-    leader_spu.start().expect("start");
-
+    start_spu(test_driver, leader).await;
     sleep(Duration::from_secs(ACK_WAIT)).await;
-
     producer.clear_errors().await;
 
     println!("sending second record");
-    // Use the same producer
     producer
-        .send(RecordKey::NULL, "msg2")
+        .send(RecordKey::NULL, "msg2_producer")
         .await
         .expect("sending");
 
@@ -77,9 +59,81 @@ pub async fn reconnection(mut test_driver: TestDriver, mut test_case: TestCase) 
 
     println!("checking msg1");
     let records = stream.next().await.expect("get next").expect("next");
-    assert_eq!(records.value(), "msg1".as_bytes());
+    assert_eq!(records.value(), "msg1_producer".as_bytes());
 
     println!("checking msg2");
     let records = stream.next().await.expect("get next").expect("next");
-    assert_eq!(records.value(), "msg2".as_bytes());
+    assert_eq!(records.value(), "msg2_producer".as_bytes());
+}
+
+async fn reconnect_consumer(test_driver: &TestDriver, test_case: &TestCase) {
+    println!("Starting reconnection test");
+
+    let topic_name = test_case.environment.base_topic_name();
+    let producer = test_driver.create_producer(&topic_name).await;
+    println!("sending first record");
+
+    let mut stream = test_driver
+        .get_consumer_with_start(&topic_name, 0, Offset::end())
+        .await;
+
+    producer
+        .send(RecordKey::NULL, "msg1_consume")
+        .await
+        .expect("sending");
+
+    producer.flush().await.expect("flushing");
+
+    println!("checking msg1");
+    let records = stream.next().await.expect("get next").expect("next");
+    assert_eq!(records.value(), "msg1_consume".as_bytes());
+
+    let leader = get_leader(test_driver).await;
+    terminate_spu(test_driver, leader).await;
+    sleep(Duration::from_secs(ACK_WAIT)).await;
+    start_spu(test_driver, leader).await;
+    sleep(Duration::from_secs(ACK_WAIT)).await;
+    producer.clear_errors().await;
+
+    println!("sending second record");
+    producer
+        .send(RecordKey::NULL, "msg2_consume")
+        .await
+        .expect("sending");
+
+    producer.flush().await.expect("flushing");
+
+    println!("checking msg2");
+    let records = stream.next().await.expect("get next").expect("next");
+    assert_eq!(records.value(), "msg2_consume".as_bytes());
+}
+
+async fn get_leader(test_driver: &TestDriver) -> i32 {
+    let admin = test_driver.client().admin().await;
+    let partitions = admin.all::<PartitionSpec>().await.expect("partitions");
+    let test_topic = &partitions[0];
+    let leader = test_topic.spec.leader;
+    println!("spu id is: {leader}");
+    leader
+}
+
+async fn terminate_spu(test_driver: &TestDriver, leader: i32) {
+    let cluster_manager = test_driver
+        .get_cluster()
+        .expect("cluster")
+        .env_driver()
+        .create_cluster_manager();
+    println!("terminating spu: {}", &leader);
+    cluster_manager.terminate_spu(leader).expect("terminate");
+}
+
+async fn start_spu(test_driver: &TestDriver, leader: i32) {
+    let cluster_manager = test_driver
+        .get_cluster()
+        .expect("cluster")
+        .env_driver()
+        .create_cluster_manager();
+    println!("starting spu again: {}", &leader);
+    let leader_spu = cluster_manager.create_spu_absolute(leader as u16);
+    leader_spu.start().expect("start");
 }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -25,6 +25,7 @@ nightly = []
 unstable = []
 
 [dependencies]
+adaptive_backoff = { workspace = true }
 async-channel = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer/config.rs
+++ b/crates/fluvio/src/consumer/config.rs
@@ -53,6 +53,14 @@ pub enum OffsetManagementStrategy {
     Auto,
 }
 
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum RetryMode {
+    Disabled,
+    TryUntil(u32),
+    #[default]
+    TryForever,
+}
+
 #[derive(Debug, Builder, Clone)]
 #[builder(build_fn(private, name = "build_impl"))]
 pub struct ConsumerConfigExt {
@@ -70,13 +78,15 @@ pub struct ConsumerConfigExt {
     #[builder(default = "DEFAULT_OFFSET_FLUSH_PERIOD")]
     pub offset_flush: Duration,
     #[builder(default)]
-    disable_continuous: bool,
+    pub disable_continuous: bool,
     #[builder(default = "*MAX_FETCH_BYTES")]
     pub max_bytes: i32,
     #[builder(default)]
     pub isolation: Isolation,
     #[builder(default)]
     pub smartmodule: Vec<SmartModuleInvocation>,
+    #[builder(default)]
+    pub retry_mode: RetryMode,
 }
 
 impl ConsumerConfigExt {
@@ -105,6 +115,7 @@ impl ConsumerConfigExt {
             smartmodule,
             offset_strategy,
             offset_flush,
+            retry_mode: _,
         } = self;
 
         let config = ConsumerConfig {
@@ -162,6 +173,7 @@ impl From<ConsumerConfigExt> for ConsumerConfig {
             max_bytes,
             isolation,
             smartmodule,
+            retry_mode: _,
         } = value;
 
         Self {

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -3,6 +3,7 @@
 mod config;
 mod stream;
 mod offset;
+mod retry;
 
 use std::sync::Arc;
 
@@ -32,9 +33,10 @@ use crate::offset::{Offset, fetch_offsets};
 use crate::spu::{SpuDirectory, SpuSocketPool};
 
 pub use config::{ConsumerConfig, ConsumerConfigBuilder};
-pub use config::{ConsumerConfigExt, ConsumerConfigExtBuilder, OffsetManagementStrategy};
+pub use config::{ConsumerConfigExt, ConsumerConfigExtBuilder, OffsetManagementStrategy, RetryMode};
 pub use stream::{ConsumerStream, MultiplePartitionConsumerStream, SinglePartitionConsumerStream};
 pub use offset::ConsumerOffset;
+pub use retry::ConsumerWithRetry;
 
 pub use fluvio_protocol::record::ConsumerRecord as Record;
 pub use fluvio_spu_schema::server::smartmodule::SmartModuleInvocation;

--- a/crates/fluvio/src/consumer/retry.rs
+++ b/crates/fluvio/src/consumer/retry.rs
@@ -1,0 +1,284 @@
+use std::future::Future;
+use std::task::{Context, Poll};
+use std::{pin::Pin, sync::Arc, time::Duration};
+
+use anyhow::Result;
+use adaptive_backoff::prelude::{
+    ExponentialBackoff, ExponentialBackoffBuilder, Backoff, BackoffBuilder,
+};
+use futures_util::stream::Stream;
+use futures_util::StreamExt;
+use tracing::{debug, info, warn};
+
+use fluvio_future::timer::sleep;
+use fluvio_protocol::record::ConsumerRecord;
+use fluvio_sc_schema::errors::ErrorCode;
+use crate::consumer::RetryMode;
+use crate::{Fluvio, FluvioConfig, Offset};
+use super::{ConsumerConfigExt, ConsumerStream};
+
+pub const SPAN_RETRY: &str = "fluvio::retry";
+pub const BACKOFF_MIN_DURATION: Duration = Duration::from_secs(1);
+pub const BACKOFF_MAX_DURATION: Duration = Duration::from_secs(30);
+pub const BACKOFF_FACTOR: f64 = 1.1;
+
+/// Type alias for a consumer stream with conditional `Send` support.
+#[cfg(target_arch = "wasm32")]
+type BoxConsumerStream =
+    Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + 'static>>;
+#[cfg(not(target_arch = "wasm32"))]
+type BoxConsumerStream =
+    Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send + 'static>>;
+
+/// Type alias for a pending future with conditional `Send` support.
+#[cfg(target_arch = "wasm32")]
+type BoxPendingFuture = Pin<
+    Box<
+        dyn Future<
+                Output = Option<
+                    Result<(ConsumerRecord, BoxConsumerStream, Option<i64>), ErrorCode>,
+                >,
+            > + 'static,
+    >,
+>;
+#[cfg(not(target_arch = "wasm32"))]
+type BoxPendingFuture = Pin<
+    Box<
+        dyn Future<
+                Output = Option<
+                    Result<(ConsumerRecord, BoxConsumerStream, Option<i64>), ErrorCode>,
+                >,
+            > + Send
+            + 'static,
+    >,
+>;
+
+#[derive(Clone)]
+pub struct ConsumerWithRetryInner {
+    fluvio_client: Arc<Fluvio>,
+    next_offset_to_read: Option<i64>,
+    consumer_config: ConsumerConfigExt,
+}
+
+/// A consumer stream that automatically retries on failure.
+pub struct ConsumerWithRetry {
+    inner: ConsumerWithRetryInner,
+    current_stream: Option<BoxConsumerStream>,
+    pending: Option<BoxPendingFuture>,
+}
+
+impl Stream for ConsumerWithRetry {
+    type Item = Result<ConsumerRecord, ErrorCode>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let self_mut = self.get_mut();
+
+        // If there is no pending future, create one using the current stream.
+        if self_mut.pending.is_none() {
+            let current_stream = if let Some(stream) = self_mut.current_stream.take() {
+                stream
+            } else {
+                return Poll::Ready(None);
+            };
+
+            let client = Arc::clone(&self_mut.inner.fluvio_client);
+            self_mut.pending = Some(Box::pin(Self::consumer_with_retry(
+                self_mut.inner.clone(),
+                client,
+                current_stream,
+            )));
+        }
+
+        // Poll the pending future and update the internal state.
+        if let Some(ref mut fut) = self_mut.pending {
+            match fut.as_mut().poll(cx) {
+                Poll::Ready(Some(Ok((record, updated_stream, new_offset)))) => {
+                    self_mut.current_stream = Some(updated_stream);
+                    self_mut.inner.next_offset_to_read = new_offset;
+                    self_mut.pending = None;
+                    Poll::Ready(Some(Ok(record)))
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    self_mut.pending = None;
+                    Poll::Ready(Some(Err(e)))
+                }
+                Poll::Ready(None) => {
+                    self_mut.pending = None;
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            Poll::Ready(None)
+        }
+    }
+}
+
+impl ConsumerStream for ConsumerWithRetry {
+    fn offset_commit(&mut self) -> std::result::Result<(), ErrorCode> {
+        if let Some(ref mut stream) = self.current_stream {
+            stream.offset_commit()
+        } else {
+            warn!("Can't commit, no current stream");
+            Err(ErrorCode::NoCurrentStream)
+        }
+    }
+
+    fn offset_flush(
+        &mut self,
+    ) -> futures_util::future::BoxFuture<'_, std::result::Result<(), ErrorCode>> {
+        if let Some(ref mut stream) = self.current_stream {
+            stream.offset_flush()
+        } else {
+            warn!("Can't flush, no current stream");
+            Box::pin(async { Err(ErrorCode::NoCurrentStream) })
+        }
+    }
+}
+
+impl ConsumerWithRetry {
+    /// Creates a new `ConsumerWithRetry` instance.
+    pub async fn new(fluvio_config: FluvioConfig, config: ConsumerConfigExt) -> Result<Self> {
+        let fluvio = Fluvio::connect_with_config(&fluvio_config).await?;
+        let stream = fluvio.consumer_with_config_inner(config.clone()).await?;
+        let boxed_stream: BoxConsumerStream = Box::pin(stream);
+
+        Ok(Self {
+            inner: ConsumerWithRetryInner {
+                fluvio_client: Arc::new(fluvio),
+                next_offset_to_read: None,
+                consumer_config: config,
+            },
+            current_stream: Some(boxed_stream),
+            pending: None,
+        })
+    }
+
+    /// Consumes records from the stream with retry logic.
+    ///
+    /// This function continuously attempts to retrieve a record from the current stream.
+    /// On failure (or end-of-stream), it waits using an exponential backoff strategy
+    /// and then attempts to reconnect.
+    async fn consumer_with_retry(
+        inner: ConsumerWithRetryInner,
+        fluvio_client: Arc<Fluvio>,
+        mut current_stream: BoxConsumerStream,
+    ) -> Option<Result<(ConsumerRecord, BoxConsumerStream, Option<i64>), ErrorCode>> {
+        let mut attempts: u32 = 0;
+        let mut backoff = if let Ok(backoff) = create_backoff() {
+            backoff
+        } else {
+            return Some(Err(ErrorCode::Other("Error creating backoff".to_string())));
+        };
+
+        loop {
+            // Try to retrieve the next record.
+            if let Some(record_result) = current_stream.as_mut().next().await {
+                match record_result {
+                    Ok(record) => {
+                        let new_offset = Some(record.offset + 1);
+                        if attempts > 0 {
+                            debug!(
+                                target: SPAN_RETRY,
+                                "Record produced successfully after reconnect"
+                            );
+                        }
+                        return Some(Ok((record, current_stream, new_offset)));
+                    }
+                    Err(e) => {
+                        warn!(target: SPAN_RETRY, "Error consuming record: {}", e);
+                        if let RetryMode::Disabled = inner.consumer_config.retry_mode {
+                            return Some(Err(e));
+                        }
+                    }
+                }
+            }
+
+            // If continuous consumption is disabled, end the stream.
+            if inner.consumer_config.disable_continuous {
+                return None;
+            }
+
+            // Wait before retrying.
+            backoff_and_wait(&mut backoff).await;
+            attempts += 1;
+
+            // Determine the offset for reconnection.
+            let offset = if let Some(next) = inner.next_offset_to_read {
+                match Offset::absolute(next) {
+                    Ok(off) => off,
+                    Err(e) => {
+                        warn!(target: SPAN_RETRY, "Error creating offset: {}", e);
+                        return Some(Err(ErrorCode::OffsetOutOfRange));
+                    }
+                }
+            } else {
+                inner.consumer_config.offset_start.clone()
+            };
+
+            // Update the consumer configuration with the new offset.
+            let mut new_config = inner.consumer_config.clone();
+            new_config.offset_start = offset;
+
+            // Reconnect loop: keep trying until a new stream is created.
+            loop {
+                info!(target: SPAN_RETRY, "Reconnecting to stream");
+                match fluvio_client
+                    .consumer_with_config_inner(new_config.clone())
+                    .await
+                {
+                    Ok(new_stream) => {
+                        backoff.reset();
+                        current_stream = Box::pin(new_stream) as BoxConsumerStream;
+                        info!(
+                            target: SPAN_RETRY,
+                            "Created new consume stream with offset: {:?}", inner.next_offset_to_read
+                        );
+                        break;
+                    }
+                    Err(e) => {
+                        backoff_and_wait(&mut backoff).await;
+                        attempts += 1;
+                        warn!(
+                            target: SPAN_RETRY,
+                            "Could not connect to stream on {}: {}",
+                            inner.consumer_config.topic,
+                            e
+                        );
+
+                        match inner.consumer_config.retry_mode {
+                            RetryMode::TryUntil(max) if attempts >= max => {
+                                return Some(Err(ErrorCode::MaxRetryReached));
+                            }
+                            RetryMode::Disabled => {
+                                return Some(Err(ErrorCode::Other(format!("{}", e))));
+                            }
+                            _ => {} // Continue retrying.
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Creates an exponential backoff configuration.
+fn create_backoff() -> Result<ExponentialBackoff> {
+    ExponentialBackoffBuilder::default()
+        .factor(BACKOFF_FACTOR)
+        .min(BACKOFF_MIN_DURATION)
+        .max(BACKOFF_MAX_DURATION)
+        .build()
+}
+
+/// Waits for the duration determined by the exponential backoff.
+async fn backoff_and_wait(backoff: &mut ExponentialBackoff) {
+    let wait_duration = backoff.wait();
+    info!(
+        target: SPAN_RETRY,
+        seconds = wait_duration.as_secs(),
+        "Starting backoff: sleeping for duration"
+    );
+    sleep(wait_duration).await;
+    debug!(target: SPAN_RETRY, "Resuming after backoff");
+}

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -297,7 +297,7 @@ impl Fluvio {
     ///        .await?;
     ///    while let Some(Ok(record)) = stream.next().await {
     ///        println!("{}", String::from_utf8_lossy(record.as_ref()));
-    ///        stream.offset_commit()?;
+    ///        stream.offset_commit().await?;
     ///        stream.offset_flush().await?;
     ///    }
     ///    Ok(())

--- a/rfc/offset-management.md
+++ b/rfc/offset-management.md
@@ -81,7 +81,7 @@ async fn offset_example() -> Result<()> {
         if some_condition {
             break;
         }
-        stream.offset_commit();
+        stream.offset_commit().await?;
     }
 
     // synchronously flush for shutdown (or none if intentionally ending processing)


### PR DESCRIPTION
Required:
- [x] https://github.com/infinyon/fluvio/pull/4402

Solves https://github.com/infinyon/fluvio/issues/2167

TryForever(default):
```rust
let config = ConsumerConfigExtBuilder::default()
    .topic(topic)
    .retry_mode(RetryMode::TryForever)
    .build()
    .expect("config");
let stream = fluvio_client.consumer_with_config(config).await?
```
or just:

```rust
let config = ConsumerConfigExtBuilder::default()
    .topic(topic)
    .build()
    .expect("config");
let stream = fluvio_client.consumer_with_config(config).await?
```

Disabled:
```rust
let config = ConsumerConfigExtBuilder::default()
    .topic(topic)
    .retry_mode(RetryMode::Disabled)
    .build()
    .expect("config");
let stream = fluvio_client.consumer_with_config(config).await?
```

Try until 10 attempts:
```rust
let config = ConsumerConfigExtBuilder::default()
    .topic(topic)
    .retry_mode(RetryMode::TryUntil(10))
    .build()
    .expect("config");
let stream = fluvio_client.consumer_with_config(config).await?
```


