### PR TITLE
fix: replication stuck when syncing large batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "mimalloc",
  "once_cell",
  "portpicker",
+ "rand",
  "serde",
  "serde_json",
  "sysinfo",

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"

--- a/crates/fluvio-protocol/src/fixture.rs
+++ b/crates/fluvio-protocol/src/fixture.rs
@@ -59,19 +59,27 @@ impl BatchProducer {
 }
 
 pub fn create_batch() -> Batch {
-    create_batch_with_producer(12, 2)
+    create_batch_with_producer(12, 2, TEST_RECORD)
 }
 
 pub fn create_recordset(num_records: u16) -> RecordSet {
     let records = RecordSet::default();
-    records.add(create_batch_with_producer(12, num_records))
+    records.add(create_batch_with_producer(12, num_records, TEST_RECORD))
 }
 
 #[cfg(feature = "compress")]
 pub fn create_raw_recordset(num_records: u16) -> RecordSet<crate::record::RawRecords> {
+    create_raw_recordset_inner(num_records, TEST_RECORD)
+}
+
+#[cfg(feature = "compress")]
+pub fn create_raw_recordset_inner(
+    num_records: u16,
+    record_bytes: &[u8],
+) -> RecordSet<crate::record::RawRecords> {
     let records = RecordSet::default();
     records.add(
-        create_batch_with_producer(12, num_records)
+        create_batch_with_producer(12, num_records, record_bytes)
             .try_into()
             .expect("converted from memory records to raw"),
     )
@@ -80,7 +88,7 @@ pub fn create_raw_recordset(num_records: u16) -> RecordSet<crate::record::RawRec
 pub const TEST_RECORD: &[u8] = &[10, 20];
 
 /// create batches with produce and records count
-pub fn create_batch_with_producer(producer: i64, records: u16) -> Batch {
+pub fn create_batch_with_producer(producer: i64, records: u16, record_bytes: &[u8]) -> Batch {
     let mut batches = Batch::default();
     let header = batches.get_mut_header();
     header.magic = 2;
@@ -89,7 +97,7 @@ pub fn create_batch_with_producer(producer: i64, records: u16) -> Batch {
 
     for _ in 0..records {
         let mut record = Record::default();
-        let bytes: Vec<u8> = TEST_RECORD.to_owned();
+        let bytes: Vec<u8> = record_bytes.to_owned();
         record.value = bytes.into();
         batches.add_record(record);
     }

--- a/crates/fluvio-protocol/src/record/batch.rs
+++ b/crates/fluvio-protocol/src/record/batch.rs
@@ -370,10 +370,14 @@ where
         } else {
             self.batch_len as usize - BATCH_HEADER_SIZE
         };
-        trace!("decoding batch records with len {}", rec_len);
+        trace!(rec_len, "decoding batch records with len");
         // not checking remaining bytes, because we do it in the record set
         let mut buf = src.take(rec_len);
-        self.records.decode(&mut buf, version)?;
+
+        if buf.remaining() > 0 {
+            self.records.decode(&mut buf, version)?;
+        }
+
         trace!("decoding batch records done");
         Ok(())
     }

--- a/crates/fluvio-protocol/src/record/batch.rs
+++ b/crates/fluvio-protocol/src/record/batch.rs
@@ -360,6 +360,7 @@ where
     {
         trace!("decoding batch");
         self.decode_from_file_buf(src, version)?;
+        trace!("decoding batch header");
         let rec_len = if self.header.has_schema() {
             let mut sid = SCHEMA_ID_NULL;
             sid.decode(src, version)?;
@@ -369,19 +370,11 @@ where
         } else {
             self.batch_len as usize - BATCH_HEADER_SIZE
         };
+        trace!("decoding batch records with len {}", rec_len);
+        // not checking remaining bytes, because we do it in the record set
         let mut buf = src.take(rec_len);
-        if buf.remaining() < rec_len {
-            return Err(Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                format!(
-                    "not enough buf records, expected: {}, found: {}",
-                    rec_len,
-                    buf.remaining()
-                ),
-            ));
-        }
-
         self.records.decode(&mut buf, version)?;
+        trace!("decoding batch records done");
         Ok(())
     }
 }

