### PR TITLE
chore: centrilize paths in root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ trybuild = { branch = "check_option", git = "https://github.com/infinyon/trybuil
 fluvio-auth = { path = "crates/fluvio-auth" }
 fluvio-benchmark = { path = "crates/fluvio-benchmark" }
 fluvio-channel = { path = "crates/fluvio-channel" }
+fluvio-cli = { path = "crates/fluvio-cli" }
 fluvio-cli-common = { path = "crates/fluvio-cli-common" }
 fluvio-connector-package = { path = "crates/fluvio-connector-package/" }
 fluvio-controlplane = { path = "crates/fluvio-controlplane" }
@@ -201,6 +202,15 @@ fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-storage = { path = "crates/fluvio-storage" }
 fluvio-kv-storage = { path = "crates/fluvio-kv-storage", default-features = false }
+fluvio-test-derive = { path = "crates/fluvio-test-derive" }
+fluvio-test-util = { path = "crates/fluvio-test-util" }
+fluvio-test-case-derive = { path = "crates/fluvio-test-case-derive" }
+fluvio-cluster = { path = "crates/fluvio-cluster" }
+fluvio-hub-protocol = { path = "crates/fluvio-hub-protocol", default-features = false }
+fluvio-connector-deployer = { path = "crates/fluvio-connector-deployer" }
+fluvio-sc = { path = "crates/fluvio-sc", default-features = false }
+fluvio-spu = { path = "crates/fluvio-spu", default-features = false }
+fluvio-connector-derive = { path = "crates/fluvio-connector-derive" }
 # Published fluvio dependencies
 fluvio = { version = "0.32.0", path = "crates/fluvio" }
 fluvio-compression = { version = "0.32.0", path = "crates/fluvio-compression", default-features = false }

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -33,7 +33,7 @@ tracing = { workspace = true }
 
 fluvio = { workspace = true }
 fluvio-cli-common = { workspace = true, features = ["serde", "version-cmd"] }
-fluvio-connector-deployer = { path = "../fluvio-connector-deployer"}
+fluvio-connector-deployer = { workspace = true }
 fluvio-connector-package = { workspace = true,  features = ["toml"]}
 fluvio-extension-common = { workspace = true }
 fluvio-future = { workspace = true, features = ["subscriber"]}

--- a/crates/fluvio-cli-common/Cargo.toml
+++ b/crates/fluvio-cli-common/Cargo.toml
@@ -40,11 +40,11 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 ureq = { workspace = true }
 
-fluvio = { path = "../fluvio", optional = true, default-features = false }
+fluvio = { workspace = true, optional = true }
 fluvio-package-index = { workspace = true,  features = ["http_agent"] }
 fluvio-types = { workspace = true , optional = true }
 fluvio-protocol = { workspace = true,  optional = true }
-fluvio-sc-schema = { path = "../fluvio-sc-schema", optional = true }
-fluvio-smartmodule = { path = "../fluvio-smartmodule", optional = true, default-features = false }
-fluvio-smartengine = { path = "../fluvio-smartengine", optional = true, features = ["transformation"] }
+fluvio-sc-schema = { workspace = true, optional = true }
+fluvio-smartmodule = { workspace = true, optional = true, default-features = false }
+fluvio-smartengine = { workspace = true, optional = true, features = ["transformation", "engine"] }
 

--- a/crates/fluvio-cli/Cargo.toml
+++ b/crates/fluvio-cli/Cargo.toml
@@ -72,7 +72,7 @@ which = { workspace = true }
 k8-config = { workspace = true, optional = true }
 k8-client = { workspace = true, optional = true }
 k8-types = { workspace = true , features = ["core"] }
-fluvio-cluster = { path = "../fluvio-cluster", default-features = false, features = ["cli"], optional = true }
+fluvio-cluster = { workspace = true, features = ["cli"], optional = true }
 
 fluvio = { workspace = true }
 fluvio-auth = { workspace = true }

--- a/crates/fluvio-connector-common/Cargo.toml
+++ b/crates/fluvio-connector-common/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { workspace = true }
 fluvio = { workspace = true, features = ["smartengine"] }
 fluvio-future = { workspace = true, features = ["subscriber"] }
 fluvio-connector-package = { workspace = true  }
-fluvio-connector-derive = { path = "../fluvio-connector-derive/", optional = true }
+fluvio-connector-derive = { workspace = true, optional = true }
 fluvio-sc-schema = { workspace = true }
 fluvio-smartengine = { workspace = true , features = [ "transformation", "engine"] }
 

--- a/crates/fluvio-connector-package/Cargo.toml
+++ b/crates/fluvio-connector-package/Cargo.toml
@@ -31,13 +31,13 @@ toml = { workspace = true, optional = true, features = [
 tracing = { workspace = true }
 
 # fluvio dependencies
-fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata/", default-features = false, features = [
+fluvio-controlplane-metadata = { workspace = true, default-features = false, features = [
     "use_serde",
 ] }
-fluvio-smartengine = { path = "../fluvio-smartengine", default-features = false, features = [
+fluvio-smartengine = { workspace = true, default-features = false, features = [
     "transformation",
 ] }
-fluvio-types = { path = "../fluvio-types" }
+fluvio-types = { workspace = true }
 bytesize-serde = "0.2.1"
 
 [dev-dependencies]

--- a/crates/fluvio-hub-util/Cargo.toml
+++ b/crates/fluvio-hub-util/Cargo.toml
@@ -48,7 +48,7 @@ clap = { workspace = true, optional = true }
 comfy-table = { workspace = true, optional = true }
 
 fluvio-future = { workspace = true, features = ["fixture", "task", "tls"] }
-fluvio-hub-protocol = { path = "../fluvio-hub-protocol" }
+fluvio-hub-protocol = { workspace = true }
 fluvio-types = { workspace = true }
 fluvio-extension-common = { workspace = true,  optional = true }
 

--- a/crates/fluvio-protocol/Cargo.toml
+++ b/crates/fluvio-protocol/Cargo.toml
@@ -58,10 +58,10 @@ tokio-util = { workspace = true, features = ["codec","compat"], optional = true 
 tracing = { workspace = true }
 
 
-fluvio-protocol-derive = { workspace = true, path = "../fluvio-protocol-derive", optional = true }
+fluvio-protocol-derive = { workspace = true, optional = true }
 fluvio-future = { workspace = true, optional = true }
 flv-util = { workspace = true,  optional = true }
-fluvio-compression = { workspace = true, path = "../fluvio-compression", default-features = false, optional = true }
+fluvio-compression = { workspace = true, default-features = false, optional = true }
 fluvio-types = { workspace = true,  optional = true }
 
 [dev-dependencies]

--- a/crates/fluvio-run/Cargo.toml
+++ b/crates/fluvio-run/Cargo.toml
@@ -31,5 +31,5 @@ thiserror = { workspace = true }
 # regardless of TLS, sc and spu always use openssl_tls for now because we need cert API
 fluvio-future = { workspace = true, features = ["subscriber"] }
 fluvio-extension-common = { workspace = true }
-fluvio-sc = { path = "../fluvio-sc", default-features = false }
-fluvio-spu = { path = "../fluvio-spu", default-features = false  }
+fluvio-sc = { workspace = true }
+fluvio-spu = { workspace = true }

--- a/crates/fluvio-smartmodule/Cargo.toml
+++ b/crates/fluvio-smartmodule/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 
 eyre = { default-features = false, features = ["auto-install"], workspace = true }
-fluvio-smartmodule-derive = { workspace = true, path = "../fluvio-smartmodule-derive" }
+fluvio-smartmodule-derive = { workspace = true }
 fluvio-protocol = { workspace = true, features = ["link", "types"] }
 
 [dev-dependencies]

--- a/crates/fluvio-test-derive/Cargo.toml
+++ b/crates/fluvio-test-derive/Cargo.toml
@@ -18,7 +18,7 @@ quote = { workspace = true }
 proc-macro2 = { workspace = true }
 serde_json = { workspace = true }
 inflections = "1.1"
-fluvio-test-util = { path = "../fluvio-test-util" }
+fluvio-test-util = { workspace = true }
 rand = { workspace = true }
 
 

--- a/crates/fluvio-test-util/Cargo.toml
+++ b/crates/fluvio-test-util/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = { workspace = true }
 fluvio = { workspace = true  }
 fluvio-types = { workspace = true }
 fluvio-future = { workspace = true, features = ["task", "timer", "subscriber", "fixture"] }
-fluvio-cluster = { path = "../fluvio-cluster" }
+fluvio-cluster = { workspace = true }
 fluvio-command = { workspace = true  }
 
 [lib]

--- a/crates/fluvio-test/Cargo.toml
+++ b/crates/fluvio-test/Cargo.toml
@@ -47,13 +47,13 @@ fluvio-future = { workspace = true, features = [
     "fixture",
 ] }
 fluvio-command = { version = "0.2.0" }
-fluvio-cli = { path = "../fluvio-cli" }
+fluvio-cli = { workspace = true }
 fluvio-controlplane-metadata = { workspace = true, features = ["k8"] }
 
 # Fluvio test framework Attribute macro
-fluvio-test-derive = { path = "../fluvio-test-derive" }
-fluvio-test-util = { path = "../fluvio-test-util" }
+fluvio-test-derive = { workspace = true }
+fluvio-test-util = { workspace = true }
 fluvio-protocol = { workspace = true, features = ["api"] }
 
 # Fluvio test framework Options derive
-fluvio-test-case-derive = { path = "../fluvio-test-case-derive" }
+fluvio-test-case-derive = { workspace = true }

--- a/crates/smartmodule-development-kit/Cargo.toml
+++ b/crates/smartmodule-development-kit/Cargo.toml
@@ -26,11 +26,11 @@ tempfile = { workspace = true }
 lib-cargo-crate = "0.2.1"
 
 
-fluvio = { path = "../fluvio", default-features = false }
-fluvio-hub-util = { path = "../fluvio-hub-util" }
+fluvio = { workspace = true }
+fluvio-hub-util = { workspace = true }
 fluvio-future = { workspace = true, features = ["subscriber"]}
-fluvio-smartengine = { path = "../fluvio-smartengine", features = ["transformation"] }
-fluvio-extension-common = { path = "../fluvio-extension-common", features = ["target"] }
-fluvio-controlplane-metadata = { path = "../fluvio-controlplane-metadata", features = ["smartmodule"] }
-fluvio-cli-common = { path = "../fluvio-cli-common", features = ["file-records", "version-cmd", "serde", "smartmodule-test"] }
+fluvio-smartengine = { workspace = true, features = ["transformation"] }
+fluvio-extension-common = { workspace = true, features = ["target"] }
+fluvio-controlplane-metadata = { workspace = true, features = ["smartmodule"] }
+fluvio-cli-common = { workspace = true, features = ["file-records", "version-cmd", "serde", "smartmodule-test"] }
 cargo-builder = { path = "../cargo-builder"}


### PR DESCRIPTION
Also fixing these warnings:

```
warning: /Users/frai/workspace/infinyon/fluvio/crates/fluvio-smartmodule/Cargo.toml: unused manifest key: dependencies.fluvio-smartmodule-derive.path
warning: /Users/frai/workspace/infinyon/fluvio/crates/fluvio-protocol/Cargo.toml: unused manifest key: dependencies.fluvio-compression.path
warning: /Users/frai/workspace/infinyon/fluvio/crates/fluvio-protocol/Cargo.toml: unused manifest key: dependencies.fluvio-protocol-derive.path
```