### PR TITLE
fix: retry consumer with custom domain connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "adaptive_backoff",
  "anyhow",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-channel 1.9.0",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "flv-tls-proxy"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e4b752f3c5146bb3318e201f75b0ddcd1b7d2e3b6aefb560a0ade46dbfb8cb"
+checksum = "ca1c26f454b01b9b49ff017f914520e66a19d72c47680389e1a560c4fd07e745"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-extension-common"
-version = "0.14.5"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -70,7 +70,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "anymap2"
@@ -507,11 +507,11 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-git2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3810b5af212b013fe7302b12d86616c6c39a48e18f2e4b812a5a9e5710213791"
+checksum = "d55eead120c93036f531829cf9b85830a474e75ce71169680879d28078321ddc"
 dependencies = [
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "git2",
  "terminal-prompt",
 ]
@@ -524,9 +524,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
 dependencies = [
  "bindgen",
  "cc",
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -761,9 +761,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 dependencies = [
  "serde",
 ]
@@ -914,7 +914,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "time",
- "toml 0.8.19",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -948,7 +948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
 dependencies = [
  "serde",
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -965,9 +965,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -996,7 +996,7 @@ dependencies = [
  "serde",
  "sysinfo",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -1033,15 +1033,15 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio",
- "toml 0.8.19",
+ "toml 0.8.20",
  "toml-diff",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1050,7 +1050,7 @@ dependencies = [
  "pure-rust-locales",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1135,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
 dependencies = [
  "clap",
 ]
@@ -1162,9 +1162,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -1214,12 +1214,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
- "strum",
- "strum_macros",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -1266,7 +1265,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1390,7 +1389,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1664,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -1760,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "debugid"
@@ -2083,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elliptic-curve"
@@ -2204,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -2314,12 +2313,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.5",
 ]
 
 [[package]]
@@ -2365,7 +2364,7 @@ dependencies = [
  "siphasher",
  "thiserror 2.0.11",
  "tokio",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
  "wasm-bindgen-test",
  "web-time",
@@ -2428,7 +2427,7 @@ dependencies = [
  "semver 1.0.25",
  "serde",
  "thiserror 2.0.11",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -2505,7 +2504,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tui",
- "which 7.0.1",
+ "which 7.0.2",
 ]
 
 [[package]]
@@ -2590,7 +2589,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "which 7.0.1",
+ "which 7.0.2",
 ]
 
 [[package]]
@@ -2679,7 +2678,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.9.34+deprecated",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -2715,7 +2714,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "thiserror 2.0.11",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -2736,15 +2735,15 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "thiserror 2.0.11",
  "timeago",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
 [[package]]
 name = "fluvio-future"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7673846b1e7fc5513b9a704ed868adbc007f6c4e2cb57ef5a3f9cefaebd7e4a"
+checksum = "aeb6426efa0dc4cc12226634b5b2657237b67028837e79ef4ad4706c4f211bd9"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -2811,7 +2810,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "thiserror 2.0.11",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
  "url",
 ]
@@ -2835,7 +2834,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-hub-protocol",
  "fluvio-types",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "http 1.2.0",
  "mime",
@@ -3299,7 +3298,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.11",
  "tokio",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -3323,7 +3322,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
  "ureq",
  "url",
@@ -3562,7 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-pki-types",
 ]
 
@@ -3638,8 +3637,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3961,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3990,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6b224b95c1e668ac0270325ad563b2eef1469fbbb8959bc7c692c844b813d9"
+checksum = "d752747ddabc4c1a70dd28e72f2e3c218a816773e0d7faf67433f1acfa6cba7c"
 dependencies = [
  "derive_builder",
  "log",
@@ -4204,7 +4215,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -4225,7 +4236,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4525,9 +4536,9 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -4865,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libgit2-sys"
@@ -4917,7 +4928,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.9",
 ]
 
 [[package]]
@@ -5017,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -5033,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "value-bag",
 ]
@@ -5178,9 +5189,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -5193,7 +5204,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -5205,7 +5216,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -5220,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -5416,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -5439,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -5471,18 +5482,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -5533,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -5606,7 +5617,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.9",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -5651,9 +5662,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -5862,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portpicker"
@@ -6015,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
 dependencies = [
  "cc",
 ]
@@ -6080,8 +6091,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
- "rustls 0.23.22",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
  "socket2",
  "thiserror 2.0.11",
  "tokio",
@@ -6095,11 +6106,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand",
  "ring",
- "rustc-hash 2.1.0",
- "rustls 0.23.22",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.11",
@@ -6110,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -6164,7 +6175,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -6207,9 +6218,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -6220,7 +6231,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -6231,7 +6242,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 2.0.11",
 ]
