### PR TITLE
fix: hard delete consumer after topic delete

### DIFF
--- a/crates/fluvio-spu/src/replication/leader/leaders_state.rs
+++ b/crates/fluvio-spu/src/replication/leader/leaders_state.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 use async_lock::RwLock;
 use fluvio_controlplane::replica::Replica;
+use fluvio_types::defaults::CONSUMER_REPLICA_KEY;
 use std::collections::HashMap;
 
 use tracing::{error, instrument};
@@ -61,6 +62,10 @@ impl<S> ReplicaLeadersState<S> {
     ) -> Option<SharedLeaderState<S>> {
         let mut writer = self.write().await;
         writer.insert(replica, state)
+    }
+
+    pub async fn is_consumer_offset_leader(&self) -> Option<LeaderReplicaState<S>> {
+        self.get(&CONSUMER_REPLICA_KEY.into()).await
     }
 }
 

--- a/crates/fluvio-spu/src/services/internal/fetch_consumer_offset_handler.rs
+++ b/crates/fluvio-spu/src/services/internal/fetch_consumer_offset_handler.rs
@@ -7,7 +7,7 @@ use fluvio_protocol::{
     link::ErrorCode,
 };
 use fluvio_storage::FileReplica;
-use fluvio_types::{PartitionId, defaults::CONSUMER_STORAGE_TOPIC};
+use fluvio_types::defaults::CONSUMER_REPLICA_KEY;
 use tracing::{instrument, debug};
 
 use crate::{
@@ -28,11 +28,8 @@ pub(crate) async fn handle_fetch_consumer_offset_request(
         replica_id,
     } = req_msg.request;
 
-    let consumers_replica_id =
-        ReplicaKey::new(CONSUMER_STORAGE_TOPIC, <PartitionId as Default>::default());
-
     let (consumer, error_code) =
-        if let Some(ref replica) = ctx.leaders_state().get(&consumers_replica_id).await {
+        if let Some(ref replica) = ctx.leaders_state().get(&CONSUMER_REPLICA_KEY.into()).await {
             match get_offset(ctx, replica, replica_id, consumer_id).await {
                 Ok(offset) => (offset, ErrorCode::None),
                 Err(e) => (None, ErrorCode::Other(e.to_string())),

--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -57,6 +57,7 @@ pub const STORAGE_MAX_REQUEST_SIZE: u32 = 33_554_432;
 pub const SPU_SMARTENGINE_STORE_MAX_BYTES: usize = 1_073_741_824; //1Gb
 
 pub const CONSUMER_STORAGE_TOPIC: &str = "consumer-offset";
+pub const CONSUMER_REPLICA_KEY: (&str, u32) = (CONSUMER_STORAGE_TOPIC, 0);
 
 // Reconnect Backoff
 pub const RECONNECT_BACKOFF_FACTOR: f64 = 1.1;


### PR DESCRIPTION
At https://github.com/infinyon/fluvio/pull/4448 we prefer just filter consumers with non deleted topic on list/fetch. 
But we still some problems, like https://github.com/infinyon/fluvio/issues/4455

This PR is hard deleting the consumer from the topic when topic is deleted.