### PR TITLE
chore: Rust 1.85.0 and 2024 edition

### DIFF
--- a/connector/cargo_template/Cargo.toml.liquid
+++ b/connector/cargo_template/Cargo.toml.liquid
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 [workspace]
 

--- a/connector/json-test-connector/Cargo.toml
+++ b/connector/json-test-connector/Cargo.toml
@@ -3,7 +3,7 @@ name = "json-test-connector"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Connector that generates JSON test data"
-edition = "2021"
+edition = "2024"
 publish = false
 
 
@@ -18,4 +18,3 @@ serde = { default-features = false, features = ["derive"], workspace = true }
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }
-

--- a/connector/sink-test-connector/Cargo.toml
+++ b/connector/sink-test-connector/Cargo.toml
@@ -3,7 +3,7 @@ name = "sink-test-connector"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Connector that reads data from a topic and prints to stdout"
-edition = "2021"
+edition = "2024"
 publish = false
 
 
@@ -17,4 +17,3 @@ serde = { default-features = false, features = ["derive"], workspace = true }
 
 fluvio = { path = "../../crates/fluvio/", features = ["smartengine"]}
 fluvio-connector-common = { path = "../../crates/fluvio-connector-common/", features = ["derive"] }
-

--- a/crates/cargo-builder/Cargo.toml
+++ b/crates/cargo-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-builder"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Build Cargo project programmability"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cdk"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Connector Development Kit"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-auth/Cargo.toml
+++ b/crates/fluvio-auth/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-auth"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/infinyon/fluvio"
 description = "Authorization framework for Fluvio"
@@ -28,4 +28,3 @@ fluvio-future = { workspace = true, features = ["net", "openssl_tls"] }
 fluvio-protocol = { workspace = true }
 fluvio-socket = { workspace = true }
 flv-tls-proxy = { workspace = true }
-

--- a/crates/fluvio-benchmark/Cargo.toml
+++ b/crates/fluvio-benchmark/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-benchmark"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio benchmarking tool"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-channel-cli/Cargo.toml
+++ b/crates/fluvio-channel-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-channel-cli"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI frontend (with channels support)"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-channel/Cargo.toml
+++ b/crates/fluvio-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-channel"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio channels support"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-cli-common"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI common code"
 repository = "https://github.com/infinyon/fluvio"
@@ -47,4 +47,3 @@ fluvio-protocol = { workspace = true,  optional = true }
 fluvio-sc-schema = { path = "../fluvio-sc-schema", optional = true }
 fluvio-smartmodule = { path = "../fluvio-smartmodule", optional = true, default-features = false }
 fluvio-smartengine = { path = "../fluvio-smartengine", optional = true, features = ["transformation"] }
-

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-cli"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio CLI"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-cluster/Cargo.toml
+++ b/crates/fluvio-cluster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-cluster"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-compression/Cargo.toml
+++ b/crates/fluvio-compression/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-compression"
 version = "0.3.5"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["compression"]

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-connector-common"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-connector-deployer/Cargo.toml
+++ b/crates/fluvio-connector-deployer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-connector-deployer"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-connector-derive/Cargo.toml
+++ b/crates/fluvio-connector-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-connector-derive"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-connector-package"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-controlplane-metadata/Cargo.toml
+++ b/crates/fluvio-controlplane-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-controlplane-metadata"
-edition = "2021"
+edition = "2024"
 version = "0.30.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Metadata definition for Fluvio control plane"

--- a/crates/fluvio-controlplane/Cargo.toml
+++ b/crates/fluvio-controlplane/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-controlplane"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "API for Fluvio Control Plane"
 authors = ["fluvio.io"]

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-extension-common"
 version = "0.14.4"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-hub-protocol/Cargo.toml
+++ b/crates/fluvio-hub-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-hub-protocol"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Hub's Shared Resources"
 authors = ["fluvio.io"]

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-hub-util"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "API for SmartModule Hub"
 authors = ["fluvio.io"]

--- a/crates/fluvio-kv-storage/Cargo.toml
+++ b/crates/fluvio-kv-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-kv-storage"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Key-Value Storage"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-package-index/Cargo.toml
+++ b/crates/fluvio-package-index/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Package Index"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [lib]

--- a/crates/fluvio-protocol-derive/Cargo.toml
+++ b/crates/fluvio-protocol-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol-derive"
 version = "0.5.4"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description =  "Procedure macro to encode/decode fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-protocol"