@@ -6246,7 +6257,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",
  "log",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -6329,7 +6340,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -6346,7 +6357,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -6407,15 +6418,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -6500,9 +6510,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -6562,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6749,9 +6759,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -6767,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6778,9 +6788,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -6989,9 +6999,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -7016,7 +7026,7 @@ dependencies = [
  "include_dir",
  "lib-cargo-crate",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -7136,25 +7146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,9 +7251,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -7270,15 +7261,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
@@ -7513,7 +7504,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -7542,9 +7533,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -7557,7 +7548,7 @@ dependencies = [
 name = "toml-diff"
 version = "0.0.0"
 dependencies = [
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -7571,15 +7562,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.1",
+ "winnow 0.7.3",
 ]
 
 [[package]]
@@ -7713,7 +7704,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -7741,9 +7732,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -7759,9 +7750,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -7865,11 +7856,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
  "serde",
 ]
 
@@ -7930,6 +7921,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasi-common"
@@ -8053,29 +8053,29 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.221.2"
+version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+checksum = "dc8444fe4920de80a4fe5ab564fff2ae58b6b73166b89751f8c6c93509da32e5"
 dependencies = [
  "leb128",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.225.0"
+version = "0.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
+checksum = "f7d81b727619aec227dce83e7f7420d4e56c79acd044642a356ea045b98d4e13"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.225.0",
+ "wasmparser 0.226.0",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.221.2"
+version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
  "bitflags 2.8.0",
  "hashbrown 0.15.2",
@@ -8098,14 +8098,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.221.2"
+name = "wasmparser"
+version = "0.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
+checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
+dependencies = [
+ "bitflags 2.8.0",
+ "indexmap 2.7.1",
+ "semver 1.0.25",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7343c42a97f2926c7819ff81b64012092ae954c5d83ddd30c9fcdefd97d0b283"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
@@ -8147,8 +8158,8 @@ dependencies = [
  "sptr",
  "target-lexicon",
  "trait-variant",
- "wasm-encoder 0.221.2",
- "wasmparser 0.221.2",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -8190,7 +8201,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.19",
+ "toml 0.8.20",
  "windows-sys 0.59.0",
  "zstd",
 ]
@@ -8236,7 +8247,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 1.0.69",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -8262,8 +8273,8 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.221.2",
- "wasmparser 0.221.2",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
  "wasmprinter",
  "wasmtime-component-util",
 ]
@@ -8343,7 +8354,7 @@ dependencies = [
  "gimli 0.31.1",
  "object 0.36.7",
  "target-lexicon",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -8372,24 +8383,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "225.0.0"
+version = "226.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61496027ff707f9fa9e0b22c34ec163eb7adb1070df565e32a9180a76e4300b"
+checksum = "0bb903956d0151eabb6c30a2304dd61e5c8d7182805226120c2b6d611fb09a26"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.225.0",
+ "wasm-encoder 0.226.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.225.0"
+version = "1.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e72a33942234fd0794bcdac30e43b448de3187512414267678e511c6755f11"
+checksum = "5f89a90ef2c401b8b5b2b704020bfa7a7f69b93c3034c7a4b4a88e21e9966581"
 dependencies = [
- "wast 225.0.0",
+ "wast 226.0.0",
 ]
 
 [[package]]
@@ -8435,9 +8446,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -8531,7 +8542,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 1.0.69",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -8588,6 +8599,12 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
@@ -8787,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -8811,10 +8828,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.221.2"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896112579ed56b4a538b07a3d16e562d101ff6265c46b515ce0c701eef16b2ac"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -8825,7 +8851,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.221.2",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
@@ -8959,18 +8985,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9020,27 +9046,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ fluvio_ws_stream_wasm = "0.7.0"
 fluvio-command = { version = "0.2.0" }
 fluvio-future = { version = "0.7.2", default-features = false }
 fluvio-helm = { version = "0.4.1" }
-flv-tls-proxy = { version = "0.9.0" }
+flv-tls-proxy = { version = "0.9.1" }
 flv-util = { version = "0.5.2", default-features = false }
 k8-client = { version = "13.1.0" }
 k8-config = { version = "2.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ x509-parser = "0.16.0"
 # External fluvio dependencies
 fluvio_ws_stream_wasm = "0.7.0"
 fluvio-command = { version = "0.2.0" }
-fluvio-future = { version = "0.7.1", default-features = false }
+fluvio-future = { version = "0.7.2", default-features = false }
 fluvio-helm = { version = "0.4.1" }
 flv-tls-proxy = { version = "0.9.0" }
 flv-util = { version = "0.5.2", default-features = false }

--- a/crates/fluvio-cli-common/src/smartmodule.rs
+++ b/crates/fluvio-cli-common/src/smartmodule.rs
@@ -9,7 +9,7 @@ use clap::Args;
 use chrono::Utc;
 use tracing::debug;
 
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use fluvio_sc_schema::smartmodule::SmartModuleApiClient;
 use fluvio_smartengine::DEFAULT_SMARTENGINE_VERSION;
 use fluvio_smartengine::metrics::SmartModuleChainMetrics;
@@ -247,7 +247,7 @@ async fn build_chain(
     config: TransformationConfig,
     lookback: Option<Lookback>,
 ) -> Result<SmartModuleChainBuilder> {
-    let client_config = FluvioConfig::load()?.try_into()?;
+    let client_config = FluvioClusterConfig::load()?.try_into()?;
     let api_client = SmartModuleApiClient::connect_with_config(client_config).await?;
     let mut chain_builder = SmartModuleChainBuilder::default();
     for transform in config.transforms {

--- a/crates/fluvio-cli/src/client/hub/smartmodule/download.rs
+++ b/crates/fluvio-cli/src/client/hub/smartmodule/download.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use anyhow::Result;
 
 use fluvio::Fluvio;
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use fluvio::metadata::smartmodule::SmartModuleSpec;
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleMetadata, SmartModuleWasm};
 use fluvio_extension_common::Terminal;
@@ -105,7 +105,7 @@ async fn download_local(
 }
 
 // download smartmodule from pkg to cluster
-async fn download_cluster(config: FluvioConfig, pkgfile: &str) -> Result<()> {
+async fn download_cluster(config: FluvioClusterConfig, pkgfile: &str) -> Result<()> {
     println!("... checking package");
     let pm = hubutil::package_get_meta(pkgfile)
         .map_err(|_| CliError::PackageError(format!("accessing metadata in {pkgfile}")))?;

--- a/crates/fluvio-cli/src/client/remote/export.rs
+++ b/crates/fluvio-cli/src/client/remote/export.rs
@@ -83,7 +83,7 @@ impl ExportOpt {
 
 #[cfg(unix)]
 fn get_tls_config(
-    fluvio_config: fluvio::config::FluvioConfig,
+    fluvio_config: fluvio::config::FluvioClusterConfig,
     cert_path: Option<String>,
     key_path: Option<String>,
     remote_id: String,
@@ -149,7 +149,7 @@ fn get_tls_config(
 
 #[cfg(not(unix))]
 fn get_tls_config(
-    _fluvio_config: fluvio::config::FluvioConfig,
+    _fluvio_config: fluvio::config::FluvioClusterConfig,
     _cert_path: Option<String>,
     _key_path: Option<String>,
     _remote_id: String,
@@ -164,7 +164,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_get_tls_config_on_unix() {
-        let fluvio_config = fluvio::config::FluvioConfig::new("localhost:9003".to_owned());
+        let fluvio_config = fluvio::config::FluvioClusterConfig::new("localhost:9003".to_owned());
         let cert_dir = std::env::current_dir()
             .unwrap()
             .join("..")
@@ -221,7 +221,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_get_tls_config_no_cert_key_when_tls_on_unix() {
-        let fluvio_config = fluvio::config::FluvioConfig::new("localhost:9003".to_owned());
+        let fluvio_config = fluvio::config::FluvioClusterConfig::new("localhost:9003".to_owned());
         let cert_dir = std::env::current_dir()
             .unwrap()
             .join("..")
@@ -256,7 +256,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_get_tls_config_wrong_cn_on_unix() {
-        let fluvio_config = fluvio::config::FluvioConfig::new("localhost:9003".to_owned());
+        let fluvio_config = fluvio::config::FluvioClusterConfig::new("localhost:9003".to_owned());
         let cert_dir = std::env::current_dir()
             .unwrap()
             .join("..")

--- a/crates/fluvio-cli/src/profile/sync/k8.rs
+++ b/crates/fluvio-cli/src/profile/sync/k8.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 use anyhow::{Result, anyhow};
 
 use fluvio::config::{Profile, ConfigFile};
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use k8_config::K8Config;
 use k8_client::K8Client;
 use k8_client::meta_client::MetadataClient;
@@ -81,7 +81,7 @@ pub async fn set_k8_context(opt: K8Opt, external_addr: String) -> Result<Profile
             cluster.tls = opt.tls.try_into()?;
         }
         None => {
-            let mut local_cluster = FluvioConfig::new(external_addr);
+            let mut local_cluster = FluvioClusterConfig::new(external_addr);
             local_cluster.tls = opt.tls.try_into()?;
             config.add_cluster(local_cluster, profile_name.clone());
         }

--- a/crates/fluvio-cli/src/profile/sync/local.rs
+++ b/crates/fluvio-cli/src/profile/sync/local.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use clap::Parser;
 use anyhow::Result;
 
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use fluvio::config::{ConfigFile, LOCAL_PROFILE, Profile};
 
 use crate::common::tls::TlsClientOpt;
@@ -45,7 +45,7 @@ pub fn set_local_context(local_config: LocalOpt) -> Result<String> {
             cluster.tls = local_config.tls.try_into()?;
         }
         None => {
-            let mut local_cluster = FluvioConfig::new(local_addr.clone());
+            let mut local_cluster = FluvioClusterConfig::new(local_addr.clone());
             local_cluster.tls = local_config.tls.try_into()?;
             config.add_cluster(local_cluster, LOCAL_PROFILE.to_owned());
         }

--- a/crates/fluvio-cluster/src/cli/status.rs
+++ b/crates/fluvio-cluster/src/cli/status.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use colored::Colorize;
 use anyhow::{Result, anyhow};
 
-use fluvio::{Fluvio, FluvioAdmin, FluvioConfig};
+use fluvio::{Fluvio, FluvioAdmin, FluvioClusterConfig};
 use fluvio::config::ConfigFile;
 use fluvio_controlplane_metadata::partition::PartitionSpec;
 use fluvio_controlplane_metadata::{spu::SpuSpec, topic::TopicSpec};
@@ -87,7 +87,7 @@ impl StatusOpt {
 
     async fn check_sc(
         pb: &ProgressRenderer,
-        fluvio_config: &FluvioConfig,
+        fluvio_config: &FluvioClusterConfig,
         config_file: &ConfigFile,
     ) -> Result<()> {
         pb.set_message(pad_format!(format!("{} Checking {}", "📝".bold(), "SC")));
@@ -109,7 +109,7 @@ impl StatusOpt {
         }
     }
 
-    async fn check_spus(pb: &ProgressRenderer, fluvio_config: &FluvioConfig) -> Result<()> {
+    async fn check_spus(pb: &ProgressRenderer, fluvio_config: &FluvioClusterConfig) -> Result<()> {
         pb.set_message(pad_format!(format!("{} Checking {}", "📝".bold(), "SPUs")));
 
         match FluvioAdmin::connect_with_config(fluvio_config).await {
@@ -162,7 +162,10 @@ impl StatusOpt {
             .to_string()
     }
 
-    async fn check_topics(pb: &ProgressRenderer, fluvio_config: &FluvioConfig) -> Result<()> {
+    async fn check_topics(
+        pb: &ProgressRenderer,
+        fluvio_config: &FluvioClusterConfig,
+    ) -> Result<()> {
         pb.set_message(pad_format!(format!(
             "{} Checking {}",
             "📝".bold(),

--- a/crates/fluvio-cluster/src/start/common.rs
+++ b/crates/fluvio-cluster/src/start/common.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use semver::Version;
 use tracing::{debug, error, info, instrument, warn};
 
-use fluvio::{Fluvio, FluvioConfig};
+use fluvio::{Fluvio, FluvioClusterConfig};
 use fluvio_future::{
     retry::{retry, ExponentialBackoff, RetryExt},
     timer::sleep,
@@ -38,12 +38,12 @@ enum TryConnectError {
 /// try connection to SC
 #[instrument]
 pub async fn try_connect_to_sc(
-    config: &FluvioConfig,
+    config: &FluvioClusterConfig,
     platform_version: &Version,
     pb: &ProgressRenderer,
 ) -> Option<Fluvio> {
     async fn try_connect_sc(
-        fluvio_config: &FluvioConfig,
+        fluvio_config: &FluvioClusterConfig,
         expected_version: &Version,
     ) -> Result<Fluvio, TryConnectError> {
         match Fluvio::connect_with_config(fluvio_config).await {

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -29,7 +29,7 @@ use k8_client::SharedK8Client;
 use k8_client::load_and_share;
 use k8_types::K8Obj;
 use k8_types::app::deployment::DeploymentSpec;
-use fluvio::{Fluvio, FluvioConfig};
+use fluvio::{Fluvio, FluvioClusterConfig};
 use fluvio::metadata::spg::SpuGroupSpec;
 use fluvio::metadata::spu::SpuSpec;
 use fluvio::config::{TlsPolicy, TlsConfig, TlsPaths, ConfigFile};
@@ -682,7 +682,7 @@ impl ClusterInstaller {
             (external_host_and_port.clone(), None)
         };
 
-        let cluster_config = FluvioConfig::new(install_host_and_port.clone())
+        let cluster_config = FluvioClusterConfig::new(install_host_and_port.clone())
             .with_tls(self.config.client_tls_policy.clone());
         pb.set_message("🔎 Discovering Fluvio SC");
         let fluvio =

--- a/crates/fluvio-cluster/src/start/local.rs
+++ b/crates/fluvio-cluster/src/start/local.rs
@@ -11,7 +11,7 @@ use serde::{Serialize, Deserialize};
 use tracing::{debug, error, instrument, warn};
 use once_cell::sync::Lazy;
 
-use fluvio::{Fluvio, FluvioConfig};
+use fluvio::{Fluvio, FluvioClusterConfig};
 use fluvio::config::{TlsPolicy, ConfigFile, LOCAL_PROFILE};
 use fluvio_controlplane_metadata::spu::{SpuSpec, CustomSpuSpec};
 use fluvio_future::timer::sleep;
@@ -579,8 +579,8 @@ impl LocalInstaller {
         sleep(Duration::from_secs(2)).await;
 
         // construct config to connect to SC
-        let cluster_config =
-            FluvioConfig::new(public_address).with_tls(self.config.client_tls_policy.clone());
+        let cluster_config = FluvioClusterConfig::new(public_address)
+            .with_tls(self.config.client_tls_policy.clone());
 
         try_connect_to_sc(&cluster_config, &self.config.platform_version, pb)
             .await

--- a/crates/fluvio-connector-common/src/consumer.rs
+++ b/crates/fluvio-connector-common/src/consumer.rs
@@ -5,7 +5,7 @@ use std::{
 use std::time::Duration;
 
 use fluvio::consumer::{ConsumerConfigExtBuilder, OffsetManagementStrategy};
-use fluvio::{Fluvio, FluvioConfig, Offset};
+use fluvio::{Fluvio, FluvioClusterConfig, Offset};
 use fluvio_connector_package::config::{ConsumerPartitionConfig, OffsetConfig, OffsetStrategyConfig};
 use crate::{config::ConnectorConfig, Result};
 use crate::ensure_topic_exists;
@@ -16,7 +16,7 @@ pub use fluvio::consumer::ConsumerStream;
 pub async fn consumer_stream_from_config(
     config: &ConnectorConfig,
 ) -> Result<(Fluvio, impl ConsumerStream)> {
-    let mut cluster_config = FluvioConfig::load()?;
+    let mut cluster_config = FluvioClusterConfig::load()?;
     cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name()));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;

--- a/crates/fluvio-connector-common/src/producer.rs
+++ b/crates/fluvio-connector-common/src/producer.rs
@@ -1,10 +1,10 @@
-use fluvio::{TopicProducerPool, Fluvio, FluvioConfig, TopicProducerConfigBuilder};
+use fluvio::{TopicProducerPool, Fluvio, FluvioClusterConfig, TopicProducerConfigBuilder};
 use crate::{config::ConnectorConfig, Result};
 
 use crate::{ensure_topic_exists, smartmodule::smartmodule_chain_from_config};
 
 pub async fn producer_from_config(config: &ConnectorConfig) -> Result<(Fluvio, TopicProducerPool)> {
-    let mut cluster_config = FluvioConfig::load()?;
+    let mut cluster_config = FluvioClusterConfig::load()?;
     cluster_config.client_id = Some(format!("fluvio_connector_{}", &config.meta().name()));
 
     let fluvio = Fluvio::connect_with_config(&cluster_config).await?;

--- a/crates/fluvio-connector-common/src/smartmodule.rs
+++ b/crates/fluvio-connector-common/src/smartmodule.rs
@@ -1,4 +1,4 @@
-use fluvio::{FluvioConfig, SmartModuleInvocation, SmartModuleKind, SmartModuleExtraParams};
+use fluvio::{FluvioClusterConfig, SmartModuleInvocation, SmartModuleKind, SmartModuleExtraParams};
 
 use crate::{config::ConnectorConfig, Result};
 
@@ -14,7 +14,7 @@ pub async fn smartmodule_chain_from_config(
     }
 
     let api_client =
-        SmartModuleApiClient::connect_with_config(FluvioConfig::load()?.try_into()?).await?;
+        SmartModuleApiClient::connect_with_config(FluvioClusterConfig::load()?.try_into()?).await?;
     let mut builder = fluvio::SmartModuleChainBuilder::default();
 
     for step in transforms {

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.14.5"
+version = "0.15.0"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"

--- a/crates/fluvio-extension-common/Cargo.toml
+++ b/crates/fluvio-extension-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-extension-common"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio extension common"

--- a/crates/fluvio-extension-common/src/installation.rs
+++ b/crates/fluvio-extension-common/src/installation.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use serde::{Serialize, Deserialize};
 
 const INSTALLATION_METADATA_NAME: &str = "installation";
@@ -63,7 +63,7 @@ impl std::fmt::Display for InstallationType {
 }
 
 impl InstallationType {
-    pub fn load(config: &FluvioConfig) -> Self {
+    pub fn load(config: &FluvioClusterConfig) -> Self {
         let install = config.query_metadata_by_name(INSTALLATION_METADATA_NAME);
         let cloud = config.has_metadata(CLOUD_METADATA_NAME);
 
@@ -74,21 +74,21 @@ impl InstallationType {
         }
     }
 
-    pub fn save_to(&self, config: &mut FluvioConfig) -> anyhow::Result<()> {
+    pub fn save_to(&self, config: &mut FluvioClusterConfig) -> anyhow::Result<()> {
         config.update_metadata_by_name(INSTALLATION_METADATA_NAME, self)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use fluvio::FluvioConfig;
+    use fluvio::FluvioClusterConfig;
 
     use super::*;
 
     #[test]
     fn test_installation_in_config_load_and_update() {
         //given
-        let mut config = FluvioConfig::new("test");
+        let mut config = FluvioClusterConfig::new("test");
         let installation = InstallationType::Local;
 
         //when

--- a/crates/fluvio-extension-common/src/lib.rs
+++ b/crates/fluvio-extension-common/src/lib.rs
@@ -89,7 +89,7 @@ pub mod target {
 
     use anyhow::Result;
 
-    use fluvio::FluvioConfig;
+    use fluvio::FluvioClusterConfig;
     use fluvio::FluvioError;
     use fluvio::Fluvio;
     use fluvio::config::ConfigFile;
@@ -135,7 +135,7 @@ pub mod target {
         }
 
         /// try to create sc config
-        pub fn load(self) -> Result<FluvioConfig> {
+        pub fn load(self) -> Result<FluvioClusterConfig> {
             let tls = self.tls.try_into()?;
 
             use fluvio::config::TlsPolicy::*;
@@ -154,13 +154,14 @@ pub mod target {
                         .into());
                     }
 
-                    let cluster = FluvioConfig::load_with_profile(&profile)?.ok_or_else(|| {
-                        IoError::new(ErrorKind::Other, "Cluster not found for profile")
-                    })?;
+                    let cluster =
+                        FluvioClusterConfig::load_with_profile(&profile)?.ok_or_else(|| {
+                            IoError::new(ErrorKind::Other, "Cluster not found for profile")
+                        })?;
                     Ok(cluster.clone())
                 }
                 (None, Some(cluster)) => {
-                    let cluster = FluvioConfig::new(cluster).with_tls(tls);
+                    let cluster = FluvioClusterConfig::new(cluster).with_tls(tls);
                     Ok(cluster)
                 }
                 (None, None) => {

--- a/crates/fluvio-socket/Cargo.toml
+++ b/crates/fluvio-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/fluvio-socket/src/versioned.rs
+++ b/crates/fluvio-socket/src/versioned.rs
@@ -141,6 +141,10 @@ impl ClientConfig {
         self.use_spu_local_address
     }
 
+    pub fn connector(&self) -> &DomainConnector {
+        &self.connector
+    }
+
     pub fn set_client_id(&mut self, id: impl Into<String>) {
         self.client_id = id.into();
     }

--- a/crates/fluvio-socket/src/versioned.rs
+++ b/crates/fluvio-socket/src/versioned.rs
@@ -172,6 +172,17 @@ impl ClientConfig {
             use_spu_local_address: self.use_spu_local_address,
         }
     }
+
+    pub fn recreate(&self) -> Self {
+        Self {
+            addr: self.addr.clone(),
+            client_id: self.client_id.clone(),
+            connector: self
+                .connector
+                .new_domain(self.connector.domain().to_owned()),
+            use_spu_local_address: self.use_spu_local_address,
+        }
+    }
 }
 
 /// wrap around versions

--- a/crates/fluvio-test-util/setup/mod.rs
+++ b/crates/fluvio-test-util/setup/mod.rs
@@ -9,7 +9,7 @@ mod cluster {
     use anyhow::Result;
 
     use fluvio_future::timer::sleep;
-    use fluvio::{Fluvio, FluvioConfig};
+    use fluvio::{Fluvio, FluvioClusterConfig};
 
     use crate::tls::load_tls;
     use crate::test_meta::environment::{EnvironmentSetup, EnvDetail};
@@ -57,9 +57,9 @@ mod cluster {
 
             let fluvio_config = if self.option.tls {
                 let (client, _server) = load_tls(&self.option.tls_user);
-                FluvioConfig::new(cluster_status.address()).with_tls(client)
+                FluvioClusterConfig::new(cluster_status.address()).with_tls(client)
             } else {
-                FluvioConfig::new(cluster_status.address())
+                FluvioClusterConfig::new(cluster_status.address())
             };
 
             let fluvio = Fluvio::connect_with_config(&fluvio_config).await?;

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/admin.rs
+++ b/crates/fluvio/src/admin.rs
@@ -21,7 +21,7 @@ use fluvio_sc_schema::objects::{
 use fluvio_sc_schema::{AdminSpec, DeletableAdminSpec, CreatableAdminSpec, TryEncodableFrom};
 use fluvio_socket::{ClientConfig, VersionedSerialSocket, SerialFrame, MultiplexerSocket};
 
-use crate::FluvioConfig;
+use crate::FluvioClusterConfig;
 use crate::config::ConfigFile;
 use crate::error::anyhow_version_error;
 use crate::metadata::objects::{ListResponse, ListRequest};
@@ -118,7 +118,7 @@ impl FluvioAdmin {
     /// # }
     /// ```
     #[instrument(skip(config))]
-    pub async fn connect_with_config(config: &FluvioConfig) -> Result<Self> {
+    pub async fn connect_with_config(config: &FluvioClusterConfig) -> Result<Self> {
         let connector = DomainConnector::try_from(config.tls.clone())?;
         let client_config =
             ClientConfig::new(&config.endpoint, connector, config.use_spu_local_address);

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -10,6 +10,10 @@ use crate::{config::TlsPolicy, FluvioError};
 
 use super::ConfigFile;
 
+//NOTE: this is to avoid breaking changes as we rename it to FluvioClusterConfig
+/// Fluvio client configuration
+pub type FluvioConfig = FluvioClusterConfig;
+
 /// Fluvio Cluster Target Configuration
 /// This is part of profile
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/fluvio/src/config/cluster.rs
+++ b/crates/fluvio/src/config/cluster.rs
@@ -14,7 +14,7 @@ use super::ConfigFile;
 /// This is part of profile
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct FluvioConfig {
+pub struct FluvioClusterConfig {
     /// The address to connect to the Fluvio cluster
     // TODO use a validated address type.
     // We don't want to have a "" address.
@@ -40,7 +40,7 @@ pub struct FluvioConfig {
     pub client_id: Option<String>,
 }
 
-impl FluvioConfig {
+impl FluvioClusterConfig {
     /// get current cluster config from default profile
     pub fn load() -> Result<Self, FluvioError> {
         let config_file = ConfigFile::load_default_or_new()?;
@@ -105,9 +105,9 @@ impl FluvioConfig {
     }
 }
 
-impl TryFrom<FluvioConfig> for fluvio_socket::ClientConfig {
+impl TryFrom<FluvioClusterConfig> for fluvio_socket::ClientConfig {
     type Error = anyhow::Error;
-    fn try_from(config: FluvioConfig) -> Result<Self, Self::Error> {
+    fn try_from(config: FluvioClusterConfig) -> Result<Self, Self::Error> {
         let connector = fluvio_future::net::DomainConnector::try_from(config.tls.clone())?;
         Ok(Self::new(
             &config.endpoint,

--- a/crates/fluvio/src/config/config.rs
+++ b/crates/fluvio/src/config/config.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 
 use fluvio_types::defaults::CLI_CONFIG_PATH;
 use fluvio_types::config_file::SaveLoadConfig;
-use crate::{FluvioConfig, FluvioError};
+use crate::{FluvioClusterConfig, FluvioError};
 
 use super::TlsPolicy;
 
@@ -167,7 +167,7 @@ impl ConfigFile {
                 cluster.tls = tls_policy.clone();
             }
             None => {
-                let mut new_cluster = FluvioConfig::new(cluster_addr);
+                let mut new_cluster = FluvioClusterConfig::new(cluster_addr);
                 new_cluster.tls = tls_policy.clone();
                 config.add_cluster(new_cluster, profile_name.to_string());
             }
@@ -198,7 +198,7 @@ pub struct Config {
     version: String,
     current_profile: Option<String>,
     pub profile: HashMap<String, Profile>,
-    pub cluster: HashMap<String, FluvioConfig>,
+    pub cluster: HashMap<String, FluvioClusterConfig>,
     client_id: Option<String>,
 }
 
@@ -212,7 +212,7 @@ impl Config {
 
     /// create new config with a single local cluster
     pub fn new_with_local_cluster(domain: String) -> Self {
-        let cluster = FluvioConfig::new(domain);
+        let cluster = FluvioClusterConfig::new(domain);
         let mut config = Self::new();
 
         config.cluster.insert(LOCAL_PROFILE.to_owned(), cluster);
@@ -225,7 +225,7 @@ impl Config {
     }
 
     /// add new cluster
-    pub fn add_cluster(&mut self, cluster: FluvioConfig, name: String) {
+    pub fn add_cluster(&mut self, cluster: FluvioClusterConfig, name: String) {
         self.cluster.insert(name, cluster);
     }
 
@@ -299,10 +299,10 @@ impl Config {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::FluvioConfig;
+    /// # use fluvio::FluvioClusterConfig;
     /// # use fluvio::config::{Config, Profile};
     /// let mut config = Config::new();
-    /// let cluster = FluvioConfig::new("https://cloud.fluvio.io".to_string());
+    /// let cluster = FluvioClusterConfig::new("https://cloud.fluvio.io".to_string());
     /// config.add_cluster(cluster, "fluvio-cloud".to_string());
     /// let profile = Profile::new("fluvio-cloud".to_string());
     /// config.add_profile(profile, "fluvio-cloud".to_string());
@@ -310,7 +310,7 @@ impl Config {
     /// config.delete_cluster("fluvio-cloud").unwrap();
     /// assert!(config.cluster("fluvio-cloud").is_none());
     /// ```
-    pub fn delete_cluster(&mut self, cluster_name: &str) -> Option<FluvioConfig> {
+    pub fn delete_cluster(&mut self, cluster_name: &str) -> Option<FluvioClusterConfig> {
         self.cluster.remove(cluster_name)
     }
 
@@ -326,10 +326,10 @@ impl Config {
     /// # Example
     ///
     /// ```
-    /// # use fluvio::FluvioConfig;
+    /// # use fluvio::FluvioClusterConfig;
     /// # use fluvio::config::{Config, Profile};
     /// let mut config = Config::new();
-    /// let cluster = FluvioConfig::new("https://cloud.fluvio.io".to_string());
+    /// let cluster = FluvioClusterConfig::new("https://cloud.fluvio.io".to_string());
     /// config.add_cluster(cluster, "fluvio-cloud".to_string());
     /// let profile = Profile::new("fluvio-cloud".to_string());
     /// config.add_profile(profile, "fluvio-cloud".to_string());
@@ -373,8 +373,8 @@ impl Config {
         self.profile.get_mut(profile_name)
     }
 
-    /// Returns the FluvioConfig belonging to the current profile.
-    pub fn current_cluster(&self) -> Result<&FluvioConfig, FluvioError> {
+    /// Returns the FluvioClusterConfig belonging to the current profile.
+    pub fn current_cluster(&self) -> Result<&FluvioClusterConfig, FluvioError> {
         let profile = self.current_profile()?;
         let maybe_cluster = self.cluster.get(&profile.cluster);
         let cluster = maybe_cluster.ok_or_else(|| {
@@ -384,8 +384,8 @@ impl Config {
         Ok(cluster)
     }
 
-    /// Returns the mutable reference to FluvioConfig belonging to the current profile.
-    pub fn current_cluster_mut(&mut self) -> Result<&mut FluvioConfig, FluvioError> {
+    /// Returns the mutable reference to FluvioClusterConfig belonging to the current profile.
+    pub fn current_cluster_mut(&mut self) -> Result<&mut FluvioClusterConfig, FluvioError> {
         let profile = self.current_profile()?.clone();
         let maybe_cluster = self.cluster.get_mut(&profile.cluster);
         let cluster = maybe_cluster.ok_or_else(|| {
@@ -395,20 +395,20 @@ impl Config {
         Ok(cluster)
     }
 
-    /// Returns the FluvioConfig belonging to the named profile.
-    pub fn cluster_with_profile(&self, profile_name: &str) -> Option<&FluvioConfig> {
+    /// Returns the FluvioClusterConfig belonging to the named profile.
+    pub fn cluster_with_profile(&self, profile_name: &str) -> Option<&FluvioClusterConfig> {
         self.profile
             .get(profile_name)
             .and_then(|profile| self.cluster.get(&profile.cluster))
     }
 
-    /// Returns a reference to the named FluvioConfig.
-    pub fn cluster(&self, cluster_name: &str) -> Option<&FluvioConfig> {
+    /// Returns a reference to the named FluvioClusterConfig.
+    pub fn cluster(&self, cluster_name: &str) -> Option<&FluvioClusterConfig> {
         self.cluster.get(cluster_name)
     }
 
-    /// Returns a mutable reference to the named FluvioConfig.
-    pub fn cluster_mut(&mut self, cluster_name: &str) -> Option<&mut FluvioConfig> {
+    /// Returns a mutable reference to the named FluvioClusterConfig.
+    pub fn cluster_mut(&mut self, cluster_name: &str) -> Option<&mut FluvioClusterConfig> {
         self.cluster.get_mut(cluster_name)
     }
 

--- a/crates/fluvio/src/consumer/retry.rs
+++ b/crates/fluvio/src/consumer/retry.rs
@@ -324,8 +324,8 @@ impl ConsumerRetryStream {
         mut backoff: ExponentialBackoff,
     ) -> Result<BoxConsumerStream> {
         info!(target: SPAN_RETRY, "Reconnecting to stream");
-        let fluvio_client = Fluvio::connect_with_client_config(
-            inner.client_config.recreate(),
+        let fluvio_client = Fluvio::connect_with_connector(
+            inner.client_config.connector().clone(),
             &inner.fluvio_cluster_config,
         )
         .await?;

--- a/crates/fluvio/src/consumer/retry.rs
+++ b/crates/fluvio/src/consumer/retry.rs
@@ -62,7 +62,7 @@ type BoxConsumerFuture = Pin<
 
 #[derive(Clone)]
 pub struct ConsumerRetryInner {
-    fluvio_cluster_config: FluvioClusterConfig,
+    cluster_config: FluvioClusterConfig,
     next_offset_to_read: Option<i64>,
     consumer_config: ConsumerConfigExt,
     client_config: Arc<ClientConfig>,
@@ -202,7 +202,7 @@ impl ConsumerRetryStream {
     /// Creates a new `ConsumerRetryStream` with the given configuration.
     pub async fn new(
         fluvio: &Fluvio,
-        fluvio_config: FluvioClusterConfig,
+        cluster_config: FluvioClusterConfig,
         config: ConsumerConfigExt,
     ) -> Result<Self> {
         let client_config = fluvio.client_config();
@@ -212,7 +212,7 @@ impl ConsumerRetryStream {
         Ok(Self {
             inner: ConsumerRetryInner {
                 client_config,
-                fluvio_cluster_config: fluvio_config,
+                cluster_config,
                 next_offset_to_read: None,
                 consumer_config: config,
             },
@@ -326,7 +326,7 @@ impl ConsumerRetryStream {
         info!(target: SPAN_RETRY, "Reconnecting to stream");
         let fluvio_client = Fluvio::connect_with_connector(
             inner.client_config.connector().clone(),
-            &inner.fluvio_cluster_config,
+            &inner.cluster_config,
         )
         .await?;
 
@@ -396,7 +396,7 @@ mod tests {
         let mut retry_stream = ConsumerRetryStream {
             inner: ConsumerRetryInner {
                 client_config: Arc::new(ClientConfig::with_addr("localhost:9010".to_string())),
-                fluvio_cluster_config: FluvioClusterConfig::new("localhost:9003".to_string()),
+                cluster_config: FluvioClusterConfig::new("localhost:9003".to_string()),
                 next_offset_to_read: None,
                 consumer_config: ConsumerConfigExt::builder()
                     .topic("test_topic".to_string())

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -31,7 +31,7 @@ use crate::{TopicProducer, PartitionConsumer, FluvioError, FluvioClusterConfig};
 pub struct Fluvio {
     socket: SharedMultiplexerSocket,
     config: Arc<ClientConfig>,
-    fluvio_config: FluvioClusterConfig,
+    cluster_config: FluvioClusterConfig,
     versions: Versions,
     spu_pool: OnceCell<Arc<SpuSocketPool>>,
     metadata: MetadataStores,
@@ -105,14 +105,14 @@ impl Fluvio {
     /// Creates a new Fluvio client with the given connector and configuration
     pub async fn connect_with_connector(
         connector: DomainConnector,
-        fluvio_config: &FluvioClusterConfig,
+        cluster_config: &FluvioClusterConfig,
     ) -> Result<Self> {
         let mut client_config = ClientConfig::new(
-            &fluvio_config.endpoint,
+            &cluster_config.endpoint,
             connector.clone(),
-            fluvio_config.use_spu_local_address,
+            cluster_config.use_spu_local_address,
         );
-        if let Some(client_id) = &fluvio_config.client_id {
+        if let Some(client_id) = &cluster_config.client_id {
             client_config.set_client_id(client_id.to_owned());
         }
         //Self::connect_with_client_config(client_config, fluvio_config).await
@@ -133,7 +133,7 @@ impl Fluvio {
             Ok(Self {
                 socket,
                 config,
-                fluvio_config: fluvio_config.clone(),
+                cluster_config: cluster_config.clone(),
                 versions,
                 spu_pool,
                 metadata,
@@ -345,7 +345,7 @@ impl Fluvio {
     ) -> Result<
         impl ConsumerStream<Item = std::result::Result<Record, fluvio_protocol::link::ErrorCode>>,
     > {
-        ConsumerRetryStream::new(self, self.fluvio_config.clone(), config).await
+        ConsumerRetryStream::new(self, self.cluster_config.clone(), config).await
     }
 
     /// Creates a new [ConsumerStream] instance without retry logic.

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -17,7 +17,7 @@ pub mod metrics;
 pub mod spu;
 
 pub use error::FluvioError;
-pub use config::FluvioClusterConfig;
+pub use config::{FluvioClusterConfig, FluvioConfig};
 pub use producer::{
     ProducerCallback, SharedProducerCallback, ProduceCompletionBatchEvent,
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey,

--- a/crates/fluvio/src/lib.rs
+++ b/crates/fluvio/src/lib.rs
@@ -17,7 +17,7 @@ pub mod metrics;
 pub mod spu;
 
 pub use error::FluvioError;
-pub use config::FluvioConfig;
+pub use config::FluvioClusterConfig;
 pub use producer::{
     ProducerCallback, SharedProducerCallback, ProduceCompletionBatchEvent,
     TopicProducerConfigBuilder, TopicProducerConfig, TopicProducer, TopicProducerPool, RecordKey,

--- a/crates/smartmodule-development-kit/src/load.rs
+++ b/crates/smartmodule-development-kit/src/load.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use anyhow::Result;
 
-use fluvio::FluvioConfig;
+use fluvio::FluvioClusterConfig;
 use fluvio_controlplane_metadata::smartmodule::{SmartModuleWasm, SmartModuleSpec, SmartModuleMetadata};
 use fluvio_extension_common::target::ClusterTarget;
 use fluvio::Fluvio;
@@ -95,7 +95,7 @@ impl LoadCmd {
 }
 
 async fn create(
-    config: FluvioConfig,
+    config: FluvioClusterConfig,
     spec: SmartModuleSpec,
     id: String,
     dry_run: bool,


### PR DESCRIPTION
Needs:
- https://github.com/infinyon/future-aio/pull/268
- https://github.com/infinyon/flv-tls-proxy/pull/34

Retry consumer was not working with consumer with a custom domain, like fluvio-web does with websocket.

This PR saves the domain connector to recreate it when needed.