--- a/crates/fluvio-protocol/src/record/data.rs
+++ b/crates/fluvio-protocol/src/record/data.rs
@@ -10,6 +10,7 @@ use std::str::Utf8Error;
 use bytes::Bytes;
 use bytes::BytesMut;
 use content_inspector::{inspect, ContentType};
+use tracing::debug;
 use tracing::{trace, warn};
 use once_cell::sync::Lazy;
 
@@ -317,7 +318,7 @@ impl<R: BatchRecords> Decoder for RecordSet<R> {
                 Ok(_) => self.batches.push(batch),
                 Err(err) => match err.kind() {
                     ErrorKind::UnexpectedEof => {
-                        warn!(
+                        debug!(
                             len,
                             remaining = buf.remaining(),
                             version,

--- a/crates/fluvio-spu/Cargo.toml
+++ b/crates/fluvio-spu/Cargo.toml
@@ -71,6 +71,7 @@ derive_builder =  { workspace = true }
 serde_json = { workspace = true }
 flate2 = { workspace = true }
 portpicker = { workspace = true }
+rand = { workspace = true }
 
 flv-util = { workspace = true, features = ["fixture"] }
 fluvio-future = { workspace = true,features = ["fixture", "subscriber"] }

--- a/crates/fluvio-spu/src/config/cli.rs
+++ b/crates/fluvio-spu/src/config/cli.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use fluvio_types::print_cli_err;
 use fluvio_types::SpuId;
 use fluvio_future::openssl::TlsAcceptor;
+use fluvio_types::defaults::SPU_PEER_MAX_BYTES;
 
 use super::SpuConfig;
 
@@ -55,7 +56,7 @@ pub struct SpuOpt {
         long,
         value_name = "integer",
         env = "FLV_PEER_MAX_BYTES",
-        default_value = "1000000"
+        default_value_t = SPU_PEER_MAX_BYTES
     )]
     pub peer_max_bytes: u32,
 

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -227,8 +227,9 @@ impl TestConfigBuilder {
 ///    
 #[fluvio_future::test(ignore)]
 async fn test_just_leader() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
-        .base_port(13000_u16)
+        .base_port(port)
         .generate("just_leader");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -269,9 +270,10 @@ async fn test_just_leader() {
 /// Replicating with existing records
 #[fluvio_future::test(ignore)]
 async fn test_replication2_existing() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13010_u16)
+        .base_port(port)
         .generate("replication2_existing");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -336,9 +338,10 @@ async fn test_replication2_existing() {
 ///    
 #[fluvio_future::test(ignore)]
 async fn test_replication2_new_records() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13020_u16)
+        .base_port(port)
         .generate("replication2_new");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -409,9 +412,10 @@ async fn test_replication2_new_records() {
 /// test with 3 SPU
 #[fluvio_future::test(ignore)]
 async fn test_replication3_existing() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(2_u16)
-        .base_port(13030_u16)
+        .base_port(port)
         .generate("replication3_existing");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -470,9 +474,10 @@ async fn test_replication3_existing() {
 ///    
 #[fluvio_future::test(ignore)]
 async fn test_replication3_new_records() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(2_u16)
-        .base_port(13040_u16)
+        .base_port(port)
         .generate("replication3_new");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -543,9 +548,10 @@ async fn test_replication3_new_records() {
 ///    
 #[fluvio_future::test(ignore)]
 async fn test_replication2_promote() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13050_u16)
+        .base_port(port)
         .generate("replication2_promote");
 
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -603,9 +609,10 @@ async fn test_replication2_promote() {
 /// receiving request from SC
 #[fluvio_future::test(ignore)]
 async fn test_replication_dispatch_in_sequence() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13060_u16)
+        .base_port(port)
         .generate("replication_dispatch_in_sequence");
 
     let leader_gctx = builder.leader_ctx().await;
@@ -679,9 +686,10 @@ async fn test_replication_dispatch_in_sequence() {
 #[fluvio_future::test(ignore)]
 async fn test_replication_dispatch_out_of_sequence() {
     //std::env::set_var("FLV_SHORT_RECONCILLATION", "1");
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13070_u16)
+        .base_port(port)
         .generate("replication_dispatch_out_of_sequence");
 
     let replica = builder.replica();
@@ -753,8 +761,9 @@ async fn test_replication_dispatch_out_of_sequence() {
 
 #[fluvio_future::test()]
 async fn test_replica_state_cleans_up_offset_producers() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
-        .base_port(13000_u16)
+        .base_port(port)
         .generate("just_leader");
 
     let (_leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -789,9 +798,10 @@ async fn test_replica_state_cleans_up_offset_producers() {
 /// Test 2 replicas but one replica is rejected, and than both is sync
 #[fluvio_future::test(ignore)]
 async fn test_sync_2_replicas_but_one_reject() {
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(2_u16)
-        .base_port(13060_u16)
+        .base_port(port)
         .generate("replication_dispatch_in_sequence");
     let replica_test1 = builder.replica();
     let (leader_gctx, leader_replica) = builder.leader_replica().await;
@@ -868,9 +878,10 @@ async fn test_sync_2_replicas_but_one_reject() {
 #[fluvio_future::test(ignore)]
 async fn test_sync_larger_records() {
     let num_records = 5;
+    let port = portpicker::pick_unused_port().expect("No free ports left");
     let builder = TestConfig::builder()
         .followers(1_u16)
-        .base_port(13070_u16)
+        .base_port(port)
         .generate("sync_larger_records");
 
     let leader_gctx = builder.leader_ctx().await;

--- a/crates/fluvio-spu/src/replication/test.rs
+++ b/crates/fluvio-spu/src/replication/test.rs
@@ -56,8 +56,6 @@ pub(crate) struct TestConfig {
     base_dir: PathBuf,
     #[builder(setter(into), default = "9000")]
     base_port: u16,
-    #[builder(setter(into), default = "2_097_152")]
-    batch_size: u32,
 }
 
 impl TestConfig {
@@ -78,7 +76,6 @@ impl TestConfig {
         assert!(follower_index < self.followers);
         let mut config = SpuConfig::default();
         config.log.base_dir.clone_from(&self.base_dir);
-        config.log.max_batch_size = self.batch_size;
         config.replication.min_in_sync_replicas = self.in_sync_replica;
         config.id = self.follower_id(follower_index);
         config

--- a/crates/fluvio-storage/src/batch.rs
+++ b/crates/fluvio-storage/src/batch.rs
@@ -270,6 +270,7 @@ mod tests {
     use std::env::temp_dir;
     use std::path::PathBuf;
 
+    use fluvio_protocol::fixture::TEST_RECORD;
     use flv_util::fixture::ensure_new_dir;
     use fluvio_protocol::fixture::create_batch;
     use fluvio_protocol::fixture::create_batch_with_producer;
@@ -327,7 +328,7 @@ mod tests {
             .await
             .expect("write");
         active_segment
-            .append_batch(&mut create_batch_with_producer(25, 2))
+            .append_batch(&mut create_batch_with_producer(25, 2, TEST_RECORD))
             .await
             .expect("batch");
 

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -197,7 +197,7 @@ impl ReplicaStorage for FileReplica {
 }
 
 impl FileReplica {
-    pub const PREFER_MAX_LEN: u32 = 1000000; // 1MB as limit
+    pub const PREFER_MAX_LEN: u32 = 33_554_432;
 
     /// Construct a new replica with specified topic and partition.
     /// It can start with arbitrary offset.  However, for normal replica,

--- a/crates/fluvio-storage/src/replica.rs
+++ b/crates/fluvio-storage/src/replica.rs
@@ -515,6 +515,7 @@ mod tests {
 
     use fluvio_future::fs::remove_dir_all;
     use fluvio_future::timer::sleep;
+    use fluvio_protocol::fixture::TEST_RECORD;
     use futures_lite::AsyncWriteExt;
     use tracing::debug;
     use tracing::info;
@@ -1124,7 +1125,7 @@ mod tests {
         .await
         .expect("replica created");
 
-        let mut batch = create_batch_with_producer(12, 5);
+        let mut batch = create_batch_with_producer(12, 5, TEST_RECORD);
         for i in 1..=20 {
             //at least 20*5*8 bytes to store these records
             replica.write_batch(&mut batch).await.expect("batch sent");

--- a/crates/fluvio-storage/src/segment.rs
+++ b/crates/fluvio-storage/src/segment.rs
@@ -473,7 +473,7 @@ mod tests {
     use fluvio_protocol::record::{Batch, MemoryRecords};
     use fluvio_protocol::record::Size;
     use fluvio_protocol::Decoder;
-    use fluvio_protocol::fixture::create_batch_with_producer;
+    use fluvio_protocol::fixture::{create_batch_with_producer, TEST_RECORD};
     use fluvio_protocol::fixture::create_batch;
     use fluvio_protocol::fixture::read_bytes_from_file;
 
@@ -513,7 +513,7 @@ mod tests {
 
         // batch of 1
         active_segment
-            .append_batch(&mut create_batch_with_producer(100, 1))
+            .append_batch(&mut create_batch_with_producer(100, 1, TEST_RECORD))
             .await
             .expect("write");
         assert_eq!(active_segment.get_end_offset(), 21);
@@ -560,7 +560,7 @@ mod tests {
             .expect("segment");
 
         active_segment
-            .append_batch(&mut create_batch_with_producer(100, 4))
+            .append_batch(&mut create_batch_with_producer(100, 4, TEST_RECORD))
             .await
             .expect("batch");
 

--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -55,6 +55,7 @@ pub const STORAGE_MAX_BATCH_SIZE: u32 = 2_097_152;
 pub const STORAGE_MAX_REQUEST_SIZE: u32 = 33_554_432;
 
 pub const SPU_SMARTENGINE_STORE_MAX_BYTES: usize = 1_073_741_824; //1Gb
+pub const SPU_PEER_MAX_BYTES: u32 = 33_554_432;
 
 pub const CONSUMER_STORAGE_TOPIC: &str = "consumer-offset";
 pub const CONSUMER_REPLICA_KEY: (&str, u32) = (CONSUMER_STORAGE_TOPIC, 0);


### PR DESCRIPTION
Should fix replica sync problem: https://github.com/infinyon/fluvio/issues/4472


I also notice more perfomance with replicas now:

before:
```
 fluvio benchmark producer -p 3 -r 3 -k --num-records 50000                                                                                                                                                                                                                                                              $ fix_replication_large_2 
Benchmark started

latencies: 19.7µs min, 7.4ms avg, 33.1ms max, 7.2ms p0.50, 15.1ms p0.95, 17.3ms p0.99
50000 total records sent, 71942 records/sec: (369.1 MB/sec), total time: 695.9ms

**Per Record E2E Latency**

|Variable| p0.00 |p0.50|p0.95 |p0.99 |p1.00 |
|--------|-------|-----|------|------|------|
|Latency |19.7µs |7.2ms|15.1ms|17.3ms|33.1ms|

**Throughput (Total Produced Bytes / Time)**

|     Variable      |   Speed    |
|-------------------|------------|
|Produced Throughput|369.1 MB/sec|

Benchmark completed
```


now: 

```
▷ flvdr benchmark producer -p 3 -r 3 -k --num-records 50000                                                                                                                                                                                                                                                               $ fix_replication_large_2 
Benchmark started

latencies: 69.2µs min, 5.9ms avg, 23.2ms max, 5.6ms p0.50, 12.6ms p0.95, 14.6ms p0.99
50000 total records sent, 99800 records/sec: (512.0 MB/sec), total time: 501.5ms

**Per Record E2E Latency**

|Variable| p0.00 |p0.50|p0.95 |p0.99 |p1.00 |
|--------|-------|-----|------|------|------|
|Latency |69.2µs |5.6ms|12.6ms|14.6ms|23.2ms|

**Throughput (Total Produced Bytes / Time)**

|     Variable      |   Speed    |
|-------------------|------------|
|Produced Throughput|512.0 MB/sec|

Benchmark completed
```
