### PR TITLE
chore: prevent batch write when storage error occurs

### DIFF
--- a/crates/fluvio-storage/src/iterators.rs
+++ b/crates/fluvio-storage/src/iterators.rs
@@ -241,7 +241,7 @@ mod test {
     fn test_file_record_iterator() -> anyhow::Result<()> {
         //given
         let base_dir = temp_dir().join("test_file_record_iterator");
-        let mut replica = run_block_on(FileReplica::create_or_load(
+        let mut replica = run_block_on(FileReplica::create_or_load_inner(
             format!(
                 "test_file_record_iterator_{}",
                 SystemTime::now()

--- a/crates/fluvio-storage/src/iterators.rs
+++ b/crates/fluvio-storage/src/iterators.rs
@@ -241,7 +241,7 @@ mod test {
     fn test_file_record_iterator() -> anyhow::Result<()> {
         //given
         let base_dir = temp_dir().join("test_file_record_iterator");
-        let mut replica = run_block_on(FileReplica::create_or_load_with_storage(
+        let mut replica = run_block_on(FileReplica::create_or_load(
             format!(
                 "test_file_record_iterator_{}",
                 SystemTime::now()

--- a/crates/fluvio-storage/src/mut_index.rs
+++ b/crates/fluvio-storage/src/mut_index.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use libc::c_void;
 use tracing::debug;
+use tracing::info;
 use tracing::instrument;
 use tracing::trace;
 use tracing::error;
@@ -43,6 +44,7 @@ unsafe impl Sync for MutLogIndex {}
 unsafe impl Send for MutLogIndex {}
 
 impl MutLogIndex {
+    #[instrument(skip(option))]
     pub async fn create(
         base_offset: Offset,
         option: Arc<SharedReplicaConfig>,
@@ -58,7 +60,7 @@ impl MutLogIndex {
 
         let max_index_interval = option.index_max_interval_bytes.get_consistent();
 
-        debug!(
+        info!(
             ?index_file_path,
             index_max_bytes = option.index_max_bytes.get(),
             index_max_interval_bytes = option.index_max_interval_bytes.get(),

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -62,7 +62,7 @@ impl ReplicaStorage for FileReplica {
             .build()
             .map_err(|err| StorageError::Other(format!("failed to build cleaner config: {err}")))?;
 
-        Self::create_or_load(
+        Self::create_or_load_inner(
             replica.topic.clone(),
             replica.partition,
             0,
@@ -213,7 +213,7 @@ impl FileReplica {
     /// The logs will be validated to ensure it's safe to use it.
     /// It is possible logs can't be used because they may be corrupted.
     #[instrument(skip(replica_config, storage_config))]
-    pub async fn create_or_load<S>(
+    pub async fn create_or_load_inner<S>(
         topic: S,
         partition: Size,
         base_offset: Offset,
@@ -497,7 +497,7 @@ mod tests {
         base_offset: Offset,
         config: ReplicaConfig,
     ) -> FileReplica {
-        FileReplica::create_or_load(topic, 0, base_offset, config, storage_config())
+        FileReplica::create_or_load_inner(topic, 0, base_offset, config, storage_config())
             .await
             .expect("replica")
     }
@@ -670,10 +670,15 @@ mod tests {
     async fn test_rep_log_roll_over() {
         let option = rollover_option(TEST_REPLICA_DIR);
 
-        let mut replica =
-            FileReplica::create_or_load("test", 1, START_OFFSET, option.clone(), storage_config())
-                .await
-                .expect("create rep");
+        let mut replica = FileReplica::create_or_load_inner(
+            "test",
+            1,
+            START_OFFSET,
+            option.clone(),
+            storage_config(),
+        )
+        .await
+        .expect("create rep");
 
         // first batch
         debug!(">>>> sending first batch");
@@ -980,10 +985,15 @@ mod tests {
             .build()
             .expect("batch");
 
-        let mut new_replica =
-            FileReplica::create_or_load("test", 0, 0, option.clone(), Arc::new(storage_config))
-                .await
-                .expect("create");
+        let mut new_replica = FileReplica::create_or_load_inner(
+            "test",
+            0,
+            0,
+            option.clone(),
+            Arc::new(storage_config),
+        )
+        .await
+        .expect("create");
         let reader = new_replica.prev_segments.read().await;
         assert!(reader.len() == 0);
         drop(reader);
@@ -1047,7 +1057,7 @@ mod tests {
         option.max_partition_size = max_partition_size;
         option.segment_max_bytes = max_segment_size;
 
-        let mut replica = FileReplica::create_or_load(
+        let mut replica = FileReplica::create_or_load_inner(
             "test",
             0,
             START_OFFSET,

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tracing::{debug, trace, instrument, info, error};
-use anyhow::{Result};
+use anyhow::Result;
 
 use fluvio_future::fs::remove_file;
 use fluvio_future::file_slice::AsyncFileSlice;
@@ -20,9 +20,9 @@ use crate::index::Index;
 use crate::records::FileRecords;
 use crate::mut_records::MutFileRecords;
 use crate::records::FileRecordsSlice;
-use crate::config::{SharedReplicaConfig};
+use crate::config::SharedReplicaConfig;
 use crate::StorageError;
-use crate::batch::{FileBatchStream};
+use crate::batch::FileBatchStream;
 use crate::index::OffsetPosition;
 use crate::validator::LogValidationError;
 

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -303,11 +303,12 @@ impl Segment<LogIndex, FileRecordsSlice> {
 impl Segment<MutLogIndex, MutFileRecords> {
     // create segment on base directory
 
+    #[instrument(skip(option))]
     pub async fn create(
         base_offset: Offset,
         option: Arc<SharedReplicaConfig>,
     ) -> Result<MutableSegment, StorageError> {
-        debug!(base_offset, "creating new active segment");
+        info!(base_offset, "creating new active segment");
         let msg_log = MutFileRecords::create(base_offset, option.clone()).await?;
 
         let index = MutLogIndex::create(base_offset, option.clone()).await?;

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -386,8 +386,8 @@ impl Segment<MutLogIndex, MutFileRecords> {
         self.index.shrink().await
     }
 
-    // perform any action during roll over
-    pub async fn roll_over(&mut self) -> Result<(), IoError> {
+    // close this segment as writeable
+    pub async fn close(&mut self) -> Result<(), IoError> {
         self.index.shrink().await
     }
 

--- a/crates/fluvio-storage/tests/replica_test.rs
+++ b/crates/fluvio-storage/tests/replica_test.rs
@@ -63,7 +63,7 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
     ensure_clean_dir(&option.base_dir);
 
     let mut replica =
-        FileReplica::create_or_load(TOPIC_NAME, 0, START_OFFSET, option, storage_config())
+        FileReplica::create_or_load_inner(TOPIC_NAME, 0, START_OFFSET, option, storage_config())
             .await
             .expect("test replica");
     replica

--- a/crates/fluvio-storage/tests/replica_test.rs
+++ b/crates/fluvio-storage/tests/replica_test.rs
@@ -62,15 +62,10 @@ async fn setup_replica() -> Result<FileReplica, StorageError> {
 
     ensure_clean_dir(&option.base_dir);
 
-    let mut replica = FileReplica::create_or_load_with_storage(
-        TOPIC_NAME,
-        0,
-        START_OFFSET,
-        option,
-        storage_config(),
-    )
-    .await
-    .expect("test replica");
+    let mut replica =
+        FileReplica::create_or_load(TOPIC_NAME, 0, START_OFFSET, option, storage_config())
+            .await
+            .expect("test replica");
     replica
         .write_recordset(&mut create_records(2), false)
         .await


### PR DESCRIPTION
Currently SPU allow to write to replica even if there was error occurred.   This could leads to undefined states in the storage.  This PR mark replica with flag to prevent that from happening.

This however doesn't cover all cases which need to be address in the future.
- if rollover fails, revert any changes including new segments.

Also, making logging more clear and change some logging to info as they are useful