### PR TITLE
chore: use right offset request in comments

### DIFF
--- a/crates/fluvio-spu-schema/src/server/fetch_offset.rs
+++ b/crates/fluvio-spu-schema/src/server/fetch_offset.rs
@@ -26,7 +26,7 @@ pub struct FetchOffsetsRequest {
     pub topics: Vec<FetchOffsetTopic>,
 
     /// The consumer id (DEPRECATED)
-    #[deprecated(note = "to get consumer offest use `GetConsumerOffsetRequest` instead")]
+    #[deprecated(note = "to get consumer offest use `FetchConsumerOffsetsRequest` instead")]
     #[fluvio(min_version = 23, max_version = 23)]
     pub consumer_id: Option<String>,
 }

--- a/crates/fluvio-spu/src/services/public/offset_request.rs
+++ b/crates/fluvio-spu/src/services/public/offset_request.rs
@@ -51,7 +51,7 @@ pub async fn handle_offset_request(
                 partition_response.last_stable_offset = hw;
 
                 // This is only for compatibility with older clients
-                // now we're usign `GetConsumerOffsetRequest` to fetch consumer offset
+                // now we're usign `FetchConsumerOffsetsRequest` to fetch consumer offset
                 #[allow(deprecated)]
                 if let Some(ref consumer_id) = request.consumer_id {
                     debug!(consumer_id, "fetch consumer offset");


### PR DESCRIPTION
I forgot to rename these comments to `FetchConsumerOffsetsRequest` in https://github.com/infinyon/fluvio/pull/4500