### PR TITLE
fix: render extra volumes under the volumes property

### DIFF
--- a/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
@@ -66,6 +66,9 @@ spec:
             {{ if .Values.scPod.extraVolumeMounts }}
             {{- toYaml .Values.scPod.extraVolumeMounts | nindent 12 }}
             {{ end }}
+        {{ else if .Values.scPod.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.scPod.extraVolumeMounts | nindent 12 }}
         {{ end }}
         {{ if .Values.scPod.extraContainers }}
         {{- toYaml .Values.scPod.extraContainers | nindent 8 }}

--- a/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
+++ b/k8-util/helm/fluvio-app/templates/sc-deployment.yaml
@@ -70,9 +70,6 @@ spec:
         {{ if .Values.scPod.extraContainers }}
         {{- toYaml .Values.scPod.extraContainers | nindent 8 }}
         {{ end }}
-        {{ if .Values.scPod.extraVolumes }}
-        {{- toYaml .Values.scPod.extraVolumes | nindent 8 }}
-        {{ end }}
       volumes:
       {{ if .Values.tls }}
         - name: cacert
@@ -92,3 +89,6 @@ spec:
               path: scopes.json
         {{ end }}
       {{ end }}
+        {{ if .Values.scPod.extraVolumes }}
+        {{- toYaml .Values.scPod.extraVolumes | nindent 8 }}
+        {{ end }}


### PR DESCRIPTION
While testing fluvio I found that the extra volumes are not rendered in the correct place. This PR fixed that.

Additionally, I've added support to render extra volume mounts when no TLS config is provided.