### PR TITLE
Export ReplyHubref{} and HUB_REF_ENDPOINT

### DIFF
--- a/crates/fluvio-hub-util/src/hubaccess.rs
+++ b/crates/fluvio-hub-util/src/hubaccess.rs
@@ -349,10 +349,9 @@ pub fn default_cfg_path() -> Result<PathBuf> {
     Ok(hub_cfg_path)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Deserialize)]
-struct ReplyHubref {
-    hub_remote: String,
+pub struct ReplyHubref {
+    pub hub_remote: String,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -363,7 +362,8 @@ fn get_hubref() -> Option<String> {
     if fcremote == DEFAULT_CLOUD_REMOTE {
         return None; // use default
     }
-    let hubref_url = format!("{fcremote}/api/v1/hubref");
+    let hubref_path = super::HUB_REF_ENDPOINT;
+    let hubref_url = format!("{fcremote}{hubref_path}");
     let reply: anyhow::Result<String> = run_block_on(async {
         let resp = htclient::get(&hubref_url)
             .await

--- a/crates/fluvio-hub-util/src/lib.rs
+++ b/crates/fluvio-hub-util/src/lib.rs
@@ -31,3 +31,7 @@ pub const HUB_API_ACT: &str = concatcp!(HUB_API_V, "/action");
 pub const HUB_API_HUBID: &str = concatcp!(HUB_API_V, "/hubid");
 pub const HUB_API_LIST: &str = concatcp!(HUB_API_V, "/list");
 pub const HUB_API_BPKG_AUTH: &str = concatcp!(HUB_API_V, "/bpkg-auth");
+
+// CLOUD API endpoint to return hub base url
+pub const HUB_REF_ENDPOINT: &str = "/api/v1/hubref";
+

--- a/crates/fluvio-hub-util/src/lib.rs
+++ b/crates/fluvio-hub-util/src/lib.rs
@@ -34,4 +34,3 @@ pub const HUB_API_BPKG_AUTH: &str = concatcp!(HUB_API_V, "/bpkg-auth");
 
 // CLOUD API endpoint to return hub base url
 pub const HUB_REF_ENDPOINT: &str = "/api/v1/hubref";
-


### PR DESCRIPTION
Export the endpoint responsible for getting the hub url, and the struct used to deserialize the response.

This is so the UIs can use it, notably here: https://github.com/infinyon/infinyon-cloud-ui/pull/1348