@@ -20,5 +20,3 @@ tracing = { workspace = true }
 [dependencies.syn]
 version = "1.0.0"
 features = ["full"]
-
-

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-protocol"
-edition = "2021"
+edition = "2024"
 version = "0.12.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"

--- a/crates/fluvio-run/Cargo.toml
+++ b/crates/fluvio-run/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-run"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Engine Runner"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-sc-schema/Cargo.toml
+++ b/crates/fluvio-sc-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-sc-schema"
 version = "0.25.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SC"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-sc/Cargo.toml
+++ b/crates/fluvio-sc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-sc"
-edition = "2021"
+edition = "2024"
 version = "0.0.0"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Controller"

--- a/crates/fluvio-service/Cargo.toml
+++ b/crates/fluvio-service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "fluvio-service"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio-smartengine/Cargo.toml
+++ b/crates/fluvio-smartengine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartengine"
 version = "0.8.5"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 keywords = ["streaming", "stream", "queue"]

--- a/crates/fluvio-smartmodule-derive/Cargo.toml
+++ b/crates/fluvio-smartmodule-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartmodule-derive"
 version = "0.6.4"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["wasm", "database", "encoding"]

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-smartmodule"
 version = "0.8.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["wasm", "database", "encoding"]

--- a/crates/fluvio-smartmodule/README.md
+++ b/crates/fluvio-smartmodule/README.md
@@ -20,7 +20,7 @@ For a quick setup using `cargo-generate`, see [the SmartModule template].
 name = "fluvio-wasm-filter"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ['cdylib']

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-socket"
 version = "0.15.1"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-spu-schema/Cargo.toml
+++ b/crates/fluvio-spu-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-spu-schema"
 version = "0.17.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio API for SPU"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-spu"
-edition = "2021"
+edition = "2024"
 version = "0.0.0"
 authors = ["fluvio.io"]
 description = "Fluvio Stream Processing Unit"

--- a/crates/fluvio-storage/Cargo.toml
+++ b/crates/fluvio-storage/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "fluvio-storage"
 version = "0.0.0"
 authors = ["fluvio.io"]

--- a/crates/fluvio-stream-dispatcher/Cargo.toml
+++ b/crates/fluvio-stream-dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-stream-dispatcher"
-edition = "2021"
+edition = "2024"
 version = "0.13.7"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream access"

--- a/crates/fluvio-stream-model/Cargo.toml
+++ b/crates/fluvio-stream-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-stream-model"
-edition = "2021"
+edition = "2024"
 version = "0.11.5"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Event Stream Model"

--- a/crates/fluvio-test-case-derive/Cargo.toml
+++ b/crates/fluvio-test-case-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Test - TestCase derive macro"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 name = "fluvio-test-case-derive"
 publish = false

--- a/crates/fluvio-test-derive/Cargo.toml
+++ b/crates/fluvio-test-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test-derive"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 description = "Fluvio Test Derive Macro"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test-util"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 description = "Fluvio Test utility"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-test"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 autotests = false
 description = "Fluvio Test Utility"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-types/Cargo.toml
+++ b/crates/fluvio-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-types"
 version = "0.5.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 description = "Fluvio common types and objects"
 repository = "https://github.com/infinyon/fluvio"
 license = "Apache-2.0"

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-version-manager"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio Version Manager"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio"
 version = "0.26.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 categories = ["database"]

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smartmodule-development-kit"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "SmartModule Development Kit"
 repository = "https://github.com/infinyon/fluvio"

--- a/examples/00-produce/Cargo.toml
+++ b/examples/00-produce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "produce"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/examples/01-produce-batch/Cargo.toml
+++ b/examples/01-produce-batch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "produce-batch"
 version = "0.1.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/01-produce-key-value/Cargo.toml
+++ b/examples/01-produce-key-value/Cargo.toml
@@ -2,7 +2,7 @@
 name = "produce-key-value"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/02-consume/Cargo.toml
+++ b/examples/02-consume/Cargo.toml
@@ -2,7 +2,7 @@
 name = "consume"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/03-echo/Cargo.toml
+++ b/examples/03-echo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "echo"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/04-admin-watch/Cargo.toml
+++ b/examples/04-admin-watch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "admin"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/partitioning-simple/Cargo.toml
+++ b/examples/partitioning-simple/Cargo.toml
@@ -2,7 +2,7 @@
 name = "partitioning-simple"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/release-tools/check-crate-version/Cargo.toml
