### PR TITLE
chore: Use GitHub registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,6 +592,7 @@ jobs:
           ls -la /tmp
           docker image load --input /tmp/fluvio-${{ matrix.rust-target }}.tar
           docker image tag fluvio-community/fluvio:${{ github.sha }}-${{ matrix.rust-target }} fluvio-community/fluvio:${{ github.sha }}
+          docker image tag fluvio-community/fluvio:${{ github.sha }}-${{ matrix.rust-target }} ghcr.io/fluvio-community/fluvio:${{ github.sha }}
           docker image ls -a
       #- name: Load Docker image for Minikube
       #    eval $(minikube -p minikube docker-env)
@@ -599,7 +600,7 @@ jobs:
       #    docker image ls -a
 
       - name: Export Docker Image to tarball
-        run: docker image save fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
+        run: docker image save ghcr.io/fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
       - name: Install K3d
         if: matrix.k8 == 'k3d'
         run: |
@@ -704,7 +705,7 @@ jobs:
           docker image ls -a
 
       - name: Export Docker Image to tarball
-        run: docker image save fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
+        run: docker image save ghcr.io/fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
 
       - name: Run upgrade test with CI artifacts
         timeout-minutes: 10
@@ -1001,7 +1002,7 @@ jobs:
         timeout-minutes: 20
         run: |
           rm -rf ~/.fvm
-          make FVM_BIN=~/bin/fvm INFINYON_HUB_REMOTE="https://hub-dev.infinyon.cloud" cli-fvm-smoke
+          make FVM_BIN=~/bin/fvm cli-fvm-smoke
 
 
   read_only_test:
@@ -1170,10 +1171,11 @@ jobs:
           ls -la /tmp
           docker image load --input /tmp/fluvio-${{ matrix.rust-target }}.tar
           docker image tag fluvio-community/fluvio:${{ github.sha }}-${{ matrix.rust-target }} fluvio-community/fluvio:${{ github.sha }}
+          docker image tag fluvio-community/fluvio:${{ github.sha }}-${{ matrix.rust-target }} ghcr.io/fluvio-community/fluvio:${{ github.sha }}
           docker image ls -a
 
       - name: Export Docker Image to tarball
-        run: docker image save fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
+        run: docker image save ghcr.io/fluvio-community/fluvio:${{ github.sha }} --output /tmp/fluvio.tar
       - name: Install K3d
         run: |
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} bash

--- a/crates/fluvio-cluster/src/check/render.rs
+++ b/crates/fluvio-cluster/src/check/render.rs
@@ -7,4 +7,4 @@ use crate::{
     render::{ProgressRenderedText, ProgressRenderer},
 };
 
-const ISSUE_URL: &str = "https://github.com/infinyon/fluvio/issues/new/choose";
+const ISSUE_URL: &str = "https://github.com/fluvio-community/fluvio/issues/new/choose";

--- a/crates/fluvio-cluster/src/start/k8.rs
+++ b/crates/fluvio-cluster/src/start/k8.rs
@@ -57,7 +57,7 @@ use super::constants::*;
 use super::common::try_connect_to_sc;
 
 pub const DEFAULT_SPU_GROUP_NAME: &str = "main";
-const DEFAULT_REGISTRY: &str = "fluvio-community";
+const DEFAULT_REGISTRY: &str = "ghcr.io/fluvio-community";
 const DEFAULT_SERVICE_TYPE: &str = "NodePort";
 
 const FLUVIO_SC_SERVICE: &str = "fluvio-sc-public";
@@ -107,7 +107,7 @@ pub struct ClusterConfig {
     /// # Example
     ///
     /// Suppose you would like to install version `0.6.0` of Fluvio from
-    /// Docker Hub, where the image is tagged as `infinyon/fluvio:0.6.0`.
+    /// a container registry, where the image is tagged as `fluvio-community/fluvio:0.6.0`.
     /// You can do that like this:
     ///
     /// ```
@@ -121,11 +121,11 @@ pub struct ClusterConfig {
     /// ```
     #[builder(setter(into, strip_option), default)]
     image_tag: Option<String>,
-    /// Sets the docker image registry to use to download Fluvio images.
+    /// Sets the container image registry prefix used to download Fluvio images.
     ///
-    /// This defaults to `infinyon` to pull from Infinyon's official Docker Hub
-    /// registry. This can be used to specify a private registry or a local
-    /// registry as a source of Fluvio images.
+    /// This defaults to `ghcr.io/fluvio-community` to pull from the GitHub
+    /// Container Registry. This can be used to specify a private registry or a
+    /// local registry as a source of Fluvio images.
     ///
     /// # Example
     ///
@@ -136,7 +136,7 @@ pub struct ClusterConfig {
     /// docker run -d -p 5000:5000 --restart=always --name registry registry:2
     /// ```
     ///
-    /// Suppose you tagged your image as `infinyon/fluvio:0.1.0` and pushed it
+    /// Suppose you tagged your image as `fluvio-community/fluvio:0.1.0` and pushed it
     /// to your `localhost:5000` registry. Your image is now located at
     /// `localhost:5000/infinyon`. You can specify that to the installer like so:
     ///

--- a/k8-util/helm/fluvio-app/values.yaml
+++ b/k8-util/helm/fluvio-app/values.yaml
@@ -8,7 +8,7 @@ scLog: info
 tls: false
 imagePullSecrets: []
 image:
-  registry: fluvio-community
+  registry: ghcr.io/fluvio-community
   tag: ""
   pullPolicy: IfNotPresent
 cert:


### PR DESCRIPTION
Current latest binary fails with `fluvio cluster start --k8` due to `fluvio-community/fluvio` image is not in docker hub 