### PR TITLE
fix: consume large and incomplete batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluvio-protocol"
 edition = "2021"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Fluvio streaming protocol"
 repository = "https://github.com/infinyon/fluvio"


### PR DESCRIPTION
Similar to https://github.com/infinyon/fluvio/pull/4474, but for consume.

Solves https://github.com/infinyon/fluvio/issues/4523


In others places like `RecordSet` we have `Batch<RawRecords>` and we ignore errors of `UnexpectedEof`, because we can receive uncompleted records limited by max_bytes.

For consuming, we handle records with `ConsumerRecord` that is created by converting `Batch<RawRecords>` to `Batch<MemoryRecords>`. So we need to ignore these errors here too.