### PR TITLE
chore: move boxed stream into main consumer api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "adaptive_backoff",
  "anyhow",

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -61,7 +61,7 @@ pub type BoxConsumerStream =
 pub type BoxConsumerStream =
     Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send + 'static>>;
 
-/// Type alias for the future returned by our retry logic.
+/// Type alias to access consume stream as a future.
 #[cfg(target_arch = "wasm32")]
 type BoxConsumerFuture = Pin<
     Box<

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -5,6 +5,8 @@ mod stream;
 mod offset;
 mod retry;
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -40,6 +42,7 @@ pub use stream::{
 };
 pub use offset::ConsumerOffset;
 pub use retry::ConsumerRetryStream;
+pub use fluvio_protocol::record::ConsumerRecord;
 
 pub use fluvio_protocol::record::ConsumerRecord as Record;
 pub use fluvio_spu_schema::server::smartmodule::SmartModuleInvocation;
@@ -49,6 +52,39 @@ pub use fluvio_spu_schema::server::smartmodule::SmartModuleContextData;
 pub use fluvio_smartmodule::dataplane::smartmodule::SmartModuleExtraParams;
 
 const STREAM_TO_SERVER_CHANNEL_SIZE: usize = 100;
+
+/// Type alias for the consumer record stream.
+#[cfg(target_arch = "wasm32")]
+pub type BoxConsumerStream =
+    Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + 'static>>;
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxConsumerStream =
+    Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send + 'static>>;
+
+/// Type alias for the future returned by our retry logic.
+#[cfg(target_arch = "wasm32")]
+type BoxConsumerFuture = Pin<
+    Box<
+        dyn Future<
+                Output = (
+                    BoxConsumerStream,
+                    Option<Result<(ConsumerRecord, Option<i64>), ErrorCode>>,
+                ),
+            > + 'static,
+    >,
+>;
+#[cfg(not(target_arch = "wasm32"))]
+type BoxConsumerFuture = Pin<
+    Box<
+        dyn Future<
+                Output = (
+                    BoxConsumerStream,
+                    Option<Result<(ConsumerRecord, Option<i64>), ErrorCode>>,
+                ),
+            > + Send
+            + 'static,
+    >,
+>;
 
 /// An interface for consuming events from a particular partition
 ///

--- a/crates/fluvio/src/consumer/retry.rs
+++ b/crates/fluvio/src/consumer/retry.rs
@@ -173,8 +173,8 @@ impl ConsumerRetryStream {
         config: ConsumerConfigExt,
     ) -> Result<Self> {
         let client_config = fluvio.client_config();
-        let boxed_stream: BoxConsumerStream =
-            Box::pin(fluvio.consumer_with_config_inner(config.clone()).await?);
+        let stream = fluvio.consumer_with_config_inner(config.clone()).await?;
+        let boxed_stream: BoxConsumerStream = Box::pin(stream);
 
         Ok(Self {
             inner: ConsumerRetryInner {

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -18,7 +18,7 @@ use fluvio_socket::{
 
 use crate::admin::FluvioAdmin;
 use crate::consumer::{
-    ConsumerConfigExt, ConsumerOffset, ConsumerStream, ConsumerRetryStream,
+    BoxConsumerStream, ConsumerConfigExt, ConsumerOffset, ConsumerRetryStream, ConsumerStream,
     MultiplePartitionConsumer, MultiplePartitionConsumerStream, PartitionSelectionStrategy, Record,
 };
 use crate::error::anyhow_version_error;
@@ -355,6 +355,16 @@ impl Fluvio {
         impl ConsumerStream<Item = std::result::Result<Record, fluvio_protocol::link::ErrorCode>>,
     > {
         ConsumerRetryStream::new(self, self.cluster_config.clone(), config).await
+    }
+
+    /// Creates boxed consumer stream.  
+    /// This is useful when consumer stream needs to be stored in the struct
+    pub async fn boxed_consumer_with_config(
+        &self,
+        config: ConsumerConfigExt,
+    ) -> Result<BoxConsumerStream> {
+        let boxed_stream: BoxConsumerStream = Box::pin(self.consumer_with_config(config).await?);
+        Ok(boxed_stream)
     }
 
     /// Creates a new [ConsumerStream] instance without retry logic.

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -357,8 +357,8 @@ impl Fluvio {
         ConsumerRetryStream::new(self, self.cluster_config.clone(), config).await
     }
 
-    /// Creates boxed consumer stream.  
-    /// This is useful when consumer stream needs to be stored in the struct
+    /// Create boxed consume stream with config.
+    /// This is usedful for storing stream in a struct
     pub async fn boxed_consumer_with_config(
         &self,
         config: ConsumerConfigExt,


### PR DESCRIPTION
BoxedConsumerStream is handy.  This moves into core part of consumer stream to make it easier to use it