+++ b/release-tools/check-crate-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "check-crate-version"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/release-tools/check-crate-version/toml-diff/Cargo.toml
+++ b/release-tools/check-crate-version/toml-diff/Cargo.toml
@@ -2,7 +2,7 @@
 name = "toml-diff"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"

--- a/smartmodule/cargo_template/Cargo.toml.liquid
+++ b/smartmodule/cargo_template/Cargo.toml.liquid
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ['cdylib']

--- a/smartmodule/examples/aggregate-average/Cargo.toml
+++ b/smartmodule/examples/aggregate-average/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-aggregate-average"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/aggregate-init/Cargo.toml
+++ b/smartmodule/examples/aggregate-init/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sm-integer-sum-aggegrate"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]
@@ -10,4 +10,3 @@ crate-type = ['cdylib']
 
 [dependencies]
 fluvio-smartmodule = { workspace = true }
-

--- a/smartmodule/examples/aggregate-json/Cargo.toml
+++ b/smartmodule/examples/aggregate-json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-aggregate-json"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/aggregate-sum/Cargo.toml
+++ b/smartmodule/examples/aggregate-sum/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-aggregate-sum"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/aggregate/Cargo.toml
+++ b/smartmodule/examples/aggregate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-aggregate"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/aggregate_with_timestamp/Cargo.toml
+++ b/smartmodule/examples/aggregate_with_timestamp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-aggregate-with-timestamp"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/array_map_json_array/Cargo.toml
+++ b/smartmodule/examples/array_map_json_array/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-array-map-array"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/array_map_json_array_with_timestamp/Cargo.toml
+++ b/smartmodule/examples/array_map_json_array_with_timestamp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-array-map-array-with-timestamp"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/array_map_json_object/Cargo.toml
+++ b/smartmodule/examples/array_map_json_object/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-array-map-object"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/array_map_json_reddit/Cargo.toml
+++ b/smartmodule/examples/array_map_json_reddit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-array-map-reddit"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter/Cargo.toml
+++ b/smartmodule/examples/filter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_hashset/Cargo.toml
+++ b/smartmodule/examples/filter_hashset/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-hashset"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_init/Cargo.toml
+++ b/smartmodule/examples/filter_init/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-init"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 description = "SmartModule filter with mandatory param"
 

--- a/smartmodule/examples/filter_json/Cargo.toml
+++ b/smartmodule/examples/filter_json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-filter-json"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_look_back/Cargo.toml
+++ b/smartmodule/examples/filter_look_back/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-lookback"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_look_back_with_timestamps/Cargo.toml
+++ b/smartmodule/examples/filter_look_back_with_timestamps/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-lookback-with-timestamps"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_map/Cargo.toml
+++ b/smartmodule/examples/filter_map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-map"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_odd/Cargo.toml
+++ b/smartmodule/examples/filter_odd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-filter-odd"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_regex/Cargo.toml
+++ b/smartmodule/examples/filter_regex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-filter-regex"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/filter_with_param/Cargo.toml
+++ b/smartmodule/examples/filter_with_param/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-filter-param"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 description = "Filter with default parameter"
 publish = false
 

--- a/smartmodule/examples/filter_with_param_v1/Cargo.toml
+++ b/smartmodule/examples/filter_with_param_v1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-filter-with-parameters-v1"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Old Fluvio WASM Filter with Parameters"
 

--- a/smartmodule/examples/map/Cargo.toml
+++ b/smartmodule/examples/map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-map"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/map_double/Cargo.toml
+++ b/smartmodule/examples/map_double/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-map-double"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/map_json/Cargo.toml
+++ b/smartmodule/examples/map_json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-map-json"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/map_regex/Cargo.toml
+++ b/smartmodule/examples/map_regex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-wasm-map-regex"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/examples/map_with_timestamp/Cargo.toml
+++ b/smartmodule/examples/map_with_timestamp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fluvio-smartmodule-map-with-timestamp"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/smartmodule/regex-filter/Cargo.toml
+++ b/smartmodule/regex-filter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "regex-filter"
 version = "0.0.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]


### PR DESCRIPTION
Updates Rust Version to 1.85.0 allowing Fluvio to adopt the Rust 2024 Edition!

https://doc.rust-lang.org/edition-guide/rust-2024/index.html