### PR TITLE
Remove outdated Kafka compatibility reference from README.

### DIFF
--- a/crates/fluvio-cli/README.md
+++ b/crates/fluvio-cli/README.md
@@ -6,10 +6,6 @@ A cluster consists of two components, which are run using the respective command
 * Streaming Controller (fluvio run sc)
 * Streaming Processing Unit (fluvio run spu)
 
-#### Kafka
-Fluvio CLI is also compatible with Kafka 2.x. Fluvio makes it easy for system administrators to provision Kafka and Fluvio environments through a common user friendly command line interface.
-
-
 #### Profiles
 Fluvio CLI uses Profile files to store most common parameters. This approach offers administrators the convenience to communicate with SC, SPU, or a Kafka environment.
 

--- a/crates/fluvio-cli/src/client/topic/describe.rs
+++ b/crates/fluvio-cli/src/client/topic/describe.rs
@@ -60,7 +60,7 @@ mod display {
     };
 
     #[allow(clippy::redundant_closure)]
-    // Connect to Kafka Controller and query server for topic
+    // Connect to Controller and query server for topic
     pub async fn describe_topics<O>(
         topics: Vec<Metadata<TopicSpec>>,
         output_type: OutputType,


### PR DESCRIPTION
Fixes #4506 