### PR TITLE
chore: set SPU_PEER_MAX_BYTES to 10mb

### DIFF
--- a/crates/fluvio-types/src/defaults.rs
+++ b/crates/fluvio-types/src/defaults.rs
@@ -55,7 +55,7 @@ pub const STORAGE_MAX_BATCH_SIZE: u32 = 2_097_152;
 pub const STORAGE_MAX_REQUEST_SIZE: u32 = 33_554_432;
 
 pub const SPU_SMARTENGINE_STORE_MAX_BYTES: usize = 1_073_741_824; //1Gb
-pub const SPU_PEER_MAX_BYTES: u32 = 1_073_741_824; //1Gb
+pub const SPU_PEER_MAX_BYTES: u32 = 10_485_760; //10mb
 
 pub const CONSUMER_STORAGE_TOPIC: &str = "consumer-offset";
 pub const CONSUMER_REPLICA_KEY: (&str, u32) = (CONSUMER_STORAGE_TOPIC, 0);


### PR DESCRIPTION
1gb was using too much memory, and performance was worse.