### PR TITLE
chore: ensure that crypto provider is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.4",
  "pin-project",
+ "rustls 0.23.28",
  "semver 1.0.26",
  "serde",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ syn = "2.0"
 sysinfo = { version = "0.33.1", default-features = false, features = [
     "system",
 ] }
+rustls = { version = "0.23.0", default-features = false }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.4.0"
 thiserror = "2.0.11"

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -15,15 +15,17 @@ name = "fluvio"
 path = "src/lib.rs"
 
 [features]
-default = ["rustls", "compress"]
+default = ["rustls", "compress", "aws-lc-rs"]
 admin = ["fluvio-sc-schema/use_serde"]
 smartengine = ["fluvio-smartengine"]
 openssl = ["fluvio-future/openssl_tls"]
-rustls = ["fluvio-future/rust_tls", "dep:rustls", "rustls?/aws-lc-rs"]
-rustls-ring = ["fluvio-future/rust_tls", "dep:rustls", "rustls?/ring"]
+rustls = ["fluvio-future/rust_tls", "dep:rustls"]
 compress = ["fluvio-compression/compress", "fluvio-protocol/compress"]
 nightly = []
 unstable = []
+# Crypto providers for rustls (mutually exclusive)
+aws-lc-rs = ["rustls?/aws-lc-rs", "rustls?/prefer-post-quantum"]
+ring = ["rustls?/ring"]
 
 [dependencies]
 adaptive_backoff = { workspace = true }
@@ -54,7 +56,11 @@ fluvio-future = { workspace = true, features = [
     "task",
     "retry",
 ] }
-rustls = { workspace = true, optional = true, default-features = false }
+rustls = { workspace = true, optional = true, default-features = false, features = [
+    "std",
+    "logging",
+    "tls12",
+] }
 fluvio-types = { workspace = true, features = ["events"] }
 fluvio-sc-schema = { workspace = true }
 fluvio-socket = { workspace = true }

--- a/crates/fluvio/Cargo.toml
+++ b/crates/fluvio/Cargo.toml
@@ -19,7 +19,8 @@ default = ["rustls", "compress"]
 admin = ["fluvio-sc-schema/use_serde"]
 smartengine = ["fluvio-smartengine"]
 openssl = ["fluvio-future/openssl_tls"]
-rustls = ["fluvio-future/rust_tls"]
+rustls = ["fluvio-future/rust_tls", "dep:rustls", "rustls?/aws-lc-rs"]
+rustls-ring = ["fluvio-future/rust_tls", "dep:rustls", "rustls?/ring"]
 compress = ["fluvio-compression/compress", "fluvio-protocol/compress"]
 nightly = []
 unstable = []
@@ -53,6 +54,7 @@ fluvio-future = { workspace = true, features = [
     "task",
     "retry",
 ] }
+rustls = { workspace = true, optional = true, default-features = false }
 fluvio-types = { workspace = true, features = ["events"] }
 fluvio-sc-schema = { workspace = true }
 fluvio-socket = { workspace = true }

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -77,7 +77,7 @@ impl Fluvio {
     /// ```
     pub async fn connect_with_config(config: &FluvioClusterConfig) -> Result<Self> {
         // if crate tls is not configured and the profile has tls, return an error
-        #[cfg(not(any(feature = "openssl", feature = "rustls")))]
+        #[cfg(not(any(feature = "openssl", feature = "rustls", feature = "rustls-ring")))]
         if crate::config::TlsPolicy::Disabled != config.tls {
             return Err(anyhow::anyhow!(
                 "Error: cluster config requires TLS, but client was not built with TLS features.\nPlease enable the `openssl` feature."

--- a/crates/fluvio/src/fluvio.rs
+++ b/crates/fluvio/src/fluvio.rs
@@ -77,7 +77,7 @@ impl Fluvio {
     /// ```
     pub async fn connect_with_config(config: &FluvioClusterConfig) -> Result<Self> {
         // if crate tls is not configured and the profile has tls, return an error
-        #[cfg(not(any(feature = "openssl", feature = "rustls", feature = "rustls-ring")))]
+        #[cfg(not(any(feature = "openssl", feature = "rustls")))]
         if crate::config::TlsPolicy::Disabled != config.tls {
             return Err(anyhow::anyhow!(
                 "Error: cluster config requires TLS, but client was not built with TLS features.\nPlease enable the `openssl` feature."


### PR DESCRIPTION
Rustls is tricky to handle when an application is using more than one crypto provider.
When more than one provider is enabled, we have these errors: 

```
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
```

Easily to have more than one provider enable if using sub library from rustls ecosystem that only support one of them.

~This PR is adding a new feature for Fluvio crate called `rustls-ring` to use ring provider instead of `aws-ls-rs`. That way we'll have sure that one is settled at least and control it by feature flags.~

This PR is adding two new feature for Fluvio crate called `ring` and `aws-ls-rs`. `aws-ls-rs` is the default.
That way we'll have sure that one is settled at least and control it by feature flags.