### PR TITLE
fix: auto management odd pauses in consumer offset

### DIFF
--- a/crates/fluvio-test/src/tests/consumer_offsets/auto/flush.rs
+++ b/crates/fluvio-test/src/tests/consumer_offsets/auto/flush.rs
@@ -43,11 +43,13 @@ pub async fn test_strategy_auto_periodic_flush(
     for _ in 0..10 {
         ensure_read(&mut stream, &mut counts).await?;
     }
-    sleep(Duration::from_secs(2)).await; // yeild  to drive auto flush flow
+    sleep(Duration::from_secs(3)).await; // yeild  to drive auto flush flow
 
-    let consumer = find_consumer(client, &consumer_id, 0).await?;
-    ensure!(consumer.is_some());
-    ensure!(consumer.unwrap().offset > 0i64);
+    for (partition, offset) in counts.iter().enumerate().take(partitions) {
+        let consumer = find_consumer(client, &consumer_id, partition).await?;
+        ensure!(consumer.is_some());
+        ensure!(consumer.unwrap().offset == *offset);
+    }
 
     drop(stream); //we keep the stream alive to prevent flush on drop occuring
 

--- a/crates/fluvio/src/consumer/config.rs
+++ b/crates/fluvio/src/consumer/config.rs
@@ -11,6 +11,7 @@ use crate::{FluvioError, Offset};
 use super::MAX_FETCH_BYTES;
 
 const DEFAULT_OFFSET_FLUSH_PERIOD: Duration = Duration::from_secs(10);
+const DEFAULT_OFFSET_FLUSHER_CHECK_PERIOD: Duration = Duration::from_millis(100);
 const DEFAULT_RETRY_MODE: RetryMode = RetryMode::TryUntil(100);
 
 /// Configures the behavior of consumer fetching and streaming
@@ -93,6 +94,8 @@ pub struct ConsumerConfigExt {
     pub offset_strategy: OffsetManagementStrategy,
     #[builder(default = "DEFAULT_OFFSET_FLUSH_PERIOD")]
     pub offset_flush: Duration,
+    #[builder(default = "DEFAULT_OFFSET_FLUSHER_CHECK_PERIOD")]
+    pub offset_flusher_check_period: Duration,
     #[builder(default)]
     pub disable_continuous: bool,
     #[builder(default = "*MAX_FETCH_BYTES")]
@@ -118,6 +121,7 @@ impl ConsumerConfigExt {
         Option<String>,
         OffsetManagementStrategy,
         Duration,
+        Duration,
     ) {
         let Self {
             topic: _,
@@ -131,6 +135,7 @@ impl ConsumerConfigExt {
             smartmodule,
             offset_strategy,
             offset_flush,
+            offset_flusher_check_period,
             retry_mode: _,
         } = self;
 
@@ -147,6 +152,7 @@ impl ConsumerConfigExt {
             offset_consumer,
             offset_strategy,
             offset_flush,
+            offset_flusher_check_period,
         )
     }
 }
@@ -185,6 +191,7 @@ impl From<ConsumerConfigExt> for ConsumerConfig {
             offset_start: _,
             offset_strategy: _,
             offset_flush: _,
+            offset_flusher_check_period: _,
             disable_continuous,
             max_bytes,
             isolation,

--- a/crates/fluvio/src/consumer/mod.rs
+++ b/crates/fluvio/src/consumer/mod.rs
@@ -605,7 +605,8 @@ where
         &self,
         config: ConsumerConfigExt,
     ) -> Result<SinglePartitionConsumerStream<impl Stream<Item = Result<Record, ErrorCode>>>> {
-        let (offset, config, consumer_id, strategy, flush_period) = config.into_parts();
+        let (offset, config, consumer_id, strategy, flush_period, flusher_check_period) =
+            config.into_parts();
         let (stream, start_offset, stream_to_server) = self
             .inner_stream_batches_with_config(offset, config, consumer_id)
             .await?;
@@ -630,6 +631,7 @@ where
             flattened,
             strategy,
             flush_period,
+            flusher_check_period,
             stream_to_server,
         ))
     }

