### PR TITLE
fix: derive clone on SpuSocketPool

### DIFF
--- a/crates/fluvio/src/spu.rs
+++ b/crates/fluvio/src/spu.rs
@@ -44,6 +44,7 @@ pub trait SpuDirectory {
 }
 
 /// connection pool to spu
+#[derive(Clone)]
 pub struct SpuSocketPool {
     config: Arc<ClientConfig>,
     pub(crate) metadata: MetadataStores,


### PR DESCRIPTION
`TopicProducerPool` cannot be cloned due to this limitation.