### PR TITLE
chore: use github release for fvm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,8 +268,6 @@ jobs:
             features: ""
           - crate: fluvio-types
             features: ""
-          - crate: fluvio-hub-util
-            features: ""
     env:
       RUST_BACKTRACE: full
     steps:
@@ -974,7 +972,6 @@ jobs:
           retention-days: 1
 
   fvm_cli_smoke:
-    if: ${{ false }} # disable until fvm is migrated to github based workflow
     name: CLI smoke test (fvm)
     needs: build_primary_binaries
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,12 @@ version = 4
 
 [[package]]
 name = "adaptive_backoff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c13fe4a0db6c40b835c26d92806193ff904a3a28c13258a7b432521c0fedf04"
+checksum = "ffd5e23cd33dd73c030d1c424967eb2fbdc917d89e0bdcf1162edc4cf504f756"
 dependencies = [
  "anyhow",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin"
@@ -43,6 +43,17 @@ dependencies = [
  "fluvio",
  "futures",
  "tokio",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -72,18 +83,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "aligned"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
 dependencies = [
  "as-slice",
 ]
@@ -114,12 +125,6 @@ name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -205,6 +210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,15 +274,13 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
- "anstyle",
  "bstr",
  "doc-comment",
- "libc",
- "predicates",
+ "predicates 2.1.5",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -347,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -387,9 +399,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -432,9 +444,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -442,11 +454,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -488,32 +499,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.101",
- "which 4.4.2",
-]
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -661,9 +649,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bytesize"
@@ -685,6 +673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "calamine"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +693,7 @@ dependencies = [
  "log",
  "quick-xml",
  "serde",
- "zip",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -909,19 +906,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -947,18 +935,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "pure-rust-locales",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1008,17 +995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.54"
+version = "4.5.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
 dependencies = [
  "clap",
 ]
@@ -1199,6 +1175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "consume"
 version = "0.0.0"
 dependencies = [
@@ -1231,6 +1213,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1317,7 +1309,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1441,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1712,6 +1704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,7 +1868,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "doc-comment"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "docopt"
@@ -1980,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2144,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2237,6 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2289,6 +2288,27 @@ dependencies = [
  "tracing",
  "wasm-bindgen-test",
  "web-time",
+]
+
+[[package]]
+name = "fluvio-artifacts-util"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fluvio-hub-protocol",
+ "hex",
+ "http 1.3.1",
+ "octocrab",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "ureq",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -2367,7 +2387,7 @@ dependencies = [
  "fluvio-future",
  "fluvio-package-index",
  "fluvio-types",
- "predicates",
+ "predicates 3.1.3",
  "rand 0.8.5",
  "tracing",
 ]
@@ -2426,7 +2446,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tui",
- "which 8.0.0",
+ "which",
 ]
 
 [[package]]
@@ -2511,7 +2531,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "which 8.0.0",
+ "which",
 ]
 
 [[package]]
@@ -2691,7 +2711,7 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "rustls-pemfile",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3244,9 +3264,11 @@ dependencies = [
  "current_platform",
  "dialoguer",
  "dirs 6.0.0",
+ "fluvio-artifacts-util",
  "fluvio-future",
- "fluvio-hub-util",
  "fs_extra",
+ "octocrab",
+ "rustls 0.23.28",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -3255,8 +3277,6 @@ dependencies = [
  "tempfile",
  "toml 0.8.22",
  "tracing",
- "ureq",
- "url",
 ]
 
 [[package]]
@@ -3622,7 +3642,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
 ]
@@ -3923,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.3.2"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759e2d5aea3287cb1190c8ec394f42866cb5bf74fcbf213f354e3c856ea26098"
+checksum = "9b3f9296c208515b87bd915a2f5d1163d4b3f863ba83337d7713cf478055948e"
 dependencies = [
  "derive_builder",
  "log",
@@ -4082,9 +4102,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "humantime-serde"
@@ -4147,7 +4167,9 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
+ "log",
  "rustls 0.23.28",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4173,7 +4195,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4191,7 +4213,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4426,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
 ]
@@ -4448,17 +4470,6 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "ipnet"
@@ -4507,15 +4518,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4610,6 +4612,21 @@ dependencies = [
  "futures",
  "serde",
  "tokio",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4717,12 +4734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,6 +4791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,16 +4814,6 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4848,6 +4855,15 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4972,6 +4988,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+dependencies = [
+ "crc",
+ "sha2",
 ]
 
 [[package]]
@@ -5135,7 +5161,7 @@ dependencies = [
  "downcast",
  "fragile",
  "mockall_derive",
- "predicates",
+ "predicates 3.1.3",
  "predicates-tree",
 ]
 
@@ -5169,10 +5195,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5358,6 +5384,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "octocrab"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1620cb765b304c2828fe3cc1c6510cad7354cbeb519561f415fd3b07aae0ef5"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tower",
+ "tower-http",
+ "url",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5426,6 +5488,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -5600,6 +5668,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -5864,12 +5942,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "itertools 0.10.5",
+ "predicates-core",
 ]
 
 [[package]]
@@ -5913,16 +6008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6028,9 +6113,9 @@ dependencies = [
 
 [[package]]
 name = "pure-rust-locales"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
 
 [[package]]
 name = "quick-xml"
@@ -6053,9 +6138,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6073,7 +6158,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
@@ -6092,16 +6177,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -6276,7 +6361,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.3",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -6501,12 +6586,6 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -6610,11 +6689,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -6751,13 +6842,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6765,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6943,6 +7056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7032,10 +7156,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "sink-test-connector"
@@ -7109,6 +7251,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7122,6 +7285,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7422,6 +7595,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -7503,27 +7677,24 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
- "slab",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7603,7 +7774,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.10",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -7623,8 +7794,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7643,6 +7816,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7773,6 +7947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
+name = "typed-path"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3015e6ce46d5ad8751e4a772543a30c7511468070e98e64e20165f8f81155b64"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7853,7 +8033,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "url",
@@ -8467,6 +8647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -8486,18 +8667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -8609,7 +8778,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -8619,23 +8788,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link 0.1.1",
- "windows-result 0.3.4",
- "windows-strings",
 ]
 
 [[package]]
@@ -8643,17 +8799,6 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8672,23 +8817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8701,24 +8829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -8758,6 +8868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8794,7 +8913,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -8954,9 +9073,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -9152,6 +9271,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "zerotrie"
@@ -9199,10 +9332,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "aes",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "generic-array",
+ "getrandom 0.3.3",
+ "hmac",
+ "indexmap 2.9.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
 name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/fluvio-compression",
     "crates/fluvio-controlplane",
     "crates/fluvio-controlplane-metadata",
+    "crates/fluvio-artifacts-util",
     "crates/fluvio-hub-util",
     "crates/fluvio-hub-protocol",
     "crates/fluvio-extension-common",
@@ -129,6 +130,7 @@ once_cell = "1.7.2"
 openssl = { version = "0.10", default-features = false }
 parking_lot = { version = "0.12.3", default-features = false }
 lib-cargo-crate = "0.2.1"
+octocrab = { version = "0.46", default-features = false }
 pin-project = "1.1.0"
 pin-utils = "0.1.0"
 portpicker = "0.1.1"
@@ -179,6 +181,7 @@ wasmparser = "0.235.0"
 web-time = "1.1.0"
 which = "8.0"
 x509-parser = "0.17.0"
+zip = "7"
 
 # External fluvio dependencies
 fluvio_ws_stream_wasm = "0.7.0"
@@ -202,6 +205,7 @@ fluvio-cli-common = { path = "crates/fluvio-cli-common" }
 fluvio-connector-package = { path = "crates/fluvio-connector-package/" }
 fluvio-controlplane = { path = "crates/fluvio-controlplane" }
 fluvio-extension-common = { path = "crates/fluvio-extension-common", default-features = false }
+fluvio-artifacts-util = { path = "crates/fluvio-artifacts-util" }
 fluvio-hub-util = { path = "crates/fluvio-hub-util" }
 fluvio-service = { path = "crates/fluvio-service" }
 fluvio-storage = { path = "crates/fluvio-storage" }

--- a/crates/fluvio-artifacts-util/.gitignore
+++ b/crates/fluvio-artifacts-util/.gitignore
@@ -1,0 +1,3 @@
+/target
+tests/*.tar.gz
+tests/*.tar

--- a/crates/fluvio-artifacts-util/Cargo.toml
+++ b/crates/fluvio-artifacts-util/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fluvio-artifacts-util"
+description = "API for getting artifacts"
+version = "0.0.0"
+publish = false
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[features]
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+hex = { workspace = true }
+http = { workspace = true }
+octocrab = { workspace = true, features = ["default-client", "rustls", "rustls-aws-lc-rs"]}
+sha2 = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features=["derive"] }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+ureq = { workspace = true }
+zip = { workspace = true }
+
+fluvio-hub-protocol = { workspace = true }
+

--- a/crates/fluvio-artifacts-util/src/fvm/api/client.rs
+++ b/crates/fluvio-artifacts-util/src/fvm/api/client.rs
@@ -1,0 +1,177 @@
+//! Hub FVM API Client
+
+use anyhow::{Result};
+use octocrab::Octocrab;
+use semver::Version;
+
+use crate::{
+    REPO_OWNER, REPO_NAME,
+    fvm::{Artifact, Channel, PackageSet},
+};
+
+// List of binaries that are installable via FVM
+// We may consider a more flexible approach in the future
+const FVM_INSTALLABLE_BINARIES: &[&str] = &["fluvio", "fluvio-run", "cdk", "smdk"];
+/// HTTP Client for interacting with the Hub FVM API
+#[derive(Debug, Default)]
+pub struct Client;
+
+impl Client {
+    /// Internal helper: resolves the GitHub release and semantic version for
+    /// a given FVM channel.
+    async fn fetch_release_and_version(
+        &self,
+        channel: &Channel,
+    ) -> Result<(octocrab::models::repos::Release, Version)> {
+        let octocrab = Octocrab::builder().build()?;
+
+        let (release, version) = match channel {
+            Channel::Stable => {
+                // we have to fetch last release id from github
+                let release = octocrab
+                    .repos(REPO_OWNER, REPO_NAME)
+                    .releases()
+                    .get_latest()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Unable to retrieve stable release: {e}"))?;
+                let version = Version::parse(release.tag_name.trim_start_matches('v'))?;
+
+                (release, version)
+            }
+            Channel::Tag(ver) => {
+                let release_id = format!("v{}", ver);
+                let release = octocrab
+                    .repos(REPO_OWNER, REPO_NAME)
+                    .releases()
+                    .get_by_tag(&release_id)
+                    .await
+                    .map_err(|e| {
+                        if let octocrab::Error::GitHub { source, .. } = &e {
+                            anyhow::anyhow!(
+                                "Unable to retrieve release for tag {release_id}: {}",
+                                source.message
+                            )
+                        } else {
+                            anyhow::anyhow!("Unable to retrieve release for tag {release_id}: {e}")
+                        }
+                    })?;
+                (release, ver.clone())
+            }
+            Channel::Latest => {
+                let release = octocrab
+                    .repos(REPO_OWNER, REPO_NAME)
+                    .releases()
+                    .get_by_tag("dev")
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Unable to retrieve release for tag dev: {e}"))?;
+
+                // Derive the version for the `latest` (dev) channel from the
+                // VERSION file in the fluvio repository at the same ref as the
+                // dev release tag
+                let content_items = octocrab
+                    .repos(REPO_OWNER, REPO_NAME)
+                    .get_content()
+                    .path("VERSION")
+                    .r#ref(release.tag_name.clone())
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Unable to retrieve VERSION file for dev release: {e}")
+                    })?;
+
+                let version_str = content_items
+                    .items
+                    .into_iter()
+                    .next()
+                    .and_then(|c| c.decoded_content())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("VERSION file for dev release is missing or empty")
+                    })?;
+
+                let version = Version::parse(version_str.trim()).map_err(|e| {
+                    anyhow::anyhow!("Invalid version string in VERSION file for dev release: {e}")
+                })?;
+
+                (release, version)
+            }
+            Channel::Other(release) => {
+                let release = octocrab
+                    .repos(REPO_OWNER, REPO_NAME)
+                    .releases()
+                    .get_by_tag(release)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Unable to retrieve release for tag {release}: {e}")
+                    })?;
+                let version = Version::parse(release.tag_name.trim_start_matches('v'))?;
+                (release, version)
+            }
+        };
+
+        Ok((release, version))
+    }
+
+    /// Fetches a [`PackageSet`] from GitHub that includes only the
+    /// "installable" binaries (e.g. fluvio, fluvio-run, cdk, smdk).
+    pub async fn fetch_default_package_set(
+        &self,
+        channel: &Channel,
+        arch: &str,
+    ) -> Result<PackageSet> {
+        // Start from the unfiltered package set (which includes all
+        // arch-specific artifacts) and then filter down to the
+        // "installable" binaries.
+        let mut pkgset = self.fetch_package_set(channel, arch).await?;
+
+        pkgset.artifacts.retain(|artifact| {
+            FVM_INSTALLABLE_BINARIES
+                .iter()
+                .any(|bin| artifact.name == *bin || artifact.name == format!("{bin}.exe"))
+        });
+
+        if pkgset.artifacts.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Release \"{}\" does not have installable artifacts for architecture: \"{arch}\"",
+                pkgset.pkgset
+            ));
+        }
+
+        Ok(pkgset)
+    }
+
+    /// Fetches a [`PackageSet`] from GitHub without filtering binaries by the
+    /// `FVM_INSTALLABLE_BINARIES` list.
+    pub async fn fetch_package_set(&self, channel: &Channel, arch: &str) -> Result<PackageSet> {
+        let (release, version) = self.fetch_release_and_version(channel).await?;
+
+        let artifacts: Vec<_> = release
+            .assets
+            .iter()
+            .filter(|asset| asset.name.ends_with(&format!("{arch}.zip")))
+            .map(|asset| Artifact {
+                name: asset
+                    .name
+                    .trim_end_matches(&format!("-{arch}.zip"))
+                    .to_string(),
+                version: version.clone(),
+                download_url: asset.browser_download_url.to_string(),
+                sha256_digest: asset.digest.clone(),
+            })
+            .collect();
+
+        if artifacts.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Release \"{}\" does not have artifacts for architecture: \"{arch}\"",
+                release.tag_name
+            ));
+        }
+
+        let package_set = PackageSet {
+            arch: arch.to_string(),
+            pkgset: version,
+            artifacts,
+        };
+
+        Ok(package_set)
+    }
+}

--- a/crates/fluvio-artifacts-util/src/fvm/api/download.rs
+++ b/crates/fluvio-artifacts-util/src/fvm/api/download.rs
@@ -1,0 +1,335 @@
+//! Download API for downloading the artifacts from the server
+
+use std::path::{Path, PathBuf};
+use std::io::{Cursor, copy};
+use std::fs::File;
+
+use anyhow::{Error, Result};
+use async_trait::async_trait;
+use http::StatusCode;
+use sha2::{Digest, Sha256};
+use tracing::instrument;
+
+use crate::fvm::Artifact;
+use crate::htclient;
+
+#[async_trait]
+pub trait Download {
+    /// Downloads the artifact to the specified directory
+    ///
+    /// Checksum validation, when metadata is available, is performed against
+    /// the raw bytes returned from the artifact's `download_url` (for example
+    /// a `.zip` archive) **before** any extraction. The checksum does not
+    /// currently apply to any binary extracted from an archive.
+    ///
+    /// Returns the path to the downloaded (and, if applicable, extracted)
+    /// artifact.
+    async fn download(&self, target_dir: PathBuf) -> Result<PathBuf>;
+}
+
+#[async_trait]
+impl Download for Artifact {
+    #[instrument(skip(self, target_dir))]
+    async fn download(&self, target_dir: PathBuf) -> Result<PathBuf> {
+        tracing::info!(
+            name = self.name,
+            download_url = ?self.download_url,
+            "Downloading artifact"
+        );
+
+        let res = htclient::get(&self.download_url)
+            .await
+            .map_err(|err| Error::msg(err.to_string()))?;
+
+        let status = http::StatusCode::from_u16(res.status().as_u16())?;
+        if status == StatusCode::OK {
+            let content_type = res
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_ascii_lowercase());
+
+            let bytes = res.into_body();
+
+            // delegate to helper which is easier to test
+            return process_downloaded_bytes(&bytes, content_type, self, &target_dir);
+        }
+
+        Err(Error::msg(format!(
+            "Server responded with Status Code {} for url {}",
+            res.status(),
+            self.download_url,
+        )))
+    }
+}
+
+/// Internal helper that implements the logic for handling downloaded bytes.
+/// Extracts files if zip, validates checksum if provided, writes final file
+/// to `target_dir` and returns the path.
+fn process_downloaded_bytes(
+    bytes: &[u8],
+    content_type: Option<String>,
+    artifact: &Artifact,
+    target_dir: &Path,
+) -> Result<PathBuf> {
+    let out_path = target_dir.join(&artifact.name);
+
+    if let Some(expected_digest) = &artifact.sha256_digest {
+        let expected = expected_digest.trim();
+        let expected = expected
+            .strip_prefix("sha256:")
+            .unwrap_or(expected)
+            .to_ascii_lowercase();
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let actual = format!("{:x}", hasher.finalize());
+
+        if actual != expected {
+            let msg = format!(
+                "DANGER: Downloaded artifact checksum did not match for {}",
+                artifact.name
+            );
+            tracing::error!(
+                name = artifact.name,
+                %expected,
+                %actual,
+                digest_scope = "archive",
+                "Checksum validation failed for downloaded artifact (archive) bytes",
+            );
+
+            return Err(Error::msg(msg));
+        }
+
+        tracing::debug!(
+            name = artifact.name,
+            %expected,
+            %actual,
+            digest_scope = "archive",
+            "Checksum validation succeeded for downloaded artifact (archive) bytes",
+        );
+    }
+
+    let mut file = File::create(&out_path)?;
+
+    let is_zip_ct = content_type.as_deref().is_some_and(|ct| ct.contains("zip"));
+
+    if is_zip_ct || is_zip_archive(bytes) {
+        // if the artifact is a zip file, we need to unzip it first
+        let reader = std::io::Cursor::new(&bytes);
+        let mut zip = zip::ZipArchive::new(reader)?;
+        if zip.is_empty() {
+            return Err(Error::msg("Downloaded zip archive is empty"));
+        }
+
+        let mut selected_index: Option<usize> = None;
+
+        // look file entries to find the one that matches the artifact name
+        for i in 0..zip.len() {
+            let file_in_zip = zip.by_index(i)?;
+
+            if file_in_zip.is_dir() {
+                continue;
+            }
+
+            let entry_name = file_in_zip.name();
+
+            if selected_index.is_none() {
+                selected_index = Some(i);
+            }
+
+            if entry_name.ends_with(&artifact.name) {
+                selected_index = Some(i);
+                break;
+            }
+        }
+
+        let selected_index = selected_index.ok_or_else(|| {
+            Error::msg("Downloaded zip archive does not contain any file entries")
+        })?;
+
+        let mut zipped_file = zip.by_index(selected_index)?;
+        let expected_size = zipped_file.size();
+        let written = copy(&mut zipped_file, &mut file)?;
+
+        if written == 0 {
+            return Err(Error::msg("Downloaded zip entry is empty"));
+        }
+
+        if written != expected_size {
+            return Err(Error::msg(
+                "Extracted file size does not match zip entry size",
+            ));
+        }
+    } else {
+        let mut buf = Cursor::new(&bytes);
+        let written = copy(&mut buf, &mut file)?;
+
+        if written == 0 {
+            return Err(Error::msg("Downloaded artifact is empty"));
+        }
+    }
+
+    tracing::debug!(
+        name = artifact.name,
+        out_path = ?out_path.display(),
+        "Artifact downloaded",
+    );
+
+    Ok(out_path)
+}
+
+fn is_zip_archive(bytes: &[u8]) -> bool {
+    const ZIP_MAGIC: [u8; 4] = [0x50, 0x4B, 0x03, 0x04];
+    bytes.len() >= ZIP_MAGIC.len() && bytes[..ZIP_MAGIC.len()] == ZIP_MAGIC
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use std::io::Write;
+    use sha2::{Digest, Sha256};
+
+    use zip::write::FileOptions;
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        hex::encode(hasher.finalize())
+    }
+
+    #[test]
+    fn extracts_correct_entry_from_multi_file_zip() {
+        let tmp = TempDir::new().unwrap();
+        let target_dir = tmp.path().to_path_buf();
+
+        // create zip with multiple files, one of them ends with "myartifact"
+        let mut buffer = Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut buffer);
+            let options: FileOptions<'_, ()> = FileOptions::default();
+
+            zip.start_file("bin/other", options).unwrap();
+            zip.write_all(b"other-content").unwrap();
+
+            zip.start_file("bin/myartifact", options).unwrap();
+            zip.write_all(b"expected-binary-data").unwrap();
+
+            zip.finish().unwrap();
+        }
+        let bytes = buffer.into_inner();
+
+        let digest = sha256_hex(&bytes);
+
+        let artifact = Artifact {
+            name: "myartifact".to_string(),
+            version: semver::Version::new(0, 0, 0),
+            download_url: "http://example.com".to_string(),
+            sha256_digest: Some(format!("sha256:{}", digest)),
+        };
+
+        let out = process_downloaded_bytes(
+            &bytes,
+            Some("application/zip".to_string()),
+            &artifact,
+            &target_dir,
+        )
+        .unwrap();
+
+        let content = std::fs::read(out).unwrap();
+        assert_eq!(content, b"expected-binary-data");
+    }
+
+    #[test]
+    fn fails_on_checksum_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        let target_dir = tmp.path().to_path_buf();
+
+        let bytes = b"notmatching".to_vec();
+        // compute different digest to ensure mismatch
+        let artifact = Artifact {
+            name: "foo".to_string(),
+            version: semver::Version::new(0, 0, 0),
+            download_url: "http://example.com".to_string(),
+            sha256_digest: Some(
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            ),
+        };
+
+        let res = process_downloaded_bytes(
+            &bytes,
+            Some("application/octet-stream".to_string()),
+            &artifact,
+            &target_dir,
+        );
+        assert!(res.is_err());
+        let msg = format!("{}", res.unwrap_err());
+        assert!(msg.contains("checksum") || msg.contains("DANGER"));
+    }
+
+    #[test]
+    fn fails_on_empty_zip() {
+        let tmp = TempDir::new().unwrap();
+        let target_dir = tmp.path().to_path_buf();
+
+        // create empty zip
+        let mut buffer = Cursor::new(Vec::new());
+        {
+            let zip = zip::ZipWriter::new(&mut buffer);
+            zip.finish().unwrap();
+        }
+        let bytes = buffer.into_inner();
+
+        let artifact = Artifact {
+            name: "something".to_string(),
+            version: semver::Version::new(0, 0, 0),
+            download_url: "http://example.com".to_string(),
+            sha256_digest: None,
+        };
+
+        let res = process_downloaded_bytes(
+            &bytes,
+            Some("application/zip".to_string()),
+            &artifact,
+            &target_dir,
+        );
+        assert!(res.is_err());
+        let msg = format!("{}", res.unwrap_err());
+        assert!(msg.contains("zip archive is empty"));
+    }
+
+    #[test]
+    fn fails_on_empty_zip_entry() {
+        let tmp = TempDir::new().unwrap();
+        let target_dir = tmp.path().to_path_buf();
+
+        // create zip with an empty file entry named "emptyfile"
+        let mut buffer = Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut buffer);
+            let options: FileOptions<'_, ()> = FileOptions::default();
+            zip.start_file("emptyfile", options).unwrap();
+            zip.finish().unwrap();
+        }
+        let bytes = buffer.into_inner();
+
+        let artifact = Artifact {
+            name: "emptyfile".to_string(),
+            version: semver::Version::new(0, 0, 0),
+            download_url: "http://example.com".to_string(),
+            sha256_digest: None,
+        };
+
+        let res = process_downloaded_bytes(
+            &bytes,
+            Some("application/zip".to_string()),
+            &artifact,
+            &target_dir,
+        );
+        assert!(res.is_err());
+        let msg = format!("{}", res.unwrap_err());
+        assert!(msg.contains("zip entry is empty"));
+    }
+}

--- a/crates/fluvio-artifacts-util/src/fvm/api/mod.rs
+++ b/crates/fluvio-artifacts-util/src/fvm/api/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod download;
+
+pub use client::Client;
+pub use download::Download;

--- a/crates/fluvio-artifacts-util/src/fvm/mod.rs
+++ b/crates/fluvio-artifacts-util/src/fvm/mod.rs
@@ -1,0 +1,397 @@
+//! Fluvio Version Manager (FVM) Types and HTTP Client.
+
+mod api;
+
+use std::fmt::Display;
+use std::cmp::Ordering;
+use std::str::FromStr;
+use std::collections::HashMap;
+
+use thiserror::Error;
+use serde::{Deserialize, Serialize};
+use semver::Version;
+
+pub use api::{Client, Download};
+
+pub const STABLE_VERSION_CHANNEL: &str = "stable";
+pub const LATEST_VERSION_CHANNEL: &str = "latest";
+pub const DEFAULT_PKGSET: &str = "default";
+
+#[derive(Clone, Debug, Error)]
+pub enum Error {
+    #[error("Invalid Fluvio Channel \"{0}\"")]
+    InvalidChannel(String),
+}
+
+/// Package Set Channels based on Fluvio Channels
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Channel {
+    Stable,
+    Latest,
+    Tag(Version),
+    Other(String),
+}
+
+impl Display for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Channel::Stable => write!(f, "{STABLE_VERSION_CHANNEL}"),
+            Channel::Latest => write!(f, "{LATEST_VERSION_CHANNEL}"),
+            Channel::Tag(version) => write!(f, "{version}"),
+            Channel::Other(version) => write!(f, "{version}"),
+        }
+    }
+}
+
+// Refer: https://rust-lang.github.io/rust-clippy/master/index.html#/derive_ord_xor_partial_ord
+impl PartialOrd for Channel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Channel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self {
+            Channel::Stable => match other {
+                Channel::Stable => Ordering::Equal,
+                Channel::Latest => Ordering::Greater,
+                Channel::Tag(_) => Ordering::Greater,
+                Channel::Other(_) => Ordering::Greater,
+            },
+            Channel::Latest => match other {
+                Channel::Stable => Ordering::Less,
+                Channel::Latest => Ordering::Equal,
+                Channel::Tag(_) => Ordering::Greater,
+                Channel::Other(_) => Ordering::Greater,
+            },
+            Channel::Tag(version) => match other {
+                Channel::Stable => Ordering::Less,
+                Channel::Latest => Ordering::Less,
+                Channel::Tag(tag_version) => version.cmp(tag_version),
+                Channel::Other(_) => Ordering::Greater,
+            },
+            Channel::Other(version) => match other {
+                Channel::Stable => Ordering::Less,
+                Channel::Latest => Ordering::Less,
+                Channel::Tag(_) => Ordering::Less,
+                Channel::Other(other_version) => version.cmp(other_version),
+            },
+        }
+    }
+}
+
+impl Channel {
+    /// Parses the provided string into a [`Channel`].
+    #[allow(unused)]
+    pub fn parse(s: impl AsRef<str>) -> Result<Self, Error> {
+        Self::from_str(s.as_ref())
+    }
+
+    /// Returns `true` if the instance is a version tag instead of a channel
+    /// string.
+    pub fn is_version_tag(&self) -> bool {
+        matches!(self, Self::Tag(_) | Self::Other(_))
+    }
+}
+
+impl FromStr for Channel {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            STABLE_VERSION_CHANNEL => Ok(Self::Stable),
+            LATEST_VERSION_CHANNEL => Ok(Self::Latest),
+            _ => {
+                if let Ok(version) = Version::parse(s) {
+                    Ok(Self::Tag(version))
+                } else {
+                    Ok(Self::Other(s.to_string()))
+                }
+            }
+        }
+    }
+}
+
+/// Artifact metadata for a single downloadable item.
+///
+/// Note: `sha256_digest`, when present, applies to the raw bytes returned
+/// from `download_url` (for example, a `.zip` archive) and is validated
+/// before any extraction or post-processing. It does **not** currently
+/// apply to an inner binary extracted from an archive.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Artifact {
+    pub name: String,
+    pub version: Version,
+    pub download_url: String,
+    /// SHA-256 digest of the downloaded artifact bytes as served at
+    /// `download_url` (e.g. the full `.zip` archive), not of any
+    /// extracted inner binary.
+    pub sha256_digest: Option<String>,
+}
+
+/// Fluvio Version Manager Package for a specific architecture and version.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PackageSetRecord {
+    pub pkgset: String,
+    pub arch: String,
+    pub artifacts: Vec<Artifact>,
+}
+
+impl From<PackageSetRecord> for PackageSet {
+    fn from(value: PackageSetRecord) -> Self {
+        let fluvio_artifact = value.artifacts.iter().find(|art| art.name == "fluvio");
+        let fluvio_version = fluvio_artifact
+            .map(|art| art.version.clone())
+            .unwrap_or_else(|| Version::new(0, 0, 0));
+
+        PackageSet {
+            pkgset: fluvio_version,
+            arch: value.arch,
+            artifacts: value.artifacts,
+        }
+    }
+}
+
+/// Fluvio Version Manager Package for a specific architecture and version.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PackageSet {
+    pub pkgset: Version,
+    pub arch: String,
+    pub artifacts: Vec<Artifact>,
+}
+
+impl PackageSet {
+    /// Checks whether `upstream` [`PackageSet`] includes missing artifacts,
+    /// and returns a `Vec<Artifact>` containing these.
+    ///
+    /// Patches included in [`PackageSet`]s are detected comparing versions
+    /// at the `artifacts` level.
+    ///
+    /// Local [`PackageSet`] artifacts are compared with `upstream` to check
+    /// for different versions or new artifacts in upstream package set.
+    ///
+    /// Whenever a version mismatch is found, such artifact is returned as part
+    /// of the output.
+    pub fn artifacts_diff(&self, upstream: &PackageSet) -> Vec<Artifact> {
+        let ours: HashMap<String, Artifact> =
+            self.artifacts.iter().fold(HashMap::new(), |mut map, art| {
+                map.insert(art.name.to_owned(), art.to_owned());
+                map
+            });
+        let theirs: HashMap<String, Artifact> =
+            upstream
+                .artifacts
+                .iter()
+                .fold(HashMap::new(), |mut map, art| {
+                    map.insert(art.name.to_owned(), art.to_owned());
+                    map
+                });
+        let mut new_artifacts: Vec<Artifact> = Vec::with_capacity(theirs.len());
+
+        for (art_name, their_artifact) in theirs {
+            if let Some(our_artifact) = ours.get(&art_name)
+                && our_artifact.version == their_artifact.version
+            {
+                continue;
+            }
+
+            new_artifacts.push(their_artifact.to_owned());
+        }
+
+        new_artifacts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::{Artifact, Channel, PackageSet, Version};
+
+    #[test]
+    fn parses_latest_channel_from_str() {
+        let channel = Channel::parse("latest").unwrap();
+
+        assert_eq!(channel, Channel::Latest);
+    }
+
+    #[test]
+    fn parses_stable_channel_from_str() {
+        let channel = Channel::parse("stable").unwrap();
+
+        assert_eq!(channel, Channel::Stable);
+    }
+
+    #[test]
+    fn determines_stable_as_greater_than_latest() {
+        let stable = Channel::parse("stable").unwrap();
+        let latest = Channel::parse("latest").unwrap();
+
+        assert!(stable > latest);
+    }
+
+    #[test]
+    fn performs_comparisons_between_tags() {
+        let ver_a = Channel::parse("0.10.10").unwrap();
+        let ver_b = Channel::parse("0.10.13-mirroring347239873+20231016").unwrap();
+
+        assert!(ver_b > ver_a);
+    }
+
+    #[test]
+    fn determines_otherversion_revisioning() {
+        let stable = Channel::parse("stable").unwrap();
+        let ssdkp1 = Channel::parse("ssdk-preview1").unwrap();
+        let ssdkp2 = Channel::parse("ssdk-preview2").unwrap();
+
+        assert!(stable > ssdkp1);
+        assert!(ssdkp2 > ssdkp1);
+    }
+
+    #[test]
+    fn determines_tag_is_greater_than_other() {
+        let tag = Channel::parse("0.1.0").unwrap();
+        let other = Channel::parse("ssdk-preview1").unwrap();
+
+        assert!(tag > other);
+    }
+
+    #[test]
+    fn determines_if_other_packageset_includes_diff_artifacts() {
+        let package_sets = vec![
+            (
+                PackageSet {
+                    pkgset: Version::from_str("0.1.0").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                PackageSet {
+                    pkgset: Version::from_str("0.1.0").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.11.6").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                1,
+            ),
+            (
+                PackageSet {
+                    pkgset: Version::from_str("0.2.0").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                PackageSet {
+                    pkgset: Version::from_str("0.2.1").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                0,
+            ),
+            (
+                PackageSet {
+                    pkgset: Version::from_str("0.3.1").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                PackageSet {
+                    pkgset: Version::from_str("0.3.2").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![],
+                },
+                0,
+            ),
+            (
+                PackageSet {
+                    pkgset: Version::from_str("0.4.7").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                PackageSet {
+                    pkgset: Version::from_str("0.4.7").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("new-pkg"),
+                        version: Version::from_str("0.1.0").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                1,
+            ),
+            (
+                PackageSet {
+                    pkgset: Version::from_str("0.3.1").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![],
+                },
+                PackageSet {
+                    pkgset: Version::from_str("0.3.2").unwrap(),
+                    arch: String::from("aarch64-apple-darwin"),
+                    artifacts: vec![Artifact {
+                        name: String::from("fluvio-cloud"),
+                        version: Version::from_str("0.2.19").unwrap(),
+                        download_url: String::from(
+                            "https://packages.fluvio.io/fluvio-cloud/aarch64-apple-darwin/0.2.19",
+                        ),
+                        sha256_digest: None,
+                    }],
+                },
+                1,
+            ),
+        ];
+
+        for (ours, theirs, new_pkgs) in package_sets {
+            let diff = ours.artifacts_diff(&theirs).len();
+
+            assert_eq!(
+                diff, new_pkgs,
+                "PackageSet Artifacts diff between PackageSets {} and {} should have {} diff items but found {}",
+                ours.pkgset, theirs.pkgset, new_pkgs, diff
+            );
+        }
+    }
+}

--- a/crates/fluvio-artifacts-util/src/htclient.rs
+++ b/crates/fluvio-artifacts-util/src/htclient.rs
@@ -1,0 +1,116 @@
+pub use http;
+pub use http::StatusCode;
+pub use http::{Request, Response};
+
+use std::env;
+
+use anyhow::{anyhow, Context, Result};
+use serde::de::DeserializeOwned;
+
+use ureq::{Agent, AgentBuilder, Proxy, OrAnyStatus};
+
+/// for simple get requests
+pub async fn get(uri: impl AsRef<str>) -> Result<Response<Vec<u8>>> {
+    use std::io::Read;
+
+    let uri = uri.as_ref();
+    let agent = configure_ureq_proxy()?; // Create agent with proxy
+
+    let req = agent.get(uri);
+    let resp = req
+        .call()
+        .or_any_status()
+        .map_err(|e| anyhow!("get transport error : {e}"))?;
+
+    let status = resp.status();
+    let content_type = resp.header("Content-Type").map(|v| v.to_string());
+    let len: usize = match resp.header("Content-Length") {
+        Some(hdr) => hdr.parse()?,
+        None => 0usize,
+    };
+
+    let mut bytes: Vec<u8> = Vec::with_capacity(len);
+    resp.into_reader().read_to_end(&mut bytes)?;
+
+    let mut builder = Response::builder().status(status);
+    if let Some(ct) = content_type {
+        builder = builder.header(http::header::CONTENT_TYPE, ct);
+    }
+    let response = builder.body(bytes)?;
+
+    Ok(response)
+}
+
+pub async fn send<T>(request: Request<T>) -> Result<Response<Vec<u8>>>
+where
+    T: Into<Vec<u8>> + std::fmt::Debug,
+{
+    let (parts, body) = request.into_parts();
+    let agent = configure_ureq_proxy()?; // Create agent with proxy
+    let mut ureq_request = agent.request(parts.method.as_ref(), &parts.uri.to_string());
+    for (name, value) in parts.headers {
+        let Some(name) = name else {
+            continue;
+        };
+        let value_str = value
+            .to_str()
+            .map_err(|e| anyhow!("invalid UTF-8 in header '{}': {e}", name.as_str()))?;
+        ureq_request = ureq_request.set(name.as_ref(), value_str);
+    }
+
+    let body_u8: Vec<u8> = body.into();
+    let response = ureq_request
+        .send_bytes(&body_u8)
+        .or_any_status()
+        .map_err(|e| anyhow!("error: {e}"))?;
+    Ok(response.into())
+}
+
+/// Configures a `ureq::Agent` with a proxy, if one is defined in the environment.
+fn configure_ureq_proxy() -> Result<Agent> {
+    let agent_builder = AgentBuilder::new();
+
+    let proxy_vars = [
+        ("ALL_PROXY", "all_proxy", "ALL"),
+        ("HTTPS_PROXY", "https_proxy", "HTTPS"),
+        ("HTTP_PROXY", "http_proxy", "HTTP"),
+    ];
+
+    let proxy_creation = |proxy_str: &str, proxy_type: &str| -> Result<Proxy> {
+        Proxy::new(proxy_str).with_context(|| format!("Failed to create {proxy_type} proxy"))
+    };
+
+    for &(upper_var, lower_var, proxy_type) in &proxy_vars {
+        if let Ok(proxy_str) = env::var(upper_var).or_else(|_| env::var(lower_var)) {
+            let proxy = proxy_creation(&proxy_str, proxy_type)?;
+            return Ok(agent_builder.proxy(proxy).build());
+        }
+    }
+
+    Ok(agent_builder.build())
+}
+
+pub trait ResponseExt {
+    fn json<T>(&self) -> Result<T>
+    where
+        T: DeserializeOwned;
+
+    fn body_string(&self) -> Result<String>;
+}
+
+impl ResponseExt for Response<Vec<u8>> {
+    fn json<T>(&self) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let body = self.body();
+        let result = serde_json::from_slice(body)?;
+        Ok(result)
+    }
+
+    fn body_string(&self) -> Result<String> {
+        let body = self.body();
+        let bstr = std::str::from_utf8(body)?;
+        Ok(bstr.to_string())
+    }
+}

--- a/crates/fluvio-artifacts-util/src/lib.rs
+++ b/crates/fluvio-artifacts-util/src/lib.rs
@@ -1,0 +1,15 @@
+mod utils;
+
+pub mod htclient;
+
+pub mod fvm;
+
+pub use http;
+pub use utils::*;
+pub use utils::sha256_digest;
+
+pub use fluvio_hub_protocol::*;
+pub use fluvio_hub_protocol::constants::*;
+
+pub const REPO_OWNER: &str = "fluvio-community";
+pub const REPO_NAME: &str = "fluvio";

--- a/crates/fluvio-artifacts-util/src/utils.rs
+++ b/crates/fluvio-artifacts-util/src/utils.rs
@@ -1,0 +1,89 @@
+use std::fs::File;
+use std::path::PathBuf;
+use std::io::copy;
+
+use sha2::{Digest, Sha256};
+
+use fluvio_hub_protocol::{Result};
+use fluvio_hub_protocol::constants::HUB_PACKAGE_EXT;
+
+/// non validating function to make canonical filenames from
+/// org pkg version triples
+pub fn make_filename(org: &str, pkg: &str, ver: &str) -> String {
+    if org.is_empty() {
+        format!("{pkg}-{ver}.{HUB_PACKAGE_EXT}")
+    } else {
+        format!("{org}-{pkg}-{ver}.{HUB_PACKAGE_EXT}")
+    }
+}
+
+/// Generates Sha256 checksum for a given file
+pub fn sha256_digest(path: &PathBuf) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut file = File::open(path)?;
+
+    copy(&mut file, &mut hasher)?;
+
+    let hash_bytes = hasher.finalize();
+
+    Ok(hex::encode(hash_bytes))
+}
+
+#[cfg(test)]
+mod util_tests {
+    use tempfile::TempDir;
+
+    use crate::sha256_digest;
+
+    #[test]
+    fn creates_shasum_digest() {
+        use std::fs::write;
+
+        let tempdir = TempDir::new().unwrap();
+        let temp_dir_path = tempdir.into_path().to_path_buf();
+        let foo_path = temp_dir_path.join("foo");
+
+        write(&foo_path, "foo").unwrap();
+
+        let foo_a_checksum = sha256_digest(&foo_path).unwrap();
+
+        assert_eq!(
+            foo_a_checksum,
+            "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+        );
+    }
+
+    #[test]
+    fn checks_files_checksums_diff() {
+        use std::fs::write;
+
+        let tempdir = TempDir::new().unwrap();
+        let temp_dir_path = tempdir.into_path().to_path_buf();
+        let foo_path = temp_dir_path.join("foo");
+        let bar_path = temp_dir_path.join("bar");
+
+        write(&foo_path, "foo").unwrap();
+        write(&bar_path, "bar").unwrap();
+
+        let foo_checksum = sha256_digest(&foo_path).unwrap();
+        let bar_checksum = sha256_digest(&bar_path).unwrap();
+
+        assert_ne!(foo_checksum, bar_checksum);
+    }
+
+    #[test]
+    fn checks_files_checksums_same() {
+        use std::fs::write;
+
+        let tempdir = TempDir::new().unwrap();
+        let temp_dir_path = tempdir.into_path().to_path_buf();
+        let foo_path = temp_dir_path.join("foo");
+
+        write(&foo_path, "foo").unwrap();
+
+        let foo_a_checksum = sha256_digest(&foo_path).unwrap();
+        let foo_b_checksum = sha256_digest(&foo_path).unwrap();
+
+        assert_eq!(foo_a_checksum, foo_b_checksum);
+    }
+}

--- a/crates/fluvio-version-manager/Cargo.toml
+++ b/crates/fluvio-version-manager/Cargo.toml
@@ -22,6 +22,8 @@ comfy-table = { workspace = true }
 current_platform = { workspace = true }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
+octocrab = { workspace = true, default-features = false, features = ["default-client", "rustls", "rustls-aws-lc-rs"] }
+rustls = { workspace = true, features = ["aws-lc-rs"]}
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -30,12 +32,10 @@ sysinfo = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 toml = { workspace = true }
-ureq = { workspace = true }
-url = { workspace = true }
 
 # Workspace Crates
-fluvio-future = { workspace = true, features = ["subscriber", "attributes"] }
-fluvio-hub-util = { workspace = true }
+fluvio-future = { workspace = true, features = ["attributes", "fixture", "task", "tls"] }
+fluvio-artifacts-util = { workspace = true }
 
 [dev-dependencies]
 fs_extra = "1.3.0"

--- a/crates/fluvio-version-manager/src/command/current.rs
+++ b/crates/fluvio-version-manager/src/command/current.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
 
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 use crate::common::notify::Notify;
 use crate::common::settings::Settings;

--- a/crates/fluvio-version-manager/src/command/install.rs
+++ b/crates/fluvio-version-manager/src/command/install.rs
@@ -7,10 +7,8 @@ use std::fs::create_dir_all;
 
 use anyhow::Result;
 use clap::Parser;
-use url::Url;
 
-use fluvio_hub_util::HUB_REMOTE;
-use fluvio_hub_util::fvm::{Client, Channel};
+use fluvio_artifacts_util::fvm::{Client, Channel};
 
 use crate::common::TARGET;
 use crate::common::notify::Notify;
@@ -23,9 +21,6 @@ pub struct InstallOpt {
     /// Binaries architecture triple to use
     #[arg(long, env = "FVM_BINARY_ARCH_TRIPLE", default_value = TARGET)]
     target: String,
-    /// Registry used to fetch Fluvio Versions
-    #[arg(long, env = "INFINYON_HUB_REMOTE", default_value = HUB_REMOTE)]
-    registry: Url,
     /// Version to install: stable, latest, or named-version x.y.z
     #[arg(index = 1, default_value_t = Channel::Stable)]
     version: Channel,
@@ -40,9 +35,9 @@ impl InstallOpt {
             create_dir_all(&versions_path)?;
         }
 
-        let client = Client::new(self.registry.as_str())?;
+        let client = Client;
         let pkgset = client
-            .fetch_package_set(&self.version, &self.target)
+            .fetch_default_package_set(&self.version, &self.target)
             .await?;
 
         VersionInstaller::new(self.version.to_owned(), pkgset, notify)

--- a/crates/fluvio-version-manager/src/command/itself/update.rs
+++ b/crates/fluvio-version-manager/src/command/itself/update.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
 use semver::Version;
+use octocrab::Octocrab;
 
-use ureq::OrAnyStatus;
+use fluvio_artifacts_util::{REPO_NAME, REPO_OWNER};
 
 use crate::{
     common::{notify::Notify, update_manager::UpdateManager},
@@ -14,10 +15,6 @@ use crate::{
 
 /// Environment variable to store the version of FVM to fetch
 const FVM_UPDATE_VERSION: &str = "FVM_UPDATE_VERSION";
-
-/// Default URL used to fetch the `stable` channel tag
-const FVM_STABLE_CHANNEL_URL: &str =
-    "https://packages.fluvio.io/v1/packages/fluvio/fvm/tags/stable";
 
 #[derive(Clone, Debug, Parser)]
 pub struct SelfUpdateOpt;
@@ -43,7 +40,7 @@ impl SelfUpdateOpt {
     }
 
     /// Determines the version of FVM to fetch taking into account
-    /// the environment variable `FVM_VERSION` and the `stable` channel
+    /// the environment variable `FVM_UPDATE_VERSION` and the `stable` channel
     async fn resolve_version(&self) -> Result<Version> {
         if let Ok(version) = var(FVM_UPDATE_VERSION) {
             return Ok(Version::parse(&version)?);
@@ -54,17 +51,20 @@ impl SelfUpdateOpt {
 
     /// Fetches the `stable` channel tag from the Fluvio Version Manager
     async fn fetch_stable_tag(&self) -> Result<Version> {
-        // let client = Client::new();
-        // let request = client.get(FVM_STABLE_CHANNEL_URL)?;
+        let octocrab = Octocrab::builder().build()?;
 
-        let request = ureq::get(FVM_STABLE_CHANNEL_URL);
-        let response = request
-            .call()
-            .or_any_status()
-            .map_err(|e| anyhow::anyhow!("Unable to retrieve stable tag for FVM: {e}"))?;
+        // Use GitHub latest release for fluvio-community/fluvio (non-prerelease)
+        let release = octocrab
+            .repos(REPO_OWNER, REPO_NAME)
+            .releases()
+            .get_latest()
+            .await
+            .map_err(|e| anyhow::anyhow!("Unable to retrieve stable release for FVM: {e}"))?;
 
-        let version = response.into_string()?;
-        let version = Version::parse(&version)?;
+        let tag = release.tag_name;
+
+        let tag = tag.trim_start_matches('v');
+        let version = Version::parse(tag)?;
 
         Ok(version)
     }

--- a/crates/fluvio-version-manager/src/command/list.rs
+++ b/crates/fluvio-version-manager/src/command/list.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use colored::Colorize;
 use comfy_table::{Table, Row};
 
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 use crate::common::manifest::VersionManifest;
 use crate::common::notify::Notify;

--- a/crates/fluvio-version-manager/src/command/switch.rs
+++ b/crates/fluvio-version-manager/src/command/switch.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
 
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 use crate::common::notify::Notify;
 use crate::common::version_directory::VersionDirectory;

--- a/crates/fluvio-version-manager/src/command/uninstall.rs
+++ b/crates/fluvio-version-manager/src/command/uninstall.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use colored::Colorize;
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 use crate::common::notify::Notify;
 

--- a/crates/fluvio-version-manager/src/command/update.rs
+++ b/crates/fluvio-version-manager/src/command/update.rs
@@ -3,10 +3,8 @@
 use anyhow::{Result, Error};
 use clap::Args;
 use colored::Colorize;
-use url::Url;
 
-use fluvio_hub_util::HUB_REMOTE;
-use fluvio_hub_util::fvm::{Client, Channel, PackageSet};
+use fluvio_artifacts_util::fvm::{Client, Channel, PackageSet};
 
 use crate::common::version_directory::VersionDirectory;
 use crate::common::workdir::fvm_versions_path;
@@ -16,11 +14,7 @@ use crate::common::settings::Settings;
 use crate::common::version_installer::VersionInstaller;
 
 #[derive(Debug, Args)]
-pub struct UpdateOpt {
-    /// Registry used to fetch Fluvio Versions
-    #[arg(long, env = "INFINYON_HUB_REMOTE", default_value = HUB_REMOTE)]
-    registry: Url,
-}
+pub struct UpdateOpt;
 
 impl UpdateOpt {
     pub async fn process(self, notify: Notify) -> Result<()> {
@@ -117,8 +111,8 @@ impl UpdateOpt {
             ));
         }
 
-        let client = Client::new(self.registry.as_str())?;
-        let pkgset = client.fetch_package_set(channel, TARGET).await?;
+        let client = Client;
+        let pkgset = client.fetch_default_package_set(channel, TARGET).await?;
 
         Ok(pkgset)
     }

--- a/crates/fluvio-version-manager/src/common/manifest.rs
+++ b/crates/fluvio-version-manager/src/common/manifest.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use semver::Version;
 
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 /// The name of the manifest file for the Package Set
 pub const PACKAGE_SET_MANIFEST_FILENAME: &str = "manifest.json";

--- a/crates/fluvio-version-manager/src/common/settings.rs
+++ b/crates/fluvio-version-manager/src/common/settings.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 
-use fluvio_hub_util::fvm::Channel;
+use fluvio_artifacts_util::fvm::Channel;
 
 use super::manifest::VersionManifest;
 use super::workdir::fvm_workdir_path;

--- a/crates/fluvio-version-manager/src/common/version_directory.rs
+++ b/crates/fluvio-version-manager/src/common/version_directory.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 
-use fluvio_hub_util::fvm::{Artifact, Channel, PackageSet};
+use fluvio_artifacts_util::fvm::{Artifact, Channel, PackageSet};
 use semver::Version;
 
 use crate::common::manifest::{PACKAGE_SET_MANIFEST_FILENAME, VersionManifest};
@@ -168,7 +168,7 @@ impl VersionDirectory {
                         version,
                         name: va.name.clone(),
                         download_url: String::from("N/A"),
-                        sha256_url: String::from("N/A"),
+                        sha256_digest: None,
                     })
                 })
                 .collect();
@@ -198,7 +198,7 @@ mod tests {
     use fs_extra::dir::{copy as copy_dir, CopyOptions};
     use tempfile::TempDir;
 
-    use fluvio_hub_util::sha256_digest;
+    use fluvio_artifacts_util::sha256_digest;
 
     use crate::common::manifest::VersionedArtifact;
     use crate::common::settings::tests::{create_fvm_dir, delete_fvm_dir};
@@ -412,19 +412,19 @@ mod tests {
                     name: String::from("fluvio"),
                     version: Version::parse("0.11.8").unwrap(),
                     download_url: String::from("N/A"),
-                    sha256_url: String::from("N/A"),
+                    sha256_digest: None,
                 },
                 Artifact {
                     name: String::from("fluvio-cloud"),
                     version: Version::parse("0.2.22").unwrap(),
                     download_url: String::from("N/A"),
-                    sha256_url: String::from("N/A"),
+                    sha256_digest: None,
                 },
                 Artifact {
                     name: String::from("cdk"),
                     version: Version::parse("0.11.8").unwrap(),
                     download_url: String::from("N/A"),
-                    sha256_url: String::from("N/A"),
+                    sha256_digest: None,
                 },
             ],
         };

--- a/crates/fluvio-version-manager/src/common/version_installer.rs
+++ b/crates/fluvio-version-manager/src/common/version_installer.rs
@@ -4,7 +4,7 @@ use std::fs::{copy, create_dir, remove_file, rename};
 use anyhow::{anyhow, Result};
 use tempfile::TempDir;
 
-use fluvio_hub_util::fvm::{Artifact, Channel, Download, PackageSet};
+use fluvio_artifacts_util::fvm::{Artifact, Channel, Download, PackageSet};
 
 use super::executable::set_executable_mode;
 use super::manifest::{VersionManifest, VersionedArtifact, PACKAGE_SET_MANIFEST_FILENAME};

--- a/crates/fluvio-version-manager/src/main.rs
+++ b/crates/fluvio-version-manager/src/main.rs
@@ -1,7 +1,7 @@
 mod command;
 mod common;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::Parser;
 use command::uninstall::UninstallOpt;
 
@@ -23,6 +23,13 @@ pub const VERSION: &str = include_str!("../../../VERSION");
 #[fluvio_future::main_async]
 async fn main() -> Result<()> {
     fluvio_future::subscriber::init_tracer(None);
+    if rustls::crypto::CryptoProvider::get_default().is_none()
+        && rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .is_err()
+    {
+        bail!("Failed to install AWS-LC-Rust as default crypto provider");
+    }
 
     let args = Cli::parse();
 


### PR DESCRIPTION
Update `fvm` to rely on github releases instead of hub. This does not update `cdk` and `smdk`. That could be added in a future PR. This PR re-enables the `fvm` bats tests.

All the logic is based on fetching the artifacts list from a given release, and then downloading and unzipping the binaries that match with the current architecture.

In a future PR, we should implement the changes for cdk, smdk, #4638 has an initial implementation for it. Also in a future PR we should create/update a `install.sh` in order to update the installation instructions.