--- a/crates/fluvio/src/consumer/stream.rs
+++ b/crates/fluvio/src/consumer/stream.rs
@@ -58,6 +58,7 @@ enum OffsetManagement {
     Auto {
         auto_flusher: AutomaticFlusher,
         flush_period: Duration,
+        flusher_check_period: Duration,
         offset_store: OffsetLocalStore,
         last_flush_time: AtomicU64,
     },
@@ -99,6 +100,7 @@ impl<T> SinglePartitionConsumerStream<T> {
         inner: T,
         offset_strategy: OffsetManagementStrategy,
         flush_period: Duration,
+        flusher_check_period: Duration,
         stream_to_server: Sender<StreamToServer>,
     ) -> Self {
         let offset_mngt = match offset_strategy {
@@ -110,6 +112,7 @@ impl<T> SinglePartitionConsumerStream<T> {
                 auto_flusher: AutomaticFlusher::new(),
                 offset_store: OffsetLocalStore::new(stream_to_server),
                 flush_period,
+                flusher_check_period,
                 last_flush_time: AtomicU64::new(0),
             },
         };
@@ -346,6 +349,7 @@ mod tests {
             records_stream(0, ["1", "2"]),
             Default::default(),
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -372,6 +376,7 @@ mod tests {
             records_stream(0, ["1"]),
             Default::default(),
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
         let (tx, _rx) = async_channel::unbounded();
@@ -379,6 +384,7 @@ mod tests {
             records_stream(1, ["2", "4", "6"]),
             Default::default(),
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
         let (tx, _rx) = async_channel::unbounded();
@@ -386,6 +392,7 @@ mod tests {
             records_stream(2, ["3", "5"]),
             Default::default(),
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
         let multi_stream = MultiplePartitionConsumerStream::new([
@@ -417,6 +424,7 @@ mod tests {
             records_stream(0, []),
             OffsetManagementStrategy::None,
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -435,6 +443,7 @@ mod tests {
             records_stream(0, []),
             OffsetManagementStrategy::None,
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -453,6 +462,7 @@ mod tests {
             records_stream(0, ["1", "2", "3", "4"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -492,6 +502,7 @@ mod tests {
             records_stream(0, ["1"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx1,
         );
         let (tx2, rx2) = async_channel::unbounded();
@@ -499,6 +510,7 @@ mod tests {
             records_stream(1, ["2", "4", "6"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx2,
         );
         let mut multi_stream =
@@ -561,6 +573,7 @@ mod tests {
             records_stream(0, ["1", "2", "3", "4"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1000),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -600,6 +613,7 @@ mod tests {
             records_stream(0, ["1"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1000),
+            Duration::from_millis(100),
             tx1,
         );
         let (tx2, rx2) = async_channel::unbounded();
@@ -607,6 +621,7 @@ mod tests {
             records_stream(1, ["2", "4", "6"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1000),
+            Duration::from_millis(100),
             tx2,
         );
         let mut multi_stream =
@@ -662,6 +677,7 @@ mod tests {
             records_stream(0, ["1", "2", "3", "4"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -701,6 +717,7 @@ mod tests {
             records_stream(0, ["1"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1),
+            Duration::from_millis(100),
             tx1,
         );
         let (tx2, rx2) = async_channel::unbounded();
@@ -708,6 +725,7 @@ mod tests {
             records_stream(1, ["2", "4", "6"]),
             OffsetManagementStrategy::Auto,
             Duration::from_secs(1),
+            Duration::from_millis(100),
             tx2,
         );
         let mut multi_stream =
@@ -763,6 +781,7 @@ mod tests {
             records_stream(0, ["1", "2", "3", "4"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx,
         );
 
@@ -802,6 +821,7 @@ mod tests {
             records_stream(0, ["1"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx1,
         );
         let (tx2, rx2) = async_channel::unbounded();
@@ -809,6 +829,7 @@ mod tests {
             records_stream(1, ["2", "4", "6"]),
             OffsetManagementStrategy::Manual,
             Default::default(),
+            Duration::from_millis(100),
             tx2,
         );
         let mut multi_stream =


### PR DESCRIPTION
Should solve https://github.com/infinyon/fluvio/issues/4505 and https://github.com/infinyon/fluvio/issues/4324


This PR:
- Adding background checker for offset management when `Auto` is the strategy, before were only checking if should flush or not when receive a new record.
- Improve drop of consumer stream
- Clean up `ConsumerRetryStream`