### PR TITLE
fix: commit and flush retry on other states

### DIFF
--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -39,7 +39,7 @@ pub use stream::{
     ConsumerBoxFuture,
 };
 pub use offset::ConsumerOffset;
-pub use retry::ConsumerWithRetry;
+pub use retry::ConsumerRetryStream;
 
 pub use fluvio_protocol::record::ConsumerRecord as Record;
 pub use fluvio_spu_schema::server::smartmodule::SmartModuleInvocation;

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -34,7 +34,10 @@ use crate::spu::{SpuDirectory, SpuSocketPool};
 
 pub use config::{ConsumerConfig, ConsumerConfigBuilder};
 pub use config::{ConsumerConfigExt, ConsumerConfigExtBuilder, OffsetManagementStrategy, RetryMode};
-pub use stream::{ConsumerStream, MultiplePartitionConsumerStream, SinglePartitionConsumerStream};
+pub use stream::{
+    ConsumerStream, MultiplePartitionConsumerStream, SinglePartitionConsumerStream,
+    ConsumerBoxFuture,
+};
 pub use offset::ConsumerOffset;
 pub use retry::ConsumerWithRetry;
 

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -18,7 +18,7 @@ use fluvio_socket::{
 use crate::admin::FluvioAdmin;
 use crate::error::anyhow_version_error;
 use crate::consumer::{
-    ConsumerConfigExt, ConsumerOffset, ConsumerStream, ConsumerWithRetry,
+    ConsumerConfigExt, ConsumerOffset, ConsumerStream, ConsumerRetryStream,
     MultiplePartitionConsumer, MultiplePartitionConsumerStream, PartitionSelectionStrategy, Record,
 };
 use crate::metrics::ClientMetrics;
@@ -339,7 +339,7 @@ impl Fluvio {
     ) -> Result<
         impl ConsumerStream<Item = std::result::Result<Record, fluvio_protocol::link::ErrorCode>>,
     > {
-        ConsumerWithRetry::new(self.fluvio_config.clone(), config).await
+        ConsumerRetryStream::new(self.fluvio_config.clone(), config).await
     }
 
     /// Creates a new [ConsumerStream] instance without retry logic.


### PR DESCRIPTION
I got some offset consumer tests failing sometimes, it's related to offset_commit and offset_flush have not been called on no idle or terminated states. I fixed it keeping state in the struct to be able to call it every moment.

Also, I changed the signature of `ConsumerStream` methods for wasm, making it to write async code for both.

I ran tests many times and now seems ok!

