### PR TITLE
fix: use proxy for requests that previously were not using it.

### DIFF
--- a/crates/fluvio-hub-util/src/htclient.rs
+++ b/crates/fluvio-hub-util/src/htclient.rs
@@ -103,7 +103,15 @@ where
     T: Into<Vec<u8>> + std::fmt::Debug,
 {
     let (parts, body) = request.into_parts();
-    let ureq_request: ureq::Request = parts.into();
+    let agent = configure_ureq_proxy()?; // Create agent with proxy
+    let mut ureq_request = agent.request(parts.method.as_ref(), &parts.uri.to_string());
+    for (name, value) in parts.headers {
+        let Some(name) = name else {
+            continue;
+        };
+        ureq_request = ureq_request.set(name.as_ref(), value.to_str().unwrap());
+    }
+
     let body_u8: Vec<u8> = body.into();
     let response = ureq_request
         .send_bytes(&body_u8)


### PR DESCRIPTION
I'm behind an HTTP proxy and was unable to use `cdk` to download packages because the request was timing out.

This PR fixes it.

I was hoping for an easier way to just set the agent on an existing `ureq::Request` but unfortunately the agent is private and doesn't have a setter so we have to manually rebuild the request which is probably slightly wasteful because it re-parses the URL.