### PR TITLE
feat: add proxy on  fvm install

### DIFF
--- a/crates/fluvio-hub-util/src/htclient.rs
+++ b/crates/fluvio-hub-util/src/htclient.rs
@@ -114,16 +114,7 @@ use anyhow::Context;
 
 fn configure_ureq_proxy() -> Result<Agent> {
     let mut agent_builder = AgentBuilder::new();
-    if let Ok(proxy_str) = env::var("HTTP_PROXY").or_else(|_| env::var("http_proxy")) {
-        let proxy = Proxy::new(proxy_str).context("Failed to create HTTP proxy")?;
-        agent_builder = agent_builder.proxy(proxy);
-    }
-    if let Ok(proxy_str) = env::var("HTTPS_PROXY").or_else(|_| env::var("https_proxy")) {
-        let proxy = Proxy::new(proxy_str).context("Failed to create HTTPS proxy")?;
-        agent_builder = agent_builder.proxy(proxy);
-    }
-    if let Ok(proxy_str) = env::var("ALL_PROXY").or_else(|_| env::var("all_proxy")) {
-        let proxy = ureq::Proxy::new(proxy_str).context("Failed to create ALL Proxy")?;
+    if let Some(proxy) = Proxy::try_from_env() {
         agent_builder = agent_builder.proxy(proxy);
     }
 

--- a/crates/fluvio-version-manager/tests/install-fvm.sh
+++ b/crates/fluvio-version-manager/tests/install-fvm.sh
@@ -113,11 +113,24 @@ downloader() {
     local _status
     local _url="$1"; shift
     local _file="$1"; shift
+    local _curl_options
+    _curl_options=(--proto '=https' --tlsv1.2 --silent --show-error --fail --location)
+
+    # Check for proxy settings
+    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
+      # Prefer lowercase, then uppercase, as per curl's documentation
+      local proxy_url="${http_proxy:-${https_proxy:-${HTTP_PROXY:-$HTTPS_PROXY}}}"
+
+      if [ -n "$proxy_url" ]; then
+          _curl_options+=(--proxy "$proxy_url")
+          echo "Using proxy: $proxy_url"
+      fi
+    fi
 
     # allow trap of error
     set +e
     # Use curl for downloads
-    _err=$(curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "${_url}" --output "${_file}" 2>&1)
+    _err=$(curl "${_curl_options[@]}" "${_url}" --output "${_file}" 2>&1)
     _status=$?
     set -e
 

--- a/crates/fluvio-version-manager/tests/install-fvm.sh
+++ b/crates/fluvio-version-manager/tests/install-fvm.sh
@@ -118,8 +118,7 @@ downloader() {
 
     # Check for proxy settings
     if [ -n "$http_proxy" ] || [ -n "$https_proxy" ] || [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
-      # Prefer lowercase, then uppercase, as per curl's documentation
-      local proxy_url="${http_proxy:-${https_proxy:-${HTTP_PROXY:-$HTTPS_PROXY}}}"
+      local proxy_url="${https_proxy:-${HTTPS_PROXY:-${http_proxy:-$HTTP_PROXY}}}"
 
       if [ -n "$proxy_url" ]; then
           _curl_options+=(--proxy "$proxy_url")


### PR DESCRIPTION
I did a pr based on #4437, but I'm not sure if I need to add proxy handling for `#[cfg(target_arch = "wasm32")]`as well, I don't know much about `wasm32`, feel free to discuss `wasm32` handling with me, as well as the addition of `tests`🤗