### PR TITLE
chore: add key record parameter to smdk test

### DIFF
--- a/crates/fluvio-cli-common/src/smartmodule.rs
+++ b/crates/fluvio-cli-common/src/smartmodule.rs
@@ -41,6 +41,7 @@ pub struct BaseTestCmd {
     pub raw: bool,
 
     /// Key to use with the test record(s)
+    #[arg(long, requires = "TestInput")]
     pub key: Option<String>,
 
     /// Print records in "[key] value" format, with "[null]" for no key

--- a/smartmodule/examples/Cargo.lock
+++ b/smartmodule/examples/Cargo.lock
@@ -450,6 +450,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-wasm-filter-odd-key"
+version = "0.0.0"
+dependencies = [
+ "fluvio-smartmodule 0.8.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fluvio-wasm-filter-regex"
 version = "0.0.0"
 dependencies = [

--- a/smartmodule/examples/Cargo.toml
+++ b/smartmodule/examples/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "filter_look_back_with_timestamps",
     "filter_with_param",
     "filter_odd",
+    "filter_odd_key",
     "filter_json",
     "filter_regex",
     "filter_with_param_v1",

--- a/smartmodule/examples/filter_odd_key/Cargo.toml
+++ b/smartmodule/examples/filter_odd_key/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fluvio-wasm-filter-odd-key"
+version = "0.0.0"
+authors = ["Fluvio Contributors <team@fluvio.io>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+thiserror = "1"
+fluvio-smartmodule = { workspace = true }

--- a/smartmodule/examples/filter_odd_key/src/lib.rs
+++ b/smartmodule/examples/filter_odd_key/src/lib.rs
@@ -1,0 +1,29 @@
+//! This example demonstrates how to use key-value pairs
+
+use fluvio_smartmodule::{smartmodule, SmartModuleRecord, Result};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SecondErrorWrapper {
+    #[error("Oops something went wrong")]
+    FirstError(#[from] FirstErrorWrapper),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FirstErrorWrapper {
+    #[error("Failed to parse int")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[smartmodule(filter)]
+pub fn filter(record: &SmartModuleRecord) -> Result<bool> {
+    let message_key = match &record.key {
+        Some(key_data) => std::str::from_utf8(key_data.as_ref())?,
+        None => "", // or some default behavior
+    };
+
+    let int = message_key
+        .parse::<i32>()
+        .map_err(FirstErrorWrapper::from)
+        .map_err(SecondErrorWrapper::from)?;
+    Ok(int % 2 == 0)
+}

--- a/tests/cli/smdk_smoke_tests/smdk-basic.bats
+++ b/tests/cli/smdk_smoke_tests/smdk-basic.bats
@@ -988,7 +988,7 @@ smdk_via_stdin() {
     assert_output --partial "[null]"
     assert_success
 
-    run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333' --key-value my-key
+    run $SMDK_BIN test --text '444' --lookback-last '1' --record '222' --record '333' --key-value --key my-key
     assert_output --partial "[my-key]"
     assert_success
 }
@@ -1069,4 +1069,23 @@ smdk_via_stdin() {
     assert_output --partial "\"Banana\"_$DATE_NOW_YEAR-$DATE_NOW_MONTH-$DATE_NOW_DAY"
     assert_output --partial "\"Cranberry\"_$DATE_NOW_YEAR-$DATE_NOW_MONTH-$DATE_NOW_DAY"
     assert_success
+}
+
+@test "Test key value on filter-odd-key" {
+    # Test with smartmodule example with Array Map with Timestamp
+    cd "$(pwd)/smartmodule/examples/filter_odd_key/"
+
+    # Build
+    run $SMDK_BIN build
+    refute_output --partial "could not compile"
+
+    # Test, only odd keys should be returned
+    run $SMDK_BIN test --verbose --text "abc" --key "1" --key-value
+    refute_output --partial "abc"
+    run $SMDK_BIN test --verbose --text "abc" --key "2" --key-value
+    assert_output --partial "abc"
+    run $SMDK_BIN test --verbose --text "abc" --key "3" --key-value
+    refute_output --partial "abc"
+    run $SMDK_BIN test --verbose --text "abc" --key "4" --key-value
+    assert_output --partial "abc"
 }


### PR DESCRIPTION
Should solve https://github.com/infinyon/fluvio/issues/4497

Currently, the key is the first and unique argument, which is odd. I changed to a named parameter.

Currently:

```
smdk test --text="Open" 123
```

With this PR:

```
smdk test --text="Open" --key